### PR TITLE
docs: add Claude Code CLI comparison analysis

### DIFF
--- a/docs/research/claudecode-cli-comparison.md
+++ b/docs/research/claudecode-cli-comparison.md
@@ -1,0 +1,495 @@
+# Claude Code CLI vs vibing.nvim 比較分析レポート
+
+**作成日:** 2026-01-17
+**調査対象:** Claude Code CLI 最新機能 (2026年版) と vibing.nvim
+
+---
+
+## 📊 エグゼクティブサマリー
+
+### vibing.nvimの独自の強み（維持すべき価値）
+
+1. **🎯 Neovimネイティブ統合** - Vimバッファ、ウィンドウ、キーマップとの完全統合
+2. **🔍 リアルタイムLSPアクセス** - 実行中のNeovim LSPサーバーに直接接続
+3. **🌳 Git Worktree統合** - ブランチごとの自動セットアップと永続的なチャット履歴
+4. **⚡ バックグラウンドLSP分析** - ウィンドウ切り替えなしでコード解析
+5. **🎨 Vimネイティブなワークフロー** - dd/gd/gfなどのVimキーバインディング活用
+
+### Claude Code CLIから学ぶべき機能（優先度順）
+
+1. **🔴 高優先度**
+   - Hooks System（PreToolUse/PostToolUse/SessionStart等）
+   - Context Auto-Summarization（コンテキスト上限時の自動要約）
+   - Long-term Project Memory（プロジェクト固有知識の永続化）
+
+2. **🟡 中優先度**
+   - MCP Tool Lazy Loading（コンテキスト使用量削減）
+   - Keyboard Shortcuts拡張（rewind menu、auto-accept mode等）
+   - Permission Pattern Enhancement（ワイルドカード `npm *` 等）
+
+3. **🟢 低優先度**
+   - Image Support（画像ペースト）
+   - Export/Share機能（会話の共有）
+   - Plugin Marketplace（コミュニティプラグイン）
+
+---
+
+## 🔍 詳細比較分析
+
+### 1. Neovim統合 vs ターミナルREPL
+
+#### vibing.nvimの強み ✅
+
+**ネイティブNeovim統合:**
+- **バッファシステム統合** - チャット、diff、outputはすべてNeovimバッファ
+- **ウィンドウ管理** - split/vsplit/float/tabなどVimネイティブなレイアウト
+- **キーマップ** - `gd`（diff viewer）、`gf`（ファイルオープン）、`dd`（選択削除）
+- **ビジュアルモード** - `:'<,'>VibingInline` で選択範囲を直接処理
+- **カーソル・セレクション** - リアルタイムでNeovimのカーソル位置とビジュアルセレクションにアクセス
+
+**例:**
+```lua
+-- チャット中にgdでdiffビューアを開く
+-- ファイルパス上でgfでファイルを開く
+-- ddで不要なAskUserQuestionオプションを削除
+```
+
+**Claude Code CLIの特徴:**
+- ターミナルREPL形式
+- VS Code/JetBrainsプラグイン経由でエディタ統合
+- ターミナルUI（Rich UI）
+
+**結論:**
+vibing.nvimはNeovimユーザーにとって**完全にネイティブな体験**を提供。Claude Code CLIはエディタ非依存だが、Neovim統合の深さでは劣る。
+
+---
+
+### 2. LSP統合
+
+#### vibing.nvimの独自の価値 ✅
+
+**リアルタイムNeovim LSPアクセス:**
+- **実行中のLSPサーバーに直接接続** - Serenなどの外部LSPツールは別プロセスでファイルを解析
+- **バックグラウンドLSP分析** - `nvim_load_buffer` でウィンドウを切り替えずにLSP解析
+- **複数バッファ解析** - チャット中に複数ファイルをバックグラウンドで解析可能
+
+```javascript
+// ウィンドウ切り替えなしでLSP分析
+const { bufnr } = await use_mcp_tool('vibing-nvim', 'nvim_load_buffer', {
+  filepath: 'src/logger.ts',
+});
+
+const calls = await use_mcp_tool('vibing-nvim', 'nvim_lsp_call_hierarchy_incoming', {
+  bufnr: bufnr,
+  line: 2,
+  col: 4,
+});
+// チャットウィンドウに留まったまま、logger.tsのLSPデータを取得
+```
+
+**利用可能なLSPツール:**
+- `nvim_lsp_definition` - 定義ジャンプ
+- `nvim_lsp_references` - 参照一覧
+- `nvim_lsp_hover` - ホバー情報
+- `nvim_diagnostics` - エラー/警告
+- `nvim_lsp_document_symbols` - シンボル一覧
+- `nvim_lsp_call_hierarchy_incoming/outgoing` - 呼び出し階層
+
+**Claude Code CLIの特徴:**
+- IDE統合（VS Code/JetBrains）でLSP情報を共有
+- ただし、NeovimのようなリアルタイムRPCアクセスはない
+
+**結論:**
+vibing.nvimは**実行中のNeovim状態に直接アクセス可能**。これはClaude Code CLIには真似できない独自の強み。
+
+---
+
+### 3. Git Worktree統合
+
+#### vibing.nvimの独自機能 ✅
+
+**`:VibingChatWorktree` の自動セットアップ:**
+- **設定ファイルのコピー** - `.gitignore`, `package.json`, `tsconfig.json` 等
+- **node_modules symlink** - 重複インストールを回避
+- **チャット履歴の永続化** - `.vibing/worktrees/<branch>/` に保存（worktree削除後も残る）
+- **既存worktreeの再利用** - 環境を再構築せずに再利用
+
+```vim
+:VibingChatWorktree right feature-auth
+" → .worktrees/feature-auth/ にworktree作成
+" → チャット履歴は .vibing/worktrees/feature-auth/ に保存
+" → node_modulesはメインworktreeへのsymlink
+```
+
+**Claude Code CLIの特徴:**
+- Git worktree自体はサポート（手動で `git worktree add`）
+- 自動セットアップやチャット履歴の永続化はない
+
+**結論:**
+vibing.nvimの **Git Worktree統合は他にない独自機能**。ブランチごとの隔離された開発環境とチャット履歴管理が可能。
+
+---
+
+### 4. Hooks System
+
+#### Claude Code CLIの強み ❌ (vibing.nvimに未実装)
+
+**利用可能なフック:**
+- **PreToolUse** - ツール実行前（追加コンテキストを返せる）
+- **PostToolUse** - ツール実行後
+- **UserPromptSubmit** - ユーザープロンプト送信時
+- **Stop** - エージェント終了時
+- **SessionStart** - セッション開始時（`agent_type` フィールド付き）
+- **PermissionRequest** - パーミッション要求時
+
+**特徴:**
+- **並列実行** - マッチするフックは並列実行
+- **重複排除** - 同じコマンドは自動で重複排除
+- **タイムアウト** - 10分の実行制限
+
+**使用例:**
+```json
+{
+  "hooks": [
+    {
+      "event": "PreToolUse",
+      "command": "echo 'Adding context...' && cat project-context.md"
+    },
+    {
+      "event": "PostToolUse",
+      "command": "npm test"
+    }
+  ]
+}
+```
+
+**vibing.nvimへの実装提案:** 🔴 **高優先度**
+
+```lua
+require("vibing").setup({
+  hooks = {
+    pre_tool_use = {
+      { event = "Edit", command = "echo 'About to edit file'" },
+    },
+    post_tool_use = {
+      { event = "Write", command = "npm run lint" },
+    },
+    session_start = {
+      { command = "echo 'Session started'" },
+    },
+  },
+})
+```
+
+**実装方法:**
+1. `config.hooks` セクションを追加
+2. Agent Wrapper側でフックイベントをサポート
+3. Neovim側で `vim.system()` でフックコマンドを実行
+4. フック結果をAgent SDKに返す
+
+---
+
+### 5. Long-term Project Memory
+
+#### Claude Code CLIの強み ❌ (vibing.nvimに未実装)
+
+**機能:**
+- **プロジェクト固有知識の永続化** - アーキテクチャ決定、スタイルガイド等
+- **セッションをまたいだ知識共有** - 前回の会話内容を参照
+- **コンテキストコスト削減** - 再アップロード不要
+
+**vibing.nvimへの実装提案:** 🔴 **高優先度**
+
+```lua
+-- 実装案
+require("vibing").setup({
+  memory = {
+    enabled = true,
+    storage = ".vibing/memory/",  -- プロジェクトメモリの保存場所
+  },
+})
+```
+
+**スラッシュコマンド:**
+```vim
+/remember <key> <value>  " メモリに保存
+/recall <key>            " メモリから取得
+/memories                " すべてのメモリを表示
+```
+
+**実装方法:**
+1. `.vibing/memory/` ディレクトリにJSON/Markdownで保存
+2. セッション開始時に自動ロード
+3. `/remember` でユーザーが明示的に保存
+4. Agent SDKのコンテキストに自動追加
+
+---
+
+### 6. Context Auto-Summarization
+
+#### Claude Code CLIの強み ❌ (vibing.nvimに未実装)
+
+**機能:**
+- **コンテキスト上限検知** - トークン数が上限に近づいたら自動検知
+- **自動要約** - 会話の自動要約で古い部分を圧縮
+- **無限会話** - 実質的に会話長の制限なし
+
+**現状のvibing.nvim:**
+- 手動で `/summarize` を実行
+
+**vibing.nvimへの実装提案:** 🔴 **高優先度**
+
+```lua
+require("vibing").setup({
+  context = {
+    auto_summarize = true,
+    threshold = 0.8,  -- 80%でトリガー
+    keep_recent_messages = 10,  -- 直近10メッセージは残す
+  },
+})
+```
+
+**実装方法:**
+1. Agent Wrapper側でトークン数を監視
+2. 80%到達時に自動で要約API呼び出し
+3. 要約結果をチャットバッファに挿入
+4. 古いメッセージを折りたたみ（Neovimの `foldmethod`）
+
+---
+
+### 7. MCP Tool Search / Lazy Loading
+
+#### Claude Code CLIの強み ❌ (vibing.nvimに部分実装)
+
+**機能:**
+- **MCPツールの遅延ロード** - 必要になったときだけツールを有効化
+- **コンテキスト使用量95%削減** - 数百のMCPツールがあっても問題なし
+- **auto:N syntax** - 自動有効化の閾値設定（N = 0-100%）
+
+**現状のvibing.nvim:**
+- vibing-nvim MCP serverは常時有効
+- ただし、ユーザーのカスタムMCPサーバーは `settingSources: ['user', 'project']` で自動ロード
+
+**vibing.nvimへの実装提案:** 🟡 **中優先度**
+
+現状でも問題ないが、将来的に多数のMCPツールを提供する場合は考慮が必要。
+
+```lua
+require("vibing").setup({
+  mcp = {
+    enabled = true,
+    lazy_loading = true,  -- 遅延ロード有効化
+    auto_enable_threshold = 50,  -- 50%以下のコンテキスト使用率で自動有効化
+  },
+})
+```
+
+---
+
+### 8. UI/UX機能
+
+#### vibing.nvimの強み ✅
+
+**Vimネイティブなワークフロー:**
+
+1. **AskUserQuestion/Tool Approval**
+   - `dd` で不要なオプションを削除
+   - Vim editing commandsで選択
+   - `<CR>` で送信
+
+2. **Rich UI Picker（`:VibingInline`）**
+   - Split-panel UI（左: アクションメニュー、右: 追加指示）
+   - `j`/`k` でナビゲーション
+   - `Tab`/`Shift-Tab` でパネル間移動
+   - `Enter` で実行
+
+3. **Diff Viewer**
+   - ファイルパス上で `gd` でdiff表示
+   - vertical split diff view
+
+4. **File Open**
+   - ファイルパス上で `gf` でファイルを開く
+
+5. **UIアニメーション**
+   - グラデーション効果（レスポンス中）
+   - カスタマイズ可能な色とインターバル
+
+**Claude Code CLIの特徴:**
+
+1. **Keyboard Shortcuts**
+   - `Esc + Esc` - Rewind menu
+   - `Ctrl+R` - Full output/context view
+   - `Ctrl+V` - Paste images
+   - `Shift+Tab` - Auto-accept mode toggle
+   - `Shift+Tab+Tab` - Plan mode
+   - `Ctrl+G` - External editor
+
+2. **Rich Terminal UI**
+   - ターミナルベースのUI
+   - `j`/`k` navigation
+   - `Tab`/`Shift+Tab` でパネル移動
+
+**vibing.nvimへの実装提案:** 🟡 **中優先度**
+
+```lua
+-- 追加すべきキーマップ
+vim.keymap.set("n", "<leader>vr", ":VibingRewind<CR>", { desc = "Rewind chat history" })
+vim.keymap.set("n", "<leader>vc", ":VibingContextView<CR>", { desc = "View full context" })
+vim.keymap.set("n", "<leader>va", ":VibingToggleAutoAccept<CR>", { desc = "Toggle auto-accept mode" })
+```
+
+**実装機能:**
+- **`:VibingRewind`** - チャット履歴を巻き戻し（特定のメッセージから再開）
+- **`:VibingContextView`** - 現在のコンテキスト全体を表示
+- **`:VibingToggleAutoAccept`** - パーミッション自動承認モードの切り替え
+
+---
+
+### 9. Permission System
+
+#### 両者の比較
+
+| 機能 | vibing.nvim | Claude Code CLI |
+|------|-------------|-----------------|
+| Permission Modes | ✅ `default`, `acceptEdits`, `bypassPermissions` | ✅ `default`, `acceptEdits`, `plan`, `bypassPermissions` |
+| Allow/Deny Lists | ✅ Tool-level | ✅ Tool-level |
+| Granular Rules | ✅ Paths, commands, patterns, domains | ✅ Paths, patterns |
+| Wildcard Patterns | ⚠️ Regex only | ✅ `npm *`, `git * main` |
+| Interactive Builder | ✅ `/permissions` command | ✅ `/permissions` command |
+| Session-level Permissions | ✅ `allow_for_session`, `deny_for_session` | ✅ Session-level |
+
+**vibing.nvimへの改善提案:** 🟡 **中優先度**
+
+```lua
+-- ワイルドカードパターンのサポート
+require("vibing").setup({
+  permissions = {
+    rules = {
+      {
+        tools = { "Bash" },
+        commands = { "npm *", "git * main" },  -- ワイルドカードサポート
+        action = "allow",
+      },
+    },
+  },
+})
+```
+
+**実装方法:**
+1. コマンドマッチングに `*` ワイルドカードを追加
+2. `npm *` → `^npm\s+.*$` に変換
+3. `git * main` → `^git\s+\S+\s+main$` に変換
+
+---
+
+### 10. その他の機能比較
+
+| 機能 | vibing.nvim | Claude Code CLI | 優先度 |
+|------|-------------|-----------------|--------|
+| Image Support | ❌ | ✅ `Ctrl+V` | 🟢 低 |
+| Export/Share | ❌ | ✅ `/export` | 🟢 低 |
+| Plugin Marketplace | ❌ | ✅ Official + Community | 🟢 低 |
+| Browser Integration | ❌ | ✅ `--chrome` | 🟢 低（Neovimプラグインには不要） |
+| Message Timestamps | ✅ 自動タイムスタンプ | ❌ | ✅ vibing独自 |
+| Tool Result Display | ✅ `none/compact/full` | ❌ | ✅ vibing独自 |
+| Concurrent Sessions | ✅ 複数チャット + inline queue | ✅ | ✅ 両方サポート |
+| Slash Commands | ✅ `/context`, `/mode`, `/permissions` etc | ✅ Built-in + Custom | ✅ 両方サポート |
+
+---
+
+## 📋 実装ロードマップ
+
+### Phase 1: 高優先度機能（3-6ヶ月）
+
+1. **Hooks System** 🔴
+   - `config.hooks` セクション追加
+   - PreToolUse/PostToolUse/SessionStart実装
+   - Agent Wrapper側のフックサポート
+
+2. **Context Auto-Summarization** 🔴
+   - トークン数監視
+   - 自動要約トリガー（80%閾値）
+   - 折りたたみ機能
+
+3. **Long-term Project Memory** 🔴
+   - `.vibing/memory/` ストレージ
+   - `/remember`, `/recall` スラッシュコマンド
+   - セッション開始時の自動ロード
+
+### Phase 2: 中優先度機能（6-12ヶ月）
+
+4. **Keyboard Shortcuts拡張** 🟡
+   - `:VibingRewind` - チャット履歴巻き戻し
+   - `:VibingContextView` - フルコンテキスト表示
+   - `:VibingToggleAutoAccept` - auto-accept mode
+
+5. **MCP Tool Lazy Loading** 🟡
+   - 遅延ロード実装
+   - `auto:N` syntax サポート
+
+6. **Permission Pattern Enhancement** 🟡
+   - ワイルドカードパターン（`npm *`）
+   - より柔軟なコマンドマッチング
+
+### Phase 3: 低優先度機能（将来的に）
+
+7. **Image Support** 🟢
+   - Neovimクリップボードから画像検出
+   - base64エンコードしてAgent SDKに送信
+
+8. **Export/Share** 🟢
+   - `/export` スラッシュコマンド
+   - 共有用にMarkdownクリーンアップ
+
+9. **Plugin System** 🟢
+   - Luarocks/GitHubベースのプラグインシステム
+   - `:VibingPlugins` コマンド
+
+---
+
+## 🎯 結論
+
+### vibing.nvimが維持すべき独自の価値
+
+1. **Neovimエコシステムとの深い統合**
+   - バッファ、ウィンドウ、キーマップのネイティブサポート
+   - Vimワークフロー（dd/gd/gf）の活用
+
+2. **リアルタイムNeovim状態へのアクセス**
+   - 実行中のLSPサーバーへの直接接続
+   - バックグラウンドLSP分析（ウィンドウ切り替えなし）
+   - カーソル/セレクション/ビューポート情報
+
+3. **Git Worktree統合**
+   - 自動セットアップと永続的なチャット履歴
+   - ブランチごとの隔離された開発環境
+
+4. **Vimネイティブなワークフロー**
+   - dd/gd/gfキーマップ
+   - Rich UI Picker（split-panel）
+   - AskUserQuestion/Tool ApprovalのVim編集フロー
+
+### Claude Code CLIから学ぶべき機能
+
+1. **高優先度** 🔴
+   - **Hooks System** - ツール実行前後のカスタマイズ
+   - **Context Auto-Summarization** - 無限会話を可能に
+   - **Long-term Project Memory** - プロジェクト知識の永続化
+
+2. **中優先度** 🟡
+   - MCP Tool Lazy Loading
+   - Keyboard Shortcuts拡張
+   - Permission Pattern Enhancement
+
+3. **低優先度** 🟢
+   - Image Support、Export/Share、Plugin Marketplace
+
+### 最終的な位置づけ
+
+**vibing.nvim = Neovimユーザーのための最高のClaude統合**
+
+- **強み:** Neovimエコシステムとの完全統合、リアルタイムLSPアクセス、Vimネイティブなワークフロー
+- **差別化要素:** Claude Code CLIには真似できないNeovim専用機能
+- **改善点:** HooksやMemoryなどのエージェント機能を追加して、よりパワフルに
+
+vibing.nvimは**Neovimユーザー専用の特化ツール**として、Claude Code CLIとは異なる価値を提供し続けるべき。


### PR DESCRIPTION
Add comprehensive comparison report between Claude Code CLI and vibing.nvim:

**vibing.nvim's unique strengths:**
- Native Neovim integration (buffers, windows, keymaps)
- Real-time LSP access to running Neovim instance
- Background LSP analysis without window switching
- Git worktree integration with auto-setup
- Vim-native workflow (dd/gd/gf keybindings)

**Should implement from Claude Code CLI (priority order):**

High priority:
- Hooks System (PreToolUse/PostToolUse/SessionStart)
- Context Auto-Summarization (automatic when reaching limit)
- Long-term Project Memory (persistent project knowledge)

Medium priority:
- MCP Tool Lazy Loading (95% context reduction)
- Extended keyboard shortcuts (rewind, auto-accept mode)
- Permission pattern enhancement (wildcards like `npm *`)

Low priority:
- Image support, export/share, plugin marketplace

**Conclusion:**
vibing.nvim should maintain its position as "the best Claude integration
for Neovim users" with deep Neovim ecosystem integration while adding
agent features (Hooks, Memory, Auto-Summarization) for more power.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed research documentation with feature-by-feature analysis, prioritized implementation roadmaps, and strategic enhancement guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->