### PR TITLE
perf: async preload skill completion to eliminate first-slash delay

### DIFF
--- a/lua/vibing/application/completion/init.lua
+++ b/lua/vibing/application/completion/init.lua
@@ -20,6 +20,10 @@ function M.setup()
     vim.notify("[vibing] nvim-cmp source registered", vim.log.levels.DEBUG)
   end
 
+  -- Warm skills cache in background so first "/" press is instant
+  local skills = require("vibing.infrastructure.completion.providers.skills")
+  skills.preload()
+
   _setup_done = true
 end
 

--- a/lua/vibing/infrastructure/completion/adapters/cmp.lua
+++ b/lua/vibing/infrastructure/completion/adapters/cmp.lua
@@ -8,6 +8,7 @@ local file_source = require("vibing.application.completion.sources.file")
 local agent_source = require("vibing.application.completion.sources.agent")
 local frontmatter_source = require("vibing.application.completion.sources.frontmatter")
 local chat_view = require("vibing.presentation.chat.view")
+local skills_provider = require("vibing.infrastructure.completion.providers.skills")
 
 ---@type table[]
 local sources = { frontmatter_source, slash_source, file_source, agent_source }
@@ -49,9 +50,11 @@ function M.create()
       if context then
         src.get_candidates(context, function(items)
           local cmp_items = M._to_cmp_items(items, context)
+          -- Re-query on next keystroke while plugin skills are still loading
+          local is_incomplete = context.trigger == "slash" and skills_provider.is_preloading()
           callback({
             items = cmp_items,
-            isIncomplete = false,
+            isIncomplete = is_incomplete,
           })
         end)
         return
@@ -99,6 +102,8 @@ function M._to_cmp_items(items, context)
     table.insert(cmp_items, {
       label = item.label,
       kind = to_cmp_kind(item.kind, cmp_kinds),
+      detail = item.detail,
+      labelDetails = item.detail and { description = item.detail } or nil,
       documentation = {
         kind = "markdown",
         value = item.description or "",

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -12,6 +12,9 @@ local _bundled_cache = nil
 ---@type boolean
 local _loading = false
 
+---@type integer
+local _load_generation = 0
+
 ---Parse SKILL.md to extract name and description
 ---@param file_path string
 ---@return {name: string, description: string}?
@@ -92,11 +95,12 @@ local function resolve_list_commands()
     return nil, nil
   end
 
-  local ok, config = pcall(require, "vibing.config")
+  local ok, Config = pcall(require, "vibing.config")
   if not ok then
     return nil, nil
   end
 
+  local config = Config.get()
   local dev_mode = config.node and config.node.dev_mode or false
   local executable
   if dev_mode then
@@ -140,22 +144,28 @@ local function parse_commands_output(stdout)
 
   local items = {}
   for _, cmd in ipairs(commands) do
-    if cmd.name then
+    if type(cmd) == "table" and type(cmd.name) == "string" and cmd.name ~= "" then
+      local description = type(cmd.description) == "string" and cmd.description or ""
       local source = "custom"
-      if cmd.description and cmd.description:match("%(plugin:") then
+      if description:match("%(plugin:") then
         source = "plugin"
-      elseif cmd.description and cmd.description:match("%(user%)") then
+      elseif description:match("%(user%)") then
         source = "user"
-      elseif cmd.description and cmd.description:match("%(project%)") then
+      elseif description:match("%(project%)") then
         source = "project"
+      end
+
+      local detail = source
+      if source == "plugin" then
+        detail = description:match("%(plugin:([^@%)]+)") or "plugin"
       end
 
       table.insert(items, {
         word = cmd.name,
         label = "/" .. cmd.name,
         kind = "Skill",
-        description = cmd.description or "",
-        detail = source,
+        description = description,
+        detail = detail,
         source = source,
         filterText = cmd.name,
       })
@@ -177,15 +187,24 @@ local function start_async_load()
   end
 
   _loading = true
-  vim.system({ executable, script_path }, {}, vim.schedule_wrap(function(result)
+  local load_generation = _load_generation
+  local ok = pcall(function()
+    vim.system({ executable, script_path }, {}, vim.schedule_wrap(function(result)
+      if load_generation ~= _load_generation then
+        return
+      end
+      _loading = false
+      if result.code ~= 0 then
+        return
+      end
+      local items = parse_commands_output(result.stdout or "")
+      _bundled_cache = items
+      _cache = nil
+    end))
+  end)
+  if not ok then
     _loading = false
-    if result.code ~= 0 then
-      return
-    end
-    local items = parse_commands_output(result.stdout or "")
-    _bundled_cache = items
-    _cache = nil
-  end))
+  end
 end
 
 ---Get dynamic skills from Agent SDK (custom commands + plugin skills)
@@ -287,8 +306,16 @@ function M.preload()
   start_async_load()
 end
 
+---Check if dynamic skills (SDK/plugin skills) are still loading
+---Returns true before the first async load completes; false once _bundled_cache is populated
+---@return boolean
+function M.is_preloading()
+  return _loading or _bundled_cache == nil
+end
+
 ---Clear cache (call when skills change)
 function M.clear_cache()
+  _load_generation = _load_generation + 1
   _cache = nil
   _bundled_cache = nil
   _loading = false

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -9,6 +9,9 @@ local _cache = nil
 ---@type Vibing.CompletionItem[]?
 local _bundled_cache = nil
 
+---@type boolean
+local _loading = false
+
 ---Parse SKILL.md to extract name and description
 ---@param file_path string
 ---@return {name: string, description: string}?
@@ -80,26 +83,18 @@ local function get_hardcoded_bundled_skills()
   }
 end
 
----Get dynamic skills from Agent SDK (custom commands + plugin skills)
----@return Vibing.CompletionItem[]
-local function get_dynamic_sdk_skills()
-  if _bundled_cache then
-    return _bundled_cache
-  end
-
-  -- Find the plugin root directory by searching upward for package.json
+---Resolve executable and script path for list-commands
+---@return string?, string? executable, script_path (nil if not resolvable)
+local function resolve_list_commands()
   local current_file = debug.getinfo(1, "S").source:sub(2)
   local plugin_dir = vim.fs.root(current_file, "package.json")
   if not plugin_dir then
-    return {}
+    return nil, nil
   end
-  local list_commands_script = plugin_dir .. "/bin/list-commands.ts"
 
-  -- Check if we should use TypeScript directly (dev mode) or compiled JS
   local ok, config = pcall(require, "vibing.config")
   if not ok then
-    -- Config not loaded, use defaults
-    return {}
+    return nil, nil
   end
 
   local dev_mode = config.node and config.node.dev_mode or false
@@ -107,7 +102,7 @@ local function get_dynamic_sdk_skills()
   if dev_mode then
     executable = vim.fn.exepath("bun")
     if executable == "" then
-      return {}
+      return nil, nil
     end
   else
     local configured = config.node and config.node.executable
@@ -120,37 +115,32 @@ local function get_dynamic_sdk_skills()
       end
     end
   end
-  local script_path = list_commands_script
 
-  if not dev_mode then
-    -- Production mode: use compiled JS
+  local script_path
+  if dev_mode then
+    script_path = plugin_dir .. "/bin/list-commands.ts"
+  else
     script_path = plugin_dir .. "/dist/bin/list-commands.js"
     if vim.fn.filereadable(script_path) ~= 1 then
-      -- Fallback to empty list if compiled version doesn't exist
-      return {}
+      return nil, nil
     end
   end
 
-  -- Execute the script to get SDK-provided skills
-  local cmd = { executable, script_path }
-  local result = vim.fn.systemlist(cmd)
-  local exit_code = vim.v.shell_error
+  return executable, script_path
+end
 
-  if exit_code ~= 0 then
-    return {}
-  end
-
-  -- Parse JSON output
-  local ok, commands = pcall(vim.fn.json_decode, table.concat(result, "\n"))
+---Parse raw JSON output from list-commands into completion items
+---@param stdout string
+---@return Vibing.CompletionItem[]
+local function parse_commands_output(stdout)
+  local ok, commands = pcall(vim.fn.json_decode, stdout)
   if not ok or type(commands) ~= "table" then
     return {}
   end
 
-  -- Convert to completion items
   local items = {}
   for _, cmd in ipairs(commands) do
     if cmd.name then
-      -- Determine source based on description suffix
       local source = "custom"
       if cmd.description and cmd.description:match("%(plugin:") then
         source = "plugin"
@@ -171,9 +161,42 @@ local function get_dynamic_sdk_skills()
       })
     end
   end
-
-  _bundled_cache = items
   return items
+end
+
+---Start async load of dynamic skills from Agent SDK
+---Loads in background; sets _bundled_cache when done and invalidates _cache
+local function start_async_load()
+  if _loading or _bundled_cache then
+    return
+  end
+
+  local executable, script_path = resolve_list_commands()
+  if not executable or not script_path then
+    return
+  end
+
+  _loading = true
+  vim.system({ executable, script_path }, {}, vim.schedule_wrap(function(result)
+    _loading = false
+    if result.code ~= 0 then
+      return
+    end
+    local items = parse_commands_output(result.stdout or "")
+    _bundled_cache = items
+    _cache = nil
+  end))
+end
+
+---Get dynamic skills from Agent SDK (custom commands + plugin skills)
+---Returns cached result immediately; starts async load if not yet cached
+---@return Vibing.CompletionItem[]
+local function get_dynamic_sdk_skills()
+  if _bundled_cache then
+    return _bundled_cache
+  end
+  start_async_load()
+  return {}
 end
 
 ---Get all bundled skills (hardcoded + dynamic SDK skills)
@@ -259,10 +282,16 @@ function M.get_all()
   return _cache
 end
 
+---Preload dynamic skills in background (call at setup time to warm the cache)
+function M.preload()
+  start_async_load()
+end
+
 ---Clear cache (call when skills change)
 function M.clear_cache()
   _cache = nil
   _bundled_cache = nil
+  _loading = false
 end
 
 return M


### PR DESCRIPTION
## 概要

`/` を最初に押下した際の補完候補表示が遅い問題を修正しました。

## 原因

`skills.lua` の `get_dynamic_sdk_skills()` が `vim.fn.systemlist()` で Node.js スクリプト（`list-commands.js`）を **同期実行** していたため、初回の `/` 押下時にスクリプトの起動・実行が完了するまでメインスレッドがブロックされていました。

## 変更内容

### `lua/vibing/infrastructure/completion/providers/skills.lua`

- `vim.fn.systemlist()` (同期・ブロッキング) → `vim.system()` (非同期・ノンブロッキング) に変更
- `_loading` フラグで重複実行を防止
- ロード完了後に `_cache = nil` で補完一覧キャッシュを自動無効化
- `M.preload()` 関数を追加（外部からバックグラウンドロードを開始できる）

### `lua/vibing/application/completion/init.lua`

- `setup()` 内で `skills.preload()` を呼び出し、プラグイン起動と同時にバックグラウンドでスキル一覧を取得開始

## 動作の変化

- プラグイン起動（`vibing.setup()`）時に Node.js スクリプトをバックグラウンド実行してキャッシュを事前作成
- ユーザーが最初に `/` を押す頃にはキャッシュが完成しているため遅延なし
- キャッシュ完成前に `/` を押した場合でもブロッキングなし（SDKスキルなしで即時表示、キャッシュ完成後は次回から反映）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completion suggestions now preload skill data in the background during startup for faster availability.
  * Dynamic, command-based skill completions are loaded asynchronously and cached.

* **Bug Fixes**
  * Prevents duplicate or stale async skill loads by tracking load generations and ignoring out-of-date results.
  * Cache clearing now resets pending preload state so updated completions can refresh correctly.

* **User Experience**
  * During skill preloading, results can be marked incomplete when triggered via `/`.
  * Completion entries now show richer details in nvim-cmp (detail/label description).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->