### PR TITLE
fix: track every rendered chat buffer, not just the most recent one

### DIFF
--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -43,6 +43,10 @@ function M.render(session, position)
 
   chat_buf:open()
 
+  -- 複数チャット同時実行時も認識できるよう、bufnrキーでも追跡する
+  -- （M._current_buffer は直近にrenderされたチャットしか指さないシングルトンのため）
+  M._attached_buffers[chat_buf.buf] = chat_buf
+
   -- セッションの内容をバッファに書き込む
   if session.file_path and vim.fn.filereadable(session.file_path) == 1 then
     local content = vim.fn.readfile(session.file_path)

--- a/tests/view_spec.lua
+++ b/tests/view_spec.lua
@@ -1,0 +1,49 @@
+-- Tests for vibing.presentation.chat.view
+-- Regression: a chat buffer created earlier must still be recognized as a
+-- chat buffer after a newer chat becomes the most-recently-rendered one.
+
+describe("vibing.presentation.chat.view", function()
+  local view
+
+  before_each(function()
+    package.loaded["vibing.presentation.chat.view"] = nil
+    require("vibing").setup({})
+    view = require("vibing.presentation.chat.view")
+    view._attached_buffers = {}
+    view._current_buffer = nil
+  end)
+
+  after_each(function()
+    for bufnr, _ in pairs(view._attached_buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    view._attached_buffers = {}
+    view._current_buffer = nil
+  end)
+
+  describe("render", function()
+    it("tracks every rendered chat buffer, not just the most recent one", function()
+      view.render({ session_id = "session-1" }, "back")
+      local first_buf = view._current_buffer.buf
+
+      view.render({ session_id = "session-2" }, "back")
+
+      assert.is_not_nil(view._attached_buffers[first_buf])
+    end)
+  end)
+
+  describe("is_current_buffer_chat", function()
+    it("recognizes an older chat buffer after a newer chat becomes current", function()
+      view.render({ session_id = "session-1" }, "back")
+      local first_buf = view._current_buffer.buf
+
+      view.render({ session_id = "session-2" }, "back")
+
+      vim.api.nvim_set_current_buf(first_buf)
+
+      assert.is_true(view.is_current_buffer_chat())
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- `M._current_buffer` in `lua/vibing/presentation/chat/view.lua` was a singleton overwritten on every `:VibingChat` / `:VibingChatFork` call, so `is_current_buffer_chat()` lost track of older chat buffers once a newer chat became current
- This caused `:VibingSetFileTitle` (and anything else relying on `is_current_buffer_chat()`) to fail with "Not in a vibing chat buffer" on a valid, previously-opened chat file, once a second chat had been rendered in the same Neovim instance
- Fix: register every buffer created by `render()` into `M._attached_buffers` (the same table already used for `:e`-reopened chats), so any chat buffer is recognized regardless of render order

## Test plan
- [x] Added `tests/view_spec.lua` reproducing the regression (fails without the fix, passes with it)
- [x] `pnpm run check` (Lua syntax)
- [x] `pnpm run test:lua` (full suite, no new failures)

🐛 Fixes an issue where `:VibingSetFileTitle` errored with "Not in a vibing chat buffer" after multiple chats were opened in the same Neovim session.