### PR TITLE
fix: apply wrap settings only to vibing buffers

### DIFF
--- a/ftplugin/vibing.lua
+++ b/ftplugin/vibing.lua
@@ -23,7 +23,7 @@ vim.wo.conceallevel = 2
 
 -- Apply wrap configuration for .vibing files using BufEnter autocmd
 -- This ensures wrap settings only affect vibing buffers and don't leak to other buffers
-local ok, ui_utils = pcall(require, "vibing.utils.ui")
+local ok, ui_utils = pcall(require, "vibing.core.utils.ui")
 if ok then
   -- Apply immediately on first load
   pcall(ui_utils.apply_wrap_config, 0)

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -183,6 +183,11 @@ function ChatBuffer:_create_window()
     })
   end
 
+  -- Apply wrap configuration for vibing chat buffer
+  local ok, ui_utils = pcall(require, "vibing.core.utils.ui")
+  if ok and self.win then
+    pcall(ui_utils.apply_wrap_config, self.win)
+  end
 end
 
 ---キーマップを設定


### PR DESCRIPTION
## 概要

`.vibing`拡張子のファイルと新規チャットバッファでのみwrap設定を適用し、他のファイルタイプには影響を与えないように修正しました。

## 変更内容

### 1. ftplugin/vibing.lua
- requireパスを修正: `vibing.utils.ui` → `vibing.core.utils.ui`
- `.vibing`拡張子のファイルを開いた時にwrap設定を適用

### 2. lua/vibing/presentation/chat/buffer.lua  
- `_create_window()`メソッドの最後にwrap設定適用コードを追加
- 新規チャットバッファ作成時にwrap設定を適用

## 動作

- ✅ `.vibing`拡張子のファイル: `ui.wrap`設定に従ってwrapが適用される
- ✅ 新規チャットバッファ(`:VibingChat`): `ui.wrap`設定に従ってwrapが適用される
- ✅ 他のファイル: wrap設定は一切変更されない（ユーザーのNeovim設定に従う）

## テスト手順

\`\`\`vim
" 新規チャットでwrap確認
:VibingChat
:set wrap? linebreak?

" .vibingファイルでwrap確認  
:e .vibing/chat/test.vibing
:set wrap? linebreak?

" 他のファイルで影響がないか確認
:e test.lua
:set wrap?  " ユーザー設定が維持されているはず
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved wrap configuration reliability: wrap settings now automatically re-apply when entering vibing buffers, ensuring consistent text formatting throughout your session
* Enhanced chat window initialization: wrap settings are now properly applied when chat windows are created or updated

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->