### PR TITLE
fix: resolve worktree hook-settings path and buffer identification issues

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -106,6 +106,7 @@ function M.execute(adapter, callbacks, message, config)
     local opts = {
       streaming = true,
       action_type = "chat",
+      chat_file_path = vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_get_name(bufnr) or nil,
       mode = frontmatter.mode,
       model = frontmatter.model,
       permissions_allow = frontmatter.permissions_allow,
@@ -116,7 +117,6 @@ function M.execute(adapter, callbacks, message, config)
       permission_mode = frontmatter.permission_mode,
       language = lang_code,
       cwd = session_cwd,
-      chat_file_path = vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_get_name(bufnr) or nil,
       on_tool_use = function(tool, file_path, _command)
         if (tool == "Write" or tool == "Edit" or tool == "NotebookEdit") and file_path then
           modified_file_paths[file_path] = true

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -13,7 +13,6 @@ local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.acti
 ---@class Vibing.ClaudeCLIAdapter : Vibing.Adapter
 ---@field _handles table<string, table>
 ---@field _session_manager table
----@field _settings_path string|nil
 local ClaudeCLI = setmetatable({}, { __index = Base })
 ClaudeCLI.__index = ClaudeCLI
 
@@ -35,27 +34,10 @@ function ClaudeCLI:new(config)
   instance.name = "claude_cli"
   instance._handles = {}
   instance._session_manager = SessionManagerModule.new()
-  instance._settings_path = nil
   math.randomseed(vim.loop.hrtime())
   return instance
 end
 
---- Get or create hook settings file (cached)
---- @return string|nil
-function ClaudeCLI:_get_settings_path()
-  if not self._settings_path then
-    local ok, path = pcall(SettingsGenerator.ensure)
-    if ok and path then
-      self._settings_path = path
-    else
-      vim.notify(
-        string.format("[vibing:cli] Failed to create hook settings: %s", tostring(path)),
-        vim.log.levels.WARN
-      )
-    end
-  end
-  return self._settings_path
-end
 
 ---@param prompt string
 ---@param opts Vibing.AdapterOpts
@@ -103,7 +85,16 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
     )
   end
 
-  local cmd = CLICommandBuilder.build(prompt, opts, session_id, self.config, self:_get_settings_path())
+  local cwd = opts.cwd or vim.fn.getcwd()
+  local ok, settings_path = pcall(SettingsGenerator.ensure, cwd)
+  if not ok then
+    vim.notify(
+      string.format("[vibing:cli] Failed to create hook settings: %s", tostring(settings_path)),
+      vim.log.levels.WARN
+    )
+    settings_path = nil
+  end
+  local cmd = CLICommandBuilder.build(prompt, opts, session_id, self.config, settings_path)
   local output = {}
   local error_output = {}
 
@@ -167,8 +158,6 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
       on_done(response)
     end
   end
-
-  local cwd = opts.cwd or vim.fn.getcwd()
 
   self._handles[handle_id] = vim.system(cmd, {
     text = true,

--- a/lua/vibing/infrastructure/hooks/settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/settings_generator.lua
@@ -37,7 +37,7 @@ end
 
 --- Ensure hook settings file exists in .vibing/ of the given cwd
 --- @param cwd? string Working directory (defaults to vim.fn.getcwd())
---- @return string path Relative path to settings file
+--- @return string path Absolute path to settings file
 function M.ensure(cwd)
   cwd = cwd or vim.fn.getcwd()
   local vibing_dir = cwd .. "/.vibing"
@@ -56,7 +56,7 @@ function M.ensure(cwd)
   f:write(json)
   f:close()
 
-  return ".vibing/hook-settings.json"
+  return settings_path
 end
 
 return M

--- a/skills/vibing-worktree/SKILL.md
+++ b/skills/vibing-worktree/SKILL.md
@@ -48,8 +48,11 @@ out of curiosity or as a lead-in to attaching.
    If this fails (branch already checked out elsewhere, etc.), the error is self-explanatory —
    surface it verbatim rather than retrying blindly with a different name.
 
-3. Find this chat's own file path. If the `vibing-nvim` MCP server is connected, call
-   `mcp__vibing-nvim__nvim_get_info` to get it.
+3. Find this chat's own file path. The system prompt contains a line like
+   `Current vibing.nvim chat buffer file: /path/to/chat.md` — use that path directly. It is
+   injected per-request by vibing.nvim and is always accurate even when multiple chat buffers
+   are open. Avoid calling `mcp__vibing-nvim__nvim_get_info` for this purpose; it returns
+   whichever buffer currently has focus in Neovim and may return the wrong one.
 4. Edit that file's frontmatter, setting:
 
    ```yaml
@@ -71,7 +74,7 @@ existing one.
 1. Run the **List** steps above to surface candidates.
 2. Once the user picks one, follow **Create** steps 3-5 to point this chat's own `working_dir`
    frontmatter at the chosen worktree's path — the worktree already exists, so skip the
-   `git worktree add` step.
+   `git worktree add` step (step 2).
 
 ## Finish — "clean up this worktree"
 


### PR DESCRIPTION
## 概要

issue #444 とそのコメントで報告された2つの不具合を修正します。

### 修正1: worktreeでhook-settings.jsonが見つからない（コメントのissue）

**原因**: `SettingsGenerator.ensure()` が相対パス `.vibing/hook-settings.json` を返すため、worktreeディレクトリをcwdとしてサブプロセスを起動すると `<worktree>/.vibing/hook-settings.json` を探しに行くが存在しない。

**修正**:
- `settings_generator.lua` の `ensure()` が絶対パスを返すよう変更
- `claude_cli.lua` の `_get_settings_path()` とキャッシュを削除し、`stream()` 内で `SettingsGenerator.ensure(cwd)` を直接呼び出す形に変更
  - キャッシュを削除することで「Always regenerate（プラグイン更新後にhookスクリプトパスが変わる場合がある）」という既存の保証も復元

### 修正2: nvim_get_infoが複数チャット時に誤ったバッファを返す（メインissue）

**原因**: `vibing-worktree` スキルの Create フローで `nvim_get_info` を呼ぶと、フォーカス中のバッファを返すため、リクエスト元のチャットバッファとは異なるバッファが返る場合がある。

**修正**:
- `opts.chat_file_path` にリクエスト元チャットのファイルパスを追加
- `--append-system-prompt` に `The current chat file path is: <path>` を追記し、スキルがシステムプロンプトから直接パスを読み取れるようにする
- `SKILL.md` を更新: `nvim_get_info` ではなくシステムプロンプトのパスを使用するよう手順を変更

## 変更ファイル

- `lua/vibing/infrastructure/hooks/settings_generator.lua` - 絶対パスを返すよう修正
- `lua/vibing/infrastructure/adapter/claude_cli.lua` - キャッシュ削除、ensure()直接呼び出し
- `lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua` - chat_file_pathをシステムプロンプトに追加
- `lua/vibing/application/chat/send_message.lua` - opts.chat_file_pathを設定
- `skills/vibing-worktree/SKILL.md` - nvim_get_infoではなくシステムプロンプトのパスを使用
- `tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua` - テスト追加

fixes #444