### PR TITLE
fix: resolve plugin skill completion not appearing in chat buffer

### DIFF
--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -5,15 +5,19 @@
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { safeJsonStringify } from './lib/utils.js';
+import { loadInstalledPlugins } from './lib/plugin-loader.js';
 
 async function listCommands() {
   try {
+    const plugins = await loadInstalledPlugins();
+
     // Create a minimal query session to get access to supportedCommands()
     const result = query({
       prompt: 'list commands',
       options: {
         cwd: process.cwd(),
         settingSources: ['user', 'project'],
+        ...(plugins.length > 0 && { plugins }),
       },
     });
 

--- a/lua/vibing/infrastructure/completion/adapters/cmp.lua
+++ b/lua/vibing/infrastructure/completion/adapters/cmp.lua
@@ -34,7 +34,7 @@ function M.create()
   end
 
   function source:get_keyword_pattern()
-    return [[\%(@\%(file\|agent\):\)\?\k*]]
+    return [[\%(@\%(file\|agent\):\)\?[[:keyword:]:-]*]]
   end
 
   ---@param params table

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -87,8 +87,12 @@ local function get_dynamic_sdk_skills()
     return _bundled_cache
   end
 
-  -- Find the plugin directory
-  local plugin_dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h:h")
+  -- Find the plugin root directory by searching upward for package.json
+  local current_file = debug.getinfo(1, "S").source:sub(2)
+  local plugin_dir = vim.fs.root(current_file, "package.json")
+  if not plugin_dir then
+    return {}
+  end
   local list_commands_script = plugin_dir .. "/bin/list-commands.ts"
 
   -- Check if we should use TypeScript directly (dev mode) or compiled JS
@@ -98,8 +102,24 @@ local function get_dynamic_sdk_skills()
     return {}
   end
 
-  local executable = config.node and config.node.executable or "node"
   local dev_mode = config.node and config.node.dev_mode or false
+  local executable
+  if dev_mode then
+    executable = vim.fn.exepath("bun")
+    if executable == "" then
+      return {}
+    end
+  else
+    local configured = config.node and config.node.executable
+    if configured and configured ~= "auto" then
+      executable = configured
+    else
+      executable = vim.fn.exepath("node")
+      if executable == "" then
+        executable = "node"
+      end
+    end
+  end
   local script_path = list_commands_script
 
   if not dev_mode then


### PR DESCRIPTION
## Summary

プラグインスキル（例: `kintone-development:create-adr`）がチャットバッファのTab補完に表示されない問題を修正。

**根本原因**: `skills.lua` の `get_dynamic_sdk_skills()` でプラグインルートディレクトリのパス解決が誤っており、`:h` の数が足りず `lua/vibing/` を指していた。`dist/bin/list-commands.js` が見つからず、SDKスキル一覧の取得がサイレントに失敗していた。

**修正内容**:
- `vim.fs.root(file, "package.json")` による動的なルートディレクトリ解決に変更（ファイル移動に強い）
- `config.node.executable` の `"auto"` 値を `vim.fn.exepath("node")` で実際のパスに解決
- `list-commands.ts` に `loadInstalledPlugins()` を追加し、プラグインスキルも `supportedCommands()` に含まれるようにした
- nvim-cmp のキーワードパターンにハイフン・コロンを追加（`kintone-development:create-adr` 等のスキル名に対応）

## Test plan

- [ ] vibing.nvim のチャットバッファで `/` を入力し、プラグインスキルが補完候補に表示されることを確認
- [ ] `/kintone-` と入力して `kintone-development:create-adr` 等が候補に出ることを確認
- [ ] ユーザースキル（`~/.claude/skills/`）とプロジェクトスキル（`.claude/skills/`）も引き続き表示されることを確認
- [ ] `dev_mode = true`（bun）と `dev_mode = false`（node）の両方で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Skills provider now supports development and production modes with intelligent executable resolution

* **Improvements**
  - Installed plugins are now properly loaded when listing commands
  - Enhanced completion keyword pattern matching for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->