### PR TITLE
fix: prevent mote diff pollution between concurrent sessions

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -50,7 +50,9 @@ function M.execute(adapter, callbacks, message, config)
 
   local bufnr = callbacks.get_bufnr()
   local session_cwd = callbacks.get_cwd and callbacks.get_cwd() or nil
-  local mote_config = M._create_session_mote_config(config, callbacks.get_session_id(), bufnr, session_cwd)
+  local frontmatter = callbacks.parse_frontmatter()
+  local mote_cwd_override = frontmatter and frontmatter.mote_cwd or nil
+  local mote_config = M._create_session_mote_config(config, callbacks.get_session_id(), bufnr, session_cwd, mote_cwd_override)
 
   -- 実際のメッセージ送信処理（mote初期化後に呼び出される）
   local function do_send()
@@ -294,8 +296,9 @@ end
 ---@param session_id string|nil セッションID
 ---@param bufnr number|nil バッファ番号（session_idがない場合のfallback用）
 ---@param session_cwd string|nil worktreeのcwd（worktreeで作業する場合のみ、worktree判定用）
+---@param mote_cwd_override string|nil VibingMoteDirで指定された追跡ディレクトリ（絶対パス）
 ---@return table|nil セッション固有のmote設定（mote未設定の場合nil）
-function M._create_session_mote_config(config, session_id, bufnr, session_cwd)
+function M._create_session_mote_config(config, session_id, bufnr, session_cwd, mote_cwd_override)
   if not config.diff or not config.diff.mote then
     return nil
   end
@@ -307,14 +310,19 @@ function M._create_session_mote_config(config, session_id, bufnr, session_cwd)
   -- プロジェクト名（設定 or 自動検出）
   mote_config.project = mote_config.project or MoteDiff.get_project_name()
 
-  -- コンテキスト名生成（worktree分離対応）
   local context_prefix = mote_config.context_prefix or "vibing"
-  mote_config.context = MoteDiff.build_context_name(context_prefix, session_cwd)
 
-  -- worktreeで作業する場合はcwdを設定
-  -- moteコマンドはこのcwdで実行され、worktree内のファイルのみを追跡する
-  if session_cwd then
-    mote_config.cwd = session_cwd
+  if mote_cwd_override then
+    -- VibingMoteDirで明示指定された追跡ディレクトリ
+    -- パスの末尾 + フルパスのハッシュでユニークなコンテキスト名を生成
+    mote_config.context = MoteDiff.build_context_name_from_path(context_prefix, mote_cwd_override)
+    mote_config.cwd = mote_cwd_override
+  else
+    -- worktree判定による自動コンテキスト（.worktrees/ パターン）
+    mote_config.context = MoteDiff.build_context_name(context_prefix, session_cwd)
+    if session_cwd then
+      mote_config.cwd = session_cwd
+    end
   end
 
   return mote_config

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -307,24 +307,14 @@ function M._create_session_mote_config(config, session_id, bufnr, session_cwd)
   -- プロジェクト名（設定 or 自動検出）
   mote_config.project = mote_config.project or MoteDiff.get_project_name()
 
-  -- mote用cwdの決定:
-  -- working_dir frontmatterがgit root(.)を指す場合は、Neovimの現在のcwdで
-  -- worktree自動検出を試みる（wt-sessionsなど任意パスのworktreeに対応）
-  local mote_cwd = session_cwd
-  local Git = require("vibing.core.utils.git")
-  local git_root = Git.get_root()
-  if git_root and (not mote_cwd or mote_cwd == git_root) then
-    local nvim_cwd = vim.fn.getcwd()
-    if nvim_cwd and nvim_cwd ~= "" and nvim_cwd ~= git_root then
-      mote_cwd = nvim_cwd
-    end
-  end
-
   -- コンテキスト名生成（worktree分離対応）
   local context_prefix = mote_config.context_prefix or "vibing"
-  mote_config.context = MoteDiff.build_context_name(context_prefix, mote_cwd)
-  if mote_cwd then
-    mote_config.cwd = mote_cwd
+  mote_config.context = MoteDiff.build_context_name(context_prefix, session_cwd)
+
+  -- worktreeで作業する場合はcwdを設定
+  -- moteコマンドはこのcwdで実行され、worktree内のファイルのみを追跡する
+  if session_cwd then
+    mote_config.cwd = session_cwd
   end
 
   return mote_config

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -307,14 +307,24 @@ function M._create_session_mote_config(config, session_id, bufnr, session_cwd)
   -- プロジェクト名（設定 or 自動検出）
   mote_config.project = mote_config.project or MoteDiff.get_project_name()
 
+  -- mote用cwdの決定:
+  -- working_dir frontmatterがgit root(.)を指す場合は、Neovimの現在のcwdで
+  -- worktree自動検出を試みる（wt-sessionsなど任意パスのworktreeに対応）
+  local mote_cwd = session_cwd
+  local Git = require("vibing.core.utils.git")
+  local git_root = Git.get_root()
+  if git_root and (not mote_cwd or mote_cwd == git_root) then
+    local nvim_cwd = vim.fn.getcwd()
+    if nvim_cwd and nvim_cwd ~= "" and nvim_cwd ~= git_root then
+      mote_cwd = nvim_cwd
+    end
+  end
+
   -- コンテキスト名生成（worktree分離対応）
   local context_prefix = mote_config.context_prefix or "vibing"
-  mote_config.context = MoteDiff.build_context_name(context_prefix, session_cwd)
-
-  -- worktreeで作業する場合はcwdを設定
-  -- moteコマンドはこのcwdで実行され、worktree内のファイルのみを追跡する
-  if session_cwd then
-    mote_config.cwd = session_cwd
+  mote_config.context = MoteDiff.build_context_name(context_prefix, mote_cwd)
+  if mote_cwd then
+    mote_config.cwd = mote_cwd
   end
 
   return mote_config

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -51,8 +51,12 @@ function M.execute(adapter, callbacks, message, config)
   local bufnr = callbacks.get_bufnr()
   local session_cwd = callbacks.get_cwd and callbacks.get_cwd() or nil
   local frontmatter = callbacks.parse_frontmatter()
-  local mote_cwd_override = frontmatter and frontmatter.mote_cwd or nil
-  local mote_config = M._create_session_mote_config(config, callbacks.get_session_id(), bufnr, session_cwd, mote_cwd_override)
+  -- mote_dirs (array) が優先。後方互換として mote_cwd (string) も読む
+  local mote_dirs = frontmatter and frontmatter.mote_dirs
+  if (not mote_dirs or #mote_dirs == 0) and frontmatter and frontmatter.mote_cwd then
+    mote_dirs = { frontmatter.mote_cwd }
+  end
+  local mote_configs = M._create_session_mote_configs(config, callbacks.get_session_id(), bufnr, session_cwd, mote_dirs)
 
   -- 実際のメッセージ送信処理（mote初期化後に呼び出される）
   local function do_send()
@@ -154,7 +158,7 @@ function M.execute(adapter, callbacks, message, config)
         end)
       end, function(response)
         vim.schedule(function()
-          M._handle_response(response, callbacks, adapter, config, mote_config)
+          M._handle_response(response, callbacks, adapter, config, mote_configs)
         end)
       end)
       -- handle_idをコールバックで設定（キャンセル用）
@@ -163,14 +167,14 @@ function M.execute(adapter, callbacks, message, config)
       end
     else
       local response = adapter:execute(formatted_prompt, opts)
-      M._handle_response(response, callbacks, adapter, config, mote_config)
+      M._handle_response(response, callbacks, adapter, config, mote_configs)
     end
   end
 
   -- mote統合が有効な場合は初期化とsnapshotを待ってから送信
   -- 無効な場合は即座に送信
-  if mote_config then
-    M._ensure_mote_initialized_and_snapshot(mote_config, bufnr, function()
+  if mote_configs and #mote_configs > 0 then
+    M._ensure_mote_initialized_and_snapshot(mote_configs, bufnr, function()
       vim.schedule(do_send)
     end)
   else
@@ -187,7 +191,7 @@ local function is_session_error(error_msg)
 end
 
 ---レスポンスを処理
-function M._handle_response(response, callbacks, adapter, config, mote_config)
+function M._handle_response(response, callbacks, adapter, config, mote_configs)
   -- Stop gradient animation
   local bufnr = callbacks.get_bufnr()
   if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
@@ -226,64 +230,82 @@ function M._handle_response(response, callbacks, adapter, config, mote_config)
     callbacks.clear_forked_from()
   end
 
-  -- mote v0.2.4: --project/--context APIではコンテキスト名は最初から確定しているためリネーム不要
-
-  -- mote統合: mote_configが存在し、初期化済みの場合にModified Files出力とpatch生成
+  -- mote統合: 有効なconfigが1つでもあればModified Files出力とpatch生成
   local MoteDiff = require("vibing.core.utils.mote_diff")
 
-  -- セッション開始時のスナップショットIDをベースラインとして設定
-  -- これにより並行セッション間で差分が混入しない
-  if mote_config and session_snapshots[bufnr] then
-    mote_config.baseline_snapshot_id = session_snapshots[bufnr]
+  -- セッション開始時のスナップショットIDをベースラインとして各configに設定
+  local active_configs = {}
+  local snapshots_by_ctx = session_snapshots[bufnr] or {}
+  for _, mc in ipairs(mote_configs or {}) do
+    if MoteDiff.is_initialized(mc.project, mc.context) then
+      local cfg = vim.deepcopy(mc)
+      cfg.baseline_snapshot_id = snapshots_by_ctx[mc.context]
+      table.insert(active_configs, cfg)
+    end
   end
 
-  local using_mote = mote_config ~= nil and MoteDiff.is_initialized(mote_config.project, mote_config.context)
+  if #active_configs > 0 then
+    -- 全configから変更ファイルを収集し、重複排除して出力
+    local all_files = {}
+    local seen_files = {}
+    local patch_paths = {}
+    local remaining = #active_configs
+    local timestamp = os.date("%Y%m%d_%H%M%S")
 
-  if using_mote then
-    MoteDiff.get_changed_files(mote_config, function(success, files, error)
-      if success and files and #files > 0 then
-        -- Patch生成（mote v0.2.4: プロジェクトローカルのcontext-dir配下に保存）
-        local context_dir = MoteDiff.build_context_dir_path(mote_config.project, mote_config.context)
-        if not context_dir then
-          vim.notify("[vibing] Failed to generate patch: git root not found", vim.log.levels.WARN)
-          return
-        end
-
-        local timestamp = os.date("%Y%m%d_%H%M%S")
-        local patch_path = string.format("%s/patches/%s.patch", context_dir, timestamp)
-
-        MoteDiff.generate_patch(mote_config, patch_path, function(patch_success, patch_error)
-          if not patch_success then
-            vim.notify("[vibing] Patch generation failed: " .. (patch_error or "Unknown error"), vim.log.levels.WARN)
-          end
-        end)
-
-        -- Modified Files出力
-        BufferReload.reload_files(files)
-
+    local function finalize()
+      if #all_files > 0 then
+        BufferReload.reload_files(all_files)
         local MAX_DISPLAY = 50
         local file_lines = {}
-        for i = 1, math.min(#files, MAX_DISPLAY) do
-          table.insert(file_lines, files[i])
+        for i = 1, math.min(#all_files, MAX_DISPLAY) do
+          table.insert(file_lines, all_files[i])
         end
-        if #files > MAX_DISPLAY then
-          table.insert(file_lines, string.format("... (%d more)", #files - MAX_DISPLAY))
+        if #all_files > MAX_DISPLAY then
+          table.insert(file_lines, string.format("... (%d more)", #all_files - MAX_DISPLAY))
         end
         callbacks.append_chunk("\n\n### Modified Files\n\n" .. table.concat(file_lines, "\n") .. "\n")
-
-        -- Patch marker (before User section)
-        callbacks.append_chunk("\n<!-- patch: " .. patch_path .. " -->\n")
-      elseif not success then
-        vim.notify("[vibing] Failed to get changed files: " .. (error or "Unknown error"), vim.log.levels.WARN)
       end
-
-      -- Userセクション追加（Modified Files + patch marker出力後）
+      for _, pp in ipairs(patch_paths) do
+        callbacks.append_chunk("\n<!-- patch: " .. pp .. " -->\n")
+      end
       vim.schedule(function()
         callbacks.add_user_section()
       end)
-    end)
+    end
+
+    for _, mc in ipairs(active_configs) do
+      MoteDiff.get_changed_files(mc, function(success, files, err)
+        if success and files then
+          for _, f in ipairs(files) do
+            if not seen_files[f] then
+              seen_files[f] = true
+              table.insert(all_files, f)
+            end
+          end
+        elseif not success then
+          vim.notify("[vibing] Failed to get changed files: " .. (err or "Unknown error"), vim.log.levels.WARN)
+        end
+
+        if #(files or {}) > 0 then
+          local context_dir = MoteDiff.build_context_dir_path(mc.project, mc.context)
+          if context_dir then
+            local patch_path = string.format("%s/patches/%s.patch", context_dir, timestamp)
+            MoteDiff.generate_patch(mc, patch_path, function(patch_success, patch_error)
+              if not patch_success then
+                vim.notify("[vibing] Patch generation failed: " .. (patch_error or "Unknown error"), vim.log.levels.WARN)
+              end
+            end)
+            table.insert(patch_paths, patch_path)
+          end
+        end
+
+        remaining = remaining - 1
+        if remaining == 0 then
+          finalize()
+        end
+      end)
+    end
   else
-    -- Modified Filesが無い場合もUserセクション追加
     callbacks.add_user_section()
   end
 
@@ -291,14 +313,12 @@ function M._handle_response(response, callbacks, adapter, config, mote_config)
   -- 次のsend_message()時にkillすることで、ゾンビプロセス対策になる
 end
 
----セッション固有のmote設定を作成
+---セッション固有のmote設定を作成（単一dir用）
 ---@param config table 全体設定
----@param session_id string|nil セッションID
----@param bufnr number|nil バッファ番号（session_idがない場合のfallback用）
----@param session_cwd string|nil worktreeのcwd（worktreeで作業する場合のみ、worktree判定用）
----@param mote_cwd_override string|nil VibingMoteDirで指定された追跡ディレクトリ（絶対パス）
----@return table|nil セッション固有のmote設定（mote未設定の場合nil）
-function M._create_session_mote_config(config, session_id, bufnr, session_cwd, mote_cwd_override)
+---@param session_cwd string|nil worktreeのcwd
+---@param mote_dir string|nil 追跡ディレクトリ（絶対パス）。nilの場合はworktree自動検出
+---@return table|nil
+function M._create_session_mote_config(config, session_cwd, mote_dir)
   if not config.diff or not config.diff.mote then
     return nil
   end
@@ -306,19 +326,13 @@ function M._create_session_mote_config(config, session_id, bufnr, session_cwd, m
   local MoteDiff = require("vibing.core.utils.mote_diff")
   local mote_config = vim.deepcopy(config.diff.mote)
 
-  -- mote v0.2.4: --project/--context APIを使用
-  -- プロジェクト名（設定 or 自動検出）
   mote_config.project = mote_config.project or MoteDiff.get_project_name()
-
   local context_prefix = mote_config.context_prefix or "vibing"
 
-  if mote_cwd_override then
-    -- VibingMoteDirで明示指定された追跡ディレクトリ
-    -- パスの末尾 + フルパスのハッシュでユニークなコンテキスト名を生成
-    mote_config.context = MoteDiff.build_context_name_from_path(context_prefix, mote_cwd_override)
-    mote_config.cwd = mote_cwd_override
+  if mote_dir then
+    mote_config.context = MoteDiff.build_context_name_from_path(context_prefix, mote_dir)
+    mote_config.cwd = mote_dir
   else
-    -- worktree判定による自動コンテキスト（.worktrees/ パターン）
     mote_config.context = MoteDiff.build_context_name(context_prefix, session_cwd)
     if session_cwd then
       mote_config.cwd = session_cwd
@@ -328,24 +342,48 @@ function M._create_session_mote_config(config, session_id, bufnr, session_cwd, m
   return mote_config
 end
 
+---複数のmote_dirsに対してmote設定の配列を作成
+---@param config table 全体設定
+---@param session_id string|nil セッションID（将来の拡張用）
+---@param bufnr number|nil バッファ番号（将来の拡張用）
+---@param session_cwd string|nil worktreeのcwd
+---@param mote_dirs string[]|nil VibingMoteDirで指定された追跡ディレクトリ一覧
+---@return table[] mote設定の配列（空の場合はempty table）
+function M._create_session_mote_configs(config, session_id, bufnr, session_cwd, mote_dirs)
+  if mote_dirs and #mote_dirs > 0 then
+    local configs = {}
+    for _, dir in ipairs(mote_dirs) do
+      local cfg = M._create_session_mote_config(config, session_cwd, dir)
+      if cfg then
+        table.insert(configs, cfg)
+      end
+    end
+    return configs
+  end
+
+  -- mote_dirs未指定: worktree自動検出（従来の動作）
+  local cfg = M._create_session_mote_config(config, session_cwd, nil)
+  return cfg and { cfg } or {}
+end
+
 -- Mote initialization timeout (10 seconds)
 local MOTE_INIT_TIMEOUT_MS = 10000
 
----mote storageの初期化を確認し、スナップショットを作成
----タイムアウト処理とエラーハンドリングを含む
----@param mote_config table セッション固有のmote設定
----@param bufnr number|nil バッファ番号（スナップショットIDの保存先キー）
+---mote storageの初期化を確認し、スナップショットを作成（複数configs対応）
+---全configの初期化+snapshot完了後に on_complete を呼ぶ
+---@param mote_configs table[] セッション固有のmote設定配列
+---@param bufnr number|nil バッファ番号（スナップショットID保存先キー）
 ---@param on_complete fun() 完了時のコールバック
-function M._ensure_mote_initialized_and_snapshot(mote_config, bufnr, on_complete)
+function M._ensure_mote_initialized_and_snapshot(mote_configs, bufnr, on_complete)
   local MoteDiff = require("vibing.core.utils.mote_diff")
-  if not MoteDiff.is_available() then
+  if not MoteDiff.is_available() or #mote_configs == 0 then
     on_complete()
     return
   end
 
-  -- Track completion to prevent double-calling on_complete
   local completed = false
   local timeout_timer = nil
+  local remaining = #mote_configs
 
   local function complete_once()
     if completed then return end
@@ -357,7 +395,13 @@ function M._ensure_mote_initialized_and_snapshot(mote_config, bufnr, on_complete
     on_complete()
   end
 
-  -- Set up timeout to prevent infinite waiting
+  local function on_one_done()
+    remaining = remaining - 1
+    if remaining == 0 then
+      complete_once()
+    end
+  end
+
   timeout_timer = vim.fn.timer_start(MOTE_INIT_TIMEOUT_MS, function()
     if not completed then
       vim.notify("[vibing] mote initialization timeout - proceeding without mote", vim.log.levels.WARN)
@@ -365,33 +409,38 @@ function M._ensure_mote_initialized_and_snapshot(mote_config, bufnr, on_complete
     end
   end)
 
-  local function create_snapshot()
-    MoteDiff.create_snapshot(mote_config, "Before request", function(success, snapshot_id, error)
-      if not success and error and not error:match("No changes to snapshot") then
-        vim.notify("[vibing] Snapshot creation failed: " .. error, vim.log.levels.WARN)
-      end
-      -- 新しいスナップショットが作成された場合のみ更新（--autoで変更なしの場合はnilのまま）
-      if snapshot_id and bufnr then
-        session_snapshots[bufnr] = snapshot_id
-      end
-      complete_once()
-    end)
-  end
+  for _, mote_config in ipairs(mote_configs) do
+    local mc = mote_config  -- ループ変数のキャプチャ
 
-  if MoteDiff.is_initialized(mote_config.project, mote_config.context) then
-    create_snapshot()
-    return
-  end
-
-  MoteDiff.initialize(mote_config, function(init_success, init_error)
-    if completed then return end -- Already timed out
-    if not init_success then
-      vim.notify("[vibing] mote initialization failed: " .. (init_error or "Unknown error"), vim.log.levels.WARN)
-      complete_once()
-      return
+    local function create_snapshot()
+      MoteDiff.create_snapshot(mc, "Before request", function(success, snapshot_id, err)
+        if not success and err and not err:match("No changes to snapshot") then
+          vim.notify("[vibing] Snapshot creation failed: " .. err, vim.log.levels.WARN)
+        end
+        if snapshot_id and bufnr then
+          if not session_snapshots[bufnr] then
+            session_snapshots[bufnr] = {}
+          end
+          session_snapshots[bufnr][mc.context] = snapshot_id
+        end
+        on_one_done()
+      end)
     end
-    create_snapshot()
-  end)
+
+    if MoteDiff.is_initialized(mc.project, mc.context) then
+      create_snapshot()
+    else
+      MoteDiff.initialize(mc, function(init_success, init_error)
+        if completed then return end
+        if not init_success then
+          vim.notify("[vibing] mote initialization failed: " .. (init_error or "Unknown error"), vim.log.levels.WARN)
+          on_one_done()
+          return
+        end
+        create_snapshot()
+      end)
+    end
+  end
 end
 
 ---フロントマターのagentフィールドに基づいてアダプターを解決

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -2,6 +2,10 @@
 ---メッセージ送信ユースケース
 local M = {}
 
+-- bufnrをキーに、セッション開始時のスナップショットIDを保持
+-- 並行セッション間でのmote差分混入を防ぐためのベースライン管理
+local session_snapshots = {}
+
 local BufferReload = require("vibing.core.utils.buffer_reload")
 local GradientAnimation = require("vibing.ui.gradient_animation")
 
@@ -164,7 +168,7 @@ function M.execute(adapter, callbacks, message, config)
   -- mote統合が有効な場合は初期化とsnapshotを待ってから送信
   -- 無効な場合は即座に送信
   if mote_config then
-    M._ensure_mote_initialized_and_snapshot(mote_config, function()
+    M._ensure_mote_initialized_and_snapshot(mote_config, bufnr, function()
       vim.schedule(do_send)
     end)
   else
@@ -224,6 +228,13 @@ function M._handle_response(response, callbacks, adapter, config, mote_config)
 
   -- mote統合: mote_configが存在し、初期化済みの場合にModified Files出力とpatch生成
   local MoteDiff = require("vibing.core.utils.mote_diff")
+
+  -- セッション開始時のスナップショットIDをベースラインとして設定
+  -- これにより並行セッション間で差分が混入しない
+  if mote_config and session_snapshots[bufnr] then
+    mote_config.baseline_snapshot_id = session_snapshots[bufnr]
+  end
+
   local using_mote = mote_config ~= nil and MoteDiff.is_initialized(mote_config.project, mote_config.context)
 
   if using_mote then
@@ -315,8 +326,9 @@ local MOTE_INIT_TIMEOUT_MS = 10000
 ---mote storageの初期化を確認し、スナップショットを作成
 ---タイムアウト処理とエラーハンドリングを含む
 ---@param mote_config table セッション固有のmote設定
+---@param bufnr number|nil バッファ番号（スナップショットIDの保存先キー）
 ---@param on_complete fun() 完了時のコールバック
-function M._ensure_mote_initialized_and_snapshot(mote_config, on_complete)
+function M._ensure_mote_initialized_and_snapshot(mote_config, bufnr, on_complete)
   local MoteDiff = require("vibing.core.utils.mote_diff")
   if not MoteDiff.is_available() then
     on_complete()
@@ -346,9 +358,13 @@ function M._ensure_mote_initialized_and_snapshot(mote_config, on_complete)
   end)
 
   local function create_snapshot()
-    MoteDiff.create_snapshot(mote_config, "Before request", function(success, _, error)
+    MoteDiff.create_snapshot(mote_config, "Before request", function(success, snapshot_id, error)
       if not success and error and not error:match("No changes to snapshot") then
         vim.notify("[vibing] Snapshot creation failed: " .. error, vim.log.levels.WARN)
+      end
+      -- 新しいスナップショットが作成された場合のみ更新（--autoで変更なしの場合はnilのまま）
+      if snapshot_id and bufnr then
+        session_snapshots[bufnr] = snapshot_id
       end
       complete_once()
     end)

--- a/lua/vibing/core/utils/mote/context.lua
+++ b/lua/vibing/core/utils/mote/context.lua
@@ -27,6 +27,23 @@ local function generate_hash(original_name)
   return string.format("%08x", hash):sub(1, 8)
 end
 
+---cwdがgit worktreeかをgitコマンドで判定し、識別子を返す
+---worktreeでは.gitがファイル（main repoではディレクトリ）
+---@param cwd string 作業ディレクトリ
+---@return string|nil worktreeの識別子（worktreeでなければnil）
+local function detect_git_worktree(cwd)
+  if vim.fn.filereadable(cwd .. "/.git") ~= 1 then
+    return nil
+  end
+  local branch = vim.fn.system(
+    "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --abbrev-ref HEAD 2>/dev/null"
+  ):gsub("\n$", "")
+  if branch ~= "" and branch ~= "HEAD" then
+    return branch
+  end
+  return cwd:match(".+/(.+)$") or cwd
+end
+
 ---Worktree固有のコンテキスト名を生成
 ---mote v0.2.4: --context API対応
 ---
@@ -42,10 +59,19 @@ end
 ---@return string Worktree固有のコンテキスト名
 function M.build_name(context_prefix, cwd)
   if cwd then
+    -- パターン1: .worktrees/ パス（後方互換）
     local worktree_path = cwd:match("%.worktrees/(.+)")
     if worktree_path then
       local worktree_name = sanitize_name(worktree_path)
       local hash_suffix = generate_hash(worktree_path)
+      return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
+    end
+
+    -- パターン2: gitコマンドによる自動検出（.gitがファイルならworktree）
+    local worktree_id = detect_git_worktree(cwd)
+    if worktree_id then
+      local worktree_name = sanitize_name(worktree_id)
+      local hash_suffix = generate_hash(worktree_id)
       return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
     end
   end

--- a/lua/vibing/core/utils/mote/context.lua
+++ b/lua/vibing/core/utils/mote/context.lua
@@ -53,6 +53,17 @@ function M.build_name(context_prefix, cwd)
   return string.format("%s-root", context_prefix)
 end
 
+---任意のディレクトリパスからユニークなコンテキスト名を生成
+---VibingMoteDirで指定されたパスに対して使用する
+---@param context_prefix string コンテキスト名のプレフィックス
+---@param abs_path string 絶対パス
+---@return string コンテキスト名
+function M.build_name_from_path(context_prefix, abs_path)
+  local path_tail = sanitize_name(abs_path:match(".+/([^/]+)$") or abs_path)
+  local hash_suffix = generate_hash(abs_path)
+  return string.format("%s-dir-%s-%s", context_prefix, path_tail, hash_suffix)
+end
+
 ---gitリポジトリ名からプロジェクト名を取得
 ---moteのコンテキスト命名ルールに従ってサニタイズ
 ---@return string|nil プロジェクト名（取得できない場合nil）

--- a/lua/vibing/core/utils/mote/context.lua
+++ b/lua/vibing/core/utils/mote/context.lua
@@ -27,37 +27,21 @@ local function generate_hash(original_name)
   return string.format("%08x", hash):sub(1, 8)
 end
 
----cwdのコンテキスト識別子を返す
----
----3ケースを処理:
----  1. git worktree（.gitがファイル）→ ブランチ名
----  2. gitリポジトリのサブディレクトリ（セッションルート等）→ git rootからの相対パス
----  3. gitリポジトリルート → nil（vibing-rootにフォールバック）
----
+---cwdがgit worktreeかをgitコマンドで判定し、識別子を返す
+---worktreeでは.gitがファイル（main repoではディレクトリ）
 ---@param cwd string 作業ディレクトリ
----@return string|nil コンテキスト識別子
-local function detect_context_path(cwd)
-  -- ケース1: .gitがファイル → git worktree
-  if vim.fn.filereadable(cwd .. "/.git") == 1 then
-    local branch = vim.fn.system(
-      "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --abbrev-ref HEAD 2>/dev/null"
-    ):gsub("\n$", "")
-    if branch ~= "" and branch ~= "HEAD" then
-      return branch
-    end
-    return cwd:match(".+/(.+)$") or cwd
+---@return string|nil worktreeの識別子（worktreeでなければnil）
+local function detect_git_worktree(cwd)
+  if vim.fn.filereadable(cwd .. "/.git") ~= 1 then
+    return nil
   end
-
-  -- ケース2: git rootのサブディレクトリ（セッションルート等）→ 相対パスを識別子に
-  local git_top = vim.fn.system(
-    "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --show-toplevel 2>/dev/null"
+  local branch = vim.fn.system(
+    "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --abbrev-ref HEAD 2>/dev/null"
   ):gsub("\n$", "")
-  if git_top ~= "" and git_top ~= cwd then
-    return cwd:sub(#git_top + 2) -- git rootからの相対パス
+  if branch ~= "" and branch ~= "HEAD" then
+    return branch
   end
-
-  -- ケース3: git rootそのもの → nil（vibing-rootにフォールバック）
-  return nil
+  return cwd:match(".+/(.+)$") or cwd
 end
 
 ---Worktree固有のコンテキスト名を生成
@@ -83,14 +67,12 @@ function M.build_name(context_prefix, cwd)
       return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
     end
 
-    -- パターン2: gitコマンドによる自動検出
-    -- worktree（.gitがファイル）→ ブランチ名
-    -- セッションルート等（git rootのサブディレクトリ）→ 相対パス
-    local context_id = detect_context_path(cwd)
-    if context_id then
-      local context_name = sanitize_name(context_id)
-      local hash_suffix = generate_hash(context_id)
-      return string.format("%s-session-%s-%s", context_prefix, context_name, hash_suffix)
+    -- パターン2: gitコマンドによる自動検出（.gitがファイルならworktree）
+    local worktree_id = detect_git_worktree(cwd)
+    if worktree_id then
+      local worktree_name = sanitize_name(worktree_id)
+      local hash_suffix = generate_hash(worktree_id)
+      return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
     end
   end
 

--- a/lua/vibing/core/utils/mote/context.lua
+++ b/lua/vibing/core/utils/mote/context.lua
@@ -27,23 +27,6 @@ local function generate_hash(original_name)
   return string.format("%08x", hash):sub(1, 8)
 end
 
----cwdがgit worktreeかをgitコマンドで判定し、識別子を返す
----worktreeでは.gitがファイル（main repoではディレクトリ）
----@param cwd string 作業ディレクトリ
----@return string|nil worktreeの識別子（worktreeでなければnil）
-local function detect_git_worktree(cwd)
-  if vim.fn.filereadable(cwd .. "/.git") ~= 1 then
-    return nil
-  end
-  local branch = vim.fn.system(
-    "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --abbrev-ref HEAD 2>/dev/null"
-  ):gsub("\n$", "")
-  if branch ~= "" and branch ~= "HEAD" then
-    return branch
-  end
-  return cwd:match(".+/(.+)$") or cwd
-end
-
 ---Worktree固有のコンテキスト名を生成
 ---mote v0.2.4: --context API対応
 ---
@@ -59,19 +42,10 @@ end
 ---@return string Worktree固有のコンテキスト名
 function M.build_name(context_prefix, cwd)
   if cwd then
-    -- パターン1: .worktrees/ パス（後方互換）
     local worktree_path = cwd:match("%.worktrees/(.+)")
     if worktree_path then
       local worktree_name = sanitize_name(worktree_path)
       local hash_suffix = generate_hash(worktree_path)
-      return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
-    end
-
-    -- パターン2: gitコマンドによる自動検出（.gitがファイルならworktree）
-    local worktree_id = detect_git_worktree(cwd)
-    if worktree_id then
-      local worktree_name = sanitize_name(worktree_id)
-      local hash_suffix = generate_hash(worktree_id)
       return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
     end
   end

--- a/lua/vibing/core/utils/mote/context.lua
+++ b/lua/vibing/core/utils/mote/context.lua
@@ -27,21 +27,37 @@ local function generate_hash(original_name)
   return string.format("%08x", hash):sub(1, 8)
 end
 
----cwdがgit worktreeかをgitコマンドで判定し、識別子を返す
----worktreeでは.gitがファイル（main repoではディレクトリ）
+---cwdのコンテキスト識別子を返す
+---
+---3ケースを処理:
+---  1. git worktree（.gitがファイル）→ ブランチ名
+---  2. gitリポジトリのサブディレクトリ（セッションルート等）→ git rootからの相対パス
+---  3. gitリポジトリルート → nil（vibing-rootにフォールバック）
+---
 ---@param cwd string 作業ディレクトリ
----@return string|nil worktreeの識別子（worktreeでなければnil）
-local function detect_git_worktree(cwd)
-  if vim.fn.filereadable(cwd .. "/.git") ~= 1 then
-    return nil
+---@return string|nil コンテキスト識別子
+local function detect_context_path(cwd)
+  -- ケース1: .gitがファイル → git worktree
+  if vim.fn.filereadable(cwd .. "/.git") == 1 then
+    local branch = vim.fn.system(
+      "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --abbrev-ref HEAD 2>/dev/null"
+    ):gsub("\n$", "")
+    if branch ~= "" and branch ~= "HEAD" then
+      return branch
+    end
+    return cwd:match(".+/(.+)$") or cwd
   end
-  local branch = vim.fn.system(
-    "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --abbrev-ref HEAD 2>/dev/null"
+
+  -- ケース2: git rootのサブディレクトリ（セッションルート等）→ 相対パスを識別子に
+  local git_top = vim.fn.system(
+    "git -C " .. vim.fn.shellescape(cwd) .. " rev-parse --show-toplevel 2>/dev/null"
   ):gsub("\n$", "")
-  if branch ~= "" and branch ~= "HEAD" then
-    return branch
+  if git_top ~= "" and git_top ~= cwd then
+    return cwd:sub(#git_top + 2) -- git rootからの相対パス
   end
-  return cwd:match(".+/(.+)$") or cwd
+
+  -- ケース3: git rootそのもの → nil（vibing-rootにフォールバック）
+  return nil
 end
 
 ---Worktree固有のコンテキスト名を生成
@@ -67,12 +83,14 @@ function M.build_name(context_prefix, cwd)
       return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
     end
 
-    -- パターン2: gitコマンドによる自動検出（.gitがファイルならworktree）
-    local worktree_id = detect_git_worktree(cwd)
-    if worktree_id then
-      local worktree_name = sanitize_name(worktree_id)
-      local hash_suffix = generate_hash(worktree_id)
-      return string.format("%s-worktree-%s-%s", context_prefix, worktree_name, hash_suffix)
+    -- パターン2: gitコマンドによる自動検出
+    -- worktree（.gitがファイル）→ ブランチ名
+    -- セッションルート等（git rootのサブディレクトリ）→ 相対パス
+    local context_id = detect_context_path(cwd)
+    if context_id then
+      local context_name = sanitize_name(context_id)
+      local hash_suffix = generate_hash(context_id)
+      return string.format("%s-session-%s-%s", context_prefix, context_name, hash_suffix)
     end
   end
 

--- a/lua/vibing/core/utils/mote/init.lua
+++ b/lua/vibing/core/utils/mote/init.lua
@@ -14,6 +14,7 @@ M.is_available = Binary.is_available
 
 -- Context module exports
 M.build_context_name = Context.build_name
+M.build_context_name_from_path = Context.build_name_from_path
 M.get_project_name = Context.get_project_name
 M.build_context_dir_path = Context.build_dir_path
 M.is_initialized = Context.is_initialized

--- a/lua/vibing/core/utils/mote/operations.lua
+++ b/lua/vibing/core/utils/mote/operations.lua
@@ -40,6 +40,9 @@ function M.get_diff(file_path, config, callback)
   local cmd = Command.build_base_args(config)
   table.insert(cmd, "snap")
   table.insert(cmd, "diff")
+  if config.baseline_snapshot_id then
+    table.insert(cmd, config.baseline_snapshot_id)
+  end
   table.insert(cmd, vim.fn.fnamemodify(file_path, ":p"))
 
   Command.run(cmd, config.cwd, function(stdout)
@@ -192,6 +195,9 @@ function M.get_changed_files(config, callback)
   local cmd = Command.build_base_args(config)
   table.insert(cmd, "snap")
   table.insert(cmd, "diff")
+  if config.baseline_snapshot_id then
+    table.insert(cmd, config.baseline_snapshot_id)
+  end
   table.insert(cmd, "--name-only")
 
   Command.run(cmd, config.cwd, function(stdout)
@@ -220,6 +226,9 @@ function M.generate_patch(config, output_path, callback)
   local cmd = Command.build_base_args(config)
   table.insert(cmd, "snap")
   table.insert(cmd, "diff")
+  if config.baseline_snapshot_id then
+    table.insert(cmd, config.baseline_snapshot_id)
+  end
   table.insert(cmd, "-o")
   table.insert(cmd, output_path)
 

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -286,7 +286,7 @@ function M._register_commands()
     local path = opts.args ~= "" and opts.args or vim.fn.getcwd()
     path = vim.fn.fnamemodify(path, ":p"):gsub("/$", "")
 
-    local success = chat_buffer:update_frontmatter("mote_cwd", path)
+    local success = chat_buffer:update_frontmatter_list("mote_dirs", path, "add")
     if success then
       vim.schedule(function()
         if vim.api.nvim_buf_is_valid(chat_buffer.buf) and chat_buffer.file_path then
@@ -295,9 +295,9 @@ function M._register_commands()
           end)
         end
       end)
-      vim.notify("[vibing] mote tracking directory: " .. path, vim.log.levels.INFO)
+      vim.notify("[vibing] Added mote tracking directory: " .. path, vim.log.levels.INFO)
     else
-      vim.notify("[vibing] Failed to set mote tracking directory", vim.log.levels.ERROR)
+      vim.notify("[vibing] Failed to add mote tracking directory", vim.log.levels.ERROR)
     end
   end, {
     nargs = "?",

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -288,6 +288,13 @@ function M._register_commands()
 
     local success = chat_buffer:update_frontmatter("mote_cwd", path)
     if success then
+      vim.schedule(function()
+        if vim.api.nvim_buf_is_valid(chat_buffer.buf) and chat_buffer.file_path then
+          vim.api.nvim_buf_call(chat_buffer.buf, function()
+            vim.cmd.write({ bang = true })
+          end)
+        end
+      end)
       vim.notify("[vibing] mote tracking directory: " .. path, vim.log.levels.INFO)
     else
       vim.notify("[vibing] Failed to set mote tracking directory", vim.log.levels.ERROR)

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -275,6 +275,29 @@ function M._register_commands()
     end
   end, { desc = "Cancel current Vibing request" })
 
+  vim.api.nvim_create_user_command("VibingMoteDir", function(opts)
+    local view = require("vibing.presentation.chat.view")
+    local chat_buffer = view.get_current() or view._current_buffer
+    if not chat_buffer then
+      vim.notify("[vibing] No chat buffer active", vim.log.levels.ERROR)
+      return
+    end
+
+    local path = opts.args ~= "" and opts.args or vim.fn.getcwd()
+    path = vim.fn.fnamemodify(path, ":p"):gsub("/$", "")
+
+    local success = chat_buffer:update_frontmatter("mote_cwd", path)
+    if success then
+      vim.notify("[vibing] mote tracking directory: " .. path, vim.log.levels.INFO)
+    else
+      vim.notify("[vibing] Failed to set mote tracking directory", vim.log.levels.ERROR)
+    end
+  end, {
+    nargs = "?",
+    desc = "Set mote tracking directory for current chat session",
+    complete = "dir",
+  })
+
   vim.api.nvim_create_user_command("VibingReloadCommands", function()
     local custom_commands = require("vibing.application.chat.custom_commands")
     local commands = require("vibing.application.chat.commands")

--- a/lua/vibing/presentation/chat/modules/frontmatter_handler.lua
+++ b/lua/vibing/presentation/chat/modules/frontmatter_handler.lua
@@ -57,7 +57,7 @@ function M.update_field(buf, key, value, update_timestamp)
     return str:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
   end
 
-  local lines = vim.api.nvim_buf_get_lines(buf, 0, 20, false)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, 50, false)
   local frontmatter_end = 0
   local key_line = nil
   local escaped_key = escape_pattern(key)

--- a/lua/vibing/presentation/chat/modules/frontmatter_handler.lua
+++ b/lua/vibing/presentation/chat/modules/frontmatter_handler.lua
@@ -2,6 +2,8 @@ local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
 
 local M = {}
 
+local FRONTMATTER_SCAN_LINES = 100
+
 ---フロントマターをパース
 ---@param buf number バッファ番号
 ---@return table<string, string|string[]|number|boolean>
@@ -10,7 +12,7 @@ function M.parse(buf)
     return {}
   end
 
-  local lines = vim.api.nvim_buf_get_lines(buf, 0, 50, false)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, FRONTMATTER_SCAN_LINES, false)
   local content = table.concat(lines, "\n")
   local parsed = Frontmatter.parse(content)
 
@@ -57,7 +59,7 @@ function M.update_field(buf, key, value, update_timestamp)
     return str:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
   end
 
-  local lines = vim.api.nvim_buf_get_lines(buf, 0, 50, false)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, FRONTMATTER_SCAN_LINES, false)
   local frontmatter_end = 0
   local key_line = nil
   local escaped_key = escape_pattern(key)
@@ -115,7 +117,7 @@ function M.update_list(buf, key, value, action)
     return false
   end
 
-  local lines = vim.api.nvim_buf_get_lines(buf, 0, 50, false)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, FRONTMATTER_SCAN_LINES, false)
 
   local frontmatter_end = 0
   local key_start = nil


### PR DESCRIPTION
## 概要

並行worktreeセッション間でmoteの差分が混入する問題と、VibingMoteDirコマンドのフロントマター書き込みバグを修正。

## 問題

### 1. スナップショットベースラインの取り違え
複数セッションが `vibing-root` を共有する場合、`snap diff` が他セッションのスナップショットを起点にしてしまう。

```
Session A: snap create → S1（最新 = S1）
Session B: snap create → S2（最新 = S2）
Session A: snap diff   → S2との差分（Aの変更ではなく全差分）
```

### 2. VibingMoteDir がフロントマターに書き込まれない

- `update_field` がフロントマター終端 `---` を20行しか探さない → 長いフロントマターで失敗
- バッファ更新後にディスク保存していない → メモリ上の変更がファイルに反映されない

## 解決策

### Fix 1: セッション固有のスナップショットIDで差分を取る

- `session_snapshots[bufnr]` にセッション開始時のIDを保存
- `snap diff <id>` で各セッション固有のベースラインから差分を取得
- ストレージ増加ゼロ（コンテキストはそのまま、起点IDが変わるだけ）

### Fix 2: VibingMoteDir コマンドの追加

`:VibingMoteDir [path]` — 現在のチャットセッションのmote追跡ディレクトリを明示設定。

- タブ補完でディレクトリパスを補完
- フロントマターに `mote_cwd: <path>` を書き込み
- 引数なしでNeovimのcwdを使用

### Fix 3: フロントマター書き込みバグの修正

- `update_field` のスキャン行数を 20 → 50 に変更（`parse()` / `update_list()` と統一）
- `VibingMoteDir` コマンドに `vim.cmd.write()` を追加してディスク保存

## 変更ファイル

- `send_message.lua`: `session_snapshots` テーブル、`mote_cwd` フロントマター読み取り
- `operations.lua`: `baseline_snapshot_id` を `snap diff` に渡す
- `context.lua`: `build_name_from_path()` 追加（パスベースのコンテキスト名生成）
- `mote/init.lua`: `build_context_name_from_path` をexport
- `init.lua`: `VibingMoteDir` コマンド登録、フロントマター保存
- `frontmatter_handler.lua`: `update_field` スキャン行数を50に修正