### PR TITLE
feat: apply frontmatter permissions to codex adapter via PreToolUse hook

### DIFF
--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -7,6 +7,8 @@ local CodexCommandBuilder = require("vibing.infrastructure.adapter.modules.codex
 local CodexEventProcessor = require("vibing.infrastructure.adapter.modules.codex_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
 local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
+local CodexSettingsGenerator = require("vibing.infrastructure.hooks.codex_settings_generator")
+local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
 
 ---@class Vibing.CodexCLIAdapter : Vibing.Adapter
 ---@field _handles table<string, table>
@@ -82,7 +84,13 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
     )
   end
 
-  local cmd = CodexCommandBuilder.build(prompt, opts, session_id, self.config)
+  local permission_mode = opts.permission_mode or "default"
+  local hook_args = nil
+  if permission_mode ~= "bypassPermissions" then
+    hook_args = CodexSettingsGenerator.get_hook_args()
+  end
+
+  local cmd = CodexCommandBuilder.build(prompt, opts, session_id, self.config, hook_args)
   local output = {}
   local error_output = {} -- filtered stderr (codex noise removed)
 
@@ -122,9 +130,21 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
     env.VIBING_NVIM_CONTEXT = "true"
   end
 
+  ActiveStreamRegistry.register({
+    handle_id = handle_id,
+    adapter = self,
+    on_insert_choices = opts.on_insert_choices,
+    on_approval_required = opts.on_approval_required,
+  })
+
+  local perm_handler = require("vibing.infrastructure.rpc.handlers.permission")
+  perm_handler.set_active_opts(vim.tbl_extend("force", opts, { _is_codex = true }))
+
   local wrapped_on_done = function(response)
     if not completed then
       completed = true
+      ActiveStreamRegistry.unregister(handle_id)
+      perm_handler.clear_active_opts()
       if timeout_timer then
         vim.fn.timer_stop(timeout_timer)
         timeout_timer = nil
@@ -172,6 +192,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
       if not received_first_response and not completed and self._handles[handle_id] then
         vim.schedule(function()
           if not completed then
+            completed = true
             vim.notify(
               "[vibing] Session resume timeout - killing hung process and resetting session",
               vim.log.levels.WARN

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -84,8 +84,9 @@ end
 --- @param opts Vibing.AdapterOpts Adapter options
 --- @param session_id string|nil Thread ID for session resumption
 --- @param config Vibing.Config Plugin config
+--- @param hook_args string[]|nil Optional -c flag pair for PreToolUse hook injection
 --- @return string[] Command array for vim.system()
-function M.build(prompt, opts, session_id, config)
+function M.build(prompt, opts, session_id, config, hook_args)
   if not cached_codex_path then
     cached_codex_path = vim.fn.exepath("codex")
     if cached_codex_path == "" then
@@ -102,6 +103,13 @@ function M.build(prompt, opts, session_id, config)
   end
 
   table.insert(cmd, "--json")
+
+  -- Hook injection for permission control
+  if hook_args then
+    for _, arg in ipairs(hook_args) do
+      table.insert(cmd, arg)
+    end
+  end
 
   -- Model selection
   local model = resolve_model(opts, config)

--- a/lua/vibing/infrastructure/hooks/codex_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/codex_settings_generator.lua
@@ -1,0 +1,21 @@
+--- Codex hook settings generator
+--- Provides -c arguments to inject PreToolUse hook into `codex exec`
+--- Reuses the same pre-tool-use.sh script as the Claude adapter
+--- @module vibing.infrastructure.hooks.codex_settings_generator
+
+local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+
+local M = {}
+
+--- Get -c arguments for injecting the PreToolUse hook into `codex exec`
+--- @return string[] Two-element array: {"-c", "hooks.pre_tool_use=[...]"}
+function M.get_hook_args()
+  local hook_script = SettingsGenerator.get_hook_script_path()
+  local escaped = hook_script:gsub("\\", "\\\\"):gsub('"', '\\"')
+  return {
+    "-c",
+    string.format('hooks.pre_tool_use=[{command="%s",timeout=120}]', escaped),
+  }
+end
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -21,6 +21,12 @@ local active_opts = nil
 --- @type table<string, {tool_name: string, tool_input: table}>
 local pending_hook_approvals = {}
 
+--- Codex uses different tool names than Claude for equivalent operations.
+--- This mapping ensures frontmatter permissions work identically across adapters.
+local CODEX_TOOL_ALIASES = {
+  apply_patch = "Edit", -- Codex's file patch tool maps to Claude's Edit
+}
+
 local APPROVAL_OPTIONS = {
   { value = "allow_once", label = "allow_once - Allow this execution only" },
   { value = "deny_once", label = "deny_once - Deny this execution only" },
@@ -139,6 +145,10 @@ function M.check_tool_permission(params)
 
   local tool_name = hook_input.tool_name or ""
   local tool_input = hook_input.tool_input or {}
+
+  if active_opts and active_opts._is_codex then
+    tool_name = CODEX_TOOL_ALIASES[tool_name] or tool_name
+  end
 
   -- AskUserQuestion: deny + insert choices into chat buffer + kill process
   if tool_name == "AskUserQuestion" then


### PR DESCRIPTION
## 概要

`agent: codex` フロントマターでも、Claude と同等の権限制御（`permission_mode` / `permissions_allow` / `permissions_deny` / `permissions_ask`）が機能するようにした。

## 背景

以前から `permissions_*` フロントマターは Claude CLI adapter のみ有効で、Codex adapter では `permission_mode` の sandbox 変換のみが行われ、allow/deny/ask リストや承認 UI は機能していなかった。

## 変更内容

### 新規ファイル
- `lua/vibing/infrastructure/hooks/codex_settings_generator.lua` — `codex exec` に `-c hooks.pre_tool_use=[...]` を渡すための引数を生成。既存の `pre-tool-use.sh` をそのまま流用する。

### 修正ファイル
- `lua/vibing/infrastructure/adapter/codex_cli.lua` — `stream()` 内で `ActiveStreamRegistry.register()` と `perm_handler.set_active_opts()` を呼び出し、完了時にクリーンアップ。`bypassPermissions` 以外では hook を注入。
- `lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua` — `hook_args` パラメータを受け取り、`--json` の直後に `-c` フラグを追加。
- `lua/vibing/infrastructure/rpc/handlers/permission.lua` — `CODEX_TOOL_ALIASES` 定数を追加し、`apply_patch` → `Edit` に正規化。`acceptEdits` モードや `permissions_allow: ["Edit"]` が Codex でも同等に機能する。

## 処理フロー（変更後）

```
codex exec --json -c hooks.pre_tool_use=[{command=".../pre-tool-use.sh"}] PROMPT
  │
  └─ ツール使用時: pre-tool-use.sh 発火（既存スクリプト、変更なし）
       └─ RPC → check_tool_permission()
            ├─ apply_patch → "Edit" に正規化（_is_codex フラグ）
            ├─ can_use_tool() で allow/deny/ask 判定
            └─ hook に allow(exit 0) or deny(exit 2+stderr) を返す
```

## 設計上のポイント

- `pre-tool-use.sh` は **無修正で流用** — Codex も Claude と同じ `tool_name`/`tool_input` フォーマットで hook に JSON を送る
- `bypassPermissions` のみ hook 不使用 — `--dangerously-bypass-approvals-and-sandbox` と役割が重複するため
- `apply_patch` → `Edit` 正規化 — `acceptEdits` モードと `permissions_allow: ["Edit"]` が Codex でも機能する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced pre-execution hook system for customizing tool behavior during streaming operations.
  * Enhanced permission mode with runtime configuration support and improved tool identifier translation for permission checks.
  * Integrated stream lifecycle management with automatic registration and cleanup of active streams.

* **Bug Fixes**
  * Fixed session-resume timeout handling to prevent duplicate completion processing and ensure proper cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shabaraba/vibing.nvim/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->