### PR TITLE
fix: Display question text with choices in AskUserQuestion

### DIFF
--- a/lua/vibing/presentation/chat/modules/renderer.lua
+++ b/lua/vibing/presentation/chat/modules/renderer.lua
@@ -153,6 +153,12 @@ function M.addUserSection(buf, win, pendingChoices, pendingApproval)
   if pendingChoices then
     local choiceLines = {}
     for _, q in ipairs(pendingChoices) do
+      -- Add question text if available
+      if q.question and q.question ~= "" then
+        table.insert(choiceLines, q.question)
+        table.insert(choiceLines, "")
+      end
+
       -- Use numbered list for single-select, bullet list for multi-select
       -- Default to single-select (numbered list) when multiSelect is not explicitly true
       local useNumberedList = q.multiSelect ~= true


### PR DESCRIPTION
## 概要

AskUserQuestionで質問が表示されたときに、質問文も選択肢と一緒にUserセクションに表示されるように改善しました。

## 問題

以前は、Claudeが`AskUserQuestion`ツールを使って質問したときに、選択肢だけがUserセクションに表示されていました。これでは、ユーザーが何に答えているのか文脈が分かりにくい問題がありました。

**修正前の表示例:**
```markdown
## User

1. PostgreSQL
2. MySQL  
3. SQLite
```

## 解決策

質問文（`q.question`）を選択肢の前に表示するように修正しました。

**修正後の表示例:**
```markdown
## User

Which database should we use?

1. PostgreSQL
2. MySQL
3. SQLite
```

## 変更内容

- `lua/vibing/presentation/chat/modules/renderer.lua`の`addUserSection`関数を修正
- 質問文が存在する場合、選択肢の前に表示
- 質問文と選択肢の間に空行を挿入して読みやすく
- nil安全性を確保（質問文が空の場合は表示しない）

## テスト

- ビルド成功
- 既存テスト成功

## チェックリスト

- [x] ビルドが成功することを確認
- [x] 既存テストが通ることを確認
- [x] nil安全性を確保

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat display to now show question text before options in choice prompts, with proper spacing for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->