### PR TITLE
fix: introduce ALWAYS_ALLOWED_TOOLS and fix local plugin loading by projectPath

### DIFF
--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -30,10 +30,12 @@ export interface PluginReference {
  * This matches the structure in installed_plugins.json.
  */
 interface InstalledPlugin {
-  /** Installation scope: 'user' or 'project' */
+  /** Installation scope: 'user' or 'local' */
   scope: string;
   /** Absolute path to the plugin installation directory */
   installPath: string;
+  /** For local-scope installs: the project directory this plugin was installed for */
+  projectPath?: string;
   /** Plugin version string */
   version: string;
   /** ISO timestamp of initial installation */
@@ -184,36 +186,25 @@ export async function loadInstalledPlugins(): Promise<PluginReference[]> {
     return [];
   }
 
-  // Load enabled plugin IDs to filter completions to only CLI-available plugins
-  const enabledIds = await loadEnabledPluginIds();
-
-  // Collect installation paths.
-  // For each plugin ID, pick only the best installation to avoid duplicate skills
-  // when multiple versions are cached (e.g. scope=user 1.1.0 + scope=local 1.1.1).
-  // Inclusion rules:
-  //   scope=local → always include (explicitly project-installed, always active)
-  //   scope=user  → include only if in enabledPlugins (needs explicit enable)
-  // Preference order when multiple installs exist: local > user scope, then most recent.
+  // Only load local-scope plugins explicitly.
+  // User-scope plugins are auto-discovered by the Agent SDK via settingSources,
+  // so passing them here is unnecessary. Local-scope plugins are project-specific:
+  // include only if projectPath matches the current working directory.
+  const currentProjectPath = process.cwd();
   const allInstallations: InstalledPlugin[] = [];
   for (const [pluginId, installations] of Object.entries(installed.plugins)) {
     if (!Array.isArray(installations) || installations.length === 0) continue;
 
-    const hasLocalInstall = installations.some((inst) => inst.scope === 'local');
-    // null means no filter — include all (mirrors behaviour when no enabledPlugins is configured)
-    const isEnabledInSettings = enabledIds === null || enabledIds.has(pluginId);
+    const localInstall = installations.find(
+      (inst) => inst.scope === 'local' && inst.projectPath === currentProjectPath
+    );
 
-    if (!hasLocalInstall && !isEnabledInSettings) {
-      debugLog(`Skipping plugin (not local and not enabled): ${pluginId}`);
+    if (!localInstall) {
+      debugLog(`Skipping plugin (no local install for current project): ${pluginId}`);
       continue;
     }
 
-    // Pick best: local scope preferred, then most recent lastUpdated
-    const best = installations.reduce((a, b) => {
-      if (a.scope === 'local' && b.scope !== 'local') return a;
-      if (b.scope === 'local' && a.scope !== 'local') return b;
-      return a.lastUpdated >= b.lastUpdated ? a : b;
-    });
-    allInstallations.push(best);
+    allInstallations.push(localInstall);
   }
 
   debugLog(`Found ${allInstallations.length} plugin installations`);

--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -30,7 +30,7 @@ export interface PluginReference {
  * This matches the structure in installed_plugins.json.
  */
 interface InstalledPlugin {
-  /** Installation scope: 'user' or 'local' */
+  /** Installation scope: 'user', 'project', or 'local' */
   scope: string;
   /** Absolute path to the plugin installation directory */
   installPath: string;

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -24,6 +24,21 @@ for _, tool in ipairs(M.VALID_TOOLS) do
   M.VALID_TOOLS_MAP[tool] = true
 end
 
+---permissions_allowの設定に関わらず、askやdenyに明示的に入っていなければ常に許可されるツール
+---@type string[]
+M.ALWAYS_ALLOWED_TOOLS = {
+  "Read",
+  "Skill",
+  "StructuredOutput",
+}
+
+---ALWAYS_ALLOWED_TOOLSの高速検索用マップ
+---@type table<string, boolean>
+M.ALWAYS_ALLOWED_TOOLS_MAP = {}
+for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
+  M.ALWAYS_ALLOWED_TOOLS_MAP[tool] = true
+end
+
 ---ツール名が有効かチェックし、正規化された名前を返す
 ---@param tool string チェックするツール名
 ---@return string|nil 有効な場合は正規化されたツール名

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -2,6 +2,8 @@
 --- Builds the command array for the Claude CLI with streaming JSON I/O
 --- @module vibing.infrastructure.adapter.modules.cli_command_builder
 
+local tools_constants = require("vibing.core.constants.tools")
+
 local M = {}
 
 local cached_claude_path = nil
@@ -39,7 +41,11 @@ local function add_permission_args(cmd, opts)
     permissions_allow = {}
   end
   local allow_tools = vim.deepcopy(permissions_allow)
-  for _, tool in ipairs({ "Read", "Skill", "mcp__vibing-nvim__*" }) do
+  local always_allowed = vim.list_extend(
+    vim.deepcopy(tools_constants.ALWAYS_ALLOWED_TOOLS),
+    { "mcp__vibing-nvim__*" }
+  )
+  for _, tool in ipairs(always_allowed) do
     if not vim.tbl_contains(allow_tools, tool) then
       table.insert(allow_tools, tool)
     end

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -15,6 +15,9 @@ local _loading = false
 ---@type integer
 local _load_generation = 0
 
+---@type string?
+local _bundled_cache_cwd = nil
+
 ---Parse SKILL.md to extract name and description
 ---@param file_path string
 ---@return {name: string, description: string}?
@@ -188,10 +191,12 @@ local function start_async_load()
     return
   end
 
+  local cwd = vim.fn.getcwd()
   _loading = true
+  _bundled_cache_cwd = cwd
   local load_generation = _load_generation
   local ok = pcall(function()
-    vim.system({ executable, script_path }, {}, vim.schedule_wrap(function(result)
+    vim.system({ executable, script_path }, { cwd = cwd }, vim.schedule_wrap(function(result)
       if load_generation ~= _load_generation then
         return
       end
@@ -206,6 +211,7 @@ local function start_async_load()
   end)
   if not ok then
     _loading = false
+    _bundled_cache_cwd = nil
   end
 end
 
@@ -213,8 +219,17 @@ end
 ---Returns cached result immediately; starts async load if not yet cached
 ---@return Vibing.CompletionItem[]
 local function get_dynamic_sdk_skills()
+  local current_cwd = vim.fn.getcwd()
   if _bundled_cache then
-    return _bundled_cache
+    if _bundled_cache_cwd == current_cwd then
+      return _bundled_cache
+    end
+    -- cwd changed: invalidate and reload
+    _bundled_cache = nil
+    _bundled_cache_cwd = nil
+    _loading = false
+    _load_generation = _load_generation + 1
+    _cache = nil
   end
   start_async_load()
   return {}
@@ -330,6 +345,7 @@ function M.clear_cache()
   _load_generation = _load_generation + 1
   _cache = nil
   _bundled_cache = nil
+  _bundled_cache_cwd = nil
   _loading = false
 end
 

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -204,6 +204,10 @@ local function start_async_load()
       if result.code ~= 0 then
         return
       end
+      -- discard if cwd changed while loading (e.g. worktree switch mid-flight)
+      if vim.fn.getcwd() ~= cwd then
+        return
+      end
       local items = parse_commands_output(result.stdout or "")
       _bundled_cache = items
       _cache = nil

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -4,17 +4,19 @@
 --- Permission evaluation order (highest to lowest priority):
 --- 1. Session-level deny list (immediate block)
 --- 2. Session-level allow list (auto-approve)
---- 3. Internal tools (always allowed)
+--- 3. Internal tools (always allowed, e.g. ToolSearch, Agent)
 --- 4. Deny list (deny takes precedence over allow)
---- 5. Permission modes (acceptEdits, default, bypassPermissions, plan, dontAsk)
---- 6. Allow list (with pattern matching support)
---- 7. Ask list (granular patterns override broader allow list permissions)
---- 8. Granular permission rules (path/command/pattern/domain based)
+--- 5. Always-allowed tools (bypass allow list; deny/ask still respected)
+--- 6. Permission modes (acceptEdits, default, bypassPermissions, plan, dontAsk)
+--- 7. Allow list (with pattern matching support)
+--- 8. Ask list (granular patterns override broader allow list permissions)
+--- 9. Granular permission rules (path/command/pattern/domain based)
 ---
 --- @module vibing.infrastructure.permissions.can_use_tool
 
 local matchers = require("vibing.infrastructure.permissions.matchers")
 local rule_checker = require("vibing.infrastructure.permissions.rule_checker")
+local tools_constants = require("vibing.core.constants.tools")
 
 local M = {}
 
@@ -192,7 +194,17 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
-    -- 5. Permission modes
+    -- 5. Always-allowed tools: bypass allow list, but respect deny (checked above) and ask
+    if tools_constants.ALWAYS_ALLOWED_TOOLS_MAP[tool_name] then
+      for _, pattern in ipairs(config.asked_tools) do
+        if matchers.matches_permission(tool_name, input, pattern) then
+          return ask()
+        end
+      end
+      return allow(input)
+    end
+
+    -- 6. Permission modes
     local mode = config.permission_mode
 
     if mode == "bypassPermissions" or mode == "dontAsk" then
@@ -211,7 +223,7 @@ function M.can_use_tool(tool_name, input, config)
       return deny("vibing.nvim MCP integration is disabled. Enable it in config: mcp.enabled = true")
     end
 
-    -- 6. Check allow list (with pattern support)
+    -- 7. Check allow list (with pattern support)
     if #config.allowed_tools > 0 then
       local is_allowed = false
       for _, pattern in ipairs(config.allowed_tools) do
@@ -225,14 +237,14 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
-    -- 7. Check ask list (AFTER allow list - granular patterns override broader permissions)
+    -- 8. Check ask list (AFTER allow list - granular patterns override broader permissions)
     for _, pattern in ipairs(config.asked_tools) do
       if matchers.matches_permission(tool_name, input, pattern) then
         return ask()
       end
     end
 
-    -- 8. Check granular permission rules
+    -- 9. Check granular permission rules
     if config.permission_rules and #config.permission_rules > 0 then
       local has_matching_allow = false
       for _, rule in ipairs(config.permission_rules) do

--- a/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
+++ b/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
@@ -1,0 +1,78 @@
+local can_use_tool = require("vibing.infrastructure.permissions.can_use_tool")
+
+--- Build a minimal PermissionConfig for tests
+---@param overrides table
+---@return PermissionConfig
+local function make_config(overrides)
+  return vim.tbl_extend("force", {
+    allowed_tools = {},
+    denied_tools = {},
+    asked_tools = {},
+    session_allowed_tools = {},
+    session_denied_tools = {},
+    permission_rules = {},
+    permission_mode = "default",
+    mcp_enabled = false,
+  }, overrides or {})
+end
+
+describe("can_use_tool", function()
+  describe("ALWAYS_ALLOWED_TOOLS (UT-PERM-010)", function()
+    local always_allowed = { "Read", "Skill", "StructuredOutput" }
+
+    for _, tool in ipairs(always_allowed) do
+      it(string.format("should allow %s even when permissions_allow is empty", tool), function()
+        local result = can_use_tool.can_use_tool(tool, {}, make_config({
+          allowed_tools = {},
+        }))
+        assert.equals("allow", result.behavior)
+      end)
+
+      it(string.format("should allow %s even when permissions_allow does not include it", tool), function()
+        local result = can_use_tool.can_use_tool(tool, {}, make_config({
+          allowed_tools = { "Edit", "Write" },
+        }))
+        assert.equals("allow", result.behavior)
+      end)
+
+      it(string.format("should deny %s when explicitly in deny list", tool), function()
+        local result = can_use_tool.can_use_tool(tool, {}, make_config({
+          denied_tools = { tool },
+        }))
+        assert.equals("deny", result.behavior)
+      end)
+
+      it(string.format("should ask for %s when in ask list", tool), function()
+        local result = can_use_tool.can_use_tool(tool, {}, make_config({
+          asked_tools = { tool },
+        }))
+        assert.equals("ask", result.behavior)
+      end)
+
+      it(string.format("should deny %s when in both deny and ask lists (deny wins)", tool), function()
+        local result = can_use_tool.can_use_tool(tool, {}, make_config({
+          denied_tools = { tool },
+          asked_tools = { tool },
+        }))
+        assert.equals("deny", result.behavior)
+      end)
+    end
+  end)
+
+  describe("non-always-allowed tools are still gated by allow list (UT-PERM-011)", function()
+    it("should ask for Bash when not in allow list and mode is default", function()
+      local result = can_use_tool.can_use_tool("Bash", {}, make_config({
+        allowed_tools = { "Read", "Edit" },
+        permission_mode = "default",
+      }))
+      assert.equals("ask", result.behavior)
+    end)
+
+    it("should allow Edit when in allow list", function()
+      local result = can_use_tool.can_use_tool("Edit", {}, make_config({
+        allowed_tools = { "Edit" },
+      }))
+      assert.equals("allow", result.behavior)
+    end)
+  end)
+end)


### PR DESCRIPTION
## 概要

2つの独立したバグ修正をまとめたPRです。

### 1. ALWAYS_ALLOWED_TOOLS による権限バイパス定数の導入

`permissions_allow` の設定に関わらず、`ask` や `deny` に明示的に入っていなければ常に許可されるツールの内部定数 `ALWAYS_ALLOWED_TOOLS` を追加しました。

**変更前の問題点：**
- `Read` / `Skill` は `cli_command_builder.lua` と `permission.lua` の2箇所にハードコードされており、重複していた
- `StructuredOutput` はデフォルト設定（`config.lua`）にのみ追加されていたため、フロントマターで `permissions_allow` を明示したチャットでは許可されない可能性があった

**変更内容：**
- `tools.lua`: `ALWAYS_ALLOWED_TOOLS = {Read, Skill, StructuredOutput}` と高速検索用マップを追加（単一の真実の源）
- `can_use_tool.lua`: step 5 として新ステップを追加。deny チェック後・allow リスト前に評価し、allow リストをバイパスしつつ deny/ask は尊重する
- `cli_command_builder.lua`: ハードコードを定数参照に変更（`StructuredOutput` も `--allowedTools` に含まれるようになった）
- `permission.lua`: 今や不要となった Read/Skill の特殊追加ロジックを削除

**`INTERNAL_TOOLS`（ToolSearch等）との違い：**
- `INTERNAL_TOOLS` → deny リストより前（完全 bypass、ユーザーが止められない）
- `ALWAYS_ALLOWED_TOOLS` → deny チェック後（deny/ask で明示的にブロック可能）

### 2. ローカルプラグインを projectPath で絞り込み + skills キャッシュを cwd 変更時に無効化

- `plugin-loader.ts`: `enabledIds` フィルターをやめ、`scope=local` かつ `projectPath` がカレントディレクトリと一致するプラグインのみ読み込むよう変更。ユーザースコープのプラグインは Agent SDK が `settingSources` 経由で自動検出するため不要。
- `skills.lua`: ロード時の `cwd` を記録し、`cwd` が変わった際にキャッシュを無効化。ワークツリー切り替え時に古いスキル補完が表示される問題を修正。

## テスト

- Lua 構文チェック通過（`pnpm run check`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local project plugin installs and matching them to the current workspace.
  * Introduced a built-in always-allowed tools set for common read/skill/output actions.
  * Improved skill loading so cached results stay aligned with the active working directory.

* **Bug Fixes**
  * Permission checks now consistently honor deny, ask, and allow rules for always-allowed tools.
  * Tool permission handling and command generation now use the same predefined always-allowed set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->