### PR TITLE
fix: skip cursor-follow when chat window shows a different buffer

### DIFF
--- a/lua/vibing/presentation/chat/modules/renderer.lua
+++ b/lua/vibing/presentation/chat/modules/renderer.lua
@@ -122,6 +122,9 @@ function M.moveCursorToEnd(win, buf)
   if not vim.api.nvim_win_is_valid(win) or not vim.api.nvim_buf_is_valid(buf) then
     return
   end
+  if vim.api.nvim_win_get_buf(win) ~= buf then
+    return
+  end
 
   local lineCount = vim.api.nvim_buf_line_count(buf)
   if lineCount > 0 then
@@ -247,7 +250,7 @@ function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_mes
     vim.api.nvim_buf_set_lines(buf, insertPos, insertPos, false, approvalLines)
   end
 
-  if win and vim.api.nvim_win_is_valid(win) then
+  if win and vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_buf(win) == buf then
     local ok, cursor = pcall(vim.api.nvim_win_get_cursor, win)
     if ok then
       local currentLine = cursor[1]

--- a/lua/vibing/presentation/chat/modules/streaming_handler.lua
+++ b/lua/vibing/presentation/chat/modules/streaming_handler.lua
@@ -41,7 +41,7 @@ function M.flush_chunks(buf, win, chunk_buffer)
 
   vim.api.nvim_buf_set_lines(buf, #lines - 1, #lines, false, chunk_lines)
 
-  if win and vim.api.nvim_win_is_valid(win) then
+  if win and vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_buf(win) == buf then
     local ok, cursor = pcall(vim.api.nvim_win_get_cursor, win)
     if ok then
       local current_line = cursor[1]


### PR DESCRIPTION
## Summary
- チャットバッファを複数splitで開き、一方がストリーミング中に、もう一方のウィンドウで全く無関係なバッファにフォーカスしていると、そのウィンドウ上でカーソル追従(自動スクロール)が発生してしまう不具合を修正
- 原因: `flush_chunks` / `moveCursorToEnd` / `addUserSection` はウィンドウが有効(valid)かどうかのみを確認しており、そのウィンドウが今も自チャットのバッファを表示しているかは確認していなかった
- ウィンドウのバッファが別の無関係なものに差し替わっている場合は、カーソル追従をスキップするようにガードを追加

## Test plan
- [ ] `:VibingChat right` などで複数のチャットを開く
- [ ] 一方でリクエストを実行しストリーミング中に、もう一方のウィンドウで無関係なファイルを開く
- [ ] ストリーミング中、無関係なファイル側でカーソルが動かないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented chat cursor repositioning when a window is displaying a different buffer.
  * Improved cursor stability during streamed responses and user message updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->