### PR TITLE
feat: add fable as a selectable Claude model

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -74,7 +74,7 @@ vibing.nvim: true
 session_id: <sdk-session-id>
 created_at: 2024-01-01T12:00:00
 working_dir: .vibing/workspace/0001-feature-branch/worktree # Optional: relative path from git root for working directory
-model: sonnet # sonnet, opus, or haiku (from config.agent.default_model)
+model: sonnet # sonnet, opus, haiku, or fable (from config.agent.default_model)
 permissions_mode: acceptEdits # default, acceptEdits, bypassPermissions, plan, or dontAsk
 permissions_allow:
   - Read

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -55,7 +55,7 @@ Slash commands can be used within the chat buffer for quick actions:
 | `/clear`                  | Clear context                                                                 |
 | `/save`                   | Save current chat                                                             |
 | `/summarize`              | Summarize conversation                                                        |
-| `/model <model>`          | Set AI model (opus/sonnet/haiku)                                              |
+| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                        |
 | `/help`                   | Show available slash commands                                                 |
 | `/permissions` or `/perm` | Interactive Permission Builder - configure tool permissions                   |
 | `/allow [tool]`           | Add tool to allow list, or show current list if no args                       |

--- a/.claude/rules/configuration.md
+++ b/.claude/rules/configuration.md
@@ -6,7 +6,7 @@ Example configuration showing all available settings:
 require("vibing").setup({
   agent = {
     default_mode = "code",    -- "code" | "plan" | "explore"
-    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku"
+    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
     prioritize_vibing_lsp = true,  -- Prioritize vibing-nvim LSP tools over generic LSP
   },
   chat = {

--- a/README.ja.md
+++ b/README.ja.md
@@ -221,7 +221,7 @@ Neovimを起動しておく必要はあります。
       },
       agent = {
         default_mode = "code",  -- "code" | "plan" | "explore"
-        default_model = "sonnet",  -- "sonnet" | "opus" | "haiku"
+        default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
         prioritize_vibing_lsp = true,  -- vibing-nvim LSPツールを優先（デフォルト：true）
       },
       permissions = {
@@ -317,7 +317,7 @@ use {
 | `/clear`                      | コンテキストをクリア                                                   |
 | `/save`                       | 現在のチャットを保存                                                   |
 | `/summarize`                  | 会話を要約                                                             |
-| `/model <model>`              | AIモデルを設定（opus/sonnet/haiku）                                    |
+| `/model <model>`              | AIモデルを設定（opus/sonnet/haiku/fable）                              |
 | `/permissions` または `/perm` | インタラクティブな権限ビルダー - ツールの許可/拒否ルールを設定         |
 | `/allow [tool]`               | 許可リストにツールを追加、引数なしで現在のリストを表示                 |
 | `/deny [tool]`                | 拒否リストにツールを追加、引数なしで現在のリストを表示                 |
@@ -690,7 +690,7 @@ remote = {
 vibing.nvim: true
 session_id: <sdk-session-id>
 created_at: 2024-01-01T12:00:00
-model: sonnet  # sonnet | opus | haiku
+model: sonnet  # sonnet | opus | haiku | fable
 permissions_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk
 permissions_allow:
   - Read

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ anything to connect to.
       },
       agent = {
         default_mode = "code",  -- "code" | "plan" | "explore"
-        default_model = "sonnet",  -- "sonnet" | "opus" | "haiku"
+        default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
         prioritize_vibing_lsp = true,  -- Prioritize vibing-nvim LSP tools (default: true)
       },
       permissions = {
@@ -313,7 +313,7 @@ use {
 | `/clear`                  | Clear context                                                            |
 | `/save`                   | Save current chat                                                        |
 | `/summarize`              | Summarize conversation                                                   |
-| `/model <model>`          | Set AI model (opus/sonnet/haiku)                                         |
+| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                   |
 | `/help`                   | Show available slash commands                                            |
 | `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules         |
 | `/allow [tool]`           | Add tool to allow list, or show current list if no args                  |
@@ -910,7 +910,7 @@ vibing.nvim: true
 session_id: <cli-session-id>
 created_at: 2024-01-01T12:00:00
 agent: claude  # claude | codex (overrides global adapter setting for this chat)
-model: sonnet  # sonnet | opus | haiku
+model: sonnet  # sonnet | opus | haiku | fable
 permissions_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk
 permissions_allow:
   - Read

--- a/lua/vibing/application/chat/commands.lua
+++ b/lua/vibing/application/chat/commands.lua
@@ -199,7 +199,7 @@ function M.get_argument_completions(command_name)
   local Modes = require("vibing.core.constants.modes")
   local completions = {
     permission = Modes.PERMISSION_MODES,
-    model = { "opus", "sonnet", "haiku" },
+    model = Modes.VALID_MODELS,
   }
   return completions[command_name]
 end

--- a/lua/vibing/application/chat/handlers/model.lua
+++ b/lua/vibing/application/chat/handlers/model.lua
@@ -1,4 +1,5 @@
 local notify = require("vibing.core.utils.notify")
+local Modes = require("vibing.core.constants.modes")
 
 ---@param args string[]
 ---@param chat_buffer Vibing.ChatBuffer
@@ -10,18 +11,9 @@ return function(args, chat_buffer)
   end
 
   local model = args[1]
-  local valid_models = { "opus", "sonnet", "haiku" }
-  local is_valid = false
 
-  for _, valid_model in ipairs(valid_models) do
-    if model == valid_model then
-      is_valid = true
-      break
-    end
-  end
-
-  if not is_valid then
-    notify.error(string.format("Invalid model: %s (valid: opus, sonnet, haiku)", model))
+  if not Modes.is_valid_model(model) then
+    notify.error(string.format("Invalid model: %s (valid: %s)", model, table.concat(Modes.VALID_MODELS, ", ")))
     return false
   end
 

--- a/lua/vibing/application/chat/init.lua
+++ b/lua/vibing/application/chat/init.lua
@@ -31,7 +31,7 @@ function M.setup()
   commands.register({
     name = "model",
     handler = require("vibing.application.chat.handlers.model"),
-    description = "Set AI model: /model <opus|sonnet|haiku>",
+    description = "Set AI model: /model <opus|sonnet|haiku|fable>",
   })
 
   commands.register({

--- a/lua/vibing/application/chat/init.lua
+++ b/lua/vibing/application/chat/init.lua
@@ -1,3 +1,5 @@
+local Modes = require("vibing.core.constants.modes")
+
 ---@class Vibing.ChatInit
 local M = {}
 
@@ -31,7 +33,7 @@ function M.setup()
   commands.register({
     name = "model",
     handler = require("vibing.application.chat.handlers.model"),
-    description = "Set AI model: /model <opus|sonnet|haiku|fable>",
+    description = string.format("Set AI model: /model <%s>", table.concat(Modes.VALID_MODELS, "|")),
   })
 
   commands.register({

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -76,9 +76,9 @@
 
 ---@class Vibing.AgentConfig
 ---Agent SDK設定
----Claudeのモード（code/plan/explore）とモデル（sonnet/opus/haiku）を指定
+---Claudeのモード（code/plan/explore）とモデル（sonnet/opus/haiku/fable）を指定
 ---@field default_mode "code"|"plan"|"explore" デフォルトモード（"code": コード生成、"plan": 計画、"explore": 探索）
----@field default_model "sonnet"|"opus"|"haiku" デフォルトモデル（"sonnet": バランス、"opus": 高性能、"haiku": 高速）
+---@field default_model "sonnet"|"opus"|"haiku"|"fable" デフォルトモデル（"sonnet": バランス、"opus": 高性能、"haiku": 高速、"fable": Claude Fable）
 ---@field prioritize_vibing_lsp boolean vibing-nvim LSPツールを優先（true: Serena等の汎用LSPより優先、false: システムプロンプトを挿入しない、デフォルト: true）
 
 ---@class Vibing.NodeConfig

--- a/lua/vibing/core/constants/modes.lua
+++ b/lua/vibing/core/constants/modes.lua
@@ -2,9 +2,9 @@
 ---モデル、権限モード、エージェントタイプの定数定義
 local M = {}
 
----有効なモデル
+---有効なモデル（claude/codex共通で許可される名称。codex固有のモデル名はcodex_command_builder側で自由入力を許可）
 ---@type string[]
-M.VALID_MODELS = { "sonnet", "opus", "haiku" }
+M.VALID_MODELS = { "sonnet", "opus", "haiku", "fable" }
 
 ---権限モード
 ---@type string[]

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -2,25 +2,20 @@
 --- Builds the command array for the Codex CLI with JSONL output
 --- @module vibing.infrastructure.adapter.modules.codex_command_builder
 
+local Modes = require("vibing.core.constants.modes")
+
 local M = {}
 
 local cached_codex_path = nil
 
---- Claude-specific model names that should not be passed to codex
-local CLAUDE_MODELS = {
-  sonnet = true,
-  opus = true,
-  haiku = true,
-}
-
 --- Resolve model name from opts or config
---- Filters out Claude-specific model names (sonnet/opus/haiku) as codex uses its own models
+--- Filters out Claude-specific model names (sonnet/opus/haiku/fable) as codex uses its own models
 --- @param opts Vibing.AdapterOpts
 --- @param config Vibing.Config
 --- @return string|nil
 local function resolve_model(opts, config)
   local model = opts.model or (config.agent and config.agent.default_model)
-  if model and CLAUDE_MODELS[model] then
+  if model and Modes.is_valid_model(model) then
     return nil
   end
   return model

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -24,6 +24,7 @@ local CLAUDE_MODELS = {
   { value = "haiku", description = "Claude Haiku (fastest)" },
   { value = "sonnet", description = "Claude Sonnet (balanced)" },
   { value = "opus", description = "Claude Opus (most capable)" },
+  { value = "fable", description = "Claude Fable" },
 }
 
 local CODEX_MODELS = {

--- a/tests/chat_init_spec.lua
+++ b/tests/chat_init_spec.lua
@@ -125,7 +125,7 @@ describe("vibing.application.chat.init", function()
         clear = "Clear context",
         save = "Save current chat",
         summarize = "Summarize conversation",
-        model = "Set AI model: /model <opus|sonnet|haiku>",
+        model = "Set AI model: /model <opus|sonnet|haiku|fable>",
       }
 
       for cmd_name, expected_desc in pairs(cmd_descriptions) do

--- a/tests/chat_init_spec.lua
+++ b/tests/chat_init_spec.lua
@@ -120,12 +120,13 @@ describe("vibing.application.chat.init", function()
     it("should register commands with correct descriptions", function()
       ChatInit.setup()
 
+      local Modes = require("vibing.core.constants.modes")
       local cmd_descriptions = {
         context = "Add file to context: /context <file_path>",
         clear = "Clear context",
         save = "Save current chat",
         summarize = "Summarize conversation",
-        model = "Set AI model: /model <opus|sonnet|haiku|fable>",
+        model = string.format("Set AI model: /model <%s>", table.concat(Modes.VALID_MODELS, "|")),
       }
 
       for cmd_name, expected_desc in pairs(cmd_descriptions) do

--- a/tests/completion/frontmatter_spec.lua
+++ b/tests/completion/frontmatter_spec.lua
@@ -51,10 +51,11 @@ describe("Frontmatter completion", function()
 
     it("should get model enum values via get_model_values", function()
       local items = frontmatter_provider.get_model_values("claude")
-      assert.are.equal(3, #items)
+      assert.are.equal(4, #items)
       assert.are.equal("haiku", items[1].word)
       assert.are.equal("sonnet", items[2].word)
       assert.are.equal("opus", items[3].word)
+      assert.are.equal("fable", items[4].word)
     end)
 
     it("should get permissions_mode enum values", function()

--- a/tests/lua/infrastructure/rpc/server_spec.lua
+++ b/tests/lua/infrastructure/rpc/server_spec.lua
@@ -1,8 +1,19 @@
 -- Tests for vibing.infrastructure.rpc.server module
 
+-- Ask the OS for a currently-free ephemeral port so tests don't collide with
+-- real vibing.nvim instances (or each other) parked on the hardcoded 9876-9925 range.
+local function find_free_port()
+  local tmp = vim.loop.new_tcp()
+  tmp:bind("127.0.0.1", 0)
+  local port = tmp:getsockname().port
+  tmp:close()
+  return port
+end
+
 describe("vibing.infrastructure.rpc.server", function()
   local server
   local registry
+  local base_port
 
   before_each(function()
     -- Reload modules before each test
@@ -10,6 +21,7 @@ describe("vibing.infrastructure.rpc.server", function()
     package.loaded["vibing.infrastructure.rpc.registry"] = nil
     server = require("vibing.infrastructure.rpc.server")
     registry = require("vibing.infrastructure.rpc.registry")
+    base_port = find_free_port()
   end)
 
   after_each(function()
@@ -21,7 +33,6 @@ describe("vibing.infrastructure.rpc.server", function()
 
   describe("start", function()
     it("should start server on base port when available", function()
-      local base_port = 9876
       local port = server.start(base_port)
 
       assert.is_true(port >= base_port)
@@ -34,7 +45,6 @@ describe("vibing.infrastructure.rpc.server", function()
 
     it("should try next port when base port is in use", function()
       -- Start first server on base port
-      local base_port = 9876
       local first_port = server.start(base_port)
       assert.is_true(server.is_running())
 
@@ -53,8 +63,6 @@ describe("vibing.infrastructure.rpc.server", function()
     it("should return 0 when all ports are exhausted", function()
       -- This test is difficult to implement without blocking 10 ports
       -- We'll test the logic by mocking registry
-      local base_port = 9876
-
       -- Mock registry.is_port_in_use to return true for all ports
       local original_is_port_in_use = registry.is_port_in_use
       registry.is_port_in_use = function()
@@ -79,7 +87,6 @@ describe("vibing.infrastructure.rpc.server", function()
     end)
 
     it("should register instance after successful start", function()
-      local base_port = 9876
       local port = server.start(base_port)
 
       assert.is_true(port > 0)
@@ -102,7 +109,6 @@ describe("vibing.infrastructure.rpc.server", function()
     end)
 
     it("should return current port if already running", function()
-      local base_port = 9876
       local first_port = server.start(base_port)
       local second_port = server.start(base_port)
 
@@ -112,8 +118,6 @@ describe("vibing.infrastructure.rpc.server", function()
     end)
 
     it("should skip ports in registry (cached instances)", function()
-      local base_port = 9876
-
       -- Register a fake instance on base_port
       local registry_dir = vim.fn.stdpath("data") .. "/vibing-instances"
       vim.fn.mkdir(registry_dir, "p")
@@ -140,7 +144,6 @@ describe("vibing.infrastructure.rpc.server", function()
 
   describe("stop", function()
     it("should stop running server", function()
-      local base_port = 9876
       server.start(base_port)
       assert.is_true(server.is_running())
 
@@ -150,7 +153,6 @@ describe("vibing.infrastructure.rpc.server", function()
     end)
 
     it("should unregister instance after stop", function()
-      local base_port = 9876
       local port = server.start(base_port)
       local current_pid = vim.fn.getpid()
 
@@ -184,7 +186,6 @@ describe("vibing.infrastructure.rpc.server", function()
     end)
 
     it("should return current port when server is running", function()
-      local base_port = 9876
       local port = server.start(base_port)
 
       assert.equals(port, server.get_port())
@@ -199,7 +200,7 @@ describe("vibing.infrastructure.rpc.server", function()
     end)
 
     it("should return true when server is running", function()
-      server.start(9876)
+      server.start(base_port)
       assert.is_true(server.is_running())
       server.stop()
     end)
@@ -210,7 +211,6 @@ describe("vibing.infrastructure.rpc.server", function()
       -- This is tested implicitly by the "try next port" test above
       -- The atomic bind() operation ensures TOCTOU is handled correctly
 
-      local base_port = 9876
       local port = server.start(base_port)
 
       -- Even if registry check passes, bind will fail atomically if port is taken
@@ -226,8 +226,6 @@ describe("vibing.infrastructure.rpc.server", function()
     it("should cache instance list during port allocation", function()
       -- This is difficult to test directly, but we can verify behavior
       -- The optimization means registry.list() is called once, not 10 times
-
-      local base_port = 9876
 
       -- Create multiple fake instances to force server to check multiple ports
       local registry_dir = vim.fn.stdpath("data") .. "/vibing-instances"
@@ -247,7 +245,7 @@ describe("vibing.infrastructure.rpc.server", function()
         table.insert(fake_files, fake_file)
       end
 
-      -- Start server - should skip first 5 ports and use port 9881
+      -- Start server - should skip the first 5 registered ports
       local port = server.start(base_port)
 
       assert.is_true(port >= base_port + 5, "Should skip all registered ports")


### PR DESCRIPTION
## Summary
- frontmatter の `model:` 補完（agent: claude 時）と `/model` スラッシュコマンドの選択肢に `fable` を追加
- モデル一覧が `handlers/model.lua` / `commands.lua` / `codex_command_builder.lua` の3箇所以上に重複定義されていたため、`core/constants/modes.lua` の `VALID_MODELS` を単一ソースとして参照するよう統一
- ドキュメント（README.md, README.ja.md, `.claude/rules/*.md`）のモデル一覧記述も更新

## Test plan
- [x] `tests/completion/frontmatter_spec.lua` の `get_model_values("claude")` 期待値を4件に更新し成功を確認
- [x] `tests/chat_init_spec.lua` の `/model` コマンド description 期待値を更新し成功を確認
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ ..."` を実行し、既存テストにリグレッションがないことを確認（`rpc/server_spec.lua` の1件のみ失敗するが、テスト実行環境のポート競合(EADDRINUSE)による既存の環境要因で本変更とは無関係）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `fable` as a supported AI model.
  - Updated model selection, configuration, chat commands, and completions to recognize `fable`.
  - Invalid model messages now display the complete list of supported options.

- **Documentation**
  - Updated English and Japanese documentation with the new model option.

- **Tests**
  - Updated coverage for model commands and frontmatter completion results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->