### PR TITLE
fix: import URL from url module to resolve ESLint error

### DIFF
--- a/bin/agent-wrapper.mjs
+++ b/bin/agent-wrapper.mjs
@@ -6,6 +6,7 @@
  */
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
+import { URL } from 'url';
 
 const args = process.argv.slice(2);
 let prompt = '';


### PR DESCRIPTION
Addresses CodeRabbit review comment on PR #146.

- Add explicit import of URL constructor from Node's url module
- Resolves ESLint error "'URL' is not defined" at line 193

## Testing

✅ ESLint passes with no errors
✅ Code formatting validated with Prettier

This fix allows the PR to pass CI checks.