### PR TITLE
fix: fix plugin skill completion truncated at 65536 bytes

### DIFF
--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -24,9 +24,6 @@ async function listCommands() {
     // Get the list of available commands
     const commands = await result.supportedCommands();
 
-    // Output as JSON
-    console.log(safeJsonStringify(commands));
-
     // Try to cancel the query (may fail in some SDK versions)
     try {
       if (typeof result.cancel === 'function') {
@@ -35,6 +32,13 @@ async function listCommands() {
     } catch {
       // Ignore cancel errors
     }
+
+    // Write output and wait for stdout to flush before exiting.
+    // process.exit() called immediately after console.log() can truncate output
+    // when stdout is a pipe and the data exceeds the 65536-byte OS pipe buffer.
+    await new Promise<void>((resolve) => {
+      process.stdout.write(safeJsonStringify(commands) + '\n', () => resolve());
+    });
 
     process.exit(0);
   } catch (error) {

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -191,29 +191,48 @@ local function start_async_load()
     return
   end
 
-  local cwd = vim.fn.getcwd()
+  local cwd = vim.fn.getcwd(-1, -1)
   _loading = true
   _bundled_cache_cwd = cwd
   local load_generation = _load_generation
-  local ok = pcall(function()
-    vim.system({ executable, script_path }, { cwd = cwd }, vim.schedule_wrap(function(result)
+  -- Accumulate streaming chunks correctly: last element of each on_stdout call
+  -- is a partial line continued by the first element of the next call.
+  local stdout_lines = { "" }
+
+  -- Do NOT use stdout_buffered=true: Neovim caps its internal buffer at 65536 bytes,
+  -- which truncates large outputs (e.g. >64KB plugin skill lists) and breaks JSON parsing.
+  -- Instead, stream chunks and reconstruct lines manually.
+  local job_id = vim.fn.jobstart({ executable, script_path }, {
+    cwd = cwd,
+    on_stdout = function(_, data, _)
+      if type(data) ~= "table" or #data == 0 then
+        return
+      end
+      -- data[1] continues the partial line from the previous call
+      stdout_lines[#stdout_lines] = stdout_lines[#stdout_lines] .. (data[1] or "")
+      for i = 2, #data do
+        table.insert(stdout_lines, data[i])
+      end
+    end,
+    on_exit = vim.schedule_wrap(function(_, code, _)
       if load_generation ~= _load_generation then
         return
       end
       _loading = false
-      if result.code ~= 0 then
+      if code ~= 0 then
         return
       end
-      -- discard if cwd changed while loading (e.g. worktree switch mid-flight)
-      if vim.fn.getcwd() ~= cwd then
+      if vim.fn.getcwd(-1, -1) ~= cwd then
         return
       end
-      local items = parse_commands_output(result.stdout or "")
+      local stdout = table.concat(stdout_lines, "\n")
+      local items = parse_commands_output(stdout)
       _bundled_cache = items
       _cache = nil
-    end))
-  end)
-  if not ok then
+    end),
+  })
+
+  if type(job_id) ~= "number" or job_id <= 0 then
     _loading = false
     _bundled_cache_cwd = nil
   end
@@ -223,7 +242,7 @@ end
 ---Returns cached result immediately; starts async load if not yet cached
 ---@return Vibing.CompletionItem[]
 local function get_dynamic_sdk_skills()
-  local current_cwd = vim.fn.getcwd()
+  local current_cwd = vim.fn.getcwd(-1, -1)
   if _bundled_cache then
     if _bundled_cache_cwd == current_cwd then
       return _bundled_cache
@@ -318,7 +337,7 @@ end
 ---@return {dir: string, source: "project"|"user"}[]
 function M.scan_directories()
   return {
-    { dir = vim.fn.getcwd() .. "/.claude/skills/", source = "project" },
+    { dir = vim.fn.getcwd(-1, -1) .. "/.claude/skills/", source = "project" },
     { dir = vim.fn.expand("~/.claude/skills/"), source = "user" },
   }
 end

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -278,6 +278,8 @@ function M._register_commands()
   vim.api.nvim_create_user_command("VibingReloadCommands", function()
     local custom_commands = require("vibing.application.chat.custom_commands")
     local commands = require("vibing.application.chat.commands")
+    local completion = require("vibing.application.completion")
+    local skills = require("vibing.infrastructure.completion.providers.skills")
 
     custom_commands.clear_cache()
     commands.custom_commands = {}
@@ -286,8 +288,11 @@ function M._register_commands()
       commands.register_custom(custom_cmd)
     end
 
-    notify.info("Custom commands reloaded")
-  end, { desc = "Reload custom slash commands" })
+    completion.clear_cache()
+    skills.preload()
+
+    notify.info("Commands and completions reloading...")
+  end, { desc = "Reload custom slash commands and completion candidates" })
 
   vim.api.nvim_create_user_command("VibingCopyUnsentUserHeader", function()
     local timestamp = require("vibing.core.utils.timestamp")


### PR DESCRIPTION
## 問題

`~/workspace/virtual-monorepo` などプラグインスキルが多いプロジェクトで vibing.nvim を起動すると、`/` 補完に `wt-sessions:*`・`oss-maintainer:*`・`self-review:*` などローカルプラグインスキルが表示されなかった。

## 根本原因

### 1. `list-commands.ts`: stdoutの未フラッシュ問題（主因）

`console.log()` の直後に `process.exit(0)` を呼ぶと、stdout が pipe 接続の場合、OS の pipe バッファ上限（65536 バイト）を超えた部分が Node.js の内部バッファに残ったままプロセスが終了し、データが破棄される。

`virtual-monorepo` の場合、`list-commands.js` の出力は約 69KB あり、65536 バイトで切り詰められた JSON は parse 失敗 → スキルが 0 件として扱われていた。

**修正**: `process.stdout.write(data, callback)` の callback で resolve する Promise を await することで、すべてのデータが OS pipe バッファに書き込まれてから `process.exit(0)` を呼ぶ。

### 2. `skills.lua`: vim.system / jobstart の stdout バッファ上限（副因）

`vim.system()` も `vim.fn.jobstart({ stdout_buffered = true })` も Neovim 内部で stdout を 65536 バイトに切り詰める。

**修正**: `stdout_buffered` なしの `jobstart` でストリーミング受信し、Neovim の部分行継続規約（各 `on_stdout` コールの `data[1]` が前コールの末尾行の続き）に従って正しく結合する。

### 3. `skills.lua`: 空テーブル EOF シグナルでのクラッシュ（バグ修正）

Neovim が EOF を通知する際に `on_stdout({})` を呼ぶ場合があり、`data[1]` が `nil` になって `.. nil` で Lua エラーが発生していた可能性がある。

**修正**: `#data == 0` ガードと `data[1] or ""` フォールバックを追加。

### 4. その他

- `vim.fn.getcwd()` → `vim.fn.getcwd(-1, -1)` に統一（window-local ではなくグローバル cwd を使用）
- `:VibingReloadCommands` でスキル補完キャッシュも再読み込みするよう拡張

## 確認結果

修正後、`virtual-monorepo` で `skills.get_all()` を呼ぶと 39 件のプラグインスキルを含む 66 件が返るようになった（修正前は plugin: 0）。

```
counts = {
  bundled = 4,
  custom = 8,
  plugin = 39,   ← 修正前は 0
  project = 10,
  user = 5,
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command output handling so generated lists are less likely to be cut off or truncated.
  * Fixed dynamic skill loading to be more reliable, especially when output is streamed or the working directory changes.

* **New Features**
  * Reloading now refreshes both commands and completion suggestions together.
  * The reload notification message now reflects that completions are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->