### PR TITLE
feat: auto-update daily summary links when renaming chat files

### DIFF
--- a/lua/vibing/application/link/sync_manager.lua
+++ b/lua/vibing/application/link/sync_manager.lua
@@ -1,0 +1,50 @@
+---@class Vibing.Application.Link.SyncManager
+local M = {}
+
+local notify = require("vibing.core.utils.notify")
+
+---@class Vibing.Application.Link.SyncResult
+---@field total number
+---@field updated number
+---@field failed number
+
+---@param old_path string
+---@param new_path string
+---@param scanners Vibing.Infrastructure.Link.Scanner[]
+---@param base_dir string
+---@return Vibing.Application.Link.SyncResult
+function M.sync_links(old_path, new_path, scanners, base_dir)
+  local total_updated = 0
+  local total_failed = 0
+  local total_scanned = 0
+
+  for _, scanner in ipairs(scanners) do
+    local files = scanner:find_target_files(base_dir)
+
+    for _, file in ipairs(files) do
+      total_scanned = total_scanned + 1
+
+      if scanner:contains_link(file, old_path) then
+        local success, err = scanner:update_link(file, old_path, new_path)
+
+        if success then
+          total_updated = total_updated + 1
+        else
+          total_failed = total_failed + 1
+          notify.error(
+            string.format("Failed to update %s: %s", vim.fn.fnamemodify(file, ":."), err or "unknown"),
+            "Link Sync"
+          )
+        end
+      end
+    end
+  end
+
+  return {
+    total = total_scanned,
+    updated = total_updated,
+    failed = total_failed,
+  }
+end
+
+return M

--- a/lua/vibing/infrastructure/link/daily_summary_scanner.lua
+++ b/lua/vibing/infrastructure/link/daily_summary_scanner.lua
@@ -1,0 +1,96 @@
+---@class Vibing.Infrastructure.Link.DailySummaryScanner : Vibing.Infrastructure.Link.Scanner
+local DailySummaryScanner = {}
+DailySummaryScanner.__index = DailySummaryScanner
+
+local Scanner = require("vibing.infrastructure.link.scanner")
+setmetatable(DailySummaryScanner, { __index = Scanner })
+
+---@return Vibing.Infrastructure.Link.DailySummaryScanner
+function DailySummaryScanner.new()
+  return setmetatable({}, DailySummaryScanner)
+end
+
+---@param base_dir string
+---@return string
+local function get_daily_summary_dir(base_dir)
+  -- base_dirがすでにdaily summaryディレクトリを指している場合はそのまま返す
+  -- （例: ObsidianVaultのように直接daily summaryディレクトリが設定されている場合）
+  if base_dir:match("/daily/?$") or base_dir:match("/Daily/?$") then
+    return base_dir:match("/$") and base_dir or (base_dir .. "/")
+  end
+
+  -- chat保存ディレクトリから派生する場合
+  if base_dir:match("/chat/$") then
+    return base_dir:gsub("/chat/$", "/daily/")
+  end
+
+  return base_dir .. "daily/"
+end
+
+---@param base_dir string
+---@return string[]
+function DailySummaryScanner:find_target_files(base_dir)
+  local daily_dir = get_daily_summary_dir(base_dir)
+
+  if vim.fn.isdirectory(daily_dir) == 0 then
+    return {}
+  end
+
+  return vim.fn.glob(daily_dir .. "*.md", false, true)
+end
+
+---@param file_path string
+---@param target_path string
+---@return boolean
+function DailySummaryScanner:contains_link(file_path, target_path)
+  local ok, content = pcall(vim.fn.readfile, file_path)
+  if not ok or not content or #content == 0 then
+    return false
+  end
+
+  local target_tilde = vim.fn.fnamemodify(target_path, ":p:~")
+
+  for _, line in ipairs(content) do
+    if line:find(target_tilde, 1, true) then
+      return true
+    end
+  end
+
+  return false
+end
+
+---@param file_path string
+---@param old_path string
+---@param new_path string
+---@return boolean success
+---@return string? error
+function DailySummaryScanner:update_link(file_path, old_path, new_path)
+  local ok, lines = pcall(vim.fn.readfile, file_path)
+  if not ok or not lines then
+    return false, string.format("Failed to read file: %s", lines or "unknown")
+  end
+
+  local old_tilde = vim.fn.fnamemodify(old_path, ":p:~")
+  local new_tilde = vim.fn.fnamemodify(new_path, ":p:~")
+
+  local updated = false
+  for i, line in ipairs(lines) do
+    if line:find(old_tilde, 1, true) then
+      lines[i] = line:gsub(vim.pesc(old_tilde), new_tilde)
+      updated = true
+    end
+  end
+
+  if not updated then
+    return true, nil
+  end
+
+  local result = vim.fn.writefile(lines, file_path)
+  if result ~= 0 then
+    return false, string.format("Failed to write file: %s", vim.v.errmsg or "unknown")
+  end
+
+  return true, nil
+end
+
+return DailySummaryScanner

--- a/lua/vibing/infrastructure/link/scanner.lua
+++ b/lua/vibing/infrastructure/link/scanner.lua
@@ -1,0 +1,27 @@
+---@class Vibing.Infrastructure.Link.Scanner
+local Scanner = {}
+Scanner.__index = Scanner
+
+---@param base_dir string
+---@return string[]
+function Scanner:find_target_files(base_dir)
+  error("Must be implemented by subclass")
+end
+
+---@param file_path string
+---@param target_path string
+---@return boolean
+function Scanner:contains_link(file_path, target_path)
+  error("Must be implemented by subclass")
+end
+
+---@param file_path string
+---@param old_path string
+---@param new_path string
+---@return boolean success
+---@return string? error
+function Scanner:update_link(file_path, old_path, new_path)
+  error("Must be implemented by subclass")
+end
+
+return Scanner


### PR DESCRIPTION
## 概要

issue #364を実装し、`:VibingSetFileTitle`でチャットファイルをリネームした際に、daily summaryファイル内のファイルパス参照を自動的に更新する機能を追加しました。

## アーキテクチャ

- **拡張可能なScannerインターフェースパターン**を導入し、将来的なリンクタイプの追加に対応
- DailySummaryScannerでdaily summaryファイルのリンク更新を実装
- SyncManagerで複数のスキャナーを統合的に管理

## 主な機能

- ファイルリネーム時のリアルタイムリンク同期
- カスタムdaily summaryディレクトリのサポート（例: ObsidianVault）
- `/daily/`または`/Daily/`ディレクトリをすでに指しているパスの適切な処理
- 部分更新のサポートと詳細なエラー報告
- 移植性の高いチルダパス形式の使用

## 変更内容

### 新規追加ファイル

- `lua/vibing/infrastructure/link/scanner.lua` - 抽象インターフェース（27行）
- `lua/vibing/infrastructure/link/daily_summary_scanner.lua` - 具象実装（96行）
- `lua/vibing/application/link/sync_manager.lua` - オーケストレーション（50行）

### 修正ファイル

- `lua/vibing/application/chat/handlers/set_file_title.lua` - リンク同期の統合

## テスト

- ObsidianVaultの実環境でdaily summaryファイルのリンク更新を確認済み
- 既存のbuild/lint/format checkすべてパス

Closes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat file renaming now automatically synchronizes related references in daily summary files, with notifications reporting sync completion and any failures.

* **Improvements**
  * Enhanced file save and rename workflow for improved reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->