### PR TITLE
feat: add language validation and improve consistency

### DIFF
--- a/lua/vibing/actions/inline.lua
+++ b/lua/vibing/actions/inline.lua
@@ -255,13 +255,9 @@ function M.custom(prompt, use_output)
     return
   end
 
-  -- 言語設定を適用（カスタムプロンプトの先頭に追加）
+  -- 言語設定を適用
   local lang_code = Language.get_language_code(config.language, "inline")
-  local final_prompt = prompt
-  if lang_code and lang_code ~= "" and lang_code ~= "en" then
-    local instruction = Language.get_language_instruction(lang_code)
-    final_prompt = "Respond" .. instruction .. ".\n\n" .. prompt
-  end
+  local final_prompt = Language.add_language_instruction(prompt, lang_code)
 
   -- プロンプトに@file:path:L10-L25形式のメンションを含める
   local full_prompt = final_prompt .. "\n\n" .. selection_context

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -68,6 +68,7 @@
 
 local notify = require("vibing.utils.notify")
 local tools_const = require("vibing.constants.tools")
+local language_utils = require("vibing.utils.language")
 
 local M = {}
 
@@ -149,6 +150,28 @@ function M.setup(opts)
       if not tools_const.VALID_TOOLS_MAP[tool] then
         notify.warn(string.format("Unknown tool '%s' in permissions.deny", tool))
       end
+    end
+  end
+
+  -- Validate language configuration
+  if M.options.language then
+    local function validate_lang_code(code, field_name)
+      if code and code ~= "" and code ~= "en" and not language_utils.language_names[code] then
+        notify.warn(string.format(
+          "Unknown language code '%s' in %s. Supported codes: %s",
+          code,
+          field_name,
+          table.concat(vim.tbl_keys(language_utils.language_names), ", ")
+        ))
+      end
+    end
+
+    if type(M.options.language) == "string" then
+      validate_lang_code(M.options.language, "language")
+    elseif type(M.options.language) == "table" then
+      validate_lang_code(M.options.language.default, "language.default")
+      validate_lang_code(M.options.language.chat, "language.chat")
+      validate_lang_code(M.options.language.inline, "language.inline")
     end
   end
 


### PR DESCRIPTION
Addresses CodeRabbit review comments on PR #142.

- Add language code validation in setup() to warn users about unknown codes
- Use add_language_instruction() in custom() for consistent language handling
- Display supported language codes in validation warning messages

## Changes
1. Language validation to catch typos and invalid entries early
2. Consistent language instruction approach across predefined and custom actions