### PR TITLE
fix: add context gathering to GitHub workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,11 +45,36 @@ jobs:
           prompt: |
             IMPORTANT: All responses MUST be in Japanese.
 
-            When you complete an implementation task, create a pull request using `gh pr create` command.
-            Make sure to:
-            - Create a descriptive PR title in English using semantic commit format
-            - Write the PR body in Japanese with clear description of changes
-            - Include "fixes #<issue-number>" if there's a related issue
+            REPOSITORY: ${{ github.repository }}
+            EVENT_TYPE: ${{ github.event_name }}
+            ISSUE_NUMBER: ${{ github.event.issue.number }}
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+
+            ## FIRST STEP: Gather Context
+            Before starting any work, you MUST gather complete context by running the appropriate commands:
+
+            ### For Issue-related events (issues, issue_comment):
+            ```bash
+            gh issue view $ISSUE_NUMBER --comments
+            ```
+            This will show you the issue title, body, and ALL comments to understand the full context.
+
+            ### For PR-related events (pull_request_review_comment, pull_request_review):
+            ```bash
+            gh pr view $PR_NUMBER --comments
+            gh pr diff $PR_NUMBER
+            ```
+            This will show you the PR title, body, ALL comments, AND the code changes.
+
+            ## Task Instructions
+            After gathering the full context above:
+            1. Read and understand ALL comments and discussions
+            2. For PRs, review the code changes in the diff
+            3. Execute the requested task based on the complete context
+            4. When you complete an implementation task, create a pull request using `gh pr create` command
+               - Create a descriptive PR title in English using semantic commit format
+               - Write the PR body in Japanese with clear description of changes
+               - Include "fixes #<issue-number>" if there's a related issue
 
           # Allow file operations and git/gh commands for implementation tasks
           claude_args: '--allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"'


### PR DESCRIPTION
## 問題

現在のGitHub Workflowでは、`@claude` メンションでトリガーされても、ClaudeがIssue/PRの内容を認識できていません。

## 解決策

ワークフローのプロンプトに以下を追加しました：

### 1. コンテキスト変数の追加
- `REPOSITORY`: リポジトリ名
- `EVENT_TYPE`: イベントタイプ
- `ISSUE_NUMBER`: Issue番号
- `PR_NUMBER`: PR番号

### 2. コンテキスト収集の指示

**Issue関連イベント時**:
```bash
gh issue view $ISSUE_NUMBER --comments
```

**PR関連イベント時**:
```bash
gh pr view $PR_NUMBER --comments
gh pr diff $PR_NUMBER
```

### 3. 明確な作業フロー
1. コンテキスト収集
2. 全コメント・議論の理解
3. PRの場合はdiffもレビュー
4. 完全な文脈理解後にタスク実行

## 効果

ClaudeがIssue/PRの完全な情報を取得し、適切なコンテキストで作業を実行できるようになります。

fixes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal development workflow automation to improve code contribution processes with better context gathering and structured task execution steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->