### PR TITLE
feat: add Telescope-based permission builder UI

### DIFF
--- a/lua/vibing/chat/handlers/perm.lua
+++ b/lua/vibing/chat/handlers/perm.lua
@@ -1,0 +1,17 @@
+local notify = require("vibing.utils.notify")
+
+---@param args string[] コマンド引数
+---@param chat_buffer Vibing.ChatBuffer チャットバッファ
+---@return boolean 成功した場合true
+return function(args, chat_buffer)
+  if #args > 0 then
+    notify.warn("The /perm command does not take arguments. Use it without arguments to open the permission builder.", "Permission")
+    return false
+  end
+
+  -- Permission pickerを表示
+  local permission_picker = require("vibing.ui.permission_picker")
+  permission_picker.show(chat_buffer)
+
+  return true
+end

--- a/lua/vibing/chat/init.lua
+++ b/lua/vibing/chat/init.lua
@@ -70,6 +70,18 @@ function M.setup()
     handler = require("vibing.chat.handlers.permission"),
     description = "Set permission mode: /permission <default|acceptEdits|bypassPermissions>",
   })
+
+  commands.register({
+    name = "perm",
+    handler = require("vibing.chat.handlers.perm"),
+    description = "Open permission builder UI",
+  })
+
+  commands.register({
+    name = "permissions",
+    handler = require("vibing.chat.handlers.perm"),
+    description = "Open permission builder UI (alias for /perm)",
+  })
 end
 
 return M

--- a/lua/vibing/ui/permission_picker.lua
+++ b/lua/vibing/ui/permission_picker.lua
@@ -1,0 +1,288 @@
+local notify = require("vibing.utils.notify")
+local tools_const = require("vibing.constants.tools")
+
+---@class Vibing.PermissionPicker
+---権限設定ピッカーUI
+---Telescopeまたはvim.ui.selectでツール一覧から選択し、allow/denyを設定
+---Bashコマンドの引数パターン指定にも対応
+local M = {}
+
+---@class Vibing.ToolItem
+---@field name string ツール名
+---@field description string ツールの説明
+---@field type "builtin"|"mcp" ツールタイプ
+---@field mcp_server string? MCPサーバー名（type="mcp"の場合のみ）
+
+---組み込みツールの説明
+---@type table<string, string>
+local TOOL_DESCRIPTIONS = {
+  Read = "Read files from the filesystem",
+  Edit = "Edit existing files with find/replace",
+  Write = "Create new files or overwrite existing ones",
+  Bash = "Execute shell commands",
+  Glob = "Find files by pattern matching",
+  Grep = "Search for patterns in files",
+  WebSearch = "Search the web for information",
+  WebFetch = "Fetch content from URLs",
+}
+
+---組み込みツールのリストを取得
+---@return Vibing.ToolItem[]
+local function get_builtin_tools()
+  local tools = {}
+  for _, name in ipairs(tools_const.VALID_TOOLS) do
+    table.insert(tools, {
+      name = name,
+      description = TOOL_DESCRIPTIONS[name] or "No description",
+      type = "builtin",
+    })
+  end
+  return tools
+end
+
+---MCPツールのリストを取得
+---現在は未実装（将来の拡張用）
+---@return Vibing.ToolItem[]
+local function get_mcp_tools()
+  -- TODO: アダプターからMCPツールを取得する実装を追加
+  return {}
+end
+
+---全ツールのリストを取得（組み込み + MCP）
+---@return Vibing.ToolItem[]
+local function get_all_tools()
+  local tools = {}
+  vim.list_extend(tools, get_builtin_tools())
+  vim.list_extend(tools, get_mcp_tools())
+  return tools
+end
+
+---権限ピッカーを表示
+---@param chat_buffer Vibing.ChatBuffer 権限を設定するチャットバッファ
+function M.show(chat_buffer)
+  if not chat_buffer or not chat_buffer.buf or not vim.api.nvim_buf_is_valid(chat_buffer.buf) then
+    notify.error("Invalid chat buffer", "Permission")
+    return
+  end
+
+  -- Telescopeが利用可能かチェック
+  local has_telescope, _ = pcall(require, "telescope")
+
+  if has_telescope then
+    M._show_telescope(chat_buffer)
+  else
+    M._show_native(chat_buffer)
+  end
+end
+
+---vim.ui.selectを使用したネイティブピッカー
+---@param chat_buffer Vibing.ChatBuffer 権限を設定するチャットバッファ
+function M._show_native(chat_buffer)
+  local all_tools = get_all_tools()
+
+  -- vim.ui.selectで選択
+  vim.ui.select(all_tools, {
+    prompt = "Select tool to configure permissions:",
+    format_item = function(item)
+      local type_tag = item.type == "mcp" and "[MCP:" .. (item.mcp_server or "unknown") .. "] " or "[builtin] "
+      return string.format("%s%s - %s", type_tag, item.name, item.description)
+    end,
+  }, function(choice)
+    if choice then
+      M._handle_tool_selection(choice, chat_buffer)
+    end
+  end)
+end
+
+---Telescopeを使用したリッチピッカー
+---@param chat_buffer Vibing.ChatBuffer 権限を設定するチャットバッファ
+function M._show_telescope(chat_buffer)
+  local pickers = require("telescope.pickers")
+  local finders = require("telescope.finders")
+  local conf = require("telescope.config").values
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+  local entry_display = require("telescope.pickers.entry_display")
+
+  local all_tools = get_all_tools()
+
+  -- エントリーメーカー: 表示フォーマットを定義
+  local displayer = entry_display.create({
+    separator = " ",
+    items = {
+      { width = 20 },  -- source
+      { width = 20 },  -- tool name
+      { remaining = true },  -- description
+    },
+  })
+
+  local make_display = function(entry)
+    local source_display = ""
+    if entry.type == "builtin" then
+      source_display = "[vibing:builtin]"
+    elseif entry.type == "mcp" then
+      source_display = "[MCP:" .. (entry.mcp_server or "unknown") .. "]"
+    end
+
+    return displayer({
+      { source_display, "TelescopeResultsComment" },
+      { entry.name, "TelescopeResultsIdentifier" },
+      { entry.description, "TelescopeResultsString" },
+    })
+  end
+
+  -- Telescopeピッカーを作成
+  pickers.new({}, {
+    prompt_title = "Permission Builder - Select Tool",
+    finder = finders.new_table({
+      results = all_tools,
+      entry_maker = function(entry)
+        return {
+          value = entry,
+          display = make_display,
+          ordinal = entry.name .. " " .. entry.description,
+          name = entry.name,
+          description = entry.description,
+          type = entry.type,
+          mcp_server = entry.mcp_server,
+        }
+      end,
+    }),
+    sorter = conf.generic_sorter({}),
+    attach_mappings = function(prompt_bufnr, map)
+      actions.select_default:replace(function()
+        actions.close(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        if selection then
+          M._handle_tool_selection(selection.value, chat_buffer)
+        end
+      end)
+      return true
+    end,
+  }):find()
+end
+
+---ツール選択後の処理: allow/denyを選択
+---@param tool Vibing.ToolItem 選択されたツール
+---@param chat_buffer Vibing.ChatBuffer 権限を設定するチャットバッファ
+function M._handle_tool_selection(tool, chat_buffer)
+  local permission_types = {
+    { value = "allow", label = "Allow - ツールの使用を許可" },
+    { value = "deny", label = "Deny  - ツールの使用を拒否" },
+  }
+
+  vim.ui.select(permission_types, {
+    prompt = string.format("Permission type for '%s':", tool.name),
+    format_item = function(item)
+      return item.label
+    end,
+  }, function(choice)
+    if choice then
+      M._handle_permission_type(tool, choice.value, chat_buffer)
+    end
+  end)
+end
+
+---権限タイプ選択後の処理: Bashの場合は引数パターンを入力
+---@param tool Vibing.ToolItem 選択されたツール
+---@param permission_type "allow"|"deny" 権限タイプ
+---@param chat_buffer Vibing.ChatBuffer 権限を設定するチャットバッファ
+function M._handle_permission_type(tool, permission_type, chat_buffer)
+  if tool.name == "Bash" then
+    -- Bashの場合は引数パターンを入力
+    M._prompt_bash_pattern(tool, permission_type, chat_buffer)
+  else
+    -- 他のツールはそのまま追加
+    M._add_permission(chat_buffer, permission_type, tool.name)
+  end
+end
+
+---Bashコマンドの引数パターンを入力
+---@param tool Vibing.ToolItem 選択されたツール
+---@param permission_type "allow"|"deny" 権限タイプ
+---@param chat_buffer Vibing.ChatBuffer 権限を設定するチャットバッファ
+function M._prompt_bash_pattern(tool, permission_type, chat_buffer)
+  -- プリセットパターンを提供
+  local presets = {
+    { pattern = "*", label = "All commands (Bash)" },
+    { pattern = "rm:*", label = "All 'rm' commands" },
+    { pattern = "git:*", label = "All 'git' commands" },
+    { pattern = "npm:*", label = "All 'npm' commands" },
+    { pattern = "docker:*", label = "All 'docker' commands" },
+    { pattern = "", label = "Custom pattern (type manually)" },
+  }
+
+  vim.ui.select(presets, {
+    prompt = "Select Bash command pattern:",
+    format_item = function(item)
+      return item.label
+    end,
+  }, function(choice)
+    if not choice then
+      return
+    end
+
+    if choice.pattern == "" then
+      -- カスタムパターンを入力
+      vim.ui.input({
+        prompt = "Enter Bash command pattern (e.g., 'rm:*' or 'git push:*'): ",
+      }, function(input)
+        if input and vim.trim(input) ~= "" then
+          local tool_name = string.format("Bash(%s)", input)
+          M._add_permission(chat_buffer, permission_type, tool_name)
+        end
+      end)
+    else
+      -- プリセットパターンを使用
+      local tool_name = choice.pattern == "*" and "Bash" or string.format("Bash(%s)", choice.pattern)
+      M._add_permission(chat_buffer, permission_type, tool_name)
+    end
+  end)
+end
+
+---権限をフロントマターに追加
+---@param chat_buffer Vibing.ChatBuffer 権限を設定するチャットバッファ
+---@param permission_type "allow"|"deny" 権限タイプ
+---@param tool_name string ツール名（Bash(rm:*)などの形式も可）
+function M._add_permission(chat_buffer, permission_type, tool_name)
+  local buf = chat_buffer.buf
+  if not vim.api.nvim_buf_is_valid(buf) then
+    notify.error("Invalid buffer", "Permission")
+    return
+  end
+
+  -- フロントマターを解析
+  local frontmatter = chat_buffer:parse_frontmatter()
+
+  -- permissions_allow または permissions_deny に追加
+  local field_name = permission_type == "allow" and "permissions_allow" or "permissions_deny"
+  local current_list = frontmatter[field_name] or {}
+
+  -- 既に存在するかチェック
+  local already_exists = false
+  for _, existing_tool in ipairs(current_list) do
+    if existing_tool == tool_name then
+      already_exists = true
+      break
+    end
+  end
+
+  if already_exists then
+    notify.warn(string.format("'%s' is already in %s", tool_name, field_name), "Permission")
+    return
+  end
+
+  -- 追加
+  table.insert(current_list, tool_name)
+  frontmatter[field_name] = current_list
+
+  -- フロントマターを更新
+  local success = chat_buffer:update_frontmatter(frontmatter)
+  if success then
+    notify.info(string.format("Added '%s' to %s", tool_name, field_name), "Permission")
+  else
+    notify.error(string.format("Failed to update %s", field_name), "Permission")
+  end
+end
+
+return M

--- a/tests/chat_init_spec.lua
+++ b/tests/chat_init_spec.lua
@@ -104,7 +104,7 @@ describe("vibing.chat.init", function()
       assert.is_not_nil(cmd.description:match("model"))
     end)
 
-    it("should have exactly 10 commands after setup", function()
+    it("should have exactly 12 commands after setup", function()
       ChatInit.setup()
 
       local count = 0
@@ -112,7 +112,7 @@ describe("vibing.chat.init", function()
         count = count + 1
       end
 
-      assert.equals(10, count)
+      assert.equals(12, count)
     end)
 
     it("should be idempotent (can be called multiple times)", function()
@@ -124,7 +124,7 @@ describe("vibing.chat.init", function()
         count = count + 1
       end
 
-      assert.equals(10, count)
+      assert.equals(12, count)
     end)
 
     it("should register commands with correct descriptions", function()
@@ -167,7 +167,7 @@ describe("vibing.chat.init", function()
 
       local list = Commands.list()
 
-      assert.equals(10, #list)
+      assert.equals(12, #list)
 
       -- Verify all command names are in the list
       local command_names = {}

--- a/tests/permission_picker_spec.lua
+++ b/tests/permission_picker_spec.lua
@@ -1,0 +1,275 @@
+-- Tests for vibing.ui.permission_picker module
+
+describe("vibing.ui.permission_picker", function()
+  local permission_picker
+
+  before_each(function()
+    -- Reload module before each test
+    package.loaded["vibing.ui.permission_picker"] = nil
+    permission_picker = require("vibing.ui.permission_picker")
+  end)
+
+  describe("module structure", function()
+    it("should have show function", function()
+      assert.is_function(permission_picker.show)
+    end)
+
+    it("should have _show_native function", function()
+      assert.is_function(permission_picker._show_native)
+    end)
+
+    it("should have _show_telescope function", function()
+      assert.is_function(permission_picker._show_telescope)
+    end)
+
+    it("should have _handle_tool_selection function", function()
+      assert.is_function(permission_picker._handle_tool_selection)
+    end)
+
+    it("should have _handle_permission_type function", function()
+      assert.is_function(permission_picker._handle_permission_type)
+    end)
+
+    it("should have _prompt_bash_pattern function", function()
+      assert.is_function(permission_picker._prompt_bash_pattern)
+    end)
+
+    it("should have _add_permission function", function()
+      assert.is_function(permission_picker._add_permission)
+    end)
+  end)
+
+  describe("show", function()
+    it("should handle invalid chat buffer gracefully", function()
+      -- Should not throw error
+      local success, err = pcall(permission_picker.show, nil)
+      -- May fail but should not crash
+      assert.is_boolean(success)
+    end)
+
+    it("should check for Telescope availability", function()
+      local mock_chat_buffer = {
+        buf = 1,
+      }
+
+      -- Mock vim.api.nvim_buf_is_valid
+      local original_is_valid = vim.api.nvim_buf_is_valid
+      vim.api.nvim_buf_is_valid = function()
+        return true
+      end
+
+      -- Track which picker was used
+      local native_called = false
+      local telescope_called = false
+
+      permission_picker._show_native = function()
+        native_called = true
+      end
+      permission_picker._show_telescope = function()
+        telescope_called = true
+      end
+
+      -- Test without Telescope
+      package.loaded["telescope"] = nil
+      permission_picker.show(mock_chat_buffer)
+
+      -- Either native or telescope should be called, depending on availability
+      assert.is_true(native_called or telescope_called)
+
+      -- Restore
+      vim.api.nvim_buf_is_valid = original_is_valid
+    end)
+  end)
+
+  describe("_add_permission", function()
+    it("should handle invalid buffer gracefully", function()
+      local mock_chat_buffer = {
+        buf = 999,  -- Invalid buffer
+        parse_frontmatter = function()
+          return {}
+        end,
+        update_frontmatter = function()
+          return true
+        end,
+      }
+
+      local original_is_valid = vim.api.nvim_buf_is_valid
+      vim.api.nvim_buf_is_valid = function()
+        return false
+      end
+
+      -- Should not crash
+      local success = pcall(permission_picker._add_permission, mock_chat_buffer, "allow", "Read")
+      assert.is_boolean(success)
+
+      -- Restore
+      vim.api.nvim_buf_is_valid = original_is_valid
+    end)
+
+    it("should add tool to permissions_allow", function()
+      local updated_frontmatter = nil
+      local mock_chat_buffer = {
+        buf = 1,
+        parse_frontmatter = function()
+          return {
+            permissions_allow = {},
+            permissions_deny = {},
+          }
+        end,
+        update_frontmatter = function(self, frontmatter)
+          updated_frontmatter = frontmatter
+          return true
+        end,
+      }
+
+      local original_is_valid = vim.api.nvim_buf_is_valid
+      vim.api.nvim_buf_is_valid = function()
+        return true
+      end
+
+      permission_picker._add_permission(mock_chat_buffer, "allow", "Read")
+
+      assert.is_not_nil(updated_frontmatter)
+      assert.is_table(updated_frontmatter.permissions_allow)
+      assert.equals(1, #updated_frontmatter.permissions_allow)
+      assert.equals("Read", updated_frontmatter.permissions_allow[1])
+
+      -- Restore
+      vim.api.nvim_buf_is_valid = original_is_valid
+    end)
+
+    it("should add tool to permissions_deny", function()
+      local updated_frontmatter = nil
+      local mock_chat_buffer = {
+        buf = 1,
+        parse_frontmatter = function()
+          return {
+            permissions_allow = {},
+            permissions_deny = {},
+          }
+        end,
+        update_frontmatter = function(self, frontmatter)
+          updated_frontmatter = frontmatter
+          return true
+        end,
+      }
+
+      local original_is_valid = vim.api.nvim_buf_is_valid
+      vim.api.nvim_buf_is_valid = function()
+        return true
+      end
+
+      permission_picker._add_permission(mock_chat_buffer, "deny", "Bash")
+
+      assert.is_not_nil(updated_frontmatter)
+      assert.is_table(updated_frontmatter.permissions_deny)
+      assert.equals(1, #updated_frontmatter.permissions_deny)
+      assert.equals("Bash", updated_frontmatter.permissions_deny[1])
+
+      -- Restore
+      vim.api.nvim_buf_is_valid = original_is_valid
+    end)
+
+    it("should not add duplicate tools", function()
+      local update_count = 0
+      local mock_chat_buffer = {
+        buf = 1,
+        parse_frontmatter = function()
+          return {
+            permissions_allow = { "Read" },
+            permissions_deny = {},
+          }
+        end,
+        update_frontmatter = function(self, frontmatter)
+          update_count = update_count + 1
+          return true
+        end,
+      }
+
+      local original_is_valid = vim.api.nvim_buf_is_valid
+      vim.api.nvim_buf_is_valid = function()
+        return true
+      end
+
+      permission_picker._add_permission(mock_chat_buffer, "allow", "Read")
+
+      -- Should not update frontmatter when tool already exists
+      assert.equals(0, update_count)
+
+      -- Restore
+      vim.api.nvim_buf_is_valid = original_is_valid
+    end)
+
+    it("should handle Bash with pattern", function()
+      local updated_frontmatter = nil
+      local mock_chat_buffer = {
+        buf = 1,
+        parse_frontmatter = function()
+          return {
+            permissions_allow = {},
+            permissions_deny = {},
+          }
+        end,
+        update_frontmatter = function(self, frontmatter)
+          updated_frontmatter = frontmatter
+          return true
+        end,
+      }
+
+      local original_is_valid = vim.api.nvim_buf_is_valid
+      vim.api.nvim_buf_is_valid = function()
+        return true
+      end
+
+      permission_picker._add_permission(mock_chat_buffer, "deny", "Bash(rm:*)")
+
+      assert.is_not_nil(updated_frontmatter)
+      assert.is_table(updated_frontmatter.permissions_deny)
+      assert.equals(1, #updated_frontmatter.permissions_deny)
+      assert.equals("Bash(rm:*)", updated_frontmatter.permissions_deny[1])
+
+      -- Restore
+      vim.api.nvim_buf_is_valid = original_is_valid
+    end)
+  end)
+end)
+
+describe("vibing.chat.handlers.perm", function()
+  local perm_handler
+  local mock_chat_buffer
+
+  before_each(function()
+    -- Clear loaded modules
+    package.loaded["vibing.chat.handlers.perm"] = nil
+    package.loaded["vibing.ui.permission_picker"] = nil
+
+    perm_handler = require("vibing.chat.handlers.perm")
+
+    -- Mock chat buffer
+    mock_chat_buffer = {
+      buf = 1,
+    }
+  end)
+
+  it("should reject arguments", function()
+    local result = perm_handler({ "arg1" }, mock_chat_buffer)
+    assert.is_false(result)
+  end)
+
+  it("should call permission_picker.show when no args", function()
+    local picker_shown = false
+
+    -- Mock permission picker
+    package.loaded["vibing.ui.permission_picker"] = {
+      show = function()
+        picker_shown = true
+      end,
+    }
+
+    perm_handler = require("vibing.chat.handlers.perm")
+    local result = perm_handler({}, mock_chat_buffer)
+
+    assert.is_true(result)
+    assert.is_true(picker_shown)
+  end)
+end)


### PR DESCRIPTION
## 概要
Telescopeベースの権限設定UIを追加しました。`/perm` または `/permissions` コマンドで起動し、ツールの権限を簡単に設定できます。

## 実装内容

### 1. Permission Picker UI（lua/vibing/ui/permission_picker.lua）
- **Telescopeサポート**
  - Telescopeが利用可能な場合はリッチなピッカーを表示
  - Telescopeがない場合は `vim.ui.select` にフォールバック
- **ツール一覧表示**
  - 組み込みツール（Read, Edit, Write, Bash, Glob, Grep, WebSearch, WebFetch）
  - MCPツールのサポート（将来の拡張用）
- **権限タイプ選択**
  - Allow: ツールの使用を許可
  - Deny: ツールの使用を拒否
- **Bashコマンドパターン**
  - Bash選択時に引数パターンを指定可能
  - プリセット: All commands, rm:*, git:*, npm:*, docker:*
  - カスタムパターン入力にも対応
- **フロントマター自動更新**
  - permissions_allow または permissions_deny に自動追加
  - 重複チェックで既存エントリーを保護

### 2. スラッシュコマンド
- `/perm` - Permission builder UIを起動
- `/permissions` - `/perm` のエイリアス
- ハンドラー: `lua/vibing/chat/handlers/perm.lua`

### 3. テスト（tests/permission_picker_spec.lua）
- モジュール構造のテスト
- 権限追加機能のテスト
- 重複防止のテスト
- Bashパターン処理のテスト
- ハンドラーの動作テスト

## 使い方

1. チャットウィンドウで `/perm` を入力
2. Telescopeピッカーまたは選択UIでツールを選択
3. Allow/Deny を選択
4. Bashの場合は引数パターンを選択/入力
5. フロントマターに自動追加

## テスト結果
```
Success: 16
Failed : 0
Errors : 0
```

## スクリーンショット

### Telescope Picker
```
┌─ Permission Builder - Select Tool ──────────────┐
│ > bash                                           │
│                                                  │
│ [vibing:builtin]    Bash           Execute s... │
│ [vibing:builtin]    Edit           Edit exi...  │
│ [vibing:builtin]    Glob           Find fil...  │
│ [vibing:builtin]    Grep           Search f...  │
│ [vibing:builtin]    Read           Read fil...  │
│ [vibing:builtin]    WebFetch       Fetch co...  │
│ [vibing:builtin]    WebSearch      Search t...  │
│ [vibing:builtin]    Write          Create n...  │
└──────────────────────────────────────────────────┘
```

### Permission Type Selection
```
┌─ Permission type for 'Bash': ───────────────────┐
│ > Allow - ツールの使用を許可                     │
│   Deny  - ツールの使用を拒否                     │
└──────────────────────────────────────────────────┘
```

### Bash Pattern Selection
```
┌─ Select Bash command pattern: ──────────────────┐
│ > All commands (Bash)                            │
│   All 'rm' commands                              │
│   All 'git' commands                             │
│   All 'npm' commands                             │
│   All 'docker' commands                          │
│   Custom pattern (type manually)                 │
└──────────────────────────────────────────────────┘
```

fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/perm` and `/permissions` commands to open a permission-builder UI.
  * Permission builder lets you pick tools, set allow/deny rules, and supports Bash pattern presets or custom patterns.
  * Permissions are saved in chat frontmatter with validation and duplicate prevention.

* **Tests**
  * Added comprehensive tests covering the permission UI, command behavior, frontmatter updates, and edge cases (including pattern handling and command registration counts).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->