### PR TITLE
fix: prevent duplicate message sends from rapid Enter presses

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -33,8 +33,6 @@ local GradientAnimation = require("vibing.ui.gradient_animation")
 ---@field set_handle_id fun(handle_id: string) handle_idを設定
 ---@field get_handle_id fun(): string|nil handle_idを取得
 ---@field clear_sending fun() 送信中フラグを解除
----@field get_accepted_handle_id fun(): string|nil 現ターンで受理済みのhandle_idを取得
----@field set_accepted_handle_id fun(handle_id: string) 現ターンで受理するhandle_idを設定
 ---@field get_cwd fun(): string|nil worktreeのcwdを取得
 
 ---メッセージを送信
@@ -212,14 +210,12 @@ end
 
 ---レスポンスを処理
 function M._handle_response(response, callbacks, adapter, config, mote_configs, modified_file_paths)
-  -- 重複送信で複数リクエストが飛んだ場合、最初に到着したレスポンスのみ受理する
+  -- キャンセル済みの古いリクエストが遅れて完了した場合、現在アクティブなハンドルIDと
+  -- 一致しないレスポンスは無視する（新しいリクエストの結果を上書きさせない）
   local incoming_handle_id = response._handle_id
-  if incoming_handle_id and callbacks.get_accepted_handle_id and callbacks.set_accepted_handle_id then
-    local accepted_handle_id = callbacks.get_accepted_handle_id()
-    if accepted_handle_id == nil then
-      callbacks.set_accepted_handle_id(incoming_handle_id)
-    elseif accepted_handle_id ~= incoming_handle_id then
-      -- 後から到着した重複リクエストのレスポンスは無視する
+  if incoming_handle_id and callbacks.get_handle_id then
+    local current_handle_id = callbacks.get_handle_id()
+    if current_handle_id and incoming_handle_id ~= current_handle_id then
       return
     end
   end

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -32,6 +32,9 @@ local GradientAnimation = require("vibing.ui.gradient_animation")
 ---@field clear_handle_id fun() handle_idをクリア
 ---@field set_handle_id fun(handle_id: string) handle_idを設定
 ---@field get_handle_id fun(): string|nil handle_idを取得
+---@field clear_sending fun() 送信中フラグを解除
+---@field get_accepted_handle_id fun(): string|nil 現ターンで受理済みのhandle_idを取得
+---@field set_accepted_handle_id fun(handle_id: string) 現ターンで受理するhandle_idを設定
 ---@field get_cwd fun(): string|nil worktreeのcwdを取得
 
 ---メッセージを送信
@@ -51,6 +54,9 @@ function M.execute(adapter, callbacks, message, config)
 
   if not adapter then
     require("vibing.core.utils.notify").error("No adapter configured", "Chat")
+    if callbacks.clear_sending then
+      callbacks.clear_sending()
+    end
     return
   end
 
@@ -166,9 +172,9 @@ function M.execute(adapter, callbacks, message, config)
     end
 
     if adapter:supports("streaming") then
-      local handle_id = adapter:stream(formatted_prompt, opts, function(chunk)
+      local handle_id = adapter:stream(formatted_prompt, opts, function(chunk, chunk_handle_id)
         vim.schedule(function()
-          callbacks.append_chunk(chunk)
+          callbacks.append_chunk(chunk, chunk_handle_id)
         end)
       end, function(response)
         vim.schedule(function()
@@ -206,6 +212,22 @@ end
 
 ---レスポンスを処理
 function M._handle_response(response, callbacks, adapter, config, mote_configs, modified_file_paths)
+  -- 重複送信で複数リクエストが飛んだ場合、最初に到着したレスポンスのみ受理する
+  local incoming_handle_id = response._handle_id
+  if incoming_handle_id and callbacks.get_accepted_handle_id and callbacks.set_accepted_handle_id then
+    local accepted_handle_id = callbacks.get_accepted_handle_id()
+    if accepted_handle_id == nil then
+      callbacks.set_accepted_handle_id(incoming_handle_id)
+    elseif accepted_handle_id ~= incoming_handle_id then
+      -- 後から到着した重複リクエストのレスポンスは無視する
+      return
+    end
+  end
+
+  if callbacks.clear_sending then
+    callbacks.clear_sending()
+  end
+
   -- Stop gradient animation
   local bufnr = callbacks.get_bufnr()
   if bufnr and vim.api.nvim_buf_is_valid(bufnr) then

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -194,7 +194,6 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
       if not received_first_response and not completed and self._handles[handle_id] then
         vim.schedule(function()
           if not completed then
-            completed = true
             vim.notify(
               "[vibing] Session resume timeout - killing hung process and resetting session",
               vim.log.levels.WARN

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -126,7 +126,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
     onFirstResponse = cancel_timeout,
     onChunk = function(chunk)
       cancel_timeout()
-      on_chunk(chunk)
+      on_chunk(chunk, handle_id)
     end,
   }
 
@@ -204,6 +204,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
               error = "Session resume timeout",
               _session_corrupted = true,
               _old_session_id = session_id,
+              _handle_id = handle_id,
             })
           end
         end)

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -198,7 +198,6 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
       if not received_first_response and not completed and self._handles[handle_id] then
         vim.schedule(function()
           if not completed then
-            completed = true
             vim.notify(
               "[vibing] Session resume timeout - killing hung process and resetting session",
               vim.log.levels.WARN

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -118,7 +118,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
     onFirstResponse = cancel_timeout,
     onChunk = function(chunk)
       cancel_timeout()
-      on_chunk(chunk)
+      on_chunk(chunk, handle_id)
     end,
   }
 
@@ -208,6 +208,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
               error = "Session resume timeout",
               _session_corrupted = true,
               _old_session_id = session_id,
+              _handle_id = handle_id,
             })
           end
         end)

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -21,7 +21,6 @@ local KeymapHandler = require("vibing.presentation.chat.modules.keymap_handler")
 ---@field _current_handle_id string? 実行中のリクエストのハンドルID
 ---@field _current_adapter table? per-chatアダプター（フロントマターagent指定時）
 ---@field _is_sending boolean 送信処理中かどうか（Enter連打による重複送信防止）
----@field _accepted_handle_id string? 現ターンで最初に受理したレスポンスのハンドルID
 ---@field _session_allow table セッションレベルの許可リスト
 ---@field _session_deny table セッションレベルの拒否リスト
 ---@field _once_tools table? 一時許可/拒否ツールのトラッキング（次のメッセージでクリア）
@@ -46,7 +45,6 @@ function ChatBuffer:new(config)
   instance._current_handle_id = nil
   instance._current_adapter = nil
   instance._is_sending = false
-  instance._accepted_handle_id = nil
   instance._session_allow = {}
   instance._session_deny = {}
   instance._once_tools = nil
@@ -311,7 +309,6 @@ function ChatBuffer:send_message()
   end
 
   self._is_sending = true
-  self._accepted_handle_id = nil
 
   -- Clean up :once tools (JS side removes during use, but this is a safety net)
   if self._once_tools then
@@ -493,12 +490,6 @@ function ChatBuffer:send_message()
     clear_sending = function()
       self._is_sending = false
     end,
-    get_accepted_handle_id = function()
-      return self._accepted_handle_id
-    end,
-    set_accepted_handle_id = function(handle_id)
-      self._accepted_handle_id = handle_id
-    end,
     get_cwd = function()
       return self:get_cwd()
     end,
@@ -526,16 +517,13 @@ function ChatBuffer:_flush_chunks()
 end
 
 ---ストリーミングチャンクを追加（バッファリング有効）
----重複送信で複数リクエストが飛んだ場合、最初に到着したチャンクのハンドルIDのみ受理する
+---キャンセル済みの古いリクエストが遅れて発火したチャンクは、現在アクティブなハンドルIDと
+---一致しない限り無視する
 ---@param chunk string
 ---@param handle_id string?
 function ChatBuffer:append_chunk(chunk, handle_id)
-  if handle_id then
-    if self._accepted_handle_id == nil then
-      self._accepted_handle_id = handle_id
-    elseif handle_id ~= self._accepted_handle_id then
-      return
-    end
+  if handle_id and self._current_handle_id and handle_id ~= self._current_handle_id then
+    return
   end
 
   self._chunk_buffer = self._chunk_buffer .. chunk

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -20,6 +20,8 @@ local KeymapHandler = require("vibing.presentation.chat.modules.keymap_handler")
 ---@field _pending_approval table? add_user_section()後に挿入する承認要求UI
 ---@field _current_handle_id string? 実行中のリクエストのハンドルID
 ---@field _current_adapter table? per-chatアダプター（フロントマターagent指定時）
+---@field _is_sending boolean 送信処理中かどうか（Enter連打による重複送信防止）
+---@field _accepted_handle_id string? 現ターンで最初に受理したレスポンスのハンドルID
 ---@field _session_allow table セッションレベルの許可リスト
 ---@field _session_deny table セッションレベルの拒否リスト
 ---@field _once_tools table? 一時許可/拒否ツールのトラッキング（次のメッセージでクリア）
@@ -43,6 +45,8 @@ function ChatBuffer:new(config)
   instance._pending_approval = nil
   instance._current_handle_id = nil
   instance._current_adapter = nil
+  instance._is_sending = false
+  instance._accepted_handle_id = nil
   instance._session_allow = {}
   instance._session_deny = {}
   instance._once_tools = nil
@@ -291,7 +295,12 @@ end
 
 ---メッセージを送信
 function ChatBuffer:send_message()
-  -- 前のリクエストが実行中ならキャンセル（競合防止）
+  -- 送信処理中はEnter連打による重複送信を無視する
+  if self._is_sending then
+    return
+  end
+
+  -- 前のリクエストが実行中ならキャンセル（ゾンビプロセス対策）
   if self._current_handle_id then
     local adapter = self:_get_active_adapter()
     if adapter then
@@ -300,6 +309,9 @@ function ChatBuffer:send_message()
     self._current_handle_id = nil
     self._current_adapter = nil
   end
+
+  self._is_sending = true
+  self._accepted_handle_id = nil
 
   -- Clean up :once tools (JS side removes during use, but this is a safety net)
   if self._once_tools then
@@ -323,6 +335,7 @@ function ChatBuffer:send_message()
   local message = self:extract_user_message()
   if not message then
     vim.notify("[vibing] No message to send", vim.log.levels.WARN)
+    self._is_sending = false
     return
   end
 
@@ -336,6 +349,7 @@ function ChatBuffer:send_message()
         message = expanded
       else
         self:add_user_section()
+        self._is_sending = false
         return
       end
     end
@@ -357,6 +371,7 @@ function ChatBuffer:send_message()
           string.format("[vibing] Failed to update permissions: %s", tostring(err)),
           vim.log.levels.ERROR
         )
+        self._is_sending = false
         return
       end
 
@@ -409,6 +424,7 @@ function ChatBuffer:send_message()
           .. "Please ensure only ONE option remains (use 'dd' to delete unwanted lines), then press <CR> again.",
         vim.log.levels.WARN
       )
+      self._is_sending = false
       return
     end
   end
@@ -431,8 +447,8 @@ function ChatBuffer:send_message()
     parse_frontmatter = function()
       return self:parse_frontmatter()
     end,
-    append_chunk = function(chunk)
-      return self:append_chunk(chunk)
+    append_chunk = function(chunk, handle_id)
+      return self:append_chunk(chunk, handle_id)
     end,
     get_session_id = function()
       return self:get_session_id()
@@ -474,6 +490,15 @@ function ChatBuffer:send_message()
     get_handle_id = function()
       return self._current_handle_id
     end,
+    clear_sending = function()
+      self._is_sending = false
+    end,
+    get_accepted_handle_id = function()
+      return self._accepted_handle_id
+    end,
+    set_accepted_handle_id = function(handle_id)
+      self._accepted_handle_id = handle_id
+    end,
     get_cwd = function()
       return self:get_cwd()
     end,
@@ -501,8 +526,18 @@ function ChatBuffer:_flush_chunks()
 end
 
 ---ストリーミングチャンクを追加（バッファリング有効）
+---重複送信で複数リクエストが飛んだ場合、最初に到着したチャンクのハンドルIDのみ受理する
 ---@param chunk string
-function ChatBuffer:append_chunk(chunk)
+---@param handle_id string?
+function ChatBuffer:append_chunk(chunk, handle_id)
+  if handle_id then
+    if self._accepted_handle_id == nil then
+      self._accepted_handle_id = handle_id
+    elseif handle_id ~= self._accepted_handle_id then
+      return
+    end
+  end
+
   self._chunk_buffer = self._chunk_buffer .. chunk
 
   if self._chunk_timer then


### PR DESCRIPTION
## Summary
- Enter連打で `ChatBuffer:send_message()` が「実行中リクエストをキャンセルして即再送」を繰り返し、同じ未編集メッセージが重複送信されてしまう問題を修正
- `_is_sending` フラグを追加し、送信処理中は再入する `send_message()` 呼び出しを無視するようにした（ゾンビプロセスkill用の既存handle_id管理は維持）
- 万一重複してリクエストが送信された場合でも、各リクエストの `handle_id` をチャンク/レスポンスに伝搬させ、そのターンで最初に到着したレスポンスのみバッファに書き込むようにした（`claude_cli.lua` / `codex_cli.lua` / `send_message.lua` / `buffer.lua`）

## Test plan
- [x] `luajit -bl` で変更ファイルの構文チェック
- [x] `nvim --headless ... PlenaryBustedDirectory tests/` で既存Luaテスト全件パス（`send_message_spec.lua` を含む）
- [ ] 実際にNeovimでチャットを開き、Enter連打してリクエストが1回しか飛ばないことを目視確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate message submissions caused by repeated Enter presses.
  * Ignored delayed responses and streaming content from canceled or outdated requests.
  * Improved timeout handling so errors and cleanup are processed correctly.
  * Cleared the sending state when requests fail or cannot be processed.
  * Improved project and context handling when working across different directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->