### PR TITLE
docs: add race condition analysis for patch storage issue

### DIFF
--- a/docs/adr/006-patch-storage-js-implementation.md
+++ b/docs/adr/006-patch-storage-js-implementation.md
@@ -17,6 +17,7 @@ Issue #281 comment #3731122580で指摘された通り、現在のpatch storage�
    - `event_processor.lua:24`: `on_tool_use`で2回目
 
 2. **タイミングの問題**
+
    ```
    tool_use出力 → vim.schedule()×2 ⏱️⏱️
         ↓
@@ -143,10 +144,12 @@ if (currentSessionModifiedFiles.size > 0) {
   if (patch) {
     const patchFilename = savePatchToFile(sessionId, patch);
 
-    console.log(safeJsonStringify({
-      type: 'patch_saved',
-      filename: patchFilename
-    }));
+    console.log(
+      safeJsonStringify({
+        type: 'patch_saved',
+        filename: patchFilename,
+      })
+    );
   }
 
   // セッション終了後にクリア
@@ -169,11 +172,7 @@ async function generateSessionPatch(files, savedContents, sessionId) {
     if (savedContent !== null && savedContent !== undefined) {
       // このセッションで変更したファイル
       // saved_contentと現在の内容の差分
-      const diff = await generateUnifiedDiff(
-        savedContent,
-        currentContent,
-        file
-      );
+      const diff = await generateUnifiedDiff(savedContent, currentContent, file);
 
       if (diff) {
         patches.push(diff);
@@ -207,10 +206,10 @@ function generateNewFileDiff(filepath, content) {
     'new file',
     '--- /dev/null',
     `+++ b/${filepath}`,
-    `@@ -0,0 +1,${lines.length} @@`
+    `@@ -0,0 +1,${lines.length} @@`,
   ];
 
-  const body = lines.map(line => '+' + line);
+  const body = lines.map((line) => '+' + line);
 
   return [...header, ...body].join('\n');
 }
@@ -264,10 +263,12 @@ elseif msg.type == "patch_saved" then
 ### Mitigation
 
 **メモリ対策:**
+
 - ファイルサイズの上限チェック（例: 1MB以上は保存しない）
 - セッション終了時に確実にクリア
 
 **テスト:**
+
 - 新規ファイル作成のテストケース
 - 大量ファイル編集のテストケース
 - git操作の有無によるテストケース


### PR DESCRIPTION
Investigated PR #281 comment #3731122580 regarding race condition
in modified files tracking.

Key findings:
- Race condition CONFIRMED through code analysis
- Double vim.schedule() queueing causes extreme delay
- on_tool_use callback executes AFTER git commit completes
- Current approach cannot capture git commit diffs reliably

Evidence:
1. stream_handler.lua:17 - First vim.schedule() on stdout
2. event_processor.lua:24 - Second vim.schedule() on tool_use
3. Agent SDK executes tools synchronously between messages
4. PatchStorage.save() runs too late to capture git diffs

Recommended solutions:
1. Use Agent SDK PreToolUse hooks
2. Use git reflog/git show for post-commit diff recovery
3. Save file contents immediately on Edit/Write (not on_tool_use)

Files added:
- analysis-race-condition.md: Detailed technical analysis
- test-race-condition.mjs: Basic timing test (for reference)
- verify-race-condition.mjs: Race condition verification script