### PR TITLE
fix: add StructuredOutput tool support and limit modified files display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,3 +113,9 @@ All `.md` files in `.claude/rules/` are automatically loaded into Claude Code's 
 - **テストフィクスチャ・スキャフォルド**: ルートディレクトリに置かない。`tests/` 配下に配置すること
   - ✅ `tests/fixtures/`, `tests/e2e/`, `tests/lua/` など
   - ❌ `test-*/`, `test-xxx/` をリポジトリルートに作成しない
+
+## Key Constants
+
+- **有効ツール名リスト (`VALID_TOOLS`)**: `lua/vibing/core/constants/tools.lua`
+  - 権限バリデーション（未知ツール名の警告）に使用
+  - 新しいツールを追加する場合はここと `lua/vibing/config.lua` の `M.defaults.permissions.allow` の両方に追加する

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -251,9 +251,14 @@ function M._handle_response(response, callbacks, adapter, config, mote_config)
         -- Modified Files出力
         BufferReload.reload_files(files)
 
+        local MAX_DISPLAY = 50
         callbacks.append_chunk("\n\n### Modified Files\n\n")
-        for _, file_path in ipairs(files) do
-          callbacks.append_chunk(file_path .. "\n")
+        local display_count = math.min(#files, MAX_DISPLAY)
+        for i = 1, display_count do
+          callbacks.append_chunk(files[i] .. "\n")
+        end
+        if #files > MAX_DISPLAY then
+          callbacks.append_chunk(string.format("... (他%d件)\n", #files - MAX_DISPLAY))
         end
 
         -- Patch marker (before User section)

--- a/lua/vibing/application/inline/modules/execution.lua
+++ b/lua/vibing/application/inline/modules/execution.lua
@@ -180,10 +180,15 @@ function M.show_results(modified_files, response_text)
   local lines = {}
 
   if #modified_files > 0 then
+    local MAX_DISPLAY = 50
     table.insert(lines, "### Modified Files")
     table.insert(lines, "")
-    for _, f in ipairs(modified_files) do
-      table.insert(lines, "- " .. f)
+    local display_count = math.min(#modified_files, MAX_DISPLAY)
+    for i = 1, display_count do
+      table.insert(lines, "- " .. modified_files[i])
+    end
+    if #modified_files > MAX_DISPLAY then
+      table.insert(lines, string.format("... (他%d件)", #modified_files - MAX_DISPLAY))
     end
     table.insert(lines, "")
   end

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -277,7 +277,7 @@ M.defaults = {
   },
   permissions = {
     mode = "acceptEdits",
-    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill" },
+    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "StructuredOutput" },
     deny = { "Bash" },
     ask = {},
     rules = {},

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -14,6 +14,7 @@ M.VALID_TOOLS = {
   "WebSearch",
   "WebFetch",
   "Skill",
+  "StructuredOutput",
 }
 
 ---有効なツール名のテーブル（高速検索用）

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -39,7 +39,11 @@ local function add_permission_args(cmd, opts)
     permissions_allow = {}
   end
   local allow_tools = vim.deepcopy(permissions_allow)
-  table.insert(allow_tools, "mcp__vibing-nvim__*")
+  for _, tool in ipairs({ "Read", "Skill", "mcp__vibing-nvim__*" }) do
+    if not vim.tbl_contains(allow_tools, tool) then
+      table.insert(allow_tools, tool)
+    end
+  end
 
   if #allow_tools > 0 then
     table.insert(cmd, "--allowedTools")

--- a/lua/vibing/presentation/chat/modules/patch_finder.lua
+++ b/lua/vibing/presentation/chat/modules/patch_finder.lua
@@ -98,7 +98,7 @@ function M.get_modified_files_in_section(buf)
     end
     if not line:match("<!%-%-") then
       local trimmed = vim.trim(line)
-      if trimmed ~= "" and not trimmed:match("^%-%-") then
+      if trimmed ~= "" and not trimmed:match("^%-%-") and not trimmed:match("^%.%.%.") then
         table.insert(files, trimmed)
       end
     end


### PR DESCRIPTION
## 変更内容

### StructuredOutput ツール対応
- `lua/vibing/core/constants/tools.lua`: `VALID_TOOLS` に `StructuredOutput` を追加
- `lua/vibing/config.lua`: デフォルトの `permissions.allow` に `StructuredOutput` を追加
  - frontmatter に記述しなくても自動許可されるようになる
- `CLAUDE.md`: `VALID_TOOLS` の場所と更新手順を「Key Constants」セクションとして追記

### Modified Files 表示の上限追加
- `lua/vibing/application/chat/send_message.lua`: Modified Files 表示を最大50件に制限
- `lua/vibing/application/inline/modules/execution.lua`: 同上
  - 50件超の場合は `... (他N件)` と表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `StructuredOutput` tool in the app’s default permissions and validation, making it available out of the box.
* **Bug Fixes**
  * Large “Modified Files” lists are now shortened after 50 items, with a note showing how many entries were omitted for easier reading.
* **Documentation**
  * Updated guidance to reflect the new tool requirement and where to update allowed tool lists when adding future tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->