### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # vibing.nvim
 
+[![CI](https://github.com/shabaraba/vibing.nvim/actions/workflows/ci.yml/badge.svg)](https://github.com/shabaraba/vibing.nvim/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Release](https://img.shields.io/github/v/release/shabaraba/vibing.nvim)](https://github.com/shabaraba/vibing.nvim/releases)
+
 A Neovim plugin that integrates Claude AI through the Agent SDK, providing intelligent chat and inline code actions directly within your editor.
 
 ## ✨ Features


### PR DESCRIPTION
## Summary
README.mdにステータスバッジを追加してプロジェクトの健全性を可視化

## Changes
3つのGitHubバッジを追加：
- **CIビルドステータスバッジ**: GitHub Actionsワークフローへのリンク
- **MITライセンスバッジ**: OSIライセンスページへのリンク
- **最新リリースバージョンバッジ**: GitHubリリースページへのリンク

## Placement
プロジェクトタイトル（h1）の直後に配置し、目立つように表示

## Benefits
- ビルドステータスの即座の確認
- プロジェクトがアクティブにメンテナンスされていることの証明
- プロフェッショナルな外観
- 最新バージョンの簡単な確認
- 潜在的なユーザーへの信頼性向上

## Preview
マージ後、README.mdの最上部にバッジが表示されます：
```markdown
[![CI](https://github.com/shabaraba/vibing.nvim/actions/workflows/ci.yml/badge.svg)](...)
[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](...)
[![Release](https://img.shields.io/github/v/release/shabaraba/vibing.nvim)](...)
```

fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI status, license, and release badges to the README header for improved project visibility and reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->