### PR TITLE
fix: resolve mote context directory against session cwd

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -315,7 +315,7 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
         end
 
         if #(files or {}) > 0 then
-          local context_dir = MoteDiff.build_context_dir_path(mc.project, mc.context)
+          local context_dir = MoteDiff.build_context_dir_path(mc.project, mc.context, mc.cwd)
           if context_dir then
             local patch_path = string.format("%s/patches/%s.patch", context_dir, timestamp)
             MoteDiff.generate_patch(mc, patch_path, function(patch_success, patch_error)

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -251,7 +251,7 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
   local active_configs = {}
   local snapshots_by_ctx = session_snapshots[bufnr] or {}
   for _, mc in ipairs(mote_configs or {}) do
-    if MoteDiff.is_initialized(mc.project, mc.context) then
+    if MoteDiff.is_initialized(mc.project, mc.context, mc.cwd) then
       local cfg = vim.deepcopy(mc)
       cfg.baseline_snapshot_id = snapshots_by_ctx[mc.context]
       table.insert(active_configs, cfg)
@@ -456,7 +456,7 @@ function M._ensure_mote_initialized_and_snapshot(mote_configs, bufnr, on_complet
       end)
     end
 
-    if MoteDiff.is_initialized(mc.project, mc.context) then
+    if MoteDiff.is_initialized(mc.project, mc.context, mc.cwd) then
       create_snapshot()
     else
       MoteDiff.initialize(mc, function(init_success, init_error)

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -353,8 +353,9 @@ function M._create_session_mote_config(config, session_cwd, mote_dir)
 
   local MoteDiff = require("vibing.core.utils.mote_diff")
   local mote_config = vim.deepcopy(config.diff.mote)
+  local effective_cwd = mote_dir or session_cwd
 
-  mote_config.project = mote_config.project or MoteDiff.get_project_name()
+  mote_config.project = mote_config.project or MoteDiff.get_project_name(effective_cwd)
   local context_prefix = mote_config.context_prefix or "vibing"
 
   if mote_dir then

--- a/lua/vibing/core/utils/diff_selector.lua
+++ b/lua/vibing/core/utils/diff_selector.lua
@@ -11,14 +11,16 @@ function M.show_diff(file_path, session_id, cwd)
   local MoteDiff = require("vibing.core.utils.mote_diff")
   local mote_config = vim.deepcopy(config.diff.mote)
 
-  -- mote v0.2.4: --project/--context APIを使用
-  mote_config.project = mote_config.project or MoteDiff.get_project_name()
-  local context_prefix = mote_config.context_prefix or "vibing"
-  mote_config.context = MoteDiff.build_context_name(context_prefix, cwd)
-
   -- Normalize cwd to absolute path
-  if cwd then
-    mote_config.cwd = vim.fn.fnamemodify(cwd, ":p")
+  local abs_cwd = cwd and vim.fn.fnamemodify(cwd, ":p") or nil
+
+  -- mote v0.2.4: --project/--context APIを使用
+  mote_config.project = mote_config.project or MoteDiff.get_project_name(abs_cwd)
+  local context_prefix = mote_config.context_prefix or "vibing"
+  mote_config.context = MoteDiff.build_context_name(context_prefix, abs_cwd)
+
+  if abs_cwd then
+    mote_config.cwd = abs_cwd
   end
 
   MoteDiff.show_diff(file_path, mote_config)

--- a/lua/vibing/core/utils/git.lua
+++ b/lua/vibing/core/utils/git.lua
@@ -15,8 +15,10 @@ function M.get_root(cwd)
   if cwd then
     opts.cwd = cwd
   end
-  local result = vim.system({ "git", "rev-parse", "--show-toplevel" }, opts):wait()
-  if result.code ~= 0 then
+  local ok, result = pcall(function()
+    return vim.system({ "git", "rev-parse", "--show-toplevel" }, opts):wait()
+  end)
+  if not ok or result.code ~= 0 then
     return nil
   end
   return vim.trim(result.stdout or "")

--- a/lua/vibing/core/utils/git.lua
+++ b/lua/vibing/core/utils/git.lua
@@ -8,13 +8,18 @@ local PathSanitizer = require("vibing.domain.security.path_sanitizer")
 local CommandValidator = require("vibing.domain.security.command_validator")
 
 ---Gitリポジトリのルートディレクトリを取得
+---@param cwd string|nil 基準ディレクトリ（nilの場合はNeovim自身のカレントディレクトリ）
 ---@return string|nil gitルートパス（Git管理外の場合はnil）
-function M.get_root()
-  local result = vim.fn.systemlist("git rev-parse --show-toplevel")[1]
-  if vim.v.shell_error ~= 0 then
+function M.get_root(cwd)
+  local opts = { text = true }
+  if cwd then
+    opts.cwd = cwd
+  end
+  local result = vim.system({ "git", "rev-parse", "--show-toplevel" }, opts):wait()
+  if result.code ~= 0 then
     return nil
   end
-  return result
+  return vim.trim(result.stdout or "")
 end
 
 ---絶対パスからgitルートからの相対パスを取得

--- a/lua/vibing/core/utils/mote/command.lua
+++ b/lua/vibing/core/utils/mote/command.lua
@@ -15,8 +15,8 @@ function M.build_base_args(config)
 
   -- -d/--context-dirでスタンドアロンモード
   -- mote v0.2.4では初回実行時に自動的にディレクトリ構造とignoreファイルを作成
-  local project = config.project or Context.get_project_name()
-  local context_dir = Context.build_dir_path(project, config.context)
+  local project = config.project or Context.get_project_name(config.cwd)
+  local context_dir = Context.build_dir_path(project, config.context, config.cwd)
   if context_dir then
     table.insert(cmd, "-d")
     table.insert(cmd, context_dir)

--- a/lua/vibing/core/utils/mote/context.lua
+++ b/lua/vibing/core/utils/mote/context.lua
@@ -65,10 +65,11 @@ end
 
 ---gitリポジトリ名からプロジェクト名を取得
 ---moteのコンテキスト命名ルールに従ってサニタイズ
+---@param cwd string|nil 基準ディレクトリ（worktree/workspaceのcwd。nilの場合はNeovim自身のカレントディレクトリ）
 ---@return string|nil プロジェクト名（取得できない場合nil）
-function M.get_project_name()
+function M.get_project_name(cwd)
   local Git = require("vibing.core.utils.git")
-  local git_root = Git.get_root()
+  local git_root = Git.get_root(cwd)
   if not git_root then
     return nil
   end
@@ -84,10 +85,11 @@ end
 ---プロジェクトローカルのcontext-dirパスを生成
 ---@param project string|nil プロジェクト名
 ---@param context string コンテキスト名
+---@param cwd string|nil 基準ディレクトリ（worktree/workspaceのcwd。nilの場合はNeovim自身のカレントディレクトリ）
 ---@return string|nil context-dirのパス（git rootが取得できない場合nil）
-function M.build_dir_path(project, context)
+function M.build_dir_path(project, context, cwd)
   local Git = require("vibing.core.utils.git")
-  local git_root = Git.get_root()
+  local git_root = Git.get_root(cwd)
   if not git_root then
     return nil
   end
@@ -100,14 +102,15 @@ end
 ---mote v0.2.4ではignoreファイルとstorageディレクトリで初期化を判定
 ---@param project string? プロジェクト名
 ---@param context string? コンテキスト名
+---@param cwd string? 基準ディレクトリ（worktree/workspaceのcwd）
 ---@return boolean moteコンテキストが初期化されている場合true
-function M.is_initialized(project, context)
+function M.is_initialized(project, context, cwd)
   local Binary = require("vibing.core.utils.mote.binary")
   if not Binary.is_available() then
     return false
   end
 
-  local context_dir = M.build_dir_path(project, context)
+  local context_dir = M.build_dir_path(project, context, cwd)
   if not context_dir then
     return false
   end

--- a/lua/vibing/core/utils/mote/operations.lua
+++ b/lua/vibing/core/utils/mote/operations.lua
@@ -114,10 +114,10 @@ function M.initialize(config, callback)
     return
   end
 
-  if Context.is_initialized(config.project, config.context) then
+  if Context.is_initialized(config.project, config.context, config.cwd) then
     -- 既に初期化済みの場合、.vibing/がignoreに含まれているか確認
-    local project = config.project or Context.get_project_name()
-    local context_dir = Context.build_dir_path(project, config.context)
+    local project = config.project or Context.get_project_name(config.cwd)
+    local context_dir = Context.build_dir_path(project, config.context, config.cwd)
     if context_dir then
       Moteignore.add_vibing_ignore(context_dir)
     end

--- a/lua/vibing/core/utils/mote/operations.lua
+++ b/lua/vibing/core/utils/mote/operations.lua
@@ -125,8 +125,8 @@ function M.initialize(config, callback)
     return
   end
 
-  local project = config.project or Context.get_project_name()
-  local context_dir = Context.build_dir_path(project, config.context)
+  local project = config.project or Context.get_project_name(config.cwd)
+  local context_dir = Context.build_dir_path(project, config.context, config.cwd)
   if not context_dir then
     callback(false, "Failed to get git root directory")
     return

--- a/lua/vibing/infrastructure/storage/mote_cleaner.lua
+++ b/lua/vibing/infrastructure/storage/mote_cleaner.lua
@@ -42,7 +42,7 @@ end
 function M.clean_snapshot(file_path, config, callback)
   local patch_files = M._extract_patch_refs(file_path)
 
-  local context_dir = MoteContext.build_dir_path(config.project, config.context)
+  local context_dir = MoteContext.build_dir_path(config.project, config.context, config.cwd)
   if not context_dir then
     callback(true, nil)
     return

--- a/lua/vibing/infrastructure/storage/mote_cleaner.lua
+++ b/lua/vibing/infrastructure/storage/mote_cleaner.lua
@@ -66,7 +66,7 @@ function M.clean_snapshot(file_path, config, callback)
     end)
   end
 
-  M._delete_snapshots_containing_file(file_path, context_dir, function(snap_deleted_count)
+  M._delete_snapshots_containing_file(file_path, context_dir, config.cwd, function(snap_deleted_count)
     if snap_deleted_count > 0 then
       vim.schedule(function()
         notify.info(
@@ -110,8 +110,9 @@ end
 
 ---@param file_path string
 ---@param context_dir string
+---@param cwd string|nil 基準ディレクトリ（worktree/workspaceのcwd）
 ---@param callback fun(deleted_count: number)
-function M._delete_snapshots_containing_file(file_path, context_dir, callback)
+function M._delete_snapshots_containing_file(file_path, context_dir, cwd, callback)
   local snapshots_dir = context_dir .. "/storage/snapshots"
 
   if vim.fn.isdirectory(snapshots_dir) ~= 1 then
@@ -119,7 +120,7 @@ function M._delete_snapshots_containing_file(file_path, context_dir, callback)
     return
   end
 
-  local git_root = vim.fn.systemlist("git rev-parse --show-toplevel")[1]
+  local git_root = require("vibing.core.utils.git").get_root(cwd)
   if not git_root then
     callback(0)
     return

--- a/tests/git_utils_spec.lua
+++ b/tests/git_utils_spec.lua
@@ -17,6 +17,26 @@ describe("vibing.core.utils.git", function()
         assert.is_not_nil(root:match("vibing%.nvim"))
       end
     end)
+
+    it("should resolve root against a given cwd, not Neovim's own cwd", function()
+      local default_root = Git.get_root()
+      if not default_root then
+        pending("Not in git repository")
+        return
+      end
+      -- Passing a subdirectory as cwd should resolve to the same git root
+      local result = Git.get_root(default_root .. "/lua")
+      assert.equals(default_root, result)
+    end)
+
+    it("should return nil instead of erroring when cwd does not exist", function()
+      -- Regression test: vim.system with a non-existent cwd raises at the
+      -- uv_spawn level, so get_root must not propagate that as a Lua error
+      -- (e.g. a stale worktree path in a chat's working_dir frontmatter).
+      local ok, result = pcall(Git.get_root, "/nonexistent/path/for/vibing-nvim-tests")
+      assert.is_true(ok)
+      assert.is_nil(result)
+    end)
   end)
 
   describe("get_relative_path", function()

--- a/tests/lua/core/utils/mote/context_spec.lua
+++ b/tests/lua/core/utils/mote/context_spec.lua
@@ -21,4 +21,33 @@ describe("mote context", function()
       assert.equals("vibing-root", Context.build_name("vibing", nil))
     end)
   end)
+
+  describe("cwd resolution against a foreign git repository", function()
+    local Git = require("vibing.core.utils.git")
+    local tmp_dir
+    local resolved_root
+
+    before_each(function()
+      tmp_dir = vim.fn.tempname()
+      vim.fn.mkdir(tmp_dir, "p")
+      vim.system({ "git", "init" }, { cwd = tmp_dir }):wait()
+      -- git rev-parse resolves symlinks (e.g. macOS /tmp -> /private/tmp),
+      -- so compare against Git.get_root's own resolution rather than tmp_dir itself.
+      resolved_root = Git.get_root(tmp_dir)
+    end)
+
+    after_each(function()
+      vim.fn.delete(tmp_dir, "rf")
+    end)
+
+    it("get_project_name resolves against the given cwd's repo, not Neovim's own cwd", function()
+      local expected = vim.fn.fnamemodify(resolved_root, ":t"):gsub("[^%w%-_]+", "-")
+      assert.equals(expected, Context.get_project_name(tmp_dir))
+    end)
+
+    it("build_dir_path is rooted under the given cwd's repo, not Neovim's own cwd", function()
+      local result = Context.build_dir_path("myproject", "myctx", tmp_dir)
+      assert.equals(resolved_root .. "/.vibing/mote/myproject/myctx", result)
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary
- `Git.get_root()` は常にNeovim自身のプロセスcwdを基準に `git rev-parse --show-toplevel` を実行しており、セッション（worktree/workspace）の実際の作業ディレクトリを考慮していなかった
- そのため、Neovim起動時のcwdとは別のgitリポジトリで作業しているセッション（virtual-monorepoなど）では、mote standaloneモードの `-d <context_dir>` が誤ったパス（または解決不能）になり、そのworkspaceの差分がmoteとして記録・表示されない不具合があった
- `Git.get_root(cwd)` にcwdを渡せるようにし、`Context.get_project_name(cwd)` / `Context.build_dir_path(project, context, cwd)` を経由して `mote/command.lua` の `build_base_args` と `mote/operations.lua` の `initialize` まで `config.cwd`（セッションのworking_dir）を貫通させた
- `send_message.lua` / `diff_selector.lua` は、cwd確定前にproject名を解決していた順序を、cwd確定後に解決するよう修正

## Test plan
- [x] `luajit -e "assert(loadfile(...))"` で変更した7ファイルの構文チェック
- [x] `nvim --headless ... PlenaryBustedDirectory tests/` でテストスイート全体（42グループ）が0 failuresで通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project and context resolution by honoring an explicitly provided working directory across diff viewing, session setup, initialization, and snapshot/patch path handling.
  * Enhanced git root detection for operations started from subdirectories or alternate locations, including safer failure handling.
  * Prevented missing or misplaced patches/snapshots caused by inconsistent cwd usage.
* **Tests**
  * Added coverage for git root behavior with provided cwd and for correct project/context path resolution against a different repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->