### PR TITLE
feat: add slash command completion in chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,9 @@ When reopening a saved chat (`:VibingOpenChat` or `:e`), the session resumes via
 
 ## Slash Commands (in Chat)
 
-Slash commands can be used within the chat buffer for quick actions:
+Slash commands can be used within the chat buffer for quick actions.
+
+**Completion**: Type `/` and press `<C-x><C-o>` for omnifunc completion to see all available commands.
 
 | Command | Description |
 |---------|-------------|

--- a/lua/vibing/chat/completion.lua
+++ b/lua/vibing/chat/completion.lua
@@ -1,0 +1,44 @@
+---Slash command completion
+local M = {}
+
+---Omnifunc for slash command completion
+---@param findstart number
+---@param base string
+---@return number|table
+function M.omnifunc(findstart, base)
+  if findstart == 1 then
+    -- カーソル位置から行頭までのテキストを取得
+    local line = vim.api.nvim_get_current_line()
+    local col = vim.fn.col(".")
+    local line_to_cursor = line:sub(1, col - 1)
+
+    -- 最後の/を探す
+    local slash_pos = line_to_cursor:match("^.*()/%S*$")
+    if slash_pos then
+      return slash_pos - 1 -- 0-indexed position
+    end
+
+    return -3 -- 補完を開始しない
+  else
+    -- 補完候補を生成
+    local commands = require("vibing.chat.commands")
+    local candidates = {}
+
+    for _, cmd in ipairs(commands.list()) do
+      local word = "/" .. cmd.name
+      -- baseで始まるコマンドのみを候補に含める
+      if base == "" or word:sub(1, #base) == base then
+        table.insert(candidates, {
+          word = word,
+          abbr = word,
+          menu = cmd.description,
+          dup = 0,
+        })
+      end
+    end
+
+    return candidates
+  end
+end
+
+return M

--- a/lua/vibing/ui/chat_buffer.lua
+++ b/lua/vibing/ui/chat_buffer.lua
@@ -60,6 +60,9 @@ function ChatBuffer:_create_buffer()
   vim.bo[self.buf].modifiable = true
   vim.bo[self.buf].swapfile = false
 
+  -- スラッシュコマンド補完を設定
+  vim.bo[self.buf].omnifunc = "v:lua.require'vibing.chat.completion'.omnifunc"
+
   -- ファイルパスが設定されている場合はそれを使う
   if self.file_path then
     vim.api.nvim_buf_set_name(self.buf, self.file_path)


### PR DESCRIPTION
## Summary
- Issue #7の実装: スラッシュコマンド補完機能
- チャットで`/`を入力後、`<C-x><C-o>`で補完

## Features
- **Omnifunc統合**: Neovimネイティブの補完
- **自動発見**: コマンドレジストリから動的に取得
- **説明表示**: 各コマンドの説明も補完候補に表示
- **前方一致フィルタ**: `/c`で`/context`と`/clear`を表示

## Usage
```
# チャットバッファで
/c<C-x><C-o>
# → /context と /clear が候補として表示される
```

## Implementation Details
- `lua/vibing/chat/completion.lua`: Omnifunc実装（44行）
- `chat_buffer.lua`: バッファ作成時にomnifuncを設定
- CLAUDE.md: 補完の使い方をドキュメント化

## Base Branch
- Base: `feature/issue-8-slash-commands` (PR #23)
- Issue #8のスラッシュコマンド実装に依存

## Code Review
- 構文チェック: ✅ Pass
- Code review: ✅ No issues found
- commands.lua依存: ✅ Verified

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)