### PR TITLE
fix: remove extra blank lines before assistant response

### DIFF
--- a/lua/vibing/presentation/chat/modules/streaming_handler.lua
+++ b/lua/vibing/presentation/chat/modules/streaming_handler.lua
@@ -14,7 +14,6 @@ function M.start_response(buf)
     "",
     "## Assistant",
     "",
-    "",
   }
   vim.api.nvim_buf_set_lines(buf, #lines, #lines, false, new_lines)
 end
@@ -31,6 +30,11 @@ function M.flush_chunks(buf, win, chunk_buffer)
 
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   local last_line = lines[#lines] or ""
+
+  -- ヘッダー直後の空行に続く先頭改行を除去（余分な空行防止）
+  if last_line == "" and chunk_buffer:sub(1, 1) == "\n" then
+    chunk_buffer = chunk_buffer:gsub("^\n+", "")
+  end
 
   local chunk_lines = vim.split(chunk_buffer, "\n", { plain = true })
   chunk_lines[1] = last_line .. chunk_lines[1]


### PR DESCRIPTION
## Summary

- `## Assistant` ヘッダー後の空行を2行から1行に削減
- `flush_chunks` でAIレスポンスの先頭改行をトリミングする処理を追加
- これにより、Assistantの応答開始時に余分な空行が表示される問題を修正

## 原因

1. `start_response()` が `## Assistant` の後に空行を2行挿入していた
2. AIモデルのレスポンス自体が先頭に改行を含む場合があり、結果的に3行以上の空行になっていた

## Test plan

- [ ] チャットでメッセージを送信し、Assistantヘッダー後の空行が1行のみであることを確認
- [ ] 複数回メッセージを送信して、空行の数が一貫していることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue causing extra blank lines to appear after the Assistant message header when streaming chat responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->