### PR TITLE
fix: resolve undefined function error in command_picker

### DIFF
--- a/lua/vibing/ui/command_picker.lua
+++ b/lua/vibing/ui/command_picker.lua
@@ -13,21 +13,11 @@ local M = {}
 function M.show(chat_buffer)
   -- チャットバッファが提供されていない場合は、現在開いているチャットを探す
   if not chat_buffer then
-    local chat = require("vibing.application.chat.use_case")
+    local view = require("vibing.presentation.chat.view")
 
-    -- 1. グローバルなchat_bufferをチェック
-    if chat.chat_buffer and chat.chat_buffer:is_open() then
-      chat_buffer = chat.chat_buffer
-    else
-      -- 2. 現在のバッファが.vibingファイルかチェック
-      local current_buf = vim.api.nvim_get_current_buf()
-      local filetype = vim.bo[current_buf].filetype
-      if filetype == "vibing" then
-        -- 現在のバッファがvibingファイルなら、それをチャットバッファとして取得
-        chat_buffer = chat.get_current_chat_buffer()
-      end
-    end
-    -- chat_bufferがまだnilの場合はブラウズ専用モード
+    -- view.get_current()で現在のチャットバッファインスタンスを取得
+    chat_buffer = view.get_current()
+    -- chat_bufferがnilの場合はブラウズ専用モード
   end
 
   -- Telescopeが利用可能かチェック


### PR DESCRIPTION
## 概要

`:VibingSlashCommands`コマンド実行時に発生していた`attempt to call field 'get_current_chat_buffer' (a nil value)`エラーを修正しました。

## 変更内容

- `command_picker.lua`で存在しない`use_case.get_current_chat_buffer()`関数を呼び出していた問題を修正
- 正しく`view.get_current()`を使用するように変更
- 不要なコードを削除してロジックを簡潔化

## 技術的な詳細

**修正前:**
```lua
local chat = require("vibing.application.chat.use_case")
if chat.chat_buffer and chat.chat_buffer:is_open() then
  chat_buffer = chat.chat_buffer
else
  chat_buffer = chat.get_current_chat_buffer()  -- ❌ 存在しない関数
end
```

**修正後:**
```lua
local view = require("vibing.presentation.chat.view")
chat_buffer = view.get_current()  -- ✅ 正しい関数を使用
```

## テスト

- [x] `:VibingSlashCommands`コマンドが正常に動作することを確認
- [x] フォーマットチェックが通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat buffer detection in the command picker to ensure it correctly identifies the active chat context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->