### PR TITLE
feat: display Claude plan usage limit in chat buffer

### DIFF
--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -14,6 +14,7 @@ end
 
 local BufferReload = require("vibing.core.utils.buffer_reload")
 local GradientAnimation = require("vibing.ui.gradient_animation")
+local UsageDisplay = require("vibing.ui.usage_display")
 
 ---@class Vibing.ChatCallbacks
 ---@field extract_conversation fun(): table 会話履歴を抽出
@@ -228,6 +229,7 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
   local bufnr = callbacks.get_bufnr()
   if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
     GradientAnimation.stop(bufnr)
+    UsageDisplay.refresh(bufnr, callbacks.get_cwd and callbacks.get_cwd() or nil)
   end
 
   -- Lua側タイムアウトによるセッション破損検出

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -254,6 +254,8 @@ function M._apply_chat_buffer_settings(bufnr)
       if ok_sm then
         send_message.cleanup_snapshots(bufnr)
       end
+      -- 利用率表示のnamespace状態をクリア（bufnr再利用時の誤表示防止）
+      require("vibing.ui.usage_display").clear(bufnr)
     end,
     desc = "Cancel running Agent SDK process on buffer unload",
   })

--- a/lua/vibing/ui/usage_display.lua
+++ b/lua/vibing/ui/usage_display.lua
@@ -1,0 +1,106 @@
+---@class Vibing.UsageDisplay
+---チャットバッファ先頭にClaudeプランの利用率をvirtual textで表示
+local M = {}
+
+---@type table<number, { ns_id: number }>
+local state = {}
+
+local cached_claude_path = nil
+
+---`claude -p "/usage"` の出力テキストからsession/week使用率を抜き出す
+---@param text string
+---@return string|nil
+local function parse_summary(text)
+  if type(text) ~= "string" then
+    return nil
+  end
+
+  local session = text:match("Current session: ([^\n]+)")
+  local week = text:match("Current week %(all models%): ([^\n]+)")
+
+  if not session and not week then
+    return nil
+  end
+
+  local parts = {}
+  if session then
+    table.insert(parts, "session " .. session)
+  end
+  if week then
+    table.insert(parts, "week " .. week)
+  end
+
+  return table.concat(parts, " / ")
+end
+
+---バッファ先頭に利用率を仮想行として表示（既存表示は上書き）
+---@param bufnr number
+---@param text string
+function M.show(bufnr, text)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  local ns_id = state[bufnr] and state[bufnr].ns_id or vim.api.nvim_create_namespace("vibing_usage_" .. bufnr)
+  vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+
+  vim.api.nvim_buf_set_extmark(bufnr, ns_id, 0, 0, {
+    virt_lines = { { { "󰊚 " .. text, "Comment" } } },
+    virt_lines_above = true,
+  })
+
+  state[bufnr] = { ns_id = ns_id }
+end
+
+---バッファの利用率表示をクリア
+---@param bufnr number
+function M.clear(bufnr)
+  local entry = state[bufnr]
+  if entry and vim.api.nvim_buf_is_valid(bufnr) then
+    vim.api.nvim_buf_clear_namespace(bufnr, entry.ns_id, 0, -1)
+  end
+  state[bufnr] = nil
+end
+
+---裏で`claude -p "/usage"`を実行し、結果をバッファ先頭に表示する
+---@param bufnr number
+---@param cwd string|nil
+function M.refresh(bufnr, cwd)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  if not cached_claude_path then
+    cached_claude_path = vim.fn.exepath("claude")
+    if cached_claude_path == "" then
+      cached_claude_path = nil
+      return
+    end
+  end
+
+  local cmd = { cached_claude_path, "-p", "/usage", "--output-format", "json" }
+  local opts = { text = true }
+  if cwd then
+    opts.cwd = cwd
+  end
+
+  vim.system(cmd, opts, function(obj)
+    vim.schedule(function()
+      if obj.code ~= 0 or not obj.stdout then
+        return
+      end
+
+      local ok, decoded = pcall(vim.json.decode, obj.stdout)
+      if not ok or not decoded or type(decoded.result) ~= "string" then
+        return
+      end
+
+      local summary = parse_summary(decoded.result)
+      if summary then
+        M.show(bufnr, summary)
+      end
+    end)
+  end)
+end
+
+return M


### PR DESCRIPTION
## Summary
- ターン完了ごとに `claude -p "/usage"` を裏で実行し、セッション/週の利用率をチャットバッファ先頭に仮想行として表示する
- バッファアンロード時に表示用namespaceをクリアし、bufnr再利用時の誤表示を防止

## Test plan
- [x] `nvim --headless` でプラグインをロードし、`usage_display.show`/`clear` でextmarkが正しく設定・削除されることを確認
- [x] `usage_display.refresh` から実際に `claude -p "/usage"` を叩き、レスポンスがバッファ先頭に反映されることを確認
- [x] Lua構文チェック（`loadfile`）と既存Luaテストスイートを実行（既存の環境依存フレーキー失敗は変更前後で同一であることを確認済み）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-editor usage display showing session and weekly utilization.
  * Usage information refreshes automatically after chat responses.
  * Usage indicators are cleared when closing a chat view.
  * Added validation and error handling for unavailable usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->