### PR TITLE
refactor: move preview config from inline to top-level section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ intelligent chat conversations and context-aware inline code actions directly in
         deny = { "Bash" },
         rules = {},  -- Optional granular permission rules
       },
-      inline = {
-        preview_enabled = false,  -- Enable diff preview UI (requires Git)
+      preview = {
+        enabled = false,  -- Enable diff preview UI (requires Git)
       },
       language = nil,  -- Optional: "ja" | "en" | { default = "ja", chat = "ja", inline = "en" }
     })
@@ -166,7 +166,7 @@ use {
 
 ### Inline Preview UI
 
-When `inline.preview_enabled = true` is set in configuration, inline actions display a Telescope-style
+When `preview.enabled = true` is set in configuration, inline actions display a Telescope-style
 preview UI after execution (requires Git repository):
 
 **Layout:**
@@ -285,8 +285,8 @@ require("vibing").setup({
     allow = { "Read", "Edit", "Write", "Glob", "Grep", "WebSearch" },
     deny = {},  -- Allow all tools
   },
-  inline = {
-    preview_enabled = true,  -- Enable diff preview for inline actions
+  preview = {
+    enabled = true,  -- Enable diff preview UI
   },
   keymaps = {
     send = "<C-CR>",  -- Custom send key
@@ -472,16 +472,17 @@ keymaps = {
 }
 ```
 
-### Inline Settings
+### Preview Settings
 
-Configure inline action behavior:
+Configure diff preview UI for inline actions and chat:
 
 ```lua
-inline = {
-  preview_enabled = false,  -- Enable Telescope-style diff preview UI
-                           -- Requires Git repository
-                           -- Shows Accept/Reject UI after code modifications
-                           -- Uses git diff and git checkout for revert
+preview = {
+  enabled = false,  -- Enable Telescope-style diff preview UI
+                    -- Requires Git repository
+                    -- Shows Accept/Reject UI after code modifications
+                    -- Uses git diff and git checkout for revert
+                    -- Works in both inline actions and chat (gp key)
 }
 ```
 

--- a/lua/vibing/actions/inline.lua
+++ b/lua/vibing/actions/inline.lua
@@ -99,7 +99,7 @@ function M.execute(action_or_prompt, additional_instruction)
     M._execute_with_output(adapter, prompt, opts, action_or_prompt)
   else
     -- Check if preview is enabled in config
-    if config.inline and config.inline.preview_enabled then
+    if config.preview and config.preview.enabled then
       M._execute_with_preview(adapter, prompt, opts, action_or_prompt, additional_instruction)
     else
       M._execute_direct(adapter, prompt, opts)
@@ -337,7 +337,7 @@ function M.custom(prompt, use_output)
     M._execute_with_output(adapter, full_prompt, opts, "Result")
   else
     -- Check if preview is enabled in config
-    if config.inline and config.inline.preview_enabled then
+    if config.preview and config.preview.enabled then
       M._execute_with_preview(adapter, full_prompt, opts, "custom", prompt)
     else
       M._execute_direct(adapter, full_prompt, opts)

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -1,9 +1,15 @@
+---@class Vibing.PreviewConfig
+---プレビューUI設定
+---インラインアクションとチャットの両方で使用されるdiffプレビューUIを制御
+---@field enabled boolean プレビューUI有効化（trueでGit diffプレビュー表示、要Gitリポジトリ）
+
 ---@class Vibing.Config
 ---vibing.nvimプラグインの設定オブジェクト
 ---Agent SDK設定、チャットウィンドウ、キーマップ、ツール権限を統合管理
 ---@field agent Vibing.AgentConfig Agent SDK設定（モード、モデル）
 ---@field chat Vibing.ChatConfig チャットウィンドウ設定（位置、サイズ、自動コンテキスト、保存先）
 ---@field keymaps Vibing.KeymapConfig キーマップ設定（送信、キャンセル、コンテキスト追加）
+---@field preview Vibing.PreviewConfig プレビューUI設定（diffプレビュー有効化）
 ---@field permissions Vibing.PermissionsConfig ツール権限設定（許可/拒否リスト）
 ---@field status Vibing.StatusConfig ステータス通知設定（Claude側のターン状態表示）
 ---@field mcp Vibing.McpConfig MCP統合設定（RPCポート、自動起動）
@@ -113,8 +119,8 @@ M.defaults = {
     open_diff = "gd",
     open_file = "gf",
   },
-  inline = {
-    preview_enabled = false,  -- Enable diff preview UI for inline actions (requires Git)
+  preview = {
+    enabled = false,  -- Enable diff preview UI for inline and chat (requires Git)
   },
   permissions = {
     mode = "acceptEdits",  -- "default" | "acceptEdits" | "bypassPermissions"


### PR DESCRIPTION
## 概要

プレビューUI機能がインラインアクションとチャットの両方で使用されるようになったため、設定の配置を`inline.preview_enabled`から`preview.enabled`に変更しました。

## 変更内容

### 1. 設定構造の変更

**Before:**
```lua
inline = {
  preview_enabled = false,
}
```

**After:**
```lua
preview = {
  enabled = false,
}
```

### 2. 影響範囲

- `lua/vibing/config.lua`: 型定義追加（`Vibing.PreviewConfig`）とデフォルト設定変更
- `lua/vibing/actions/inline.lua`: 設定参照を2箇所修正
- `README.md`: ドキュメント更新（4箇所）、セクション名を"Preview Settings"に変更

## 理由

1. **機能の範囲が拡大**: プレビューUIは以下の両方で使用されます
   - インラインアクション（`:'<,'>VibingInline fix`など）
   - チャットセッション（`gp`キーで変更ファイル一覧をプレビュー）

2. **論理的な配置**: `inline`セクションではなく、トップレベルの`preview`セクションに配置することで、横断的な機能であることが明確になります

3. **将来の拡張性**: プレビュー関連の設定（レイアウト、カラー設定など）を追加しやすくなります

## 破壊的変更

既存のユーザーは設定を以下のように変更する必要があります：

```diff
require("vibing").setup({
- inline = {
-   preview_enabled = true,
- },
+ preview = {
+   enabled = true,
+ },
})
```

## テスト

- フォーマットチェック: ✅ Pass
- 型定義の整合性: ✅ OK
- すべての参照を更新済み: ✅ OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline Preview UI to review generated changes in a multi-panel view (action, files, diff, response). Responsive layout, diff highlighting, multi-file navigation. Keys: gp to preview all modified files, j/k or Up/Down to move, a to accept, r to reject (Git revert), q to quit. Disabled by default; requires Git.

* **Documentation**
  * Full docs and configuration examples, keybindings, and usage guidance added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->