### PR TITLE
fix: Support simultaneous main/worktree sessions + staging warnings

### DIFF
--- a/bin/lib/patch-storage.ts
+++ b/bin/lib/patch-storage.ts
@@ -24,7 +24,15 @@ class PatchStorage {
 
   setSessionId(sessionId: string): void {
     this.sessionId = sessionId;
-    this.snapshotTag = `claude-session-${sessionId}`;
+
+    // Detect worktree environment
+    const worktreeInfo = this.gitOps.detectWorktree();
+
+    // Generate worktree-specific tag name
+    const worktreeId = worktreeInfo.isWorktree ? `wt-${worktreeInfo.worktreeName}` : 'main';
+
+    // New format: vibing-patch-<worktree-id>-<session-id>
+    this.snapshotTag = `vibing-patch-${worktreeId}-${sessionId}`;
   }
 
   setCwd(cwd: string): void {


### PR DESCRIPTION
## 概要

Worktree使用時の2つの問題を修正しました：
1. MainとWorktreeを同時使用時のセッション破損
2. 無害だが混乱を招くステージング状態のWarning

## 問題1: Worktreeでのセッション破損

### 症状
```
[vibing.nvim] Removing existing snapshot tag: claude-session-<uuid>
Session has been reset. Your next message will start a new session.
```

### 原因
- patch-storageが作成するtag: `claude-session-<uuid>`
- Gitタグは全worktreeで共有される
- 同じtag名での衝突 → セッションリセット

### 解決策
**Tag形式を変更:**
```diff
- claude-session-<session-id>
+ vibing-patch-<worktree-id>-<session-id>
```

**具体例:**
- Main worktree: `vibing-patch-main-abc123-def456-789`
- Git worktree: `vibing-patch-wt-feature-branch-abc123-def456-789`

**実装:**
- `detectWorktree()`関数を追加（git-operations.ts）
- `PatchStorage.setSessionId()`でworktree固有のtag名生成
- agent-wrapper.tsのtag削除ロジック更新
- 旧形式との後方互換性維持

## 問題2: ステージング状態のWarning

### 症状
```
[WARN] Failed to restore staging state: error: No valid patches in input (allow with "--allow-empty")
```

### 原因
- `saveStagingState()`が空のステージングエリアをキャプチャ
- `restoreStagingState()`が無効なパッチで`git apply`実行
- git applyがエラーで拒否

### 解決策
**Diff検証を追加:**
```typescript
// パッチマーカー(diff --git または @@)の存在確認
const hasDiffMarkers = /^(diff --git|@@)/m.test(stagedDiff);
if (!hasDiffMarkers) {
  return true; // 有効なパッチなし、スキップ
}
```

## メリット

✅ **MainとWorktreeを同時使用可能**
✅ **Tag衝突なし** - worktree固有の名前空間
✅ **セッションリセットエラーなし**
✅ **Warningなし** - ログがクリーン
✅ **後方互換性** - 既存セッション継続動作
✅ **明確な命名** - `vibing-patch-`プレフィックスでAgent SDKと区別

## 変更内容

### 修正ファイル

**bin/lib/git-operations.ts:**
- `detectWorktree()` - Worktree検出ユーティリティ
- `restoreStagingState()` - Diff検証ロジック追加

**bin/lib/patch-storage.ts:**
- `setSessionId()` - Worktree固有のtag名生成

**bin/agent-wrapper.ts:**
- Tag削除ロジックを新形式に対応
- 旧形式のサポート（後方互換性）

## テスト計画

- [x] ビルド成功
- [ ] Main worktreeでtag作成: `vibing-patch-main-<id>`
- [ ] Worktreeでtag作成: `vibing-patch-wt-<branch>-<id>`
- [ ] 同時使用（両方のtagが共存）
- [ ] セッション再開動作
- [ ] 空ステージングエリアでWarningなし

## ドキュメント

詳細な分析:
- `docs/troubleshooting/session-corruption-in-worktrees.md`
- `docs/troubleshooting/staging-state-restore-warning.md`
- `docs/troubleshooting/worktree-session-fix-plan.md`

Fixes #298