### PR TITLE
feat: add individual commands for inline actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,5 +84,10 @@ When reopening a saved chat (`:VibingOpenChat` or `:e`), the session resumes via
 | `:VibingContext [path]` | Add file to context |
 | `:VibingClearContext` | Clear all context |
 | `:VibingInline [action]` | Run inline action on selection (fix/feat/explain/refactor/test) |
+| `:VibingExplain` | Explain selected code |
+| `:VibingFix` | Fix selected code issues |
+| `:VibingFeature` | Implement feature in selected code |
+| `:VibingRefactor` | Refactor selected code |
+| `:VibingTest` | Generate tests for selected code |
 | `:VibingCancel` | Cancel current request |
 | `:VibingOpenChat <file>` | Open saved chat file |

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -58,6 +58,27 @@ function M._register_commands()
     require("vibing.actions.inline").execute(opts.args)
   end, { nargs = "?", range = true, desc = "Run inline action" })
 
+  -- Individual inline action commands
+  vim.api.nvim_create_user_command("VibingExplain", function()
+    require("vibing.actions.inline").execute("explain")
+  end, { range = true, desc = "Explain selected code" })
+
+  vim.api.nvim_create_user_command("VibingFix", function()
+    require("vibing.actions.inline").execute("fix")
+  end, { range = true, desc = "Fix selected code issues" })
+
+  vim.api.nvim_create_user_command("VibingFeature", function()
+    require("vibing.actions.inline").execute("feat")
+  end, { range = true, desc = "Implement feature in selected code" })
+
+  vim.api.nvim_create_user_command("VibingRefactor", function()
+    require("vibing.actions.inline").execute("refactor")
+  end, { range = true, desc = "Refactor selected code" })
+
+  vim.api.nvim_create_user_command("VibingTest", function()
+    require("vibing.actions.inline").execute("test")
+  end, { range = true, desc = "Generate tests for selected code" })
+
   vim.api.nvim_create_user_command("VibingCancel", function()
     if M.adapter then
       M.adapter:cancel()


### PR DESCRIPTION
## 概要

Issue #9の実装：inline actionsを個別のコマンドに分割しました。

## 変更内容

### 新規コマンド

- `:VibingExplain` - 選択したコードの説明
- `:VibingFix` - 選択したコードの問題を修正
- `:VibingFeature` - 選択したコードに機能を実装
- `:VibingRefactor` - 選択したコードをリファクタリング
- `:VibingTest` - 選択したコードのテストを生成

### 実装

**lua/vibing/init.lua:**
- 各inline actionに対応する個別コマンドを追加
- 既存の`:VibingInline [action]`は後方互換性のため維持
- 全てのコマンドは`range = true`でビジュアルモード対応

**CLAUDE.md:**
- User Commandsテーブルに新コマンドを追加

## メリット

1. **キーマッピングの設定が容易**: 各アクションに直接キーをマッピング可能
2. **明確なコマンド補完**: タブ補完で`:Vibing`と打つと全てのアクションが表示される
3. **利用頻度の把握**: 各アクションの使用統計を取りやすい

## 後方互換性

既存の`:VibingInline [action]`コマンドは維持されており、既存のユーザー設定に影響はありません。

## テスト

- ✅ Lua構文チェック
- ✅ コードレビュー（高信頼度の問題なし）

fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new inline-action commands: VibingExplain, VibingFix, VibingFeature, VibingRefactor, and VibingTest for code analysis, issue fixes, feature implementation, refactoring, and test generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->