### PR TITLE
feat: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in vibing.nvim
+title: '[Bug]: '
+labels: ['bug']
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us resolve the issue quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Detailed steps to reproduce the behavior
+      placeholder: |
+        1. Run :VibingChat
+        2. Type message
+        3. Press <CR>
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: The chat should send the message and receive a response
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+      placeholder: Error message appeared in the buffer
+    validations:
+      required: true
+
+  - type: input
+    id: nvim-version
+    attributes:
+      label: Neovim Version
+      description: Output of `:version` or `nvim --version`
+      placeholder: 'NVIM v0.9.5'
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Which OS are you using?
+      placeholder: 'macOS 14.0, Ubuntu 22.04, Windows 11'
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin Version
+      description: Version or commit hash of vibing.nvim
+      placeholder: 'v1.1.0 or commit hash'
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Logs
+      description: Any relevant error messages or logs
+      placeholder: Paste error messages here
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Your vibing.nvim configuration
+      placeholder: |
+        require("vibing").setup({
+          -- your config here
+        })
+      render: lua
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information that might be helpful
+      placeholder: Screenshots, related issues, workarounds, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/shabaraba/vibing.nvim/blob/main/README.md
+    about: Read the README for usage instructions and configuration
+  - name: Help File
+    url: https://github.com/shabaraba/vibing.nvim/blob/main/doc/vibing.txt
+    about: Vim help documentation (:help vibing)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,82 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for vibing.nvim
+title: '[Feature]: '
+labels: ['enhancement']
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please provide as much detail as possible.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Use Case
+      description: Describe the problem or use case this feature would solve
+      placeholder: I often need to... but there's no way to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe how you envision this feature working
+      placeholder: |
+        Add a new command :VibingSomething that...
+        Or add a config option that allows...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other solutions or workarounds have you considered?
+      placeholder: I tried using... but it doesn't work because...
+    validations:
+      required: false
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Example Usage
+      description: Show how you would use this feature
+      placeholder: |
+        :VibingNewFeature "do something"
+        -- or in Lua:
+        require("vibing").new_feature({ option = "value" })
+      render: lua
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Low - Nice to have
+        - Medium - Would improve workflow
+        - High - Critical for my use case
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information, mockups, or references
+      placeholder: Links to similar features in other plugins, screenshots, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be willing to help implement this feature?
+      options:
+        - label: I'm willing to submit a PR for this feature
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,83 @@
+# Pull Request
+
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+<!-- List the main changes in this PR -->
+
+- Change 1
+- Change 2
+- Change 3
+
+## Type of Change
+
+<!-- Mark the relevant option with an "x" -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Performance improvement
+- [ ] Test addition or update
+- [ ] CI/CD update
+
+## Testing
+
+<!-- Describe how you tested your changes -->
+
+- [ ] Tested locally in Neovim
+- [ ] Ran `npm run validate`
+- [ ] Ran `npm run lint`
+- [ ] Ran `npm run format:check`
+- [ ] Tested with multiple configurations
+- [ ] Manual testing completed
+
+### Test Environment
+
+- **Neovim version**: <!-- e.g., NVIM v0.9.5 -->
+- **Operating System**: <!-- e.g., macOS 14.0 -->
+- **Node.js version**: <!-- e.g., v20.0.0 -->
+
+## Documentation
+
+<!-- Mark the relevant options with an "x" -->
+
+- [ ] README.md updated (if applicable)
+- [ ] CONTRIBUTING.md updated (if applicable)
+- [ ] doc/vibing.txt updated (if applicable)
+- [ ] CLAUDE.md updated (if applicable)
+- [ ] Code comments added/updated (if applicable)
+
+## Checklist
+
+<!-- Ensure all items are completed before submitting -->
+
+- [ ] My code follows the project's code style
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code where necessary
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
+- [ ] New and existing tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Related Issues
+
+<!-- Link related issues here using "fixes #123" or "relates to #123" -->
+
+Fixes #
+
+## Screenshots / Videos
+
+<!-- If applicable, add screenshots or videos to help explain your changes -->
+
+## Additional Context
+
+<!-- Any other information that reviewers should know -->
+
+---
+
+<!-- Thank you for contributing to vibing.nvim! -->


### PR DESCRIPTION
## Summary
GitHubのissueとPRテンプレートを追加してプロジェクト管理を改善

## Changes

### Issue Templates
- **bug_report.yml**: 構造化されたバグレポートフォーム
  - 説明、再現手順、期待値/実際の動作
  - 環境情報（Neovim/OS/プラグインバージョン）
  - エラーログ、設定、追加情報
- **feature_request.yml**: 機能リクエストフォーム
  - 問題/ユースケース、提案ソリューション
  - 代替案、使用例、優先度
  - 貢献意思の確認
- **config.yml**: テンプレート設定
  - ドキュメントリンク（README、Vim help）
  - 空issueの許可設定

### PR Template
- **PULL_REQUEST_TEMPLATE.md**: 包括的PRチェックリスト
  - サマリー、変更内容、変更タイプ
  - テスト詳細（環境情報含む）
  - ドキュメント更新チェック
  - 完全なレビューチェックリスト
  - 関連issueリンク、スクリーンショット

## Benefits
- 一貫したissue/PRフォーマット
- 必要情報の確実な収集
- 確認往復の削減
- より良いissueトリアージと優先順位付け
- プロフェッショナルなプロジェクト外観
- コントリビューターへの明確なガイド

## Testing
テンプレートはマージ後、新しいissue/PR作成時に自動的に表示されます。

fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)