### PR TITLE
chore: add .editorconfig for consistent code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,57 @@
+# EditorConfig for vibing.nvim
+# https://editorconfig.org
+
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Lua files (plugin code)
+[*.lua]
+indent_style = space
+indent_size = 2
+
+# JavaScript/Node.js files
+[*.{js,mjs,cjs}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+# Vim help files
+[*.txt]
+indent_style = space
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2
+
+# Git config files
+[.gitignore]
+indent_style = space
+indent_size = 2
+
+# Package manager files
+[{package.json,package-lock.json}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Summary
.editorconfigを追加してコードスタイルを統一

## Changes
- `.editorconfig`を作成
- 全ファイルタイプの基本設定（UTF-8、LF改行、末尾空白削除）
- Lua、JavaScript、JSON、YAML、Markdownの2スペースインデント
- Markdownでは末尾空白を保持（特殊処理）

## Benefits
- エディタ間でコードスタイルを自動統一
- 新しいコントリビューターでも一貫したフォーマット
- PRでのフォーマット差分を削減
- EditorConfig標準に準拠（広くサポート）

## Supported Editors
- VS Code
- Neovim（editorconfig-vimプラグイン）
- IntelliJ IDEA / WebStorm
- Sublime Text
- Atom
- その他多数

fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)