### PR TITLE
fix: handle table language config in build_command

### DIFF
--- a/lua/vibing/infrastructure/adapter/agent_sdk.lua
+++ b/lua/vibing/infrastructure/adapter/agent_sdk.lua
@@ -145,9 +145,15 @@ function AgentSDK:build_command(prompt, opts, session_id)
   -- Add language: opts (frontmatter) > config
   local language = opts.language
   if not language and self.config.language then
-    language = self.config.language
+    -- config.language can be a string or a table {default, chat, inline}
+    if type(self.config.language) == "table" then
+      -- For title generation (and other non-chat/inline uses), use default
+      language = self.config.language.default or self.config.language.chat
+    else
+      language = self.config.language
+    end
   end
-  if language then
+  if language and type(language) == "string" then
     table.insert(cmd, "--language")
     table.insert(cmd, language)
   end


### PR DESCRIPTION
## 問題

`:VibingSetFileTitle`コマンド実行時に以下のエラーが発生していました：

```
Error: Failed to generate title: Usage: agent-wrapper.mjs --prompt <prompt> [--cwd <dir>] [--context <file>...]
```

## 原因

`config.language`がテーブル形式（例: `{default="ja", chat="ja", inline="en"}`）の場合、`build_command()`がテーブル全体を`--language`引数として渡していました。

`agent-wrapper.mjs`は文字列の言語コードを期待しているため、引数パースに失敗し、結果的に`--prompt`引数が認識されずエラーになっていました。

## 修正内容

`build_command()`で`config.language`がテーブルの場合、適切に文字列値を抽出するように修正：

- テーブルの場合：`default`フィールド、または`chat`フィールドの値を使用
- 文字列の場合：そのまま使用
- 文字列であることを確認してから`--language`引数に追加

## テスト

- [x] `:VibingSetFileTitle`が正常に動作することを確認
- [x] フォーマットチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced language configuration handling with improved fallback logic when language is not explicitly specified
  * Added validation to ensure language values are properly formatted before being applied to commands

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->