### PR TITLE
fix: fix plugin skill completion truncated at 65536 bytes

### DIFF
--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -36,8 +36,11 @@ async function listCommands() {
     // Write output and wait for stdout to flush before exiting.
     // process.exit() called immediately after console.log() can truncate output
     // when stdout is a pipe and the data exceeds the 65536-byte OS pipe buffer.
-    await new Promise<void>((resolve) => {
-      process.stdout.write(safeJsonStringify(commands) + '\n', () => resolve());
+    await new Promise<void>((resolve, reject) => {
+      process.stdout.write(safeJsonStringify(commands) + '\n', (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
     });
 
     process.exit(0);

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -2,8 +2,6 @@
 ---メッセージ送信ユースケース
 local M = {}
 
-local Context = require("vibing.application.context.manager")
-local Formatter = require("vibing.infrastructure.context.formatter")
 local BufferReload = require("vibing.core.utils.buffer_reload")
 local GradientAnimation = require("vibing.ui.gradient_animation")
 
@@ -52,8 +50,7 @@ function M.execute(adapter, callbacks, message, config)
 
   -- 実際のメッセージ送信処理（mote初期化後に呼び出される）
   local function do_send()
-    local contexts = Context.get_all(config.chat.auto_context)
-    local formatted_prompt = Formatter.format_prompt(message, contexts, config.chat.context_position)
+    local formatted_prompt = message
 
     local conversation = callbacks.extract_conversation()
     if #conversation == 0 then

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -126,6 +126,7 @@
 ---@field add_context string コンテキスト追加キー（デフォルト: "<C-a>"）
 ---@field open_diff string ファイルパス上でdiff表示キー（デフォルト: "gd"）
 ---@field open_file string ファイルパス上でファイルを開くキー（デフォルト: "gf"）
+---@field open_url string カーソル行のURLをブラウザで開くキー（デフォルト: "gx"）
 
 ---@class Vibing.LanguageConfig
 ---言語設定（詳細）
@@ -264,6 +265,7 @@ M.defaults = {
     add_context = "<C-a>",
     open_diff = "gd",
     open_file = "gf",
+    open_url = "gx",
   },
   diff = {
     tool = "auto",

--- a/lua/vibing/presentation/chat/modules/keymap_handler.lua
+++ b/lua/vibing/presentation/chat/modules/keymap_handler.lua
@@ -75,8 +75,63 @@ function M.setup(buf, callbacks, keymaps)
       local file_path = FilePath.is_cursor_on_file_path(buf)
       if file_path then
         FilePath.open_file(file_path)
+      else
+        -- Modified Files セクション外では <cfile> で検出したパスを使う
+        local cfile = vim.fn.expand("<cfile>")
+        if cfile ~= "" then
+          local expanded = vim.fn.expand(cfile)
+          if vim.fn.filereadable(expanded) == 1 then
+            FilePath.open_file(expanded)
+          end
+        end
       end
     end, { buffer = buf, desc = "Open file under cursor" })
+
+    vim.keymap.set("n", keymaps.open_url, function()
+      if not vim.ui.open then
+        vim.notify("vim.ui.open requires Neovim 0.10+", vim.log.levels.WARN)
+        return
+      end
+      -- バッファ行全体を取得（ソフト折り返し時も完全なURLを取得できる）
+      local line = vim.fn.getline(".")
+      local col = vim.api.nvim_win_get_cursor(0)[2] + 1 -- 1-indexed
+
+      local url_pat = "(https?://[^ \t\n%]%)>\"']+)"
+      local found_url = nil
+      local best_dist = math.huge
+      local max_dist = 10
+
+      local search_pos = 1
+      while true do
+        local url_start, url_end, url = line:find(url_pat, search_pos)
+        if not url_start then
+          break
+        end
+        -- 末尾の句読点を除去
+        url = url:gsub("[.,;:!?]+$", "")
+        url_end = url_start + #url - 1
+
+        if col >= url_start and col <= url_end then
+          found_url = url
+          break
+        end
+        local dist = math.min(math.abs(col - url_start), math.abs(col - url_end))
+        if dist < best_dist and dist <= max_dist then
+          best_dist = dist
+          found_url = url
+        end
+        search_pos = url_end + 1
+      end
+
+      if found_url then
+        local err = vim.ui.open(found_url)
+        if err then
+          vim.notify("Failed to open URL: " .. tostring(err), vim.log.levels.ERROR)
+        end
+      else
+        vim.notify("No URL found on current line", vim.log.levels.INFO)
+      end
+    end, { buffer = buf, desc = "Open URL on current line" })
 
     -- NOTE: gp (preview all) was removed - use gd on individual files in Modified Files section
     -- Diff display now uses patch files in .vibing/patches/<session_id>/


### PR DESCRIPTION
## 変更内容

### fix: プラグインスキルの補完が65536バイトで切れる問題を修正

- `bin/list-commands.ts` のバッファサイズ上限を撤廃
- `lua/vibing/infrastructure/completion/providers/skills.lua` の補完取得処理を改善
- `lua/vibing/init.lua` の関連初期化を修正

### feat: コンテキストのプロンプト自動付加を廃止

- `:VibingContext` でファイルを追加するとクリップボードにコピーされる（既存機能）
- プロンプト送信時にコンテキストを自動付加する処理を削除
- ユーザーが手動でユーザーセクションに貼り付けて送るフローのみサポート

### feat: チャットバッファに `gx` URLオープナーを追加

- カーソル行の URL を `gx` でブラウザ開く（Neovim 0.10+ 必須）
- カーソルが URL 上にない場合は近傍 10 文字以内の URL を検索
- `gf` のフォールバックとして `<cfile>` 検出によるファイルオープンを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new keybinding to open the URL under the cursor in your browser.
  * Improved file-opening behavior by falling back to nearby file text when no direct file path is detected.

* **Bug Fixes**
  * Made command output handling more reliable by properly reporting write errors.
  * Simplified message sending so input is sent more directly and consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->