### PR TITLE
fix: custom command execution error due to missing use_case.send

### DIFF
--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -783,15 +783,16 @@ function ChatBuffer:send_message()
   -- スラッシュコマンドかチェック
   local commands = require("vibing.application.chat.commands")
   if commands.is_command(message) then
-    local handled, is_custom = commands.execute(message, self)
+    local handled, expanded = commands.execute(message, self)
     if handled then
-      -- コマンドが処理された
-      -- カスタムコマンドはM.send()内でadd_user_section()を呼ぶため、ここでは呼ばない
-      -- ビルトインコマンドのみここでadd_user_section()を呼ぶ
-      if not is_custom then
+      if expanded then
+        -- カスタムコマンド: 展開されたメッセージでAI送信を続行
+        message = expanded
+      else
+        -- ビルトインコマンドまたは展開失敗: 処理完了
         self:add_user_section()
+        return
       end
-      return
     end
   end
 


### PR DESCRIPTION
## Summary

- カスタムコマンド実行時に `use_case.send()` が存在しないためエラーが発生していた問題を修正
- リファクタリングでcallbackパターンに変更された際に、カスタムコマンドの送信ロジックが更新されていなかった

## Changes

- `execute_custom_command` を `expand_custom_command` にリネーム（テンプレート展開のみ）
- `commands.execute()` が展開されたメッセージを2番目の戻り値として返すように変更
- `ChatBuffer:send_message()` で展開されたメッセージを通常のAI送信フローに渡すように修正
- 引数が必要なカスタムコマンドで引数なしの場合は警告を表示

## Flow (After Fix)

```
1. User enters /custom-command and presses Enter
2. send_message() calls commands.execute()
3. commands.execute() returns expanded message
4. send_message() continues with expanded message to AI
```

## Test plan

- [ ] `/clear` コマンドが正常に動作する
- [ ] カスタムコマンド（`~/.claude/commands/*.md`）が正常に展開・送信される
- [ ] 引数が必要なカスタムコマンドで引数なしの場合、警告が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom commands now support returning expanded output messages for more flexible and dynamic command responses.

* **Improvements**
  * Refined command execution and message processing workflow for improved handling of custom command operations.
  * Enhanced error handling and improved consistency across different command execution paths.
  * Strengthened custom command expansion mechanism for more reliable processing of command results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->