### PR TITLE
fix: remove hardcoded READ_ONLY_TOOLS in plan mode to respect permissions_allow

### DIFF
--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -34,14 +34,6 @@ local INTERNAL_TOOLS = {
   NotebookEdit = true,
 }
 
-local READ_ONLY_TOOLS = {
-  Read = true,
-  Glob = true,
-  Grep = true,
-  LSP = true,
-  WebFetch = true,
-  WebSearch = true,
-}
 
 --- @class CanUseToolResult
 --- @field behavior "allow"|"deny"|"ask"
@@ -205,17 +197,6 @@ function M.can_use_tool(tool_name, input, config)
 
     if mode == "bypassPermissions" or mode == "dontAsk" then
       return allow(input)
-    end
-
-    if mode == "plan" then
-      if READ_ONLY_TOOLS[tool_name] then
-        return allow(input)
-      end
-      -- Also allow MCP read tools
-      if tool_name:match("^mcp__") and not tool_name:match("set_") and not tool_name:match("write_") then
-        return allow(input)
-      end
-      return ask()
     end
 
     if mode == "acceptEdits" and (tool_name == "Edit" or tool_name == "Write") then


### PR DESCRIPTION
## 概要

`permission_mode: plan` の時、`permissions_allow` に `Bash` が含まれていても `find`, `ls` 等の読み取り専用Bashコマンドで承認UIが表示されるバグを修正。

## 原因

`can_use_tool.lua` の `plan` モードハンドラがハードコードされた `READ_ONLY_TOOLS` テーブルでツールを判別し、それ以外を即座に `ask()` で返していた。`permissions_allow` リストを一切チェックしていなかった。

## 修正内容

- `READ_ONLY_TOOLS` テーブルを削除
- `plan` モード専用ハンドラを削除
- plan モードでも他のモードと同じ allow/ask/deny フローを通るように統一

planモードのツール制限は CLI 側（`--permission-mode plan`）が担い、vibing.nvim の hook はモードに関係なく allow/ask/deny リストのみを適用する設計に変更。

## 修正後の動作

| 設定 | 動作 |
|------|------|
| `Bash` が `permissions_allow` にある | allow |
| `Bash(rm:*)` が `permissions_ask` にある | `rm` コマンドだけ ask |
| `Bash` が `permissions_allow` にない | ask |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified permission evaluation in plan mode to follow standard permission checks instead of having special-case handling for read-only tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->