### PR TITLE
fix: avoid scientific-notation handle_id breaking the approval hook

### DIFF
--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -71,7 +71,10 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   opts = opts or {}
 
   local debug_mode = vim.g.vibing_debug_stream
-  local handle_id = tostring(vim.loop.hrtime()) .. "_" .. tostring(math.random(100000))
+  -- hex format avoids LuaJIT's tostring() rendering large hrtime doubles in scientific
+  -- notation (e.g. "2.64e+15"), which pre-tool-use.sh's char-sanitized VIBING_HANDLE_ID
+  -- would then fail to match against this exact registry key
+  local handle_id = string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
   local session_id = opts._session_id
 
   if debug_mode then

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -70,7 +70,10 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   opts = opts or {}
 
   local debug_mode = vim.g.vibing_debug_stream
-  local handle_id = tostring(vim.loop.hrtime()) .. "_" .. tostring(math.random(100000))
+  -- hex format avoids LuaJIT's tostring() rendering large hrtime doubles in scientific
+  -- notation (e.g. "2.64e+15"), which pre-tool-use.sh's char-sanitized VIBING_HANDLE_ID
+  -- would then fail to match against this exact registry key
+  local handle_id = string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
   local session_id = opts._session_id
 
   if debug_mode then


### PR DESCRIPTION
## Summary
- `tostring(vim.loop.hrtime())` in `claude_cli.lua`/`codex_cli.lua` produces scientific notation on LuaJIT for large hrtime values (e.g. `2.64e+15`)
- That string is used both as the `active_stream_registry` key and as the `VIBING_HANDLE_ID` env var sent to `bin/hooks/pre-tool-use.sh`
- The hook sanitizes the env var to `[A-Za-z0-9_]` before sending it back over RPC, stripping `.` and `+`, so it never matches the original registry key
- Any tool requiring approval (`ask` permission) then fails with "vibing.nvim could not find the chat buffer to show the approval prompt in (internal error)" and the turn hangs
- Fixed by hex-formatting the handle_id (`string.format("%016x_%x", ...)`), matching the convention already used in `lua/vibing/presentation/chat/modules/file_manager.lua`

## Test plan
- [x] `pnpm run check` (luac syntax check) passes
- [x] `pnpm run test:lua` — no new failures introduced (one pre-existing, unrelated RPC registry-directory flake from concurrent test runs)
- [x] Reproduced live: a Bash(rm:*) approval request failed with the exact "could not find the chat buffer" error before the fix, and succeeded after reloading vibing.nvim with the fix applied