### PR TITLE
fix: cancel Agent SDK process immediately on approval_required event

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -23,6 +23,7 @@ local GradientAnimation = require("vibing.ui.gradient_animation")
 ---@field get_session_deny fun(): table セッションレベルの拒否リストを取得
 ---@field clear_handle_id fun() handle_idをクリア
 ---@field set_handle_id fun(handle_id: string) handle_idを設定
+---@field get_handle_id fun(): string|nil handle_idを取得
 ---@field get_cwd fun(): string|nil worktreeのcwdを取得
 
 ---メッセージを送信
@@ -109,6 +110,12 @@ function M.execute(adapter, callbacks, message, config)
       on_approval_required = function(tool, input, options)
         vim.schedule(function()
           callbacks.insert_approval_request(tool, input, options)
+
+          -- Cancel the current request immediately
+          local handle_id = callbacks.get_handle_id()
+          if handle_id then
+            adapter:cancel(handle_id)
+          end
         end)
       end,
     }

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -162,8 +162,8 @@ function ChatBuffer:_setup_keymaps()
     end,
     cancel = function()
       local adapter = vibing.get_adapter()
-      if adapter then
-        adapter:cancel()
+      if adapter and self._current_handle_id then
+        adapter:cancel(self._current_handle_id)
       end
     end,
     update_context_line = function()
@@ -428,6 +428,9 @@ function ChatBuffer:send_message()
     end,
     set_handle_id = function(handle_id)
       self._current_handle_id = handle_id
+    end,
+    get_handle_id = function()
+      return self._current_handle_id
     end,
     get_cwd = function()
       return self:get_cwd()


### PR DESCRIPTION
## Summary

`approval_required`イベント受信時に、Agent SDKプロセスを即座にキャンセルするように修正しました。これにより、Tool Approval UIが期待通りのタイミング（Claudeのレスポンス完了を待たずに）で表示されるようになります。

## 問題

現在の実装では：
1. `approval_required`イベントが送信される
2. `canUseTool`が`deny()`を返す
3. しかし**Agent SDKのストリームは継続**
4. Claudeが他のタスクを続ける
5. 最終的にレスポンス完了後、Tool Approval UIが表示される

これにより、ユーザーは承認を求められる前に、Claudeが別の作業を続けてしまう問題がありました。

## 解決策

`on_approval_required`コールバック内で、`adapter:cancel(handle_id)`を呼び出して**プロセスを即座に停止**します：

```lua
on_approval_required = function(tool, input, options)
  vim.schedule(function()
    callbacks.insert_approval_request(tool, input, options)

    -- Cancel the current request immediately
    local handle_id = callbacks.get_handle_id()
    if handle_id then
      adapter:cancel(handle_id)
    end
  end)
end,
```

## 変更内容

### 1. `get_handle_id`コールバックの追加
- `ChatBuffer:send_message()`に`get_handle_id`コールバックを追加
- 現在の`handle_id`を取得できるようにする

### 2. `on_approval_required`での即座のキャンセル
- `approval_required`イベント受信時に、現在の`handle_id`を使ってプロセスをキャンセル
- これにより、Claudeのレスポンス継続を即座に停止

### 3. `Ctrl-C`キャンセルの改善
- グローバルキャンセルから、特定の`handle_id`を指定したキャンセルに変更
- 複数チャットセッション実行時の相互干渉を防止

## 動作の変化

**変更前:**
```
approval_required → UIキュー → Claude継続 → レスポンス完了 → UI表示
```

**変更後:**
```
approval_required → プロセスキャンセル → UI即座に表示 → ユーザー承認 → 新規リクエスト
```

## テスト

- ✅ ビルド成功（`npm run build`）
- ✅ Lua構文チェック成功（`npm run check`）
- ✅ フォーマットチェック成功

## 参考

- ADR 005: AskUserQuestion Tool UX Design - `deny()`でClaudeを待機状態にする設計思想
- `Ctrl-C`キャンセルの既存実装 - `adapter:cancel(handle_id)`の使用例

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request cancellation in approval flows to properly terminate active in-flight requests
  * Improved handle ID tracking for more reliable request management during cancellation operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->