### PR TITLE
feat: auto-generate chat file names from first message

### DIFF
--- a/lua/vibing/actions/chat.lua
+++ b/lua/vibing/actions/chat.lua
@@ -103,6 +103,12 @@ function M.send(chat_buffer, message)
     end
   end
 
+  -- 最初のメッセージの場合、ファイル名を更新
+  local conversation = chat_buffer:extract_conversation()
+  if #conversation == 0 then
+    chat_buffer:update_filename_from_message(message)
+  end
+
   -- 応答セクションを開始
   chat_buffer:start_response()
 

--- a/lua/vibing/ui/chat_buffer.lua
+++ b/lua/vibing/ui/chat_buffer.lua
@@ -68,7 +68,7 @@ function ChatBuffer:_create_buffer()
     local project_root = vim.fn.getcwd()
     local default_path = project_root .. "/.vibing/chat/"
     vim.fn.mkdir(default_path, "p")
-    local filename = os.date("chat-%Y%m%d-%H%M%S.md")
+    local filename = os.date("chat_%Y%m%d_%H%M%S.md")
     self.file_path = default_path .. filename
     vim.api.nvim_buf_set_name(self.buf, self.file_path)
   end
@@ -480,6 +480,42 @@ end
 ---@return number?
 function ChatBuffer:get_buffer()
   return self.buf
+end
+
+---最初のメッセージからファイル名を更新
+---@param message string
+function ChatBuffer:update_filename_from_message(message)
+  if not self.buf or not vim.api.nvim_buf_is_valid(self.buf) then
+    return
+  end
+
+  -- 既にファイル名が意味のある名前になっている場合はスキップ
+  if self.file_path and not self.file_path:match("chat_%d+_%d+") then
+    return
+  end
+
+  local filename_util = require("vibing.utils.filename")
+  local base_filename = filename_util.generate_from_message(message)
+
+  -- 新しいファイルパスを生成
+  local project_root = vim.fn.getcwd()
+  local chat_dir = project_root .. "/.vibing/chat/"
+  vim.fn.mkdir(chat_dir, "p")
+
+  local new_filename = base_filename .. ".md"
+  local new_file_path = chat_dir .. new_filename
+
+  -- ファイル名が重複する場合は連番を追加
+  local counter = 1
+  while vim.fn.filereadable(new_file_path) == 1 do
+    new_filename = base_filename .. "_" .. counter .. ".md"
+    new_file_path = chat_dir .. new_filename
+    counter = counter + 1
+  end
+
+  -- バッファ名を更新
+  self.file_path = new_file_path
+  vim.api.nvim_buf_set_name(self.buf, new_file_path)
 end
 
 return ChatBuffer

--- a/lua/vibing/utils/filename.lua
+++ b/lua/vibing/utils/filename.lua
@@ -1,0 +1,57 @@
+---Filename generation utilities
+local M = {}
+
+---ファイル名として安全な文字列に変換
+---@param text string
+---@return string
+local function sanitize(text)
+  -- 小文字に変換
+  text = text:lower()
+  -- 空白とハイフンをアンダースコアに
+  text = text:gsub("[%s%-]+", "_")
+  -- ファイル名に使えない文字を削除
+  text = text:gsub("[^%w_%-]", "")
+  -- 連続するアンダースコアを1つに
+  text = text:gsub("_+", "_")
+  -- 先頭と末尾のアンダースコアを削除
+  text = text:gsub("^_+", ""):gsub("_+$", "")
+  -- 最大32文字に制限
+  if #text > 32 then
+    text = text:sub(1, 32)
+  end
+  return text
+end
+
+---会話内容からファイル名を生成
+---@param message string 最初のユーザーメッセージ
+---@return string filename
+function M.generate_from_message(message)
+  if not message or message == "" then
+    return os.date("chat_%Y%m%d_%H%M%S")
+  end
+
+  -- 最初の行または最初の50文字を取得
+  local first_line = message:match("^([^\n]+)") or message
+  if #first_line > 50 then
+    first_line = first_line:sub(1, 50)
+  end
+
+  -- サニタイズしてトピック名を生成
+  local topic = sanitize(first_line)
+
+  -- トピックが空の場合はタイムスタンプのみ
+  if topic == "" then
+    return os.date("chat_%Y%m%d_%H%M%S")
+  end
+
+  -- YYYYMMDD_topic形式
+  return os.date("%Y%m%d") .. "_" .. topic
+end
+
+---デフォルトのファイル名を生成
+---@return string filename
+function M.generate_default()
+  return os.date("chat_%Y%m%d_%H%M%S")
+end
+
+return M


### PR DESCRIPTION
## Summary
- Issue #5の実装: 最初のメッセージから自動的にファイル名を生成
- タイムスタンプ形式から意味のある名前へ

## Features
- **自動命名**: 最初のユーザーメッセージから自動生成
- **安全なファイル名**: 特殊文字を削除、32文字以内に制限
- **重複回避**: 既存ファイルと重複する場合は連番追加
- **フォールバック**: 空メッセージ時はタイムスタンプ形式

## Filename Format
```
# Before:  chat_20251217_143025.md
# After:   20251217_fix_authentication_bug.md
           20251217_add_new_feature.md
           20251217_refactor_code.md
```

## Implementation Details
- `lua/vibing/utils/filename.lua`: サニタイゼーション・生成ロジック（58行）
- `chat_buffer.lua`: `update_filename_from_message()`メソッド追加
- `chat.lua`: 最初のメッセージ送信時にファイル名更新

## Logic
1. 最初の行または最初の50文字を取得
2. 特殊文字を削除、小文字化
3. `YYYYMMDD_sanitized_topic`形式で生成
4. ファイルが存在する場合は`_1`, `_2`...を追加

## Code Review
- 構文チェック: ✅ Pass
- Code review (初回): 4つの問題を検出
  - ファイル名フォーマット不整合（Critical）
  - パターンマッチング不一致（Critical）
  - ループ内の重複呼び出し（Important）
  - ディレクトリ作成保証なし（Important）
- Code review (修正後): ✅ No issues found

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat files now auto-rename based on message content instead of using timestamps alone, with incremental suffixes for duplicate files.

* **Improvements**
  * Updated default filename format to use underscores instead of hyphens for better consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->