### PR TITLE
feat: Add position argument to VibingChat command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,7 +616,7 @@ require("vibing").setup({
 
 | Command                          | Description                                                                       |
 | -------------------------------- | --------------------------------------------------------------------------------- |
-| `:VibingChat [file]`             | Always create a new chat window or open saved chat file (new conversation)        |
+| `:VibingChat [position\|file]`   | Create new chat with optional position (current\|right\|left) or open saved file  |
 | `:VibingToggleChat`              | Toggle existing chat window (preserve current conversation)                       |
 | `:VibingSlashCommands`           | Show slash command picker in chat                                                 |
 | `:VibingContext [path]`          | Add file to context (or from oil.nvim if no path)                                 |
@@ -626,7 +626,12 @@ require("vibing").setup({
 
 **Command Semantics:**
 
-- **`:VibingChat`** - Use when you want to start a new conversation on a different topic. Always creates a fresh chat window.
+- **`:VibingChat`** - Always creates a fresh chat window. Optionally specify position (`current`, `right`, `left`) to control window placement.
+  - `:VibingChat` - New chat using default position from config
+  - `:VibingChat current` - New chat in current window
+  - `:VibingChat right` - New chat in right split
+  - `:VibingChat left` - New chat in left split
+  - `:VibingChat path/to/file.vibing` - Open saved chat file
 - **`:VibingToggleChat`** - Use to show/hide your current conversation. Preserves the existing chat state.
 
 ### Inline Action Examples

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ use {
 
 | Command                               | Description                                                                       |
 | ------------------------------------- | --------------------------------------------------------------------------------- |
-| `:VibingChat [file]`                  | Always create a new chat window or open saved chat file (new conversation)        |
+| `:VibingChat [position\|file]`        | Create new chat with optional position (current\|right\|left) or open saved file  |
 | `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                       |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                 |
 | `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                 |
@@ -123,7 +123,12 @@ use {
 
 **Command Semantics:**
 
-- **`:VibingChat`** - Use when you want to start a new conversation on a different topic. Always creates a fresh chat window.
+- **`:VibingChat`** - Always creates a fresh chat window. Optionally specify position (`current`, `right`, `left`) to control window placement.
+  - `:VibingChat` - New chat using default position from config
+  - `:VibingChat current` - New chat in current window
+  - `:VibingChat right` - New chat in right split
+  - `:VibingChat left` - New chat in left split
+  - `:VibingChat path/to/file.vibing` - Open saved chat file
 - **`:VibingToggleChat`** - Use to show/hide your current conversation. Preserves the existing chat state.
 
 ### Inline Actions

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -74,7 +74,31 @@ function M._register_commands()
   -- チャット関連コマンド
   vim.api.nvim_create_user_command("VibingChat", function(opts)
     require("vibing.presentation.chat.controller").handle_open(opts.args)
-  end, { nargs = "?", desc = "Open Vibing chat or chat file", complete = "file" })
+  end, {
+    nargs = "?",
+    desc = "Open Vibing chat with optional position (current|right|left) or file",
+    complete = function(arg_lead, cmd_line, cursor_pos)
+      -- First argument: position or file
+      local args = vim.split(cmd_line, "%s+")
+      if #args == 2 then
+        -- Complete position keywords or files
+        local positions = { "current", "right", "left" }
+        local matches = {}
+        for _, pos in ipairs(positions) do
+          if pos:find("^" .. vim.pesc(arg_lead)) then
+            table.insert(matches, pos)
+          end
+        end
+        -- Also add file completion
+        local files = vim.fn.getcompletion(arg_lead, "file")
+        for _, file in ipairs(files) do
+          table.insert(matches, file)
+        end
+        return matches
+      end
+      return {}
+    end,
+  })
 
   vim.api.nvim_create_user_command("VibingToggleChat", function()
     require("vibing.presentation.chat.controller").handle_toggle()

--- a/lua/vibing/presentation/chat/controller.lua
+++ b/lua/vibing/presentation/chat/controller.lua
@@ -6,23 +6,37 @@ local M = {}
 local notify = require("vibing.core.utils.notify")
 
 ---チャットウィンドウを開く（新規または既存ファイル）
----@param args string ファイルパス（空文字列の場合は新規チャット）
+---@param args string 引数文字列（位置指定またはファイルパス）
 function M.handle_open(args)
   local use_case = require("vibing.application.chat.use_case")
   local view = require("vibing.presentation.chat.view")
 
+  -- 引数をパース（位置指定 or ファイルパス）
+  local position = nil
+  local file_path = nil
+
   if args and args ~= "" then
-    -- 既存ファイルを開く
-    local session = use_case.open_file(args)
-    if session then
-      view.render(session)
+    -- 位置キーワードのチェック
+    if args == "current" or args == "right" or args == "left" then
+      position = args
     else
-      notify.error("Failed to load: " .. args, "Chat")
+      -- ファイルパスとして扱う
+      file_path = args
+    end
+  end
+
+  if file_path then
+    -- 既存ファイルを開く
+    local session = use_case.open_file(file_path)
+    if session then
+      view.render(session, position)
+    else
+      notify.error("Failed to load: " .. file_path, "Chat")
     end
   else
-    -- 新規チャットを開く
+    -- 新規チャットを開く（位置指定あり/なし）
     local session = use_case.create_new()
-    view.render(session)
+    view.render(session, position)
   end
 end
 

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -16,23 +16,24 @@ M._attached_buffers = {}
 
 ---セッションをチャットバッファに描画
 ---@param session Vibing.ChatSession
-function M.render(session)
+---@param position? string 位置指定（current|right|left）
+function M.render(session, position)
   local vibing = require("vibing")
   local config = vibing.get_config()
 
-  -- 既存バッファを再利用するか新規作成
-  local chat_buf
-  if M._current_buffer and M._current_buffer:is_open() then
-    chat_buf = M._current_buffer
-  else
-    chat_buf = ChatBuffer:new(config.chat)
-    M._current_buffer = chat_buf
-  end
+  -- 毎回新規バッファを作成（既存バッファを再利用しない）
+  local chat_buf = ChatBuffer:new(config.chat)
+  M._current_buffer = chat_buf
 
   -- セッションデータをバッファに反映
   if session.file_path then
     chat_buf.file_path = session.file_path
     chat_buf.session_id = session.session_id
+  end
+
+  -- 位置指定が指定されている場合は一時的にオーバーライド
+  if position then
+    chat_buf.config.window.position = position
   end
 
   chat_buf:open()


### PR DESCRIPTION
## 概要

`VibingChat`コマンドに位置指定の引数(`current`/`right`/`left`)を追加し、チャットバッファの開き方を柔軟にしました。

## 変更内容

### コマンド構文

```vim
:VibingChat [current|right|left]
```

### 動作

- `:VibingChat` - 設定のデフォルト位置で新規チャットを開く
- `:VibingChat current` - 現在のウィンドウで新規チャットを開く
- `:VibingChat right` - 右側に垂直分割して新規チャットを開く
- `:VibingChat left` - 左側に垂直分割して新規チャットを開く
- `:VibingChat path/to/file.vibing` - 既存のチャットファイルを開く

### 主な変更

- **毎回新規バッファを作成**: コマンド実行のたびに新しいチャットバッファを作成（既存バッファを再利用しない）
- **タブ補完**: 位置キーワード(`current`/`right`/`left`)とファイルパスの両方に対応
- **ドキュメント更新**: README.mdとCLAUDE.mdに使用方法を追加

## 技術的な詳細

### 変更ファイル

1. `lua/vibing/init.lua` - コマンド定義の更新、タブ補完の実装
2. `lua/vibing/presentation/chat/controller.lua` - 引数パース処理の追加
3. `lua/vibing/presentation/chat/view.lua` - 新規バッファ作成ロジック、位置指定のサポート
4. `README.md`, `CLAUDE.md` - ドキュメント更新

### 動作確認

- ✅ Lua構文チェック: 問題なし
- ✅ 既存テスト: 問題なし
- ✅ タブ補完: 動作確認済み

## 使用例

```vim
" デフォルト位置で新規チャット
:VibingChat

" 現在のウィンドウにチャット1を開く
:VibingChat current

" 右に分割してチャット2を開く
:VibingChat right

" 左に分割してチャット3を開く
:VibingChat left

" 結果：複数の独立したチャットバッファが開いている
```

## 破壊的変更

なし。既存の動作は完全に保持されています。

## チェックリスト

- [x] `current`/`right`/`left`引数が動作
- [x] 引数なしの場合、既存の設定に従う
- [x] 毎回新規バッファが作成される
- [x] タブ補完が動作
- [x] ドキュメント更新（README、CLAUDE.md）
- [x] 既存の`VibingToggleChat`コマンドは影響を受けない

Fixes #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VibingChat command now supports optional position arguments (current, right, left) to control chat window placement.
  * VibingChat command can now open saved chat files by providing the file path.
  * Enhanced auto-completion for position options and file paths.

* **Documentation**
  * Updated VibingChat command documentation with new usage variants and examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->