### PR TITLE
feat: respect user-invocable: false in skill slash-command completion

### DIFF
--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -52,10 +52,10 @@ const BUILTIN_COMMANDS: CommandEntry[] = [
   },
 ];
 
-/** Parse a SKILL.md file's YAML frontmatter for name/description. */
+/** Parse a SKILL.md file's YAML frontmatter for name/description/user-invocable. */
 async function parseSkillFrontmatter(
   skillMdPath: string
-): Promise<{ name: string; description: string } | null> {
+): Promise<{ name: string; description: string; userInvocable: boolean } | null> {
   let content: string;
   try {
     content = await readFile(skillMdPath, 'utf8');
@@ -69,10 +69,14 @@ async function parseSkillFrontmatter(
   const nameMatch = frontmatterMatch[1].match(/^name:\s*(.+)$/m);
   if (!nameMatch) return null;
   const descMatch = frontmatterMatch[1].match(/^description:\s*(.+)$/m);
+  // Default true, matching Claude Code CLI's own opt-out convention: skills are
+  // visible in the slash menu unless they explicitly declare `user-invocable: false`.
+  const userInvocableMatch = frontmatterMatch[1].match(/^user-invocable:\s*(.+)$/m);
 
   return {
     name: nameMatch[1].trim(),
     description: descMatch ? descMatch[1].trim() : '',
+    userInvocable: userInvocableMatch ? userInvocableMatch[1].trim() !== 'false' : true,
   };
 }
 
@@ -104,7 +108,10 @@ async function scanPluginSkills(pluginPath: string, pluginName: string): Promise
   );
 
   return parsed
-    .filter((skill): skill is { name: string; description: string } => skill !== null)
+    .filter(
+      (skill): skill is { name: string; description: string; userInvocable: boolean } =>
+        skill !== null && skill.userInvocable
+    )
     .map((skill) => ({
       name: `${pluginName}:${skill.name}`,
       description: skill.description,

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -21,6 +21,28 @@ local _bundled_cache_cwd = nil
 ---@type number?
 local _bundled_cache_script_mtime = nil
 
+---Check if SKILL.md frontmatter opts out of slash-menu visibility via `user-invocable: false`.
+---Matches Claude Code CLI's own convention: skills are visible in the `/` menu by default.
+---@param lines string[]
+---@return boolean
+local function is_user_invocable(lines)
+  local in_frontmatter = false
+  for _, line in ipairs(lines) do
+    if line == "---" then
+      if in_frontmatter then
+        break
+      end
+      in_frontmatter = true
+    elseif in_frontmatter then
+      local value = line:match("^user%-invocable:%s*(%S+)")
+      if value == "false" then
+        return false
+      end
+    end
+  end
+  return true
+end
+
 ---Parse SKILL.md to extract name and description
 ---@param file_path string
 ---@return {name: string, description: string}?
@@ -31,6 +53,10 @@ local function parse_skill(file_path)
 
   local lines = vim.fn.readfile(file_path, "", 50)
   if not lines or #lines == 0 then
+    return nil
+  end
+
+  if not is_user_invocable(lines) then
     return nil
   end
 

--- a/skills/nvim-context/SKILL.md
+++ b/skills/nvim-context/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nvim-context
 description: Use when working on a project that has a running Neovim instance via vibing.nvim (the vibing-nvim MCP server is connected). Reads live buffer, window, cursor, and selection state through vibing-nvim MCP tools before editing or answering, instead of relying on stale file reads or guesses about what the user currently has open or selected.
+user-invocable: false
 ---
 
 # Neovim Live Context

--- a/skills/nvim-lsp-navigation/SKILL.md
+++ b/skills/nvim-lsp-navigation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nvim-lsp-navigation
 description: Use when navigating or analyzing a codebase that's open in a running Neovim instance via vibing.nvim with an LSP client attached. Prefers the vibing-nvim MCP LSP tools (definitions, references, hover, diagnostics, symbols, call hierarchy) over text search for "where is X defined/used/called", "what type is this", "what's broken here" style questions, since they reflect language-aware, live analysis rather than a text match.
+user-invocable: false
 ---
 
 # Neovim LSP Navigation


### PR DESCRIPTION
## Summary
- チャットバッファの `/` 補完がすべての SKILL.md を無条件でスラッシュコマンド候補として表示していた問題を修正
- Claude Code CLI 本来の opt-out 規約（`user-invocable: false` を明示しない限りデフォルトで表示される）を、プラグインスキル側 (`bin/list-commands.ts`) とプロジェクト/ユーザースキル側 (`skills.lua`) の両方で解釈するように対応
- `nvim-context` / `nvim-lsp-navigation` は単体アクションを持たないツール選択方針スキルのため `user-invocable: false` を付与し、補完から除外。`vibing-worktree` は list/create/attach/finish の具体アクションを持つため引き続き補完対象

## Test plan
- [x] `pnpm run build` — `dist/bin/list-commands.js` 再生成、成功
- [x] `pnpm run check` — Lua構文チェック、エラーなし
- [x] `pnpm run lint` — ESLint、エラーなし
- [x] リポジトリの `skills/` を直接読ませて `parseSkillFrontmatter` ロジックを検証し、`nvim-context`/`nvim-lsp-navigation` が `userInvocable: false`、`vibing-worktree` が `userInvocable: true` になることを確認
- [x] Neovim上で `skills.lua` の `is_user_invocable` を実データに対して実行し、`nvim-context`/`nvim-lsp-navigation` が補完候補から除外され `vibing-worktree` が残ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for marking skills as unavailable for direct user invocation via `user-invocable: false`.
  * Skills marked non-invocable are now hidden from command lists and completion suggestions.
  * Skills remain user-invocable by default when the opt-out is not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->