### PR TITLE
feat: add configurable chat file save location

### DIFF
--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -23,6 +23,7 @@
 ---@class Vibing.ChatConfig
 ---@field window Vibing.WindowConfig
 ---@field auto_context boolean
+---@field save_location_type "project"|"user"|"custom"
 ---@field save_dir string
 
 ---@class Vibing.WindowConfig
@@ -55,7 +56,8 @@ M.defaults = {
       border = "rounded",
     },
     auto_context = true,
-    save_dir = vim.fn.stdpath("data") .. "/vibing/chats",
+    save_location_type = "project",  -- "project" | "user" | "custom"
+    save_dir = vim.fn.stdpath("data") .. "/vibing/chats",  -- Used when save_location_type is "custom"
   },
   inline = {
     default_action = "fix",
@@ -121,7 +123,7 @@ function M.setup(opts)
     end
   end
 
-  vim.fn.mkdir(M.options.chat.save_dir, "p")
+  -- Directory creation is handled by chat_buffer.lua _get_save_directory()
 end
 
 ---@return Vibing.Config

--- a/lua/vibing/ui/chat_buffer.lua
+++ b/lua/vibing/ui/chat_buffer.lua
@@ -64,13 +64,38 @@ function ChatBuffer:_create_buffer()
   if self.file_path then
     vim.api.nvim_buf_set_name(self.buf, self.file_path)
   else
-    -- 新規の場合はプロジェクトの.vibing/chat/に保存
-    local project_root = vim.fn.getcwd()
-    local default_path = project_root .. "/.vibing/chat/"
-    vim.fn.mkdir(default_path, "p")
-    local filename = os.date("chat_%Y%m%d_%H%M%S.md")
-    self.file_path = default_path .. filename
+    -- 新規の場合は設定に基づいて保存先を決定
+    local save_path = self:_get_save_directory()
+    vim.fn.mkdir(save_path, "p")
+    local filename = os.date("chat-%Y%m%d-%H%M%S.md")
+    self.file_path = save_path .. filename
     vim.api.nvim_buf_set_name(self.buf, self.file_path)
+  end
+end
+
+---保存ディレクトリを取得
+---@return string directory_path
+function ChatBuffer:_get_save_directory()
+  local location_type = self.config.save_location_type or "project"
+
+  if location_type == "project" then
+    -- プロジェクトローカル
+    local project_root = vim.fn.getcwd()
+    return project_root .. "/.vibing/chat/"
+  elseif location_type == "user" then
+    -- ユーザーグローバル
+    return vim.fn.stdpath("data") .. "/vibing/chats/"
+  elseif location_type == "custom" then
+    -- カスタムパス
+    local custom_path = self.config.save_dir
+    -- 末尾にスラッシュを追加（必要な場合）
+    if not custom_path:match("/$") then
+      custom_path = custom_path .. "/"
+    end
+    return custom_path
+  else
+    -- デフォルトはproject
+    return vim.fn.getcwd() .. "/.vibing/chat/"
   end
 end
 


### PR DESCRIPTION
## 概要

Issue #6の実装：チャットファイルの保存場所を設定で変更できるようにしました。

## 変更内容

### 新規設定

**lua/vibing/config.lua:**
- `save_location_type`: "project" | "user" | "custom"
  - **"project"** (デフォルト): `{cwd}/.vibing/chat/` - プロジェクトローカル
  - **"user"**: `{stdpath("data")}/vibing/chats/` - ユーザーグローバル
  - **"custom"**: `save_dir`設定値を使用 - カスタムパス

**lua/vibing/ui/chat_buffer.lua:**
- `_get_save_directory()`: 設定に基づいて保存先ディレクトリを決定

## 使用例

```lua
-- プロジェクトローカル（デフォルト）
require("vibing").setup({
  chat = {
    save_location_type = "project"
  }
})

-- ユーザーグローバル
require("vibing").setup({
  chat = {
    save_location_type = "user"
  }
})

-- カスタムパス
require("vibing").setup({
  chat = {
    save_location_type = "custom",
    save_dir = "~/my-chats/"
  }
})
```

## メリット

1. **プロジェクト固有の履歴**: 各プロジェクトでチャット履歴を分離
2. **グローバル履歴**: 全プロジェクトで共有したい場合
3. **カスタム制御**: 任意のディレクトリに保存可能

## テスト

- ✅ Lua構文チェック
- ✅ コードレビュー（指摘事項修正済み）

fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable chat save location with three options: project-local (default), global user data directory, or custom location. Users can now choose where to store chat history based on their workflow and project structure preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->