### PR TITLE
fix: remove unresolved merge conflict marker in lsp.lua

### DIFF
--- a/lua/vibing/rpc_server/handlers/lsp.lua
+++ b/lua/vibing/rpc_server/handlers/lsp.lua
@@ -337,5 +337,4 @@ function M.lsp_call_hierarchy_outgoing(params)
   return { calls = calls }
 end
 
-<<<<<<< HEAD
 return M


### PR DESCRIPTION
## 概要

`lua/vibing/rpc_server/handlers/lsp.lua`に残っていたGitマージコンフリクトマーカー（`<<<<<<< HEAD`）を削除しました。

## 問題

- プラグイン読み込み時に「unexpected symbol near '<'」というLua構文エラーが発生
- `VibingChat`コマンドが登録されず、プラグインが使用不可能な状態
- lazy.nvimの`config`実行時にエラーが発生

## 修正内容

- `lua/vibing/rpc_server/handlers/lsp.lua:340`のマージコンフリクトマーカーを削除
- ファイルの最後の`return M`のみを残す

## テスト

- Prettierフォーマットチェック: ✅ 合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up a stray marker in the codebase with no functional impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->