### PR TITLE
feat: move cursor to end after send to enable auto-scroll mode

### DIFF
--- a/lua/vibing/ui/chat_buffer.lua
+++ b/lua/vibing/ui/chat_buffer.lua
@@ -793,6 +793,9 @@ function ChatBuffer:send_message()
 
   -- 通常のメッセージ送信
   require("vibing.actions.chat").send(self, message)
+
+  -- カーソルを末尾に移動してスクロールモードを有効化
+  self:_move_cursor_to_end()
 end
 
 -- スピナーフレーム
@@ -850,6 +853,18 @@ function ChatBuffer:_flush_chunks()
 
   -- バッファをクリア
   self._chunk_buffer = ""
+end
+
+---カーソルを末尾に移動（スクロールモード有効化用）
+function ChatBuffer:_move_cursor_to_end()
+  if not self:is_open() or not vim.api.nvim_win_is_valid(self.win) or not vim.api.nvim_buf_is_valid(self.buf) then
+    return
+  end
+
+  local line_count = vim.api.nvim_buf_line_count(self.buf)
+  if line_count > 0 then
+    pcall(vim.api.nvim_win_set_cursor, self.win, { line_count, 0 })
+  end
 end
 
 ---ストリーミングチャンクを追加（バッファリング有効）


### PR DESCRIPTION
## 概要

`<CR>`でメッセージ送信後、カーソルを自動的にバッファ末尾に移動することで、既存のスマート自動スクロール機能を有効化します。

## 問題

現状、メッセージ送信後にカーソルが入力位置(バッファ中央付近)に残るため、自動スクロールが無効化され、ストリーミング応答が画面外に流れてしまう問題がありました。

## 解決方法

`send_message()`実行後に新しい`_move_cursor_to_end()`ヘルパー関数を呼び出し、カーソルをバッファ末尾に移動します。これにより、既存の条件付き自動スクロールロジック(`current_line >= old_line_count`)が有効化されます。

## 変更内容

### 追加機能

1. **`_move_cursor_to_end()`** - カーソルをバッファ末尾に移動する新しいヘルパー関数
   - ウィンドウ/バッファの有効性チェック
   - `pcall`によるエラーハンドリング
   - 既存の`_flush_chunks()`と同じガードパターンを使用

2. **`send_message()`の拡張** - メッセージ送信後に自動的にカーソルを末尾に移動

### 技術的詳細

```lua
-- 新規ヘルパー関数
function ChatBuffer:_move_cursor_to_end()
  if not self:is_open() or not vim.api.nvim_win_is_valid(self.win) 
     or not vim.api.nvim_buf_is_valid(self.buf) then
    return
  end
  
  local line_count = vim.api.nvim_buf_line_count(self.buf)
  if line_count > 0 then
    pcall(vim.api.nvim_win_set_cursor, self.win, { line_count, 0 })
  end
end
```

## 動作確認

- [x] Lua構文チェック通過
- [x] フォーマットチェック通過
- [x] コードレビュー(pr-review-toolkit)で問題なし
- [x] 既存の自動スクロールロジックとの整合性確認

## Before/After

### Before
1. `<CR>`でメッセージ送信
2. カーソルが入力位置に残る
3. 自動スクロール無効化
4. ストリーミング応答が画面外に

### After
1. `<CR>`でメッセージ送信
2. カーソルが自動的に末尾に移動
3. 自動スクロール有効化
4. ストリーミング応答が常に追従表示

## 関連Issue

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)