### PR TITLE
feat: record permissions in chat frontmatter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,16 @@ Chat files are saved as Markdown with YAML frontmatter:
 vibing.nvim: true
 session_id: <sdk-session-id>
 created_at: 2024-01-01T12:00:00
+permissions_allow:
+  - Read
+  - Edit
+  - Write
+permissions_deny:
+  - Bash
 ---
 ```
 
-When reopening a saved chat (`:VibingOpenChat` or `:e`), the session resumes via the stored `session_id`.
+When reopening a saved chat (`:VibingOpenChat` or `:e`), the session resumes via the stored `session_id`. Configured permissions are recorded in frontmatter for transparency and auditability.
 
 ### Key Patterns
 

--- a/lua/vibing/ui/chat_buffer.lua
+++ b/lua/vibing/ui/chat_buffer.lua
@@ -139,22 +139,43 @@ end
 
 ---初期コンテンツを設定
 function ChatBuffer:_init_content()
+  local vibing = require("vibing")
+  local config = vibing.get_config()
+
   local lines = {
     "---",
     "vibing.nvim: true",
     "session_id: ",
     "created_at: " .. os.date("%Y-%m-%dT%H:%M:%S"),
-    "---",
-    "",
-    "# Vibing Chat",
-    "",
-    "Context: " .. Context.format_for_display(),
-    "",
-    "---",
-    "",
-    "## User",
-    "",
   }
+
+  -- Add permissions if configured
+  if config.permissions then
+    if config.permissions.allow and #config.permissions.allow > 0 then
+      table.insert(lines, "permissions_allow:")
+      for _, tool in ipairs(config.permissions.allow) do
+        table.insert(lines, "  - " .. tool)
+      end
+    end
+    if config.permissions.deny and #config.permissions.deny > 0 then
+      table.insert(lines, "permissions_deny:")
+      for _, tool in ipairs(config.permissions.deny) do
+        table.insert(lines, "  - " .. tool)
+      end
+    end
+  end
+
+  table.insert(lines, "---")
+  table.insert(lines, "")
+  table.insert(lines, "# Vibing Chat")
+  table.insert(lines, "")
+  table.insert(lines, "Context: " .. Context.format_for_display())
+  table.insert(lines, "")
+  table.insert(lines, "---")
+  table.insert(lines, "")
+  table.insert(lines, "## User")
+  table.insert(lines, "")
+
   vim.api.nvim_buf_set_lines(self.buf, 0, -1, false, lines)
   vim.api.nvim_win_set_cursor(self.win, { #lines, 0 })
 end
@@ -183,21 +204,43 @@ function ChatBuffer:parse_frontmatter()
     return {}
   end
 
-  local lines = vim.api.nvim_buf_get_lines(self.buf, 0, 20, false)
+  local lines = vim.api.nvim_buf_get_lines(self.buf, 0, 50, false)
   local frontmatter = {}
   local in_frontmatter = false
   local frontmatter_end = 0
+  local current_key = nil
+  local current_list = nil
 
   for i, line in ipairs(lines) do
     if i == 1 and line == "---" then
       in_frontmatter = true
     elseif in_frontmatter and line == "---" then
+      if current_key and current_list then
+        frontmatter[current_key] = current_list
+      end
       frontmatter_end = i
       break
     elseif in_frontmatter then
-      local key, value = line:match("^([%w_]+):%s*(.*)$")
-      if key then
-        frontmatter[key] = value
+      if line:match("^  %- ") and current_list then
+        local item = line:match("^  %- (.+)$")
+        if item then
+          table.insert(current_list, item)
+        end
+      else
+        if current_key and current_list then
+          frontmatter[current_key] = current_list
+        end
+        local key, value = line:match("^([%w_]+):%s*(.*)$")
+        if key then
+          if value == "" then
+            current_key = key
+            current_list = {}
+          else
+            frontmatter[key] = value
+            current_key = nil
+            current_list = nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## 概要
Issue #13の部分実装。設定されたpermissionsをチャットファイルのfrontmatterに記録し、監査可能性と透明性を向上させます。

## 実装内容
- `_init_content()`でconfig.permissionsをfrontmatterに書き込み
- `permissions_allow`と`permissions_deny`を YAML list形式で記録
- parse_frontmatter()を拡張してYAML list構文をサポート
- CLAUDE.mdにfrontmatter例を追加

## 機能の範囲
この実装はpermissionsの**記録**のみを行います。実際のpermission適用はIssue #12 (PR #27)で実装済みです。

## frontmatter例
```yaml
---
vibing.nvim: true
session_id: abc123
permissions_allow:
  - Read
  - Edit
  - Write
permissions_deny:
  - Bash
---
```

## メリット
- どのpermissionが有効だったかを後から確認可能
- セキュリティ監査に有用
- チャットファイルが自己文書化される

Related to #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)