### PR TITLE
chore: add test commits to CHANGELOG via release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
         { "type": "perf", "section": "Performance Improvements" },
+        { "type": "test", "section": "Tests" },
         { "type": "refactor", "section": "Code Refactoring" },
         { "type": "docs", "section": "Documentation" },
         { "type": "chore", "section": "Miscellaneous" }


### PR DESCRIPTION
## Summary

Enhances release-please configuration to include test-type commits in the CHANGELOG, providing better visibility of testing improvements in release notes.

## Changes

### Configuration Update
Added `"test"` type to `changelog-sections` in `release-please-config.json`:

```json
{
  "type": "test",
  "section": "Tests"
}
```

## Impact

**Before:** Test commits (e.g., `test: add automated test infrastructure`) were excluded from CHANGELOG
**After:** Test commits will appear in a dedicated "Tests" section in release notes

## Benefits

1. **Complete Documentation**: All significant changes, including test infrastructure, are documented in releases
2. **Test Visibility**: Users can see testing improvements and coverage expansions
3. **Semantic Commit Compliance**: Fully supports conventional commit types (feat, fix, test, docs, etc.)
4. **Better Release Notes**: More comprehensive change tracking for maintainers and users

## Example CHANGELOG Entry

With this change, future releases will include:

```markdown
## Tests

- test: add automated test infrastructure with plenary.nvim (#66)
- test: expand test coverage for core modules (#68)
```

## Testing

This is a configuration-only change. The next release-please PR will demonstrate the new CHANGELOG format including test commits from issues #65, #66, and #67.

Fixes #69