### PR TITLE
fix: skip mote diff when no files were modified to reduce response latency

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -91,6 +91,9 @@ function M.execute(adapter, callbacks, message, config)
     local session_allow = callbacks.get_session_allow()
     local session_deny = callbacks.get_session_deny()
 
+    -- レスポンス中にWrite/Editで変更されたファイルパスを追跡
+    local modified_file_paths = {}
+
     local opts = {
       streaming = true,
       action_type = "chat",
@@ -104,6 +107,11 @@ function M.execute(adapter, callbacks, message, config)
       permission_mode = frontmatter.permission_mode,
       language = lang_code,
       cwd = session_cwd,
+      on_tool_use = function(tool, file_path, _command)
+        if (tool == "Write" or tool == "Edit" or tool == "NotebookEdit") and file_path then
+          modified_file_paths[file_path] = true
+        end
+      end,
       on_insert_choices = function(questions)
         vim.schedule(function()
           callbacks.insert_choices(questions)
@@ -158,7 +166,7 @@ function M.execute(adapter, callbacks, message, config)
         end)
       end, function(response)
         vim.schedule(function()
-          M._handle_response(response, callbacks, adapter, config, mote_configs)
+          M._handle_response(response, callbacks, adapter, config, mote_configs, modified_file_paths)
         end)
       end)
       -- handle_idをコールバックで設定（キャンセル用）
@@ -167,7 +175,7 @@ function M.execute(adapter, callbacks, message, config)
       end
     else
       local response = adapter:execute(formatted_prompt, opts)
-      M._handle_response(response, callbacks, adapter, config, mote_configs)
+      M._handle_response(response, callbacks, adapter, config, mote_configs, modified_file_paths)
     end
   end
 
@@ -191,7 +199,7 @@ local function is_session_error(error_msg)
 end
 
 ---レスポンスを処理
-function M._handle_response(response, callbacks, adapter, config, mote_configs)
+function M._handle_response(response, callbacks, adapter, config, mote_configs, modified_file_paths)
   -- Stop gradient animation
   local bufnr = callbacks.get_bufnr()
   if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
@@ -244,15 +252,26 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs)
     end
   end
 
-  if #active_configs > 0 then
+  -- Write/Editで実際にファイルが変更された場合のみmote diffを実行
+  local has_file_changes = next(modified_file_paths or {}) ~= nil
+
+  if #active_configs > 0 and has_file_changes then
     -- 全configから変更ファイルを収集し、重複排除して出力
     local all_files = {}
     local seen_files = {}
     local patch_paths = {}
     local remaining = #active_configs
     local timestamp = os.date("%Y%m%d_%H%M%S")
+    local diff_finalized = false
+    local diff_timeout_timer = nil
 
     local function finalize()
+      if diff_finalized then return end
+      diff_finalized = true
+      if diff_timeout_timer then
+        vim.fn.timer_stop(diff_timeout_timer)
+        diff_timeout_timer = nil
+      end
       if #all_files > 0 then
         BufferReload.reload_files(all_files)
         local MAX_DISPLAY = 50
@@ -272,6 +291,9 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs)
         callbacks.add_user_section()
       end)
     end
+
+    -- mote diffに時間がかかる場合でもUserセクションを即座に表示するタイムアウト
+    diff_timeout_timer = vim.fn.timer_start(5000, vim.schedule_wrap(finalize))
 
     for _, mc in ipairs(active_configs) do
       MoteDiff.get_changed_files(mc, function(success, files, err)

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -6,6 +6,12 @@ local M = {}
 -- 並行セッション間でのmote差分混入を防ぐためのベースライン管理
 local session_snapshots = {}
 
+---バッファのセッションスナップショットをクリア（BufUnload時に呼ぶ）
+---@param bufnr number
+function M.cleanup_snapshots(bufnr)
+  session_snapshots[bufnr] = nil
+end
+
 local BufferReload = require("vibing.core.utils.buffer_reload")
 local GradientAnimation = require("vibing.ui.gradient_animation")
 
@@ -53,6 +59,9 @@ function M.execute(adapter, callbacks, message, config)
   local frontmatter = callbacks.parse_frontmatter()
   -- mote_dirs (array) が優先。後方互換として mote_cwd (string) も読む
   local mote_dirs = frontmatter and frontmatter.mote_dirs
+  if type(mote_dirs) == "string" then
+    mote_dirs = { mote_dirs }
+  end
   if (not mote_dirs or #mote_dirs == 0) and frontmatter and frontmatter.mote_cwd then
     mote_dirs = { frontmatter.mote_cwd }
   end
@@ -110,6 +119,11 @@ function M.execute(adapter, callbacks, message, config)
       on_tool_use = function(tool, file_path, _command)
         if (tool == "Write" or tool == "Edit" or tool == "NotebookEdit") and file_path then
           modified_file_paths[file_path] = true
+        elseif tool == "FileChange" and file_path then
+          -- Codex adapter reports comma-joined paths
+          for path in file_path:gmatch("[^,]+") do
+            modified_file_paths[vim.trim(path)] = true
+          end
         end
       end,
       on_insert_choices = function(questions)

--- a/lua/vibing/core/utils/mote/operations.lua
+++ b/lua/vibing/core/utils/mote/operations.lua
@@ -173,7 +173,7 @@ function M.create_snapshot(config, message, callback)
   end
 
   Command.run(cmd, config.cwd, function(stdout)
-    local snapshot_id = stdout:match("snapshot%s+(%w+)")
+    local snapshot_id = stdout:match("snapshot%s+([%w%-]+)")
     callback(true, snapshot_id, nil)
   end, function(error)
     callback(false, nil, error)

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -220,9 +220,11 @@ local function start_async_load()
       end
       _loading = false
       if code ~= 0 then
+        -- Failed: allow retry on next completion trigger
         return
       end
       if vim.fn.getcwd(-1, -1) ~= cwd then
+        -- cwd changed: retry will happen on next trigger with correct cwd
         return
       end
       local stdout = table.concat(stdout_lines, "\n")
@@ -345,10 +347,15 @@ end
 ---Get all skill candidates (cached)
 ---@return Vibing.CompletionItem[]
 function M.get_all()
-  if not _cache then
-    _cache = scan_skills()
+  if _cache then
+    return _cache
   end
-  return _cache
+  local items = scan_skills()
+  -- Only cache when dynamic load is complete; avoid caching incomplete results
+  if not (_loading or _bundled_cache == nil) then
+    _cache = items
+  end
+  return items
 end
 
 ---Preload dynamic skills in background (call at setup time to warm the cache)

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -260,6 +260,11 @@ function M._apply_chat_buffer_settings(bufnr)
       end
       -- アタッチ済みバッファからクリーンアップ
       M._attached_buffers[bufnr] = nil
+      -- moteスナップショットIDをクリア（bufnr再利用時の誤ったベースライン防止）
+      local ok_sm, send_message = pcall(require, "vibing.application.chat.send_message")
+      if ok_sm then
+        send_message.cleanup_snapshots(bufnr)
+      end
     end,
     desc = "Cancel running Agent SDK process on buffer unload",
   })

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -225,8 +225,13 @@ function M._apply_chat_buffer_settings(bufnr)
       buffer = bufnr,
       callback = function()
         pcall(ui_utils.apply_wrap_config, 0, bufnr, true)
+        -- Re-apply completion settings to prevent markdown ftplugin from overwriting omnifunc
+        local ok_c, completion = pcall(require, "vibing.application.completion")
+        if ok_c and completion.setup_buffer then
+          pcall(completion.setup_buffer, bufnr)
+        end
       end,
-      desc = "Apply vibing wrap settings after filetype detection",
+      desc = "Apply vibing wrap and completion settings after filetype detection",
     })
 
     -- BufWritePost: フロントマターが変更された可能性があるためキャッシュをクリア


### PR DESCRIPTION
## 概要

レスポンス完了後に User セクションが表示されるまで長時間待たされる問題を修正。

## 原因

mote が初期化済みの場合、ファイル変更の有無にかかわらず毎回 `mote snap diff --name-only` が実行されていた。このコマンドはプロジェクト全ファイルをスキャンするため、変更がなくても数秒かかることがあった。

## 修正内容

- **ファイル変更追跡**: `on_tool_use` コールバックで Write/Edit/NotebookEdit ツールの使用を検出し、変更されたファイルパスを記録
- **条件付きmote diff実行**: 実際にファイルが変更された場合のみ `mote snap diff` を実行。チャットのみのやり取りでは mote コマンドが一切走らない
- **5秒タイムアウト**: mote が遅い場合のフォールバックとして、5秒経過したら Modified Files セクションなしで User セクションを即座に表示
- **スキル補完キャッシュ修正**: 非同期ロード中に不完全な結果をキャッシュしないよう修正
- **補完設定の再適用**: FileType autocmd で markdown ftplugin による omnifunc 上書きを防止

## 効果

- ファイル変更なし（会話のみ）: mote 実行ゼロ → 待ち時間ゼロ
- ファイル変更あり: 従来通り mote diff を実行（タイムアウトで最長5秒に制限）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat response handling so file-based follow-up actions only run when actual edits were made, helping avoid unnecessary processing and delays.
  * Fixed completion behavior in chat buffers so editor settings stay intact after file type detection, especially in markdown views.
  * Made skill suggestions more reliable by avoiding stale or incomplete cached results while background loading is still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->