### PR TITLE
fix: use claude_args instead of invalid allowed_tools param

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,4 +52,4 @@ jobs:
             - Include "fixes #<issue-number>" if there's a related issue
 
           # Allow file operations and git/gh commands for implementation tasks
-          allowed_tools: 'Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)'
+          claude_args: '--allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"'


### PR DESCRIPTION
## 概要

`allowed_tools`パラメータはclaude-code-actionでは無効です。
`claude_args`に`--allowed-tools`フラグを使用する必要があります。

## 変更内容

```diff
- allowed_tools: 'Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)'
+ claude_args: '--allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"'
```

## エラーメッセージ

```
Unexpected input(s) 'allowed_tools', valid inputs are ['trigger_phrase', 'assignee_trigger', ...]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow configuration to modify how development tools are authorized within the CI/CD pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->