### PR TITLE
fix: remove self-development assumption and simplify system prompt

### DIFF
--- a/bin/lib/prompt-builder.ts
+++ b/bin/lib/prompt-builder.ts
@@ -94,9 +94,11 @@ You are running inside vibing.nvim, a Neovim plugin with Claude Code integration
 
 Key capabilities:
 - \`:VibingChatWorktree <branch>\` - Create git worktree with auto-setup (preferred over manual \`git worktree\`)
-- \`mcp__vibing-nvim__nvim_lsp_*\` - LSP operations on running Neovim instance (preferred over Serena)
+- \`mcp__vibing-nvim__nvim_lsp_*\` - LSP operations on running Neovim instance
+  Connects to live LSP, not stale files. Use \`nvim_load_buffer\` for background analysis without window switching.
+  Preferred over Serena LSP tools.
 - \`mcp__vibing-nvim__nvim_*\` - Buffer/window operations
-- \`AskUserQuestion\` - Ask clarifying questions when uncertain (use proactively)
+- \`AskUserQuestion\` - Ask questions when uncertain; user deletes unwanted choices and presses Enter (use proactively)
 
 For command details or usage examples, ask the user.
 </vibing-nvim-system>


### PR DESCRIPTION
## 概要

他のプロジェクトで vibing.nvim を使用したときに、vibing.nvim 自身の開発だと誤解釈される問題を修正しました。

## 問題

- vibing.nvim のシステムプロンプトに「You are working on vibing.nvim itself」という記述があった
- 170行の詳細なガイドラインがプロジェクト固有の CLAUDE.md を圧倒していた
- 他のプロジェクトでも vibing.nvim の開発と誤解釈されていた

## 解決策

### 1. Self-Development Context の削除 (bf82b15)
- 「vibing.nvim 自体の開発」という決めつけを削除
- 一般的な "Best Practices" に置き換え
- 表現を柔軟化：CRITICAL/NEVER → GUIDELINE/AVOID

### 2. システムプロンプトの大幅削減 (d658315)
- 170行 → 10行に削減
- バンドルサイズ：28.7kb → 22.1kb
- 詳細はユーザーに質問する方針に

## 変更後のシステムプロンプト

```
You are running inside vibing.nvim, a Neovim plugin with Claude Code integration.

Key capabilities:
- :VibingChatWorktree <branch> - Create git worktree with auto-setup
- mcp__vibing-nvim__nvim_lsp_* - LSP operations on running Neovim instance
- mcp__vibing-nvim__nvim_* - Buffer/window operations
- AskUserQuestion - Ask clarifying questions when uncertain

For command details or usage examples, ask the user.
```

## 期待される効果

- ✅ 他のプロジェクトで使用時、そのプロジェクトに集中できる
- ✅ プロジェクト固有の CLAUDE.md が優先される
- ✅ vibing.nvim は控えめな存在に（必要なときだけ機能提供）
- ✅ バンドルサイズの削減

## テスト

- ✅ ビルド成功
- ✅ 基本動作確認
- ✅ フォーマットチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined vibing.nvim system prompt with simplified guidance structure and clearer capabilities overview.
  * Updated language instruction handling in prompt generation.
  * Reduced redundant documentation sections in system prompts while retaining core functionality information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->