### PR TITLE
docs: add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 A Neovim plugin that integrates Claude AI through the Agent SDK, providing intelligent chat and inline code actions directly within your editor.
 
+## Table of Contents
+
+- [Features](#-features)
+- [Installation](#-installation)
+- [Usage](#-usage)
+- [Configuration Examples](#️-configuration-examples)
+- [Remote Control](#-remote-control)
+- [Chat File Format](#-chat-file-format)
+- [Architecture](#️-architecture)
+- [Contributing](#-contributing)
+- [License](#-license)
+- [Links](#-links)
+
 ## ✨ Features
 
 - **💬 Chat Interface** - Interactive chat window with Claude AI


### PR DESCRIPTION
## Summary
README.mdに目次を追加してナビゲーションを改善

## Changes
包括的な目次を追加：
- Features
- Installation
- Usage
- Configuration Examples
- Remote Control
- Chat File Format
- Architecture
- Contributing
- License
- Links

## Placement
- バッジと説明文の直後に配置
- Featuresセクションの前
- GitHub-flavored markdownアンカーリンク使用

## Benefits
- 特定セクションへの素早いナビゲーション
- 長いREADMEでのユーザー体験向上
- プロフェッショナルなドキュメント構造
- 関連情報の発見が容易
- 包括的READMEの標準的な手法

## Testing
マージ後、README.mdの目次リンクがすべて正しく機能することを確認します。

fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)