### PR TITLE
fix: scope cmp.setup.buffer() to the target buffer explicitly

### DIFF
--- a/lua/vibing/application/completion/init.lua
+++ b/lua/vibing/application/completion/init.lua
@@ -45,13 +45,21 @@ function M.setup_buffer(buf)
     -- Fallback to omnifunc
     vim.bo[buf].omnifunc = "v:lua.require('vibing.application.completion').omnifunc"
   else
-    -- Prepend vibing source to existing global sources for this buffer
-    local global_sources = cmp.get_config().sources or {}
-    local sources = { { name = "vibing" } }
-    for _, src in ipairs(global_sources) do
-      table.insert(sources, src)
-    end
-    cmp.setup.buffer({ sources = sources })
+    -- cmp.setup.buffer()は呼び出し時点のカレントバッファに紐づくため、
+    -- 非同期アタッチ経由（別バッファがカレントなタイミング）で呼ばれても
+    -- 対象bufに設定されるようnvim_buf_callで明示的にスコープする
+    vim.api.nvim_buf_call(buf, function()
+      -- Prepend vibing source to existing sources for this buffer.
+      -- 既存のvibingエントリは除外してから追加し直す（再呼び出し時の重複登録を防ぐ）
+      local existing_sources = cmp.get_config().sources or {}
+      local sources = { { name = "vibing", priority = 1000 } }
+      for _, src in ipairs(existing_sources) do
+        if src.name ~= "vibing" then
+          table.insert(sources, src)
+        end
+      end
+      cmp.setup.buffer({ sources = sources })
+    end)
   end
 
   vim.bo[buf].completeopt = "menu,menuone,noselect"

--- a/lua/vibing/application/completion/init.lua
+++ b/lua/vibing/application/completion/init.lua
@@ -50,7 +50,8 @@ function M.setup_buffer(buf)
     -- 対象bufに設定されるようnvim_buf_callで明示的にスコープする
     vim.api.nvim_buf_call(buf, function()
       -- Prepend vibing source to existing sources for this buffer.
-      -- 既存のvibingエントリは除外してから追加し直す（再呼び出し時の重複登録を防ぐ）
+      -- setup_bufferはFileType再適用などで複数回呼ばれ得るため、既存のvibing
+      -- エントリを除外してから追加し直し、重複登録を防ぐ
       local existing_sources = cmp.get_config().sources or {}
       local sources = { { name = "vibing", priority = 1000 } }
       for _, src in ipairs(existing_sources) do

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -176,9 +176,7 @@ function M._apply_chat_buffer_settings(bufnr)
   vim.bo[bufnr].textwidth = 0
   vim.bo[bufnr].formatoptions = "tcqj"
 
-  -- 補完設定（cmpソース登録も含めcompletion.setup_bufferに一本化。
-  -- 呼び出し時点のカレントバッファに紐づくcmp.setup.buffer()のスコープ管理は
-  -- completion.setup_buffer内でnvim_buf_callにより行われる）
+  -- 補完設定（cmpソースのバッファスコープ管理も含め、completion.setup_buffer側の責務）
   local ok_completion, completion = pcall(require, "vibing.application.completion")
   if ok_completion and completion.setup_buffer then
     pcall(completion.setup_buffer, bufnr)
@@ -192,8 +190,18 @@ function M._apply_chat_buffer_settings(bufnr)
   -- wrap設定の適用
   local ok_ui, ui_utils = pcall(require, "vibing.core.utils.ui")
   if ok_ui then
+    -- win=0（カレントウィンドウ）をそのまま渡すと、非同期アタッチ時にbufnrと
+    -- 無関係なウィンドウのwrap設定を書き換えてしまうため、bufnrを表示している
+    -- 実際のウィンドウを解決してから適用する（表示中のウィンドウがなければ何もしない）
+    local function apply_wrap_for_bufnr()
+      local winnr = vim.fn.bufwinnr(bufnr)
+      if winnr > 0 then
+        pcall(ui_utils.apply_wrap_config, vim.fn.win_getid(winnr), bufnr, true)
+      end
+    end
+
     -- 初回適用（force=trueで強制適用、新規作成直後のバッファはまだフロントマターがないため）
-    pcall(ui_utils.apply_wrap_config, 0, bufnr, true)
+    apply_wrap_for_bufnr()
 
     -- Mark buffer as chat buffer immediately (cache for performance)
     vim.b[bufnr].vibing_is_chat_buffer = true
@@ -205,7 +213,7 @@ function M._apply_chat_buffer_settings(bufnr)
       group = group,
       buffer = bufnr,
       callback = function()
-        pcall(ui_utils.apply_wrap_config, 0, bufnr, true)
+        apply_wrap_for_bufnr()
         -- Re-apply completion settings to prevent markdown ftplugin from overwriting omnifunc
         local ok_c, completion = pcall(require, "vibing.application.completion")
         if ok_c and completion.setup_buffer then

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -195,21 +195,27 @@ function M._apply_chat_buffer_settings(bufnr)
       completion_module.setup()
     end
 
-    local global_config_cmp = cmp.get_config()
-    local existing_sources = global_config_cmp.sources or {}
+    -- cmp.setup.buffer()は呼び出し時点の「カレントバッファ」に紐付くため、
+    -- 対象がカレントでないタイミング（chat_detect.lua経由のvim.schedule等）で
+    -- 呼ぶと無関係なバッファにvibingソースが登録されてしまう。
+    -- nvim_buf_callでbufnrを明示的にカレント化してから設定する。
+    vim.api.nvim_buf_call(bufnr, function()
+      local global_config_cmp = cmp.get_config()
+      local existing_sources = global_config_cmp.sources or {}
 
-    local merged_sources = {
-      { name = "vibing", priority = 1000 },
-    }
-    for _, source in ipairs(existing_sources) do
-      if source.name ~= "vibing" then
-        table.insert(merged_sources, source)
+      local merged_sources = {
+        { name = "vibing", priority = 1000 },
+      }
+      for _, source in ipairs(existing_sources) do
+        if source.name ~= "vibing" then
+          table.insert(merged_sources, source)
+        end
       end
-    end
 
-    cmp.setup.buffer({
-      sources = merged_sources,
-    })
+      cmp.setup.buffer({
+        sources = merged_sources,
+      })
+    end)
   end
 
   -- wrap設定の適用

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -176,7 +176,9 @@ function M._apply_chat_buffer_settings(bufnr)
   vim.bo[bufnr].textwidth = 0
   vim.bo[bufnr].formatoptions = "tcqj"
 
-  -- 補完設定
+  -- 補完設定（cmpソース登録も含めcompletion.setup_bufferに一本化。
+  -- 呼び出し時点のカレントバッファに紐づくcmp.setup.buffer()のスコープ管理は
+  -- completion.setup_buffer内でnvim_buf_callにより行われる）
   local ok_completion, completion = pcall(require, "vibing.application.completion")
   if ok_completion and completion.setup_buffer then
     pcall(completion.setup_buffer, bufnr)
@@ -184,37 +186,6 @@ function M._apply_chat_buffer_settings(bufnr)
     pcall(function()
       vim.bo[bufnr].omnifunc = "v:lua.require('vibing.application.completion').omnifunc"
       vim.bo[bufnr].completeopt = "menu,menuone,noselect"
-    end)
-  end
-
-  -- nvim-cmp設定
-  local has_cmp, cmp = pcall(require, "cmp")
-  if has_cmp then
-    local ok_completion_module, completion_module = pcall(require, "vibing.application.completion")
-    if ok_completion_module then
-      completion_module.setup()
-    end
-
-    -- cmp.setup.buffer()は呼び出し時点の「カレントバッファ」に紐付くため、
-    -- 対象がカレントでないタイミング（chat_detect.lua経由のvim.schedule等）で
-    -- 呼ぶと無関係なバッファにvibingソースが登録されてしまう。
-    -- nvim_buf_callでbufnrを明示的にカレント化してから設定する。
-    vim.api.nvim_buf_call(bufnr, function()
-      local global_config_cmp = cmp.get_config()
-      local existing_sources = global_config_cmp.sources or {}
-
-      local merged_sources = {
-        { name = "vibing", priority = 1000 },
-      }
-      for _, source in ipairs(existing_sources) do
-        if source.name ~= "vibing" then
-          table.insert(merged_sources, source)
-        end
-      end
-
-      cmp.setup.buffer({
-        sources = merged_sources,
-      })
     end)
   end
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary
- pile.nvim等でバッファ復元後にvibing.nvimチャットバッファへアタッチしても、nvim-cmpの補完（`vibing`ソース）が効かないケースがあった
- 原因: `_apply_chat_buffer_settings()` 内の `cmp.setup.buffer()` は呼び出し時点の「カレントバッファ」に紐づく仕様のため、`chat_detect.lua` の `vim.schedule()` による非同期アタッチ時に、対象と異なるバッファへ`vibing`ソースが誤登録されていた
- `vim.api.nvim_buf_call(bufnr, function() ... end)` で対象バッファを明示的にカレント化してから `cmp.get_config()` / `cmp.setup.buffer()` を呼ぶよう修正
- あわせて、ローカルに存在していた未追跡の `pnpm-workspace.yaml`（`allowBuilds: esbuild: true`）もコミット。pnpmはesbuildのpostinstallビルドスクリプトをデフォルトでブロックするため、これがないとpnpmでインストールする各コントリビューターが個別に承認プロンプトを踏むことになる

実機のNeovimインスタンスで、修正前は復元バッファのcmpソースが `nvim_lsp,buffer,path`（`vibing`欠落）、修正後は `vibing,nvim_lsp,buffer,path` になることを確認済み。

## Test plan
- [ ] `npm run test:lua` / `npm run check` が通ること
- [ ] pile.nvim等でチャットファイルを復元した状態で、`:VibingChat <file>` を開かずに直接編集し、`@file:` 補完が候補に出ることを確認
- [ ] 新規 `:VibingChat` でも従来通り補完が動作することを確認（回帰なし）
- [ ] `pnpm install` がesbuildのビルド承認プロンプトなしで通ること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion behavior in chat buffers, including more reliable setup during asynchronous operations.
  * Prevented duplicate Vibing completion entries when buffer completion is initialized repeatedly.

* **Chores**
  * Enabled required workspace build execution for improved installation and setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->