### PR TITLE
feat: remove time from VibingSetFileTitle filename format

### DIFF
--- a/lua/vibing/core/utils/filename.lua
+++ b/lua/vibing/core/utils/filename.lua
@@ -64,7 +64,7 @@ function M.generate_default()
 end
 
 ---AIが生成したタイトルからファイル名を生成
----形式: {type}-yyyymmdd-HHmm-{title}.vibing (例: chat-20250627-1430-fix_auth_bug.vibing)
+---形式: {type}-yyyymmdd-{title}.vibing (例: chat-20250627-fix_auth_bug.vibing)
 ---:VibingSetFileTitleコマンドで使用
 ---@param title string AIが生成したタイトル（サニタイズ前）
 ---@param file_type "chat"|"inline" ファイルタイプ
@@ -77,7 +77,7 @@ function M.generate_with_title(title, file_type)
     sanitized = "untitled"
   end
 
-  local timestamp = os.date("%Y%m%d-%H%M")
+  local timestamp = os.date("%Y%m%d")
   return string.format("%s-%s-%s.vibing", file_type, timestamp, sanitized)
 end
 


### PR DESCRIPTION
## 概要

`:VibingSetFileTitle`コマンドで生成されるファイル名から時刻部分を削除し、日付のみを残すように変更しました。

## 変更内容

- ファイル名フォーマットを簡略化
  - 変更前: `chat-20250108-1430-title.vibing`
  - 変更後: `chat-20250108-title.vibing`
- `lua/vibing/core/utils/filename.lua`の`generate_with_title`関数を修正
  - タイムスタンプフォーマット: `%Y%m%d-%H%M` → `%Y%m%d`

## 動機

ファイル名をよりシンプルにしつつ、日付による整理は維持する。同日に複数のチャットを作成する場合でも、タイトル部分で区別できるため、時刻は不要。

## テスト計画

- [ ] `:VibingSetFileTitle`実行時に新形式でファイル名が生成されることを確認
- [ ] 既存のチャットファイルに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified AI-generated filename format by removing the hourly timestamp component. Filenames now use daily date format only instead of including time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->