### PR TITLE
fix: resolve merge conflict in agent-wrapper.mjs

### DIFF
--- a/bin/agent-wrapper.mjs
+++ b/bin/agent-wrapper.mjs
@@ -92,7 +92,6 @@ const queryOptions = {
   includePartialMessages: true,
 };
 
-<<<<<<< HEAD
 // Add canUseTool callback for permission control
 if (allowedTools.length > 0 || deniedTools.length > 0) {
   // Normalize tool names to lowercase for case-insensitive comparison
@@ -124,7 +123,8 @@ if (allowedTools.length > 0 || deniedTools.length > 0) {
       updatedInput: input,
     };
   };
-=======
+}
+
 // Add mode if provided
 if (mode) {
   queryOptions.mode = mode;
@@ -133,7 +133,6 @@ if (mode) {
 // Add model if provided
 if (model) {
   queryOptions.model = model;
->>>>>>> 85102f8 (feat: add default mode and model configuration for Agent SDK)
 }
 
 // Resume session if provided


### PR DESCRIPTION
## Problem
mainブランチのbin/agent-wrapper.mjsにマージコンフリクトマーカー（`<<<<<<< HEAD`、`=======`、`>>>>>>>`）が残っていました。

## Solution
手動でマージコンフリクトを解決し、両方の機能を統合：
- Permission control（canUseTool callback）
- Mode and model configuration

## Impact
- Prettierのフォーマットチェックが失敗していた
- 構文エラーが発生していた
- 修正により正常なコードに復旧

## Testing
マージ後、CIが正常に実行されることを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)