### PR TITLE
feat: add filetype detection for .vibing extension

### DIFF
--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -21,6 +21,13 @@ function M.setup(opts)
   Config.setup(opts)
   M.config = Config.get()
 
+  -- Register .vibing filetype
+  vim.filetype.add({
+    extension = {
+      vibing = "vibing",
+    },
+  })
+
   -- アダプターの初期化
   local adapter_name = M.config.adapter
   local ok, adapter_module = pcall(require, "vibing.adapters." .. adapter_name)


### PR DESCRIPTION
## 概要

`.vibing` 拡張子のファイルを `vibing` ファイルタイプとして自動認識する機能を追加しました。

## 変更内容

- `lua/vibing/init.lua`: `setup()` 関数内で `vim.filetype.add()` を呼び出し、`.vibing` 拡張子を登録
- `tests/init_spec.lua`: filetype 登録のテストケースを追加

## 動作確認

- ✅ 全テストが成功（`npm run test:lua`）
- ✅ filetype 登録のテストケースが追加され、成功を確認

## 効果

ユーザーが手動で以下のような設定をする必要がなくなります：

```lua
vim.filetype.add({
  extension = {
    vibing = "vibing",
  },
})
```

プラグインの `setup()` を呼ぶだけで、`.vibing` ファイルが自動的に認識されるようになります。

Fixes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic file type detection for .vibing files in Neovim, enabling proper syntax highlighting and file type-specific features for vibing configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->