### PR TITLE
refactor: split vibing-worktree skill into per-operation skills

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -183,10 +183,11 @@ supporting multi-language development workflows.
 ## Git Worktree Integration
 
 Worktree-backed development goes through natural-language requests backed by the
-`vibing-worktree` Claude Code skill bundled with this plugin (`skills/vibing-worktree`), not
-through a vibing.nvim chat command. There is no bespoke lifecycle script or metadata file —
-worktrees are created with plain `git worktree add -b <branch> .vibing/worktrees/<branch>/` and
-removed with `git worktree remove`; a worktree's existence on disk is its entire state. The
-chat's own `working_dir` frontmatter field (unchanged by this) is what keeps a conversation
-attached to its worktree across turns. See `skills/vibing-worktree/SKILL.md` for the full
-list/create/attach/finish workflow.
+`vibing-worktree-{list,create,attach,run,finish}` Claude Code skills bundled with this plugin
+(`skills/vibing-worktree-*`), not through a vibing.nvim chat command. There is no bespoke
+lifecycle script or metadata file — worktrees are created with plain
+`git worktree add -b <branch> .vibing/worktrees/<branch>/` and removed with
+`git worktree remove`; a worktree's existence on disk is its entire state. The chat's own
+`working_dir` frontmatter field (unchanged by this) is what keeps a conversation attached to its
+worktree across turns. See `skills/vibing-worktree-list/SKILL.md` (and its sibling `-create`,
+`-attach`, `-run`, `-finish` skills) for the full list/create/attach/finish workflow.

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -64,6 +64,8 @@ Slash commands can be used within the chat buffer for quick actions:
 | `/permission [mode]`      | Set permission mode (default/acceptEdits/plan/auto/dontAsk/bypassPermissions) |
 | `/new-session`            | Reset session and start fresh                                                 |
 
-Worktree lifecycle (list/create/attach/finish) is handled entirely through natural-language
-requests backed by the `vibing-worktree` Claude Code skill bundled with this plugin (`skills/`),
-not by chat slash commands. See `skills/vibing-worktree/SKILL.md`.
+Worktree lifecycle (list/create/attach/run/finish) is handled entirely through natural-language
+requests backed by the `vibing-worktree-{list,create,attach,run,finish}` Claude Code skills
+bundled with this plugin (`skills/`), not by chat slash commands. See
+`skills/vibing-worktree-list/SKILL.md` and its sibling `-create`, `-attach`, `-run`, `-finish`
+skills.

--- a/.claude/rules/self-development.md
+++ b/.claude/rules/self-development.md
@@ -6,11 +6,11 @@ When you (Claude Agent SDK) are working on vibing.nvim itself, follow these guid
 
 **For Feature Development:**
 
-1. Use the `vibing-worktree` skill for isolated development environments — ask in natural
-   language ("split this off into its own worktree", "what worktrees exist", "attach to the
-   auth-fix worktree", "clean up this worktree"). It runs plain `git worktree` commands under
-   `.vibing/worktrees/<branch>/` and updates the current chat's `working_dir` frontmatter; there
-   is no separate metadata file or lifecycle state to manage.
+1. Use the `vibing-worktree-{list,create,attach,run,finish}` skills for isolated development
+   environments — ask in natural language ("split this off into its own worktree", "what
+   worktrees exist", "attach to the auth-fix worktree", "clean up this worktree"). They run plain
+   `git worktree` commands under `.vibing/worktrees/<branch>/` and update the current chat's
+   `working_dir` frontmatter; there is no separate metadata file or lifecycle state to manage.
 
 **For Buffer/Window Operations:**
 
@@ -36,8 +36,8 @@ When you (Claude Agent SDK) are working on vibing.nvim itself, follow these guid
 
 ```typescript
 // ✅ CORRECT - vibing.nvim-aware workflow
-// 1. Create an isolated worktree for the new feature (invoke the vibing-worktree skill's
-//    "Create" recipe directly — plain `git worktree add` under .vibing/worktrees/<branch>/)
+// 1. Create an isolated worktree for the new feature (invoke the vibing-worktree-create skill
+//    directly — plain `git worktree add` under .vibing/worktrees/<branch>/)
 
 // 2. Load file in background for LSP analysis
 const { bufnr } = await use_mcp_tool('vibing-nvim', 'nvim_load_buffer', {
@@ -81,8 +81,7 @@ const refs = await use_mcp_tool("serena", "lsp_references", { ... });
 
 - ❌ Wrong: `git worktree add ../feature-branch` or `git worktree add .worktrees/feature-branch`
 - ✅ Correct: `git worktree add -b feature-branch .vibing/worktrees/feature-branch` (what the
-  `vibing-worktree` skill's "Create" recipe does), then update the chat's `working_dir`
-  frontmatter to match
+  `vibing-worktree-create` skill does), then update the chat's `working_dir` frontmatter to match
 - Why: `.vibing/worktrees/` is the convention every vibing.nvim chat is told about via its system
   prompt, and it's already covered by the `.vibing/` mote-ignore rule; a worktree placed elsewhere
   won't be picked up by that convention and needs its own ignore handling

--- a/.claude/rules/self-testing.md
+++ b/.claude/rules/self-testing.md
@@ -234,12 +234,15 @@ When implementing new features, add E2E tests for:
 
 ### Worktree Features
 
-- [ ] `vibing-worktree` skill lists worktrees via `git worktree list --porcelain`
-- [ ] `vibing-worktree` skill creates a worktree under `.vibing/worktrees/<branch>/` and rewrites
-      the current chat's `working_dir` frontmatter
-- [ ] `vibing-worktree` skill attaches a chat (new or existing) to an already-existing worktree
-- [ ] `vibing-worktree` skill removes a worktree via `git worktree remove` (never `--force`) and
-      clears `working_dir` if it was the current chat's own worktree
+- [ ] `vibing-worktree-list` skill lists worktrees via `git worktree list --porcelain`
+- [ ] `vibing-worktree-create` skill creates a worktree under `.vibing/worktrees/<branch>/` and
+      rewrites the current chat's `working_dir` frontmatter
+- [ ] `vibing-worktree-attach` skill attaches a chat (new or existing) to an already-existing
+      worktree
+- [ ] `vibing-worktree-run` skill gets a worktree branch's code actually running without
+      merging or rebasing it
+- [ ] `vibing-worktree-finish` skill removes a worktree via `git worktree remove` (never
+      `--force`) and clears `working_dir` if it was the current chat's own worktree
 
 ### MCP Tools
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ use {
   - `:VibingChat bottom` - New chat in bottom split
   - `:VibingChat back` - New chat as background buffer only (no window)
   - `:VibingChat path/to/file.md` - Open saved chat file
-- **Worktree lifecycle** - Use the `vibing-worktree` Claude Code skill bundled with this plugin, entirely via natural language, to list/create/attach/finish git worktrees under `.vibing/worktrees/<branch>/`.
+- **Worktree lifecycle** - Use the `vibing-worktree-{list,create,attach,run,finish}` Claude Code skills bundled with this plugin, entirely via natural language, to list/create/attach/run/finish git worktrees under `.vibing/worktrees/<branch>/`.
 - **`:VibingChatFork`** - Fork current chat conversation for branching in a different direction.
 - **`:VibingToggleChat`** - Use to show/hide your current conversation. Preserves the existing chat state.
 
@@ -322,8 +322,10 @@ use {
 | `/permission [mode]`      | Set permission mode (default/acceptEdits/bypassPermissions/plan/dontAsk) |
 | `/new-session`            | Reset session and start fresh                                            |
 
-Worktree lifecycle is handled by the `vibing-worktree` Claude Code skill bundled with this
-plugin, not by chat slash commands — see `skills/vibing-worktree/SKILL.md`.
+Worktree lifecycle is handled by the `vibing-worktree-{list,create,attach,run,finish}` Claude
+Code skills bundled with this plugin, not by chat slash commands — see
+`skills/vibing-worktree-list/SKILL.md` and its sibling `-create`, `-attach`, `-run`, `-finish`
+skills.
 
 ### Chat Keybindings
 

--- a/docs/e2e-tests/08-worktree-integration.md
+++ b/docs/e2e-tests/08-worktree-integration.md
@@ -1,8 +1,9 @@
-# E2E Test Scenarios: Worktree Integration (`vibing-worktree` skill)
+# E2E Test Scenarios: Worktree Integration (`vibing-worktree-*` skills)
 
-These scenarios exercise the `vibing-worktree` skill's four natural-language flows against a
-real chat session. Each scenario assumes a fresh chat in a git repository with at least one
-commit, and that the `vibing-nvim` MCP server is connected unless a scenario says otherwise.
+These scenarios exercise the `vibing-worktree-{list,create,attach,finish}` skills' four
+natural-language flows against a real chat session. Each scenario assumes a fresh chat in a git
+repository with at least one commit, and that the `vibing-nvim` MCP server is connected unless a
+scenario says otherwise.
 
 ## 1. List worktrees
 

--- a/skills/vibing-worktree-attach/SKILL.md
+++ b/skills/vibing-worktree-attach/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: vibing-worktree-attach
+description: Attach the current or a new vibing.nvim chat to an already-existing git worktree via natural language — no separate UI. Use when the user wants to switch/attach a chat to an existing worktree ("let's go into the auth-fix worktree", "attach to worktree X", "continue in the feature-y worktree").
+---
+
+# vibing-worktree-attach
+
+Git worktrees provide isolated working directories for parallel development. This skill points
+this chat's own `working_dir` frontmatter at an already-existing worktree — it never creates one
+(see the `vibing-worktree-create` skill for that) and never runs `git worktree add`.
+
+## Attach — "what worktrees are there? — let's go into the auth one"
+
+Works the same whether this is a brand-new chat's first exchange or mid-conversation in an
+existing one.
+
+1. Surface candidates (see the `vibing-worktree-list` skill):
+
+   ```bash
+   git worktree list --porcelain
+   ```
+
+2. Once the user picks one, find this chat's own file path. The system prompt contains a line
+   like `Current vibing.nvim chat buffer file: /path/to/chat.md` — use that path directly. It is
+   injected per-request by vibing.nvim and is always accurate even when multiple chat buffers are
+   open. Avoid calling `mcp__vibing-nvim__nvim_get_info` for this purpose; it returns whichever
+   buffer currently has focus in Neovim and may return the wrong one.
+3. Edit that chat's frontmatter through the live Neovim buffer, not the file on disk — a brand-new
+   chat (first exchange in a freshly opened buffer) has no file on disk yet, so `Read`/`Edit`
+   against the path will simply fail or find nothing. Use the `vibing-nvim` MCP tools instead,
+   which operate on buffer content regardless of save state:
+   1. Call `nvim_list_buffers` and match `name` against the chat buffer path from the system
+      prompt to get its `bufnr`. Don't assume `bufnr: 0` (current buffer) — the chat buffer may
+      not have focus.
+   2. Call `nvim_get_buffer({ bufnr })` to read the current content.
+   3. Set `working_dir: <chosen worktree's path>` (relative to the git root) in the frontmatter
+      block, then call `nvim_set_buffer({ bufnr, lines })` with the full updated content.
+
+   Don't open a new chat buffer — the current conversation continues, and its next turn already
+   runs in the chosen worktree.
+
+4. If the `vibing-nvim` MCP connection isn't available at all, tell the user which worktree path
+   to use and that they'll need to set `working_dir` in the chat's frontmatter by hand (or open a
+   new chat there) to actually start using it.

--- a/skills/vibing-worktree-attach/SKILL.md
+++ b/skills/vibing-worktree-attach/SKILL.md
@@ -20,25 +20,8 @@ existing one.
    git worktree list --porcelain
    ```
 
-2. Once the user picks one, find this chat's own file path. The system prompt contains a line
-   like `Current vibing.nvim chat buffer file: /path/to/chat.md` — use that path directly. It is
-   injected per-request by vibing.nvim and is always accurate even when multiple chat buffers are
-   open. Avoid calling `mcp__vibing-nvim__nvim_get_info` for this purpose; it returns whichever
-   buffer currently has focus in Neovim and may return the wrong one.
-3. Edit that chat's frontmatter through the live Neovim buffer, not the file on disk — a brand-new
-   chat (first exchange in a freshly opened buffer) has no file on disk yet, so `Read`/`Edit`
-   against the path will simply fail or find nothing. Use the `vibing-nvim` MCP tools instead,
-   which operate on buffer content regardless of save state:
-   1. Call `nvim_list_buffers` and match `name` against the chat buffer path from the system
-      prompt to get its `bufnr`. Don't assume `bufnr: 0` (current buffer) — the chat buffer may
-      not have focus.
-   2. Call `nvim_get_buffer({ bufnr })` to read the current content.
-   3. Set `working_dir: <chosen worktree's path>` (relative to the git root) in the frontmatter
-      block, then call `nvim_set_buffer({ bufnr, lines })` with the full updated content.
-
-   Don't open a new chat buffer — the current conversation continues, and its next turn already
-   runs in the chosen worktree.
-
-4. If the `vibing-nvim` MCP connection isn't available at all, tell the user which worktree path
-   to use and that they'll need to set `working_dir` in the chat's frontmatter by hand (or open a
-   new chat there) to actually start using it.
+2. Once the user picks one, follow steps 3-5 of the `vibing-worktree-create` skill to point this
+   chat's own `working_dir` frontmatter at the chosen worktree's path via the `vibing-nvim` MCP
+   tools — the worktree already exists, so there's no `git worktree add` step to run first, and
+   there's no new chat buffer to open (the current conversation continues, and its next turn
+   already runs in the chosen worktree).

--- a/skills/vibing-worktree-create/SKILL.md
+++ b/skills/vibing-worktree-create/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: vibing-worktree
-description: Create, list, attach to, and finish git-worktree-backed isolated work areas for vibing.nvim chats, entirely via natural language — no separate UI. Use when the user wants to isolate work in its own worktree ("split this into its own worktree", "start this in isolation"), wants to see what worktrees/branches exist ("what worktrees do I have", "what's in progress"), wants to switch/attach the current or a new chat to an existing worktree ("let's go into the auth-fix worktree", "attach to worktree X"), or wants to clean one up when done ("clean up this worktree", "I'm done with this branch's worktree").
+name: vibing-worktree-create
+description: Create a new git-worktree-backed isolated work area for the current vibing.nvim chat via natural language — no separate UI. Use when the user wants to isolate work in its own worktree ("split this into its own worktree", "start this in isolation", "give this its own branch").
 ---
 
-# vibing-worktree
+# vibing-worktree-create
 
 Git worktrees provide isolated working directories for parallel development. This skill uses
 plain `git` commands and this chat's own frontmatter — no bespoke helper script, no metadata
@@ -14,25 +14,7 @@ file. A worktree's existence on disk is its entire state.
 Worktrees created for isolated work go under `.vibing/worktrees/<branch-name>/` at the git
 root — flat, one worktree per directory, nothing else stored alongside it. This convention is
 also stated in every vibing.nvim chat's system prompt; follow it so `git worktree list` stays
-predictable for later listing.
-
-## List — "what worktrees exist?"
-
-```bash
-git worktree list --porcelain
-```
-
-For a one-line hint of what was last done on a given worktree's branch:
-
-```bash
-git log -1 --format=%s <branch>
-```
-
-This shows every worktree registered against the repo, not just ones under
-`.vibing/worktrees/` — including ones created outside vibing.nvim entirely (a bare
-`git worktree add`, or `claude --worktree` run directly in a terminal). Present branch, path,
-and (if you fetched it) the last commit message so the user can pick one, whether they're asking
-out of curiosity or as a lead-in to attaching.
+predictable for later listing (see the `vibing-worktree-list` skill).
 
 ## Create — "split this off into its own worktree"
 
@@ -70,27 +52,3 @@ out of curiosity or as a lead-in to attaching.
 5. If the `vibing-nvim` MCP connection isn't available at all, tell the user the worktree is
    ready at `.vibing/worktrees/<branch>` and that they'll need to set `working_dir` in the chat's
    frontmatter by hand (or open a new chat there) to actually start using it.
-
-## Attach — "what worktrees are there? — let's go into the auth one"
-
-Works the same whether this is a brand-new chat's first exchange or mid-conversation in an
-existing one.
-
-1. Run the **List** steps above to surface candidates.
-2. Once the user picks one, follow **Create** steps 3-5 to point this chat's own `working_dir`
-   frontmatter at the chosen worktree's path — the worktree already exists, so skip the
-   `git worktree add` step (step 2).
-
-## Finish — "clean up this worktree"
-
-```bash
-git worktree remove <path>
-```
-
-Never add `--force`. If git refuses because of uncommitted changes, that's it protecting the
-user from losing work — report the exact error and let them decide whether to commit, stash, or
-discard those changes themselves, rather than retrying with `--force` on their behalf.
-
-If the removed path was this chat's own `working_dir`, clear that frontmatter field once removal
-succeeds (reverting to the main repo root) — leaving it pointed at a now-deleted directory would
-break the next turn.

--- a/skills/vibing-worktree-finish/SKILL.md
+++ b/skills/vibing-worktree-finish/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: vibing-worktree-finish
+description: Remove a git-worktree-backed isolated work area for vibing.nvim chats via natural language — no separate UI. Use when the user wants to clean one up when done ("clean up this worktree", "I'm done with this branch's worktree", "remove the auth-fix worktree").
+---
+
+# vibing-worktree-finish
+
+Git worktrees provide isolated working directories for parallel development. This skill removes
+one via plain `git worktree remove` — no bespoke helper script, no metadata file to update beyond
+this chat's own frontmatter.
+
+## Finish — "clean up this worktree"
+
+```bash
+git worktree remove <path>
+```
+
+Never add `--force`. If git refuses because of uncommitted changes, that's it protecting the
+user from losing work — report the exact error and let them decide whether to commit, stash, or
+discard those changes themselves, rather than retrying with `--force` on their behalf.
+
+If the removed path was this chat's own `working_dir`, clear that frontmatter field once removal
+succeeds (reverting to the main repo root) — leaving it pointed at a now-deleted directory would
+break the next turn. Follow the `vibing-nvim` MCP buffer-editing approach described in steps 3-4
+of the `vibing-worktree-create` skill to edit the live buffer rather than the file on disk.

--- a/skills/vibing-worktree-list/SKILL.md
+++ b/skills/vibing-worktree-list/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: vibing-worktree-list
+description: List git-worktree-backed isolated work areas for vibing.nvim chats via natural language — no separate UI. Use when the user wants to see what worktrees/branches exist ("what worktrees do I have", "what's in progress", "show me all worktrees").
+---
+
+# vibing-worktree-list
+
+Git worktrees provide isolated working directories for parallel development. This skill uses
+plain `git` commands — no bespoke helper script, no metadata file. A worktree's existence on disk
+is its entire state.
+
+## Directory convention
+
+Worktrees created for isolated work go under `.vibing/worktrees/<branch-name>/` at the git
+root — flat, one worktree per directory, nothing else stored alongside it. This convention is
+also stated in every vibing.nvim chat's system prompt.
+
+## List — "what worktrees exist?"
+
+```bash
+git worktree list --porcelain
+```
+
+For a one-line hint of what was last done on a given worktree's branch:
+
+```bash
+git log -1 --format=%s <branch>
+```
+
+This shows every worktree registered against the repo, not just ones under
+`.vibing/worktrees/` — including ones created outside vibing.nvim entirely (a bare
+`git worktree add`, or `claude --worktree` run directly in a terminal). Present branch, path,
+and (if you fetched it) the last commit message so the user can pick one, whether they're asking
+out of curiosity or as a lead-in to attaching (see the `vibing-worktree-attach` skill).

--- a/skills/vibing-worktree-run/SKILL.md
+++ b/skills/vibing-worktree-run/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: vibing-worktree-run
+description: Get a git worktree branch's code actually running (dev server, tests, CLI invocation, etc.) without merging or rebasing it, for vibing.nvim chats. Use when the user wants to run or try out a worktree branch for real ("I want to check this branch really works", "let me try this worktree's code for real", "run this worktree in the main directory").
+---
+
+# vibing-worktree-run
+
+Merging or rebasing is out of scope here, and so is judging whether the result is correct — the
+goal is only to get a worktree branch's code into a state where it can actually be executed,
+temporarily, without touching git history. The right technique depends on whether this project's
+tooling requires the repo to live at one fixed absolute path; investigate that once per project
+and remember the answer instead of re-deriving it every time.
+
+1. Read `.vibing/system-prompt.md` at the git root (vibing.nvim auto-creates it, empty, the first
+   time a project chat is opened — it's gitignored and local-only, so don't expect it in `git
+status` or try to commit it). Look for a `## Worktree run method` section.
+   - **If present**: follow the documented method exactly and skip straight to running it —
+     do not re-investigate.
+   - **If absent** (or the file doesn't exist yet): continue to step 2.
+2. Investigate what this project actually needs, cheapest option first:
+   1. **Default — no path-swap needed.** A worktree is a fully independent, working checkout.
+      Try running the project's normal command (test suite, dev server, build, CLI invocation,
+      whatever the project normally uses) directly from inside the worktree directory. This is
+      sufficient for the large majority of projects.
+   2. **Fixed-path dependency.** Only reach for this if 2.1 provably doesn't work because some
+      tool hardcodes an absolute path to the repo root (an editor plugin manager's `dir =`
+      config, a daemon watching one fixed path, a docker-compose bind mount, etc.). Decide
+      between two techniques based on whether that tool resolves symlinks to their real path:
+      - **Symlink swap** (fast, non-destructive; silently wrong for tools that resolve to the
+        canonical/real path): make the fixed path a symlink once, repoint it at the worktree to
+        run, repoint it back at the main checkout when done.
+      - **Checkout swap** (slower, but always correct regardless of tool internals): temporarily
+        `git worktree remove <path>` (only when clean — never `--force`), `git checkout <branch>`
+        in the main directory, run it, `git checkout` back to the original branch, then
+        `git worktree add <path> <branch>` to restore the worktree.
+        When genuinely unsure which technique the project's tooling needs, ask the user rather than
+        guessing.
+3. Record the decided method under a `## Worktree run method` heading in
+   `.vibing/system-prompt.md` (`Edit` to append, or `Write` if the file is still empty) so future
+   turns and sessions reuse it without re-investigating. Keep the note short and concrete — the
+   actual command(s) to run, not prose about the investigation that produced it.


### PR DESCRIPTION
## Summary
- `skills/vibing-worktree/`（list/create/attach/finish の単一スキル）を操作ごとの5スキルに分割: `vibing-worktree-{list,create,attach,run,finish}`
- 新設した `vibing-worktree-run` は、merge/rebaseせずにworktreeブランチのコードを実際に動かす方法を判断するスキル。デフォルトはworktreeディレクトリ内でそのまま実行、固定パス依存があるプロジェクトのみsymlink張り替え／checkout一時退避を使い分ける。決定した方法は `.vibing/system-prompt.md` に記録し、次回以降は再調査しない
- `.claude/rules/*.md`・README.md・`docs/e2e-tests/08-worktree-integration.md` 内の `vibing-worktree` スキルへの相互参照をすべて新しいスキル名に更新

## Test plan
- [ ] `npm run check` でLua構文を確認
- [ ] 各スキルディレクトリを `vibing-nvim` chatから自然言語で呼び出し、list/create/attach/run/finishが期待通り動作することを確認