### PR TITLE
feat: add VibingCleanMote command and fix mote patch path resolution

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -252,14 +252,14 @@ function M._handle_response(response, callbacks, adapter, config, mote_config)
         BufferReload.reload_files(files)
 
         local MAX_DISPLAY = 50
-        callbacks.append_chunk("\n\n### Modified Files\n\n")
-        local display_count = math.min(#files, MAX_DISPLAY)
-        for i = 1, display_count do
-          callbacks.append_chunk(files[i] .. "\n")
+        local file_lines = {}
+        for i = 1, math.min(#files, MAX_DISPLAY) do
+          table.insert(file_lines, files[i])
         end
         if #files > MAX_DISPLAY then
-          callbacks.append_chunk(string.format("... (他%d件)\n", #files - MAX_DISPLAY))
+          table.insert(file_lines, string.format("... (%d more)", #files - MAX_DISPLAY))
         end
+        callbacks.append_chunk("\n\n### Modified Files\n\n" .. table.concat(file_lines, "\n") .. "\n")
 
         -- Patch marker (before User section)
         callbacks.append_chunk("\n<!-- patch: " .. patch_path .. " -->\n")

--- a/lua/vibing/application/chat/use_cases/delete_chats.lua
+++ b/lua/vibing/application/chat/use_cases/delete_chats.lua
@@ -45,15 +45,21 @@ function M.delete_selected(entities, config, on_complete)
   })
 end
 
----@param entities Vibing.Domain.Chat.FileEntity[]
 ---@param config table
----@param on_complete fun(success: boolean, message: string)
-function M._execute_deletion(entities, config, on_complete)
-  local mote_config = {
+---@return table
+function M._build_mote_config(config)
+  return {
     project = (config.diff and config.diff.mote and config.diff.mote.project) or vim.fn.fnamemodify(vim.fn.getcwd(), ":t"),
     context = MoteContext.build_name(nil),
     cwd = vim.fn.getcwd(),
   }
+end
+
+---@param entities Vibing.Domain.Chat.FileEntity[]
+---@param config table
+---@param on_complete fun(success: boolean, message: string)
+function M._execute_deletion(entities, config, on_complete)
+  local mote_config = M._build_mote_config(config)
 
   MoteCleaner.clean_batch(entities, mote_config, function(_, mote_failed, mote_errors)
     local delete_result = ChatRepository.delete_batch(entities)
@@ -70,12 +76,14 @@ end
 ---@param success_count number
 ---@param failed_count number
 ---@param errors string[]
+---@param success_label string|nil defaults to "Deleted"
 ---@return string
-function M._build_result_message(success_count, failed_count, errors)
+function M._build_result_message(success_count, failed_count, errors, success_label)
+  success_label = success_label or "Deleted"
   local parts = {}
 
   if success_count > 0 then
-    table.insert(parts, string.format("Deleted %d file(s)", success_count))
+    table.insert(parts, string.format("%s %d file(s)", success_label, success_count))
   end
 
   if failed_count > 0 then
@@ -101,27 +109,8 @@ function M.clean_mote_selected(entities, config, on_complete)
     return
   end
 
-  local mote_config = {
-    project = (config.diff and config.diff.mote and config.diff.mote.project) or vim.fn.fnamemodify(vim.fn.getcwd(), ":t"),
-    context = MoteContext.build_name(nil),
-    cwd = vim.fn.getcwd(),
-  }
-
-  MoteCleaner.clean_batch(entities, mote_config, function(success_count, failed_count, errors)
-    local parts = {}
-
-    if success_count > 0 then
-      table.insert(parts, string.format("Cleaned mote objects for %d file(s)", success_count))
-    end
-
-    if failed_count > 0 then
-      local error_summary = #errors > 3
-        and table.concat(vim.list_slice(errors, 1, 3), ", ") .. string.format(" (and %d more)", #errors - 3)
-        or table.concat(errors, ", ")
-      table.insert(parts, string.format("Failed for %d file(s): %s", failed_count, error_summary))
-    end
-
-    on_complete(failed_count == 0, table.concat(parts, ". "))
+  MoteCleaner.clean_batch(entities, M._build_mote_config(config), function(success_count, failed_count, errors)
+    on_complete(failed_count == 0, M._build_result_message(success_count, failed_count, errors, "Cleaned mote objects for"))
   end)
 end
 

--- a/lua/vibing/application/chat/use_cases/delete_chats.lua
+++ b/lua/vibing/application/chat/use_cases/delete_chats.lua
@@ -92,6 +92,39 @@ function M._build_result_message(success_count, failed_count, errors)
   return table.concat(parts, ". ")
 end
 
+---@param entities Vibing.Domain.Chat.FileEntity[]
+---@param config table
+---@param on_complete fun(success: boolean, message: string)
+function M.clean_mote_selected(entities, config, on_complete)
+  if not entities or #entities == 0 then
+    on_complete(false, "No files selected")
+    return
+  end
+
+  local mote_config = {
+    project = (config.diff and config.diff.mote and config.diff.mote.project) or vim.fn.fnamemodify(vim.fn.getcwd(), ":t"),
+    context = MoteContext.build_name(nil),
+    cwd = vim.fn.getcwd(),
+  }
+
+  MoteCleaner.clean_batch(entities, mote_config, function(success_count, failed_count, errors)
+    local parts = {}
+
+    if success_count > 0 then
+      table.insert(parts, string.format("Cleaned mote objects for %d file(s)", success_count))
+    end
+
+    if failed_count > 0 then
+      local error_summary = #errors > 3
+        and table.concat(vim.list_slice(errors, 1, 3), ", ") .. string.format(" (and %d more)", #errors - 3)
+        or table.concat(errors, ", ")
+      table.insert(parts, string.format("Failed for %d file(s): %s", failed_count, error_summary))
+    end
+
+    on_complete(failed_count == 0, table.concat(parts, ". "))
+  end)
+end
+
 ---@param save_dir string
 ---@param config table
 ---@param on_complete fun(success: boolean, message: string)

--- a/lua/vibing/application/inline/modules/execution.lua
+++ b/lua/vibing/application/inline/modules/execution.lua
@@ -188,7 +188,7 @@ function M.show_results(modified_files, response_text)
       table.insert(lines, "- " .. modified_files[i])
     end
     if #modified_files > MAX_DISPLAY then
-      table.insert(lines, string.format("... (他%d件)", #modified_files - MAX_DISPLAY))
+      table.insert(lines, string.format("... (%d more)", #modified_files - MAX_DISPLAY))
     end
     table.insert(lines, "")
   end

--- a/lua/vibing/infrastructure/storage/mote_cleaner.lua
+++ b/lua/vibing/infrastructure/storage/mote_cleaner.lua
@@ -27,6 +27,9 @@ end
 ---@param context_dir string
 ---@return string
 function M._resolve_patch_path(patch_ref, context_dir)
+  if patch_ref:match("^/") then
+    return patch_ref
+  end
   if patch_ref:match("^%.vibing/") then
     return vim.fn.fnamemodify(patch_ref, ":p")
   end

--- a/lua/vibing/infrastructure/storage/mote_cleaner.lua
+++ b/lua/vibing/infrastructure/storage/mote_cleaner.lua
@@ -53,8 +53,8 @@ function M.clean_snapshot(file_path, config, callback)
     local patch_path = M._resolve_patch_path(patch_ref, context_dir)
 
     if vim.fn.filereadable(patch_path) == 1 then
-      local ok = pcall(vim.fn.delete, patch_path)
-      if ok then
+      local _, result = pcall(vim.fn.delete, patch_path)
+      if result == 0 then
         deleted_count = deleted_count + 1
       end
     end
@@ -120,6 +120,10 @@ function M._delete_snapshots_containing_file(file_path, context_dir, callback)
   end
 
   local git_root = vim.fn.systemlist("git rev-parse --show-toplevel")[1]
+  if not git_root then
+    callback(0)
+    return
+  end
   local relative_path = vim.fn.fnamemodify(file_path, ":p"):gsub("^" .. vim.pesc(git_root .. "/"), "")
 
   local handle = vim.loop.fs_scandir(snapshots_dir)

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -219,6 +219,10 @@ function M._register_commands()
     end,
   })
 
+  vim.api.nvim_create_user_command("VibingCleanMote", function()
+    require("vibing.presentation.chat.deletion_controller").handle_clean_mote_command(M.config)
+  end, { desc = "Clean mote objects for chat files without deleting chats" })
+
   -- コンテキスト関連コマンド
   vim.api.nvim_create_user_command("VibingContext", function(opts)
     require("vibing.presentation.context.controller").handle_add(opts)

--- a/lua/vibing/presentation/chat/deletion_controller.lua
+++ b/lua/vibing/presentation/chat/deletion_controller.lua
@@ -26,4 +26,10 @@ function M.handle_delete_command(opts, config)
   end
 end
 
+---@param config table
+function M.handle_clean_mote_command(config)
+  local save_dir = FileManager.get_save_directory(config)
+  ChatDeletionPicker.show(save_dir, config, false, "clean_mote")
+end
+
 return M

--- a/lua/vibing/ui/chat_deletion_picker.lua
+++ b/lua/vibing/ui/chat_deletion_picker.lua
@@ -18,20 +18,22 @@ end
 ---@param save_dir string
 ---@param config table
 ---@param unrenamed_only boolean|nil
-function M.show(save_dir, config, unrenamed_only)
+---@param mode string|nil "delete" | "clean_mote" (default: "delete")
+function M.show(save_dir, config, unrenamed_only, mode)
   local has_telescope = pcall(require, "telescope")
   if not has_telescope then
-    M._show_native(save_dir, config, unrenamed_only)
+    M._show_native(save_dir, config, unrenamed_only, mode)
     return
   end
 
-  M._show_telescope(save_dir, config, unrenamed_only)
+  M._show_telescope(save_dir, config, unrenamed_only, mode)
 end
 
 ---@param save_dir string
 ---@param config table
 ---@param unrenamed_only boolean|nil
-function M._show_telescope(save_dir, config, unrenamed_only)
+---@param mode string|nil
+function M._show_telescope(save_dir, config, unrenamed_only, mode)
   local pickers = require("telescope.pickers")
   local finders = require("telescope.finders")
   local conf = require("telescope.config").values
@@ -55,9 +57,18 @@ function M._show_telescope(save_dir, config, unrenamed_only)
     },
   })
 
-  local picker = pickers.new({}, {
+  local is_clean_mote = mode == "clean_mote"
+  local prompt_title
+  if is_clean_mote then
+    prompt_title = unrenamed_only and "Clean Mote (Unrenamed) (<Tab> to select, <CR> to clean)"
+      or "Clean Mote Objects (<Tab> to select, <CR> to clean)"
+  else
     prompt_title = unrenamed_only and "Delete Unrenamed Chats (<Tab> to select, <CR> to delete)"
-      or "Delete Chats (<Tab> to select, <CR> to delete)",
+      or "Delete Chats (<Tab> to select, <CR> to delete)"
+  end
+
+  local picker = pickers.new({}, {
+    prompt_title = prompt_title,
     finder = finders.new_oneshot_job(find_command, {
       entry_maker = function(line)
         -- フロントマターでvibing.nvimチャットファイルかどうかを判定
@@ -111,7 +122,11 @@ function M._show_telescope(save_dir, config, unrenamed_only)
 
         local selected_entities = vim.tbl_map(function(s) return s.value end, selections)
 
-        DeleteChatsUseCase.delete_selected(selected_entities, config, notify_result)
+        if is_clean_mote then
+          DeleteChatsUseCase.clean_mote_selected(selected_entities, config, notify_result)
+        else
+          DeleteChatsUseCase.delete_selected(selected_entities, config, notify_result)
+        end
       end)
 
       return true
@@ -124,7 +139,9 @@ end
 ---@param save_dir string
 ---@param config table
 ---@param unrenamed_only boolean|nil
-function M._show_native(save_dir, config, unrenamed_only)
+---@param mode string|nil
+function M._show_native(save_dir, config, unrenamed_only, mode)
+  local is_clean_mote = mode == "clean_mote"
   local entities = unrenamed_only and DeleteChatsUseCase.list_unrenamed_files(save_dir)
     or DeleteChatsUseCase.list_all_files(save_dir)
 
@@ -133,8 +150,15 @@ function M._show_native(save_dir, config, unrenamed_only)
     return
   end
 
+  local prompt
+  if is_clean_mote then
+    prompt = unrenamed_only and "Select unrenamed chat to clean mote:" or "Select chat to clean mote:"
+  else
+    prompt = unrenamed_only and "Select unrenamed chat to delete:" or "Select chat to delete:"
+  end
+
   vim.ui.select(entities, {
-    prompt = unrenamed_only and "Select unrenamed chat to delete:" or "Select chat to delete:",
+    prompt = prompt,
     format_item = function(entity)
       return string.format("%s - %s (%s)", entity:get_display_name(), entity:get_formatted_date(), entity:get_formatted_size())
     end,
@@ -143,7 +167,11 @@ function M._show_native(save_dir, config, unrenamed_only)
       return
     end
 
-    DeleteChatsUseCase.delete_selected({ choice }, config, notify_result)
+    if is_clean_mote then
+      DeleteChatsUseCase.clean_mote_selected({ choice }, config, notify_result)
+    else
+      DeleteChatsUseCase.delete_selected({ choice }, config, notify_result)
+    end
   end)
 end
 


### PR DESCRIPTION
## 概要

- `:VibingCleanMote` コマンドを追加
- `VibingDeleteChats` でパッチファイルが削除されないバグを修正

## 変更内容

### feat: `:VibingCleanMote` コマンド

チャットファイル自体を削除せず、moteオブジェクトだけをクリーンアップする新コマンド。

- チャットファイル内の `<!-- patch: ... -->` 参照パッチファイルを削除
- moteスナップショット内の対象ファイルを削除
- `mote snap gc` でGCを実行
- Telescope / native UI どちらにも対応（複数選択可）

### fix: 絶対パスのパッチ参照が正しく解決されない問題

`_resolve_patch_path` が相対パスとファイル名のみを想定していたため、チャットファイルに絶対パスで記録されたパッチ参照（`<!-- patch: /Users/.../patches/xxx.patch -->`）が解決できず、`VibingDeleteChats` 実行後もパッチファイルが残り続けていた。

絶対パス（`^/`）を先に判定して返すことで修正。

## テスト手順

- [ ] `:VibingCleanMote` を実行してチャット選択ピッカーが表示されること
- [ ] 選択後に mote パッチファイルとスナップショットが削除されること
- [ ] チャットファイル自体が残っていること
- [ ] `:VibingDeleteChats` 実行後に `gd` で差分が見えなくなること（パッチファイルが削除される）