### PR TITLE
fix: load local-scope plugins and fix skill completion for plugin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 4.1.0 (2026-06-25)
 
 ## What's Changed
-* feat: apply frontmatter permissions to codex adapter via PreToolUse hook by @shabaraba in https://github.com/shabaraba/vibing.nvim/pull/419
-* perf: async preload skill completion to eliminate first-slash delay by @shabaraba in https://github.com/shabaraba/vibing.nvim/pull/420
 
+- feat: apply frontmatter permissions to codex adapter via PreToolUse hook by @shabaraba in https://github.com/shabaraba/vibing.nvim/pull/419
+- perf: async preload skill completion to eliminate first-slash delay by @shabaraba in https://github.com/shabaraba/vibing.nvim/pull/420
 
 **Full Changelog**: https://github.com/shabaraba/vibing.nvim/compare/v4.0.0...v4.1.0
 

--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -147,6 +147,11 @@ async function loadEnabledPluginIds(): Promise<Set<string> | null> {
       .filter(([, v]) => v === true)
       .map(([k]) => k)
   );
+  if (enabled.size === 0) {
+    // Only false entries present — no allowlist to apply, load all plugins
+    debugLog('enabledPlugins has no positively-enabled entries; loading all installed plugins');
+    return null;
+  }
   debugLog(`Enabled plugins (user+project+local): ${[...enabled].join(', ')}`);
   return enabled;
 }
@@ -192,7 +197,8 @@ export async function loadInstalledPlugins(): Promise<PluginReference[]> {
     if (!Array.isArray(installations) || installations.length === 0) continue;
 
     const hasLocalInstall = installations.some((inst) => inst.scope === 'local');
-    const isEnabledInSettings = enabledIds !== null && enabledIds.has(pluginId);
+    // null means no filter — include all (mirrors behaviour when no enabledPlugins is configured)
+    const isEnabledInSettings = enabledIds === null || enabledIds.has(pluginId);
 
     if (!hasLocalInstall && !isEnabledInSettings) {
       debugLog(`Skipping plugin (not local and not enabled): ${pluginId}`);

--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -104,6 +104,53 @@ async function pathExists(path: string): Promise<boolean> {
  * query({ prompt: '...', options: { plugins } });
  * ```
  */
+/**
+ * Read enabled plugin IDs from a single settings.json file.
+ */
+async function readEnabledPluginsFromFile(settingsFile: string): Promise<Record<string, boolean>> {
+  try {
+    const content = await readFile(settingsFile, 'utf8');
+    const settings = JSON.parse(content) as { enabledPlugins?: Record<string, boolean> };
+    if (settings.enabledPlugins && typeof settings.enabledPlugins === 'object') {
+      return settings.enabledPlugins;
+    }
+  } catch {
+    // File missing or invalid JSON — ignore
+  }
+  return {};
+}
+
+/**
+ * Read the merged set of enabled plugin IDs from both user (~/.claude/settings.json)
+ * and project (.claude/settings.json) settings files.
+ * Returns null if neither file has enabledPlugins (meaning no filtering should apply).
+ */
+async function loadEnabledPluginIds(): Promise<Set<string> | null> {
+  const userSettingsFile = join(homedir(), '.claude', 'settings.json');
+  const projectSettingsFile = join(process.cwd(), '.claude', 'settings.json');
+  const localSettingsFile = join(process.cwd(), '.claude', 'settings.local.json');
+
+  const [userEnabled, projectEnabled, localEnabled] = await Promise.all([
+    readEnabledPluginsFromFile(userSettingsFile),
+    readEnabledPluginsFromFile(projectSettingsFile),
+    readEnabledPluginsFromFile(localSettingsFile),
+  ]);
+
+  const merged = { ...userEnabled, ...projectEnabled, ...localEnabled };
+  if (Object.keys(merged).length === 0) {
+    debugLog('No enabledPlugins found in user, project, or local settings, loading all installed plugins');
+    return null;
+  }
+
+  const enabled = new Set(
+    Object.entries(merged)
+      .filter(([, v]) => v === true)
+      .map(([k]) => k)
+  );
+  debugLog(`Enabled plugins (user+project+local): ${[...enabled].join(', ')}`);
+  return enabled;
+}
+
 export async function loadInstalledPlugins(): Promise<PluginReference[]> {
   const pluginsFile = join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
 
@@ -130,12 +177,35 @@ export async function loadInstalledPlugins(): Promise<PluginReference[]> {
     return [];
   }
 
-  // Collect all installation paths
+  // Load enabled plugin IDs to filter completions to only CLI-available plugins
+  const enabledIds = await loadEnabledPluginIds();
+
+  // Collect installation paths.
+  // For each plugin ID, pick only the best installation to avoid duplicate skills
+  // when multiple versions are cached (e.g. scope=user 1.1.0 + scope=local 1.1.1).
+  // Inclusion rules:
+  //   scope=local → always include (explicitly project-installed, always active)
+  //   scope=user  → include only if in enabledPlugins (needs explicit enable)
+  // Preference order when multiple installs exist: local > user scope, then most recent.
   const allInstallations: InstalledPlugin[] = [];
-  for (const installations of Object.values(installed.plugins)) {
-    if (Array.isArray(installations)) {
-      allInstallations.push(...installations);
+  for (const [pluginId, installations] of Object.entries(installed.plugins)) {
+    if (!Array.isArray(installations) || installations.length === 0) continue;
+
+    const hasLocalInstall = installations.some((inst) => inst.scope === 'local');
+    const isEnabledInSettings = enabledIds !== null && enabledIds.has(pluginId);
+
+    if (!hasLocalInstall && !isEnabledInSettings) {
+      debugLog(`Skipping plugin (not local and not enabled): ${pluginId}`);
+      continue;
     }
+
+    // Pick best: local scope preferred, then most recent lastUpdated
+    const best = installations.reduce((a, b) => {
+      if (a.scope === 'local' && b.scope !== 'local') return a;
+      if (b.scope === 'local' && a.scope !== 'local') return b;
+      return a.lastUpdated >= b.lastUpdated ? a : b;
+    });
+    allInstallations.push(best);
   }
 
   debugLog(`Found ${allInstallations.length} plugin installations`);

--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -138,7 +138,9 @@ async function loadEnabledPluginIds(): Promise<Set<string> | null> {
 
   const merged = { ...userEnabled, ...projectEnabled, ...localEnabled };
   if (Object.keys(merged).length === 0) {
-    debugLog('No enabledPlugins found in user, project, or local settings, loading all installed plugins');
+    debugLog(
+      'No enabledPlugins found in user, project, or local settings, loading all installed plugins'
+    );
     return null;
   }
 

--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -16,7 +16,7 @@ async function listCommands() {
       prompt: 'list commands',
       options: {
         cwd: process.cwd(),
-        settingSources: ['user', 'project'],
+        settingSources: ['user', 'project', 'local'],
         ...(plugins.length > 0 && { plugins }),
       },
     });

--- a/lua/vibing/application/completion/init.lua
+++ b/lua/vibing/application/completion/init.lua
@@ -39,11 +39,19 @@ end
 ---Setup completion for a specific buffer
 ---@param buf number Buffer number
 function M.setup_buffer(buf)
-  local has_cmp = pcall(require, "cmp")
+  local has_cmp, cmp = pcall(require, "cmp")
 
   if not has_cmp then
     -- Fallback to omnifunc
     vim.bo[buf].omnifunc = "v:lua.require('vibing.application.completion').omnifunc"
+  else
+    -- Prepend vibing source to existing global sources for this buffer
+    local global_sources = cmp.get_config().sources or {}
+    local sources = { { name = "vibing" } }
+    for _, src in ipairs(global_sources) do
+      table.insert(sources, src)
+    end
+    cmp.setup.buffer({ sources = sources })
   end
 
   vim.bo[buf].completeopt = "menu,menuone,noselect"

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -147,7 +147,7 @@ function M.build(prompt, opts, session_id, config, settings_path)
   end
 
   table.insert(cmd, "--setting-sources")
-  table.insert(cmd, "user,project")
+  table.insert(cmd, "user,project,local")
 
   -- Build prompt with context prefix (only for new sessions, not resume)
   local full_prompt = prompt

--- a/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
@@ -217,6 +217,16 @@ local function handle_result_event(msg, context)
   end
 end
 
+--- Handle "text" event (error/unknown-command responses that bypass streaming)
+local function handle_text_event(msg, context)
+  if msg.text and context.onChunk then
+    table.insert(context.output, msg.text)
+    vim.schedule(function()
+      context.onChunk(msg.text)
+    end)
+  end
+end
+
 --- Event handler dispatch table
 local event_handlers = {
   system = function(msg, context)
@@ -237,6 +247,10 @@ local event_handlers = {
   end,
   result = function(msg, context)
     handle_result_event(msg, context)
+    return true
+  end,
+  text = function(msg, context)
+    handle_text_event(msg, context)
     return true
   end,
   rate_limit_event = function()

--- a/lua/vibing/infrastructure/completion/adapters/cmp.lua
+++ b/lua/vibing/infrastructure/completion/adapters/cmp.lua
@@ -50,8 +50,9 @@ function M.create()
       if context then
         src.get_candidates(context, function(items)
           local cmp_items = M._to_cmp_items(items, context)
-          -- Re-query on next keystroke while plugin skills are still loading
-          local is_incomplete = context.trigger == "slash" and skills_provider.is_preloading()
+          -- Always re-query for slash: our source does substring filtering,
+          -- but cmp's own client-side cache uses prefix matching only.
+          local is_incomplete = context.trigger == "slash"
           callback({
             items = cmp_items,
             isIncomplete = is_incomplete,
@@ -109,7 +110,7 @@ function M._to_cmp_items(items, context)
         value = item.description or "",
       },
       insertText = insert_text,
-      filterText = item.label,
+      filterText = item.filterText or item.word,
       sortText = item.word,
     })
   end

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -101,32 +101,23 @@ local function resolve_list_commands()
   end
 
   local config = Config.get()
-  local dev_mode = config.node and config.node.dev_mode or false
-  local executable
-  if dev_mode then
-    executable = vim.fn.exepath("bun")
-    if executable == "" then
-      return nil, nil
-    end
-  else
-    local configured = config.node and config.node.executable
-    if configured and configured ~= "auto" then
-      executable = configured
-    else
-      executable = vim.fn.exepath("node")
-      if executable == "" then
-        executable = "node"
-      end
-    end
+
+  -- Always use compiled JS + node for list-commands regardless of dev_mode.
+  -- Running list-commands.ts via bun causes the process to hang indefinitely
+  -- due to SDK async operations not resolving under bun.
+  local script_path = plugin_dir .. "/dist/bin/list-commands.js"
+  if vim.fn.filereadable(script_path) ~= 1 then
+    return nil, nil
   end
 
-  local script_path
-  if dev_mode then
-    script_path = plugin_dir .. "/bin/list-commands.ts"
+  local configured = config.node and config.node.executable
+  local executable
+  if configured and configured ~= "auto" then
+    executable = configured
   else
-    script_path = plugin_dir .. "/dist/bin/list-commands.js"
-    if vim.fn.filereadable(script_path) ~= 1 then
-      return nil, nil
+    executable = vim.fn.exepath("node")
+    if executable == "" then
+      executable = "node"
     end
   end
 
@@ -160,14 +151,25 @@ local function parse_commands_output(stdout)
         detail = description:match("%(plugin:([^@%)]+)") or "plugin"
       end
 
+      -- For plugin skills without a namespace (no ":" in name), prepend the plugin name.
+      -- Native Claude Code invokes these as "plugin:skill" (e.g. "wt-sessions:start").
+      -- Skip if detail looks like a git hash (all hex chars, >= 8 chars).
+      local word = cmd.name
+      if source == "plugin" and not cmd.name:find(":") then
+        local is_hash = detail:match("^[0-9a-f]+$") and #detail >= 8
+        if not is_hash then
+          word = detail .. ":" .. cmd.name
+        end
+      end
+
       table.insert(items, {
-        word = cmd.name,
-        label = "/" .. cmd.name,
+        word = word,
+        label = "/" .. word,
         kind = "Skill",
         description = description,
         detail = detail,
         source = source,
-        filterText = cmd.name,
+        filterText = word,
       })
     end
   end
@@ -188,22 +190,33 @@ local function start_async_load()
 
   _loading = true
   local load_generation = _load_generation
+  local tmpfile = vim.fn.tempname()
   local ok = pcall(function()
-    vim.system({ executable, script_path }, {}, vim.schedule_wrap(function(result)
-      if load_generation ~= _load_generation then
-        return
-      end
-      _loading = false
-      if result.code ~= 0 then
-        return
-      end
-      local items = parse_commands_output(result.stdout or "")
-      _bundled_cache = items
-      _cache = nil
-    end))
+    vim.system(
+      { "sh", "-c", vim.fn.shellescape(executable) .. " " .. vim.fn.shellescape(script_path) .. " > " .. tmpfile },
+      {},
+      vim.schedule_wrap(function(result)
+        if load_generation ~= _load_generation then
+          vim.fn.delete(tmpfile)
+          return
+        end
+        _loading = false
+        if result.code ~= 0 then
+          vim.fn.delete(tmpfile)
+          return
+        end
+        local lines = vim.fn.readfile(tmpfile)
+        vim.fn.delete(tmpfile)
+        local stdout = table.concat(lines, "\n")
+        local items = parse_commands_output(stdout)
+        _bundled_cache = items
+        _cache = nil
+      end)
+    )
   end)
   if not ok then
     _loading = false
+    vim.fn.delete(tmpfile)
   end
 end
 
@@ -276,11 +289,21 @@ local function scan_skills()
     end
   end
 
-  table.sort(items, function(a, b)
+  -- Deduplicate by word
+  local seen = {}
+  local deduped = {}
+  for _, item in ipairs(items) do
+    if not seen[item.word] then
+      seen[item.word] = true
+      table.insert(deduped, item)
+    end
+  end
+
+  table.sort(deduped, function(a, b)
     return a.word < b.word
   end)
 
-  return items
+  return deduped
 end
 
 ---Define directories to scan for skills

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -190,33 +190,22 @@ local function start_async_load()
 
   _loading = true
   local load_generation = _load_generation
-  local tmpfile = vim.fn.tempname()
   local ok = pcall(function()
-    vim.system(
-      { "sh", "-c", vim.fn.shellescape(executable) .. " " .. vim.fn.shellescape(script_path) .. " > " .. tmpfile },
-      {},
-      vim.schedule_wrap(function(result)
-        if load_generation ~= _load_generation then
-          vim.fn.delete(tmpfile)
-          return
-        end
-        _loading = false
-        if result.code ~= 0 then
-          vim.fn.delete(tmpfile)
-          return
-        end
-        local lines = vim.fn.readfile(tmpfile)
-        vim.fn.delete(tmpfile)
-        local stdout = table.concat(lines, "\n")
-        local items = parse_commands_output(stdout)
-        _bundled_cache = items
-        _cache = nil
-      end)
-    )
+    vim.system({ executable, script_path }, {}, vim.schedule_wrap(function(result)
+      if load_generation ~= _load_generation then
+        return
+      end
+      _loading = false
+      if result.code ~= 0 then
+        return
+      end
+      local items = parse_commands_output(result.stdout or "")
+      _bundled_cache = items
+      _cache = nil
+    end))
   end)
   if not ok then
     _loading = false
-    vim.fn.delete(tmpfile)
   end
 end
 


### PR DESCRIPTION
## 概要

vibing.nvim 経由で `/wt-sessions:start` などの local スコーププラグインスキルが動作しない問題を修正。

## 原因

- `claude -p --setting-sources user,project` が `settings.local.json` を読まないため、`--scope local` でインストールしたプラグインが実行時にロードされなかった
- 補完（`list-commands.ts`）も同様に local スコープのプラグインスキルが表示されなかった

## 変更内容

### 実行側の修正
- `cli_command_builder.lua`: `--setting-sources user,project` → `user,project,local` に変更
  - `settings.local.json` が読まれ、local スコーププラグインがロードされる

### 補完側の修正
- `plugin-loader.ts`: `loadEnabledPluginIds()` で `settings.local.json` も読むよう追加
- `plugin-loader.ts`: local スコープのプラグインを `scope=local` の場合は無条件で含めるよう変更
- `list-commands.ts`: `settingSources: ['user', 'project', 'local']` に変更
- `skills.lua`: プラグインスキルを `plugin:skill` 形式（例: `wt-sessions:start`）でフォーマット
- `skills.lua`: bun では SDK の async 処理がハングするため `list-commands` は常に node + compiled JS を使用
- `skills.lua`: スキル補完アイテムの重複排除を追加

### UX 改善
- `cli_event_processor.lua`: `text` イベントハンドラを追加し `Unknown command` 等のレスポンスをチャットに表示
- `cmp.lua`: slash 補完で常に `isIncomplete=true` を返し再クエリを強制
- `cmp.lua`: `filterText` を label でなく word ベースに修正
- `completion/init.lua`: cmp が利用可能な場合にバッファごとに vibing ソースを登録するよう修正

## 動作確認

```bash
# virtual-monorepo で list-commands が wt-sessions:start を返すことを確認
cd /path/to/virtual-monorepo
node dist/bin/list-commands.js | jq '.[] | select(.name | contains("start"))'
```

fixes: local-scope plugin (e.g. `wt-sessions:start`) not appearing in completion or working in chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin and command lists now respect additional local settings, so enabled items can be controlled more precisely.
  * Completion now prioritizes vibing suggestions and handles plain text responses more consistently.

* **Bug Fixes**
  * Removed duplicate plugin and skill entries in completion results.
  * Improved handling of command output so error and unknown-command text can appear properly.
  * Completion filtering now uses the most relevant text for matching, improving search accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->