### PR TITLE
feat: add oil.nvim integration for sending files to chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ require("vibing").setup({
 | `:VibingOpenChat <file>` | Open saved chat file |
 | `:VibingRemote <command>` | Execute command in remote Neovim instance (requires `--listen`) |
 | `:VibingRemoteStatus` | Show remote Neovim status (mode, buffer, cursor position) |
+| `:VibingSendToChat` | Send file from oil.nvim to chat (requires oil.nvim) |
 
 ## Slash Commands (in Chat)
 

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -117,6 +117,10 @@ function M._register_commands()
       vim.notify("[vibing] Remote control not available", vim.log.levels.ERROR)
     end
   end, { desc = "Get remote Neovim status" })
+
+  vim.api.nvim_create_user_command("VibingSendToChat", function()
+    require("vibing.integrations.oil").send_to_chat()
+  end, { desc = "Send file from oil.nvim to chat" })
 end
 
 ---@return Vibing.Adapter?

--- a/lua/vibing/integrations/oil.lua
+++ b/lua/vibing/integrations/oil.lua
@@ -1,0 +1,132 @@
+---@class Vibing.OilIntegration
+local M = {}
+
+---oil.nvimが利用可能かチェック
+---@return boolean
+function M.is_available()
+  return pcall(require, "oil")
+end
+
+---現在のバッファがoil.nvimバッファかチェック
+---@return boolean
+function M.is_oil_buffer()
+  if not M.is_available() then
+    return false
+  end
+
+  local oil = require("oil")
+  local current_dir = oil.get_current_dir()
+  return current_dir ~= nil
+end
+
+---カーソル位置のファイルパスを取得
+---@return string? file_path
+function M.get_cursor_file()
+  if not M.is_oil_buffer() then
+    return nil
+  end
+
+  local oil = require("oil")
+  local entry = oil.get_cursor_entry()
+
+  if not entry then
+    return nil
+  end
+
+  -- ディレクトリの場合はスキップ
+  if entry.type == "directory" then
+    return nil
+  end
+
+  local dir = oil.get_current_dir()
+  if not dir then
+    return nil
+  end
+
+  -- パスを結合（末尾のスラッシュを考慮）
+  local file_path = dir
+  if not file_path:match("/$") then
+    file_path = file_path .. "/"
+  end
+  file_path = file_path .. entry.name
+
+  return file_path
+end
+
+---選択されたファイルパスを取得（カーソル位置のファイルのみ）
+---@return string[] file_paths
+function M.get_selected_files()
+  local file = M.get_cursor_file()
+  if file then
+    return { file }
+  end
+  return {}
+end
+
+---ファイルパスをチャットに送信
+function M.send_to_chat()
+  if not M.is_oil_buffer() then
+    vim.notify("[vibing] Not in an oil.nvim buffer", vim.log.levels.WARN)
+    return
+  end
+
+  local files = M.get_selected_files()
+
+  if #files == 0 then
+    vim.notify("[vibing] No file selected (directories are not supported)", vim.log.levels.WARN)
+    return
+  end
+
+  -- チャットバッファを取得または作成
+  local chat = require("vibing.actions.chat")
+  if not chat.chat_buffer or not chat.chat_buffer:is_open() then
+    chat.open()
+  end
+
+  -- カーソル位置を取得
+  local buf = chat.chat_buffer:get_buffer()
+  if not buf then
+    vim.notify("[vibing] Failed to get chat buffer", vim.log.levels.ERROR)
+    return
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local insert_line = #lines
+
+  -- ファイルパスを@file:path形式で挿入
+  local cwd = vim.fn.getcwd():gsub("/$", "")
+  local added_count = 0
+
+  for _, file_path in ipairs(files) do
+    -- ファイルが存在するか確認
+    if vim.fn.filereadable(file_path) ~= 1 then
+      vim.notify("[vibing] File not readable: " .. file_path, vim.log.levels.WARN)
+      goto continue
+    end
+
+    -- 相対パスに変換
+    local relative_path = file_path
+    if file_path:sub(1, #cwd + 1) == cwd .. "/" then
+      relative_path = file_path:sub(#cwd + 2)
+    end
+
+    local file_mention = "@file:" .. relative_path
+    vim.api.nvim_buf_set_lines(buf, insert_line, insert_line, false, { file_mention })
+    insert_line = insert_line + 1
+    added_count = added_count + 1
+
+    ::continue::
+  end
+
+  -- カーソルを挿入位置に移動
+  if chat.chat_buffer:is_open() and chat.chat_buffer.win then
+    pcall(vim.api.nvim_win_set_cursor, chat.chat_buffer.win, { insert_line, 0 })
+  end
+
+  vim.notify(
+    string.format("[vibing] Added %d file(s) to chat", added_count),
+    vim.log.levels.INFO
+  )
+end
+
+return M


### PR DESCRIPTION
## Summary
- Issue #11の実装: oil.nvimからファイルをチャットに送信
- `:VibingSendToChat`コマンドを追加

## Changes
- **新規**: `lua/vibing/integrations/oil.lua` - oil.nvim統合モジュール
- `lua/vibing/init.lua`: `:VibingSendToChat`コマンドを追加
- `CLAUDE.md`: コマンド表を更新

## Features
- oil.nvimのカーソル位置のファイルをチャットに送信
- 自動的に相対パスに変換して`@file:path`形式で挿入
- チャットが開いていない場合は自動的に新規作成
- ディレクトリは自動的にスキップ（ファイルのみ対応）

## Usage Example
```vim
" oil.nvimでファイルブラウザを開く
:Oil

" カーソルでファイルを選択して
:VibingSendToChat
```

## Technical Details
- oil.nvim APIを使用: `get_cursor_entry()`, `get_current_dir()`
- エラーハンドリング:
  - ファイル存在確認
  - パス正規化（トレーリングスラッシュ対応）
  - 安全なウィンドウカーソル操作（pcall使用）
- oil.nvimが未インストールでも動作（適切なエラーメッセージ）

## Code Review
- 構文チェック: ✅ Pass
- Code review (初回): 3つの重要な問題を検出
- Code review (修正後): ✅ No issues found

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `:VibingSendToChat` command to send files from oil.nvim directly to chat (requires oil.nvim plugin installed)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->