### PR TITLE
fix: unify AskUserQuestion and permissions_ask flows to prevent repeated questions

### DIFF
--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -168,9 +168,17 @@ Please select and press <CR> to send.
 
 **Implementation Details:**
 
-- Agent Wrapper sends `approval_required` event and denies the tool
-- Approval UI is inserted into chat buffer as plain markdown with numbered list
+- RPC hook fires in `permission.lua` when Claude requests a tool in the `ask` list
+- `cancel_and_deny()` immediately cancels the Claude process and sends a deny response to the hook
+- `on_approval_required` callback inserts the approval UI into the chat buffer (runs on vim main thread via `vim.schedule`)
 - User edits to select option and sends via normal message flow (`<CR>`)
-- Buffer parser detects approval response and updates session permissions
-- Assistant responds with confirmation message
-- Claude retries the tool with updated session permissions
+- Buffer parser detects the approval response and updates session permissions
+- `hook_request_id` is cleared after processing to prevent double-processing
+- User message is replaced with a retry instruction (e.g., "I approved Bash tool. Please proceed.")
+- New Claude session starts with the updated session-level permissions
+- Claude retries the operation and auto-approves due to updated session state
+
+**Important implementation notes:**
+
+- `on_approval_required` must be called from the vim main thread (inside `vim.schedule`). The caller must ensure this — no inner `vim.schedule` wrapper should be added inside the implementation.
+- `_pending_approval` is set before `add_user_section()` is called, ensuring the approval UI is rendered at the correct position in the chat buffer.

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -148,17 +148,8 @@ function M.execute(adapter, callbacks, message, config)
       on_approval_required = function(tool, input, options, hook_request_id)
         vim.schedule(function()
           callbacks.insert_approval_request(tool, input, options, hook_request_id)
-
-          if hook_request_id then
-            -- Hook-based: render approval UI immediately (hook is blocking)
-            callbacks.add_user_section()
-          else
-            -- Agent-wrapper: cancel process, add_user_section called in on_done
-            local handle_id = callbacks.get_handle_id()
-            if handle_id then
-              adapter:cancel(handle_id)
-            end
-          end
+          -- cancel は permission.lua 側で実行済み（hook-based / agent-wrapper 共通）
+          -- add_user_section は on_done 経由で呼ばれる
         end)
       end,
     }

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -146,11 +146,11 @@ function M.execute(adapter, callbacks, message, config)
         end)
       end,
       on_approval_required = function(tool, input, options, hook_request_id)
-        vim.schedule(function()
-          callbacks.insert_approval_request(tool, input, options, hook_request_id)
-          -- cancel は permission.lua 側で実行済み（hook-based / agent-wrapper 共通）
-          -- add_user_section は on_done 経由で呼ばれる
-        end)
+        -- permission.lua の vim.schedule 内から呼ばれるためすでにメインスレッド上
+        -- 二重 vim.schedule を避けることで _pending_approval が add_user_section より確実に先に設定される
+        callbacks.insert_approval_request(tool, input, options, hook_request_id)
+        -- cancel は permission.lua 側で実行済み（hook-based / agent-wrapper 共通）
+        -- add_user_section は on_done 経由で呼ばれる
       end,
     }
 

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -17,10 +17,6 @@ local session_state = {
 --- @type table|nil
 local active_opts = nil
 
---- Pending hook approvals waiting for user response
---- @type table<string, {tool_name: string, tool_input: table}>
-local pending_hook_approvals = {}
-
 --- Codex uses different tool names than Claude for equivalent operations.
 --- This mapping ensures frontmatter permissions work identically across adapters.
 local CODEX_TOOL_ALIASES = {
@@ -150,20 +146,20 @@ function M.check_tool_permission(params)
     tool_name = CODEX_TOOL_ALIASES[tool_name] or tool_name
   end
 
-  -- AskUserQuestion: deny + insert choices into chat buffer + kill process
+  -- AskUserQuestion: kill process first, then insert choices + write deny
   if tool_name == "AskUserQuestion" then
-    write_hook_response(request_id, false)
     vim.schedule(function()
       local registry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
       local stream = registry.get()
       if stream then
-        if stream.on_insert_choices and tool_input.questions then
-          stream.on_insert_choices(tool_input.questions)
-        end
         if stream.adapter and stream.handle_id then
           stream.adapter:cancel(stream.handle_id)
         end
+        if stream.on_insert_choices and tool_input.questions then
+          stream.on_insert_choices(tool_input.questions)
+        end
       end
+      write_hook_response(request_id, false)
     end)
     return { status = "denied", reason = "AskUserQuestion intercepted" }
   end
@@ -178,43 +174,24 @@ function M.check_tool_permission(params)
     write_hook_response(request_id, false)
     return { status = "denied", reason = result.message }
   else
-    -- "ask" → show approval UI in chat buffer, hook blocks until user responds
-    pending_hook_approvals[request_id] = {
-      tool_name = tool_name,
-      tool_input = tool_input,
-    }
-
-    -- Clean up if user never responds (hook script times out after 120s)
-    vim.defer_fn(function()
-      pending_hook_approvals[request_id] = nil
-    end, 130000)
-
+    -- "ask" → kill process first, show approval UI, then write deny
+    -- User's approval choice updates session state; Claude retries on next message
     vim.schedule(function()
       local registry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
       local stream = registry.get()
 
-      if stream and stream.on_approval_required then
-        stream.on_approval_required(tool_name, tool_input, APPROVAL_OPTIONS, request_id)
-      else
-        write_hook_response(request_id, false)
-        pending_hook_approvals[request_id] = nil
+      if stream then
+        if stream.adapter and stream.handle_id then
+          stream.adapter:cancel(stream.handle_id)
+        end
+        if stream.on_approval_required then
+          stream.on_approval_required(tool_name, tool_input, APPROVAL_OPTIONS, request_id)
+        end
       end
+      write_hook_response(request_id, false)
     end)
     return { status = "pending" }
   end
-end
-
---- Resolve a pending hook approval (called from chat buffer after user responds)
---- @param request_id string
---- @param allow boolean
-function M.resolve_hook_approval(request_id, allow)
-  local pending = pending_hook_approvals[request_id]
-  if not pending then
-    return
-  end
-
-  pending_hook_approvals[request_id] = nil
-  write_hook_response(request_id, allow)
 end
 
 --- Add tool to session allow list
@@ -231,7 +208,6 @@ end
 function M.reset_session()
   session_state.allowed = {}
   session_state.denied = {}
-  pending_hook_approvals = {}
 end
 
 --- Get current session state

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -146,8 +146,9 @@ function M.check_tool_permission(params)
     tool_name = CODEX_TOOL_ALIASES[tool_name] or tool_name
   end
 
-  -- AskUserQuestion: kill process first, then insert choices + write deny
-  if tool_name == "AskUserQuestion" then
+  -- Kill process first, call UI callback, then write deny response.
+  -- Used by both AskUserQuestion and "ask" permission paths.
+  local function cancel_and_deny(on_stream_fn)
     vim.schedule(function()
       local registry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
       local stream = registry.get()
@@ -155,11 +156,17 @@ function M.check_tool_permission(params)
         if stream.adapter and stream.handle_id then
           stream.adapter:cancel(stream.handle_id)
         end
-        if stream.on_insert_choices and tool_input.questions then
-          stream.on_insert_choices(tool_input.questions)
-        end
+        on_stream_fn(stream)
       end
       write_hook_response(request_id, false)
+    end)
+  end
+
+  if tool_name == "AskUserQuestion" then
+    cancel_and_deny(function(stream)
+      if stream.on_insert_choices and tool_input.questions then
+        stream.on_insert_choices(tool_input.questions)
+      end
     end)
     return { status = "denied", reason = "AskUserQuestion intercepted" }
   end
@@ -176,19 +183,10 @@ function M.check_tool_permission(params)
   else
     -- "ask" → kill process first, show approval UI, then write deny
     -- User's approval choice updates session state; Claude retries on next message
-    vim.schedule(function()
-      local registry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
-      local stream = registry.get()
-
-      if stream then
-        if stream.adapter and stream.handle_id then
-          stream.adapter:cancel(stream.handle_id)
-        end
-        if stream.on_approval_required then
-          stream.on_approval_required(tool_name, tool_input, APPROVAL_OPTIONS, request_id)
-        end
+    cancel_and_deny(function(stream)
+      if stream.on_approval_required then
+        stream.on_approval_required(tool_name, tool_input, APPROVAL_OPTIONS, request_id)
       end
-      write_hook_response(request_id, false)
     end)
     return { status = "pending" }
   end

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -157,6 +157,8 @@ function M.check_tool_permission(params)
           stream.adapter:cancel(stream.handle_id)
         end
         on_stream_fn(stream)
+      else
+        vim.notify("[vibing] cancel_and_deny: no active stream found", vim.log.levels.WARN)
       end
       write_hook_response(request_id, false)
     end)

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -291,19 +291,8 @@ end
 
 ---メッセージを送信
 function ChatBuffer:send_message()
-  -- Hook-based approval pending: don't cancel the active stream,
-  -- but only if the user message is actually a valid approval response
-  local skip_cancel = false
-  if self._pending_approval and self._pending_approval.hook_request_id then
-    local peek_message = self:extract_user_message()
-    if peek_message then
-      local ApprovalParserPeek = require("vibing.presentation.chat.modules.approval_parser")
-      skip_cancel = ApprovalParserPeek.is_approval_response(peek_message)
-    end
-  end
-
   -- 前のリクエストが実行中ならキャンセル（競合防止）
-  if self._current_handle_id and not skip_cancel then
+  if self._current_handle_id then
     local adapter = self:_get_active_adapter()
     if adapter then
       adapter:cancel(self._current_handle_id)
@@ -371,14 +360,11 @@ function ChatBuffer:send_message()
         return
       end
 
-      -- Hook-based approval: resolve by writing response file, don't send message
+      -- Hook-based approval: update session state, then fall through to normal message flow
+      -- (process was already cancelled and hook was denied in permission.lua)
       local hook_request_id = self._pending_approval.hook_request_id
       if hook_request_id then
         local perm_handler = require("vibing.infrastructure.rpc.handlers.permission")
-        local is_allow = approval.action == "allow_once" or approval.action == "allow_for_session"
-        perm_handler.resolve_hook_approval(hook_request_id, is_allow)
-
-        -- Mirror session-level permissions into RPC handler's session state
         local tool = self._pending_approval.tool
         if tool then
           if approval.action == "allow_for_session" then
@@ -391,10 +377,7 @@ function ChatBuffer:send_message()
             perm_handler.add_session_deny(tool, true)
           end
         end
-
-        self._pending_approval = nil
-        self:add_user_section()
-        return
+        self._pending_approval.hook_request_id = nil
       end
 
       -- Get tool name and input for message (before clearing _pending_approval)

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -377,6 +377,9 @@ function ChatBuffer:send_message()
             perm_handler.add_session_deny(tool, true)
           end
         end
+        -- hook_request_id を nil にしてこのフィールドを消費済みとしてマーク。
+        -- hook denial は cancel_and_deny() で既に送信済みのため、再送を防ぐ。
+        -- _pending_approval 全体は tool/input 参照後に nil にする。
         self._pending_approval.hook_request_id = nil
       end
 

--- a/tests/e2e/ask_user_question_spec.lua
+++ b/tests/e2e/ask_user_question_spec.lua
@@ -1,0 +1,99 @@
+-- E2E Tests: AskUserQuestion - no repeated questions
+-- Regression test for the duplicate-question bug where
+-- AskUserQuestion and permissions_ask flows inserted UI multiple times.
+local helper = require("vibing.testing.e2e_helper")
+
+local TIMEOUTS = {
+  CHAT_CREATION = 2000,
+  BUFFER_READY = 5000,
+  ASSISTANT_RESPONSE = 30000,
+}
+
+--- Count how many lines in the current buffer match the given pattern.
+---@param nvim_instance table
+---@param pattern string Lua pattern
+---@return number
+local function count_lines_matching(nvim_instance, pattern)
+  local lines = vim.fn.rpcrequest(nvim_instance.job_id, "nvim_buf_get_lines", { 0, 0, -1, false })
+  local count = 0
+  for _, line in ipairs(lines) do
+    if line:match(pattern) then
+      count = count + 1
+    end
+  end
+  return count
+end
+
+describe("E2E: AskUserQuestion - no repeated questions", function()
+  local nvim_instance
+
+  before_each(function()
+    nvim_instance = helper.spawn_nvim_instance({
+      headless = true,
+      init_script = "tests/minimal_init.lua",
+    })
+  end)
+
+  after_each(function()
+    helper.cleanup_instance(nvim_instance)
+  end)
+
+  it("should display AskUserQuestion prompt exactly once", function()
+    helper.send_keys(nvim_instance, ":VibingChat<CR>")
+    vim.wait(TIMEOUTS.CHAT_CREATION)
+
+    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    assert.is_true(ok, "Chat buffer should be created")
+
+    -- Prompt Claude to use AskUserQuestion tool
+    helper.send_keys(nvim_instance, "G")
+    helper.send_keys(nvim_instance, "i")
+    helper.send_keys(
+      nvim_instance,
+      "Use the AskUserQuestion tool to ask me: 'Which option?' with options A and B."
+    )
+    helper.send_keys(nvim_instance, "<Esc>")
+    helper.send_keys(nvim_instance, "<CR>")
+
+    -- Wait for question prompt
+    ok = helper.wait_for_buffer_content(nvim_instance, "Please answer the question", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, "AskUserQuestion prompt should appear")
+
+    -- Verify prompt appears exactly once (regression: was duplicated before the fix)
+    local count = count_lines_matching(nvim_instance, "Please answer the question")
+    assert.equals(1, count, "Question prompt must appear exactly once — no duplicate UI insertion")
+  end)
+
+  it("should not repeat the question prompt after user answers", function()
+    helper.send_keys(nvim_instance, ":VibingChat<CR>")
+    vim.wait(TIMEOUTS.CHAT_CREATION)
+
+    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    assert.is_true(ok, "Chat buffer should be created")
+
+    -- Prompt Claude to use AskUserQuestion tool
+    helper.send_keys(nvim_instance, "G")
+    helper.send_keys(nvim_instance, "i")
+    helper.send_keys(
+      nvim_instance,
+      "Use the AskUserQuestion tool to ask me: 'Which color?' with options Red and Blue."
+    )
+    helper.send_keys(nvim_instance, "<Esc>")
+    helper.send_keys(nvim_instance, "<CR>")
+
+    -- Wait for question prompt to appear
+    ok = helper.wait_for_buffer_content(nvim_instance, "Please answer the question", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, "AskUserQuestion prompt should appear")
+
+    -- Send an answer by pressing <CR> (all options remain — Claude understands)
+    helper.send_keys(nvim_instance, "<CR>")
+
+    -- Wait for Claude to process the answer and produce a follow-up response
+    ok = helper.wait_for_buffer_content(nvim_instance, "## .* Assistant", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, "Claude should respond after the answer is sent")
+
+    -- Verify prompt still appears only once (not re-inserted after answering)
+    local count = count_lines_matching(nvim_instance, "Please answer the question")
+    assert.equals(1, count, "Question prompt must not be re-inserted after the user answers")
+  end)
+end)


### PR DESCRIPTION
## 問題

`AskUserQuestion` と `permissions_ask` のどちらも、ユーザーにボールを返した後、ユーザーが返答しても同じ質問を繰り返す問題があった。

### 根本原因

**AskUserQuestion:**
```
write_hook_response(deny)  ← 先に書く → hook script 解放 → Claude が deny を受け取って続行
vim.schedule:
  on_insert_choices()
  cancel()                  ← 遅れてキャンセル（競合状態）
```

**permissions_ask:**
```
{ status: "pending" }       ← hook script がブロック
on_approval_required()
ユーザー選択 → resolve_hook_approval() → write_hook_response()
                               ↑ セッション状態更新より先に hook 解放 → タイミング問題
```

## 修正内容

両フローを統一し、`cancel → UI表示 → write_hook_response(deny)` の順番に変更：

1. **`permission.lua`**: `cancel()` を先に実行してから選択肢/承認UIを表示し、最後に `write_hook_response(deny)` を書く。`pending_hook_approvals` と `resolve_hook_approval` を削除
2. **`send_message.lua`**: hook-based の分岐を削除（cancel は permission.lua 側で実行済み）
3. **`buffer.lua`**: `skip_cancel` ロジック削除、hook-based approval path でセッション状態更新後に通常メッセージフローへ fall-through

### 修正後のフロー（両フロー共通）

```
1. cancel()         — Claude プロセスをkill
2. UI表示           — 選択肢 or 承認オプション
3. write_hook_response(deny) — hook script を解放
4. on_done → add_user_section
5. ユーザーが選択して <CR>
6. セッション状態更新（permissions_ask の場合のみ）
7. 通常メッセージとして送信（Claude 再実行）
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat tool-approval flow by canceling streams and updating the approval/deny UI in a safer order, preventing duplicate or out-of-sequence prompts.
  * Streamlined “AskUserQuestion” handling so the app returns to the normal send flow without lingering per-request approval state.

* **New Features**
  * Added end-to-end regression coverage for “AskUserQuestion”, verifying the prompt appears exactly once before and after answering.

* **Documentation**
  * Updated the Tool Approval UI implementation details with clearer, step-by-step behavior and important main-thread requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->