### PR TITLE
fix: Display plugin slash commands with plugin name in VibingSlashCommands

### DIFF
--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -84,12 +84,7 @@ function M._register_commands()
   end, { desc = "Toggle Vibing chat window" })
 
   vim.api.nvim_create_user_command("VibingSlashCommands", function()
-    local chat = require("vibing.actions.chat")
-    if not chat.chat_buffer or not chat.chat_buffer:is_open() then
-      notify.warn("Please open a chat window first")
-      return
-    end
-    require("vibing.ui.command_picker").show(chat.chat_buffer)
+    require("vibing.ui.command_picker").show()
   end, { desc = "Show slash command picker" })
 
   ---@private


### PR DESCRIPTION
## Summary

プラグインからインストールしたスラッシュコマンドが`VibingSlashCommands`で表示されない問題を修正しました。また、プラグイン名の表示とコマンドブラウズ機能を改善しました。

## 修正内容

### 1. プラグインキャッシュのスキャン対応

- `~/.claude/plugins/cache/`ディレクトリのスキャンを追加
- `--add-dir`で追加したローカルプラグインのコマンドも検出可能に
- パターン: `{owner}/{plugin}/{version}/commands/*.md`

### 2. プラグイン名の表示

- コマンドピッカーでプラグイン名を表示
- 表示形式: `[plugin:dev-org] /refactor - Description`
- どのプラグイン由来かが一目でわかるように改善

### 3. VibingSlashCommandsのアクセシビリティ向上

- チャットウィンドウなしでもコマンドをブラウズ可能
- `.vibing`ファイルを開いている場合は自動的にチャットバッファとして認識
- ブラウズ専用モード: チャットがない場合はコマンド情報を表示

## 変更ファイル

- `lua/vibing/chat/custom_commands.lua`: プラグイン名抽出、キャッシュスキャン
- `lua/vibing/ui/command_picker.lua`: プラグイン名表示、オプショナルバッファ対応
- `lua/vibing/init.lua`: チャットバッファ要件の削除

## テスト方法

1. `:VibingReloadCommands`でコマンドを再スキャン
2. チャットウィンドウなしで`:VibingSlashCommands`を実行
3. プラグインコマンドが`[plugin:プラグイン名]`形式で表示されることを確認
4. `.vibing`ファイルを開いて`:VibingSlashCommands`を実行し、コマンド挿入が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for plugin-sourced custom commands, allowing plugins to contribute commands to the system.
  * Command picker now operates in browse-only mode when no chat buffer is available, enabling command browsing and viewing without an active chat.

* **Improvements**
  * Enhanced command display to show plugin identification tags for plugin-sourced commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->