### PR TITLE
refactor: nest mote config under diff section

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -269,12 +269,12 @@ end
 ---@param session_cwd string|nil worktreeのcwd（worktreeで作業する場合のみ、worktree判定用）
 ---@return table|nil セッション固有のmote設定（mote未設定の場合nil）
 function M._create_session_mote_config(config, session_id, bufnr, session_cwd)
-  if not config.mote then
+  if not config.diff or not config.diff.mote then
     return nil
   end
 
   local MoteDiff = require("vibing.core.utils.mote_diff")
-  local mote_config = vim.deepcopy(config.mote)
+  local mote_config = vim.deepcopy(config.diff.mote)
 
   -- mote v0.2.4: --project/--context APIを使用
   -- プロジェクト名（設定 or 自動検出）

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -263,9 +263,12 @@ M.defaults = {
     open_diff = "gd",
     open_file = "gf",
   },
-  mote = {
-    project = nil,  -- nil = auto-detect from git repo name
-    context_prefix = "vibing",
+  diff = {
+    tool = "auto",
+    mote = {
+      project = nil,  -- nil = auto-detect from git repo name
+      context_prefix = "vibing",
+    },
   },
   preview = {
     enabled = false,
@@ -295,8 +298,8 @@ M.defaults = {
   },
 }
 
----@type Vibing.Config
-M.options = {}
+---@type Vibing.Config?
+M.options = nil
 
 ---Lazy.nvimのdevモードを検出
 ---vibing.nvimプラグインがLazy.nvimでdev=trueとして設定されているかチェック
@@ -543,10 +546,10 @@ end
 
 ---現在の設定を取得
 ---setup()で初期化された設定オブジェクトを返す
----setup()が未実行の場合は空のテーブルを返す
+---setup()が未実行の場合はデフォルト設定を返す
 ---@return Vibing.Config 現在の設定オブジェクト
 function M.get()
-  return M.options
+  return M.options or M.defaults
 end
 
 return M

--- a/lua/vibing/core/types.lua
+++ b/lua/vibing/core/types.lua
@@ -32,21 +32,7 @@
 ---@field execute fun(done: fun())
 ---@field cancel fun()?
 
----@class Vibing.PermissionRule
----@field tools string[]
----@field paths string[]?
----@field commands string[]?
----@field patterns string[]?
----@field domains string[]?
----@field action "allow"|"deny"
----@field message string?
-
----@class Vibing.PermissionConfig
----@field mode "default"|"acceptEdits"|"bypassPermissions"
----@field allow string[]?
----@field deny string[]?
----@field ask string[]?
----@field rules Vibing.PermissionRule[]?
+-- Vibing.PermissionRule and Vibing.PermissionsConfig are defined in config.lua
 
 ---@class Vibing.AdapterOpts
 ---@field streaming boolean?
@@ -67,16 +53,6 @@
 ---@field error string?
 ---@field _handle_id string?
 
----@class Vibing.WindowConfig
----@field position "current"|"right"|"left"|"float"
----@field width number
----@field border string?
-
----@class Vibing.ChatConfig
----@field window Vibing.WindowConfig
----@field auto_context boolean
----@field save_location_type "project"|"user"|"custom"
----@field save_dir string?
----@field context_position "prepend"|"append"
+-- Vibing.WindowConfig and Vibing.ChatConfig are defined in config.lua
 
 return {}

--- a/lua/vibing/core/utils/diff_selector.lua
+++ b/lua/vibing/core/utils/diff_selector.lua
@@ -9,7 +9,7 @@ local M = {}
 function M.show_diff(file_path, session_id, cwd)
   local config = require("vibing.config").get()
   local MoteDiff = require("vibing.core.utils.mote_diff")
-  local mote_config = vim.deepcopy(config.mote)
+  local mote_config = vim.deepcopy(config.diff.mote)
 
   -- mote v0.2.4: --project/--context APIを使用
   mote_config.project = mote_config.project or MoteDiff.get_project_name()


### PR DESCRIPTION
## Summary

- `mote` 設定を新しい `diff` セクション配下に移動
- `diff.tool` オプションを追加（"auto" | "git" | "mote"）
- `config.get()` を改善し、setup() 未実行時にデフォルト設定を返すように変更
- 型定義を `config.lua` に一元化し、`types.lua` の重複を削除

## 変更内容

### 設定構造の変更

```lua
-- Before
mote = {
  project = nil,
  context_prefix = "vibing",
}

-- After
diff = {
  tool = "auto",  -- "auto" | "git" | "mote"
  mote = {
    project = nil,
    context_prefix = "vibing",
  },
}
```

### config.get() の改善

```lua
-- Before: setup() 未実行時に空テーブルを返す
M.options = {}
return M.options

-- After: setup() 未実行時にデフォルト設定を返す
M.options = nil
return M.options or M.defaults
```

## BREAKING CHANGE

`mote` 設定がトップレベルから `diff.mote` に移動しました。既存の設定を使用している場合は更新が必要です。

## Test plan

- [ ] `npm run build` が成功することを確認
- [ ] mote diff が正常に動作することを確認（`gd` keymap）
- [ ] setup() 未実行時に `config.get()` がデフォルト値を返すことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized configuration structure with a new `diff` configuration section
  * Improved default configuration handling when initial setup is not executed
  * Moved type definitions for better code organization

* **New Features**
  * Added `diff.tool` configuration option for automatic tool selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->