### PR TITLE
docs: add ADR 003 - Agent SDK vs CLI Architecture Decision

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -5,6 +5,7 @@
     "code_blocks": false,
     "tables": false
   },
+  "MD024": false,
   "MD033": false,
   "MD036": false,
   "MD041": false

--- a/docs/adr/adr-index-and-guide.md
+++ b/docs/adr/adr-index-and-guide.md
@@ -4,7 +4,8 @@ This directory contains Architecture Decision Records for vibing.nvim.
 
 ## What is an ADR?
 
-An Architecture Decision Record (ADR) documents important architectural decisions made during the development of the project, including:
+An Architecture Decision Record (ADR) documents important architectural decisions made
+during the development of the project, including:
 
 - The context and problem being addressed
 - The decision that was made
@@ -13,7 +14,8 @@ An Architecture Decision Record (ADR) documents important architectural decision
 - Alternatives that were considered
 - References to related discussions, issues, or commits
 
-ADRs help future maintainers understand WHY certain design choices were made, especially when those choices involve non-obvious constraints or trade-offs.
+ADRs help future maintainers understand WHY certain design choices were made,
+especially when those choices involve non-obvious constraints or trade-offs.
 
 ## Index
 
@@ -22,7 +24,8 @@ ADRs help future maintainers understand WHY certain design choices were made, es
 **Status:** Accepted
 **Date:** 2025-01-26
 
-Documents the implementation of the three-tier permission system (deny/ask/allow) and the critical workarounds required for Claude Agent SDK constraints, particularly:
+Documents the implementation of the three-tier permission system (deny/ask/allow) and the
+critical workarounds required for Claude Agent SDK constraints, particularly:
 
 - Why `permissionMode` is intentionally left undefined
 - How Issue #29 (resume session bypass) is mitigated
@@ -73,7 +76,9 @@ Documents the implementation of concurrent execution support for multiple chat w
 **Status:** Accepted
 **Date:** 2026-01-04
 
-Comprehensive comparison between Claude Agent SDK (`query()` API) and Claude CLI (`claude -p`) for vibing.nvim's architecture. Documents the decision to continue using Agent SDK based on:
+Comprehensive comparison between Claude Agent SDK (`query()` API) and Claude CLI
+(`claude -p`) for vibing.nvim's architecture. Documents the decision to continue using
+Agent SDK based on:
 
 - Custom permission control requirements (`canUseTool` callback)
 - Dependency management reliability (npm vs global binary)


### PR DESCRIPTION
Add comprehensive Architecture Decision Record comparing Claude Agent SDK
and Claude CLI (`claude -p`) implementations for vibing.nvim.

Key findings:
- Agent SDK provides necessary custom permission control via canUseTool
- CLI lacks flexibility for vibing.nvim's granular permission requirements
- Agent SDK has better dependency management (npm vs global binary)
- Agent SDK offers superior performance (in-process vs subprocess)
- CLI has several critical unresolved bugs (JSON truncation, resume bugs)

Decision: Continue using Agent SDK (@anthropic-ai/claude-agent-sdk)

Related:
- ADR 001: Permission system requires canUseTool callback
- ADR 002: Concurrent execution architecture
- Agent SDK Issue #29: Resume session bypass (mitigated)
- CLI Issues: #913, #1920, #3187, #3188, #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Record comparing Agent SDK vs CLI and documenting the decision to continue with the Agent SDK, rationale, trade-offs, known issues, mitigations, and re-evaluation criteria.
  * Updated the ADR index and related ADR rationale and references.
* **Style**
  * Adjusted Markdown linting configuration to disable the MD024 rule.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->