### PR TITLE
feat: make --setting-sources configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,12 @@ agent = {
                                  -- true: Use vibing-nvim LSP (connects to running Neovim)
                                  -- false: Allow generic LSP tools (e.g., Serena)
                                  -- Default: true
+
+  setting_sources = { "user", "project", "local" },  -- Sources passed to the CLI's
+                                 -- --setting-sources flag. Drop "user" to skip loading your
+                                 -- global CLAUDE.md and personal MCP servers on every chat,
+                                 -- reducing fixed per-session token cost.
+                                 -- Default: { "user", "project", "local" }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -606,8 +606,9 @@ agent = {
 
   setting_sources = { "user", "project", "local" },  -- Sources passed to the CLI's
                                  -- --setting-sources flag. Drop "user" to skip loading your
-                                 -- global CLAUDE.md and personal MCP servers on every chat,
-                                 -- reducing fixed per-session token cost.
+                                 -- global CLAUDE.md on every chat, reducing fixed per-session
+                                 -- token cost. Note: this does not affect MCP server loading —
+                                 -- use --strict-mcp-config for that.
                                  -- Default: { "user", "project", "local" }
 }
 ```

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -80,6 +80,7 @@
 ---@field default_mode "code"|"plan"|"explore" デフォルトモード（"code": コード生成、"plan": 計画、"explore": 探索）
 ---@field default_model "sonnet"|"opus"|"haiku"|"fable" デフォルトモデル（"sonnet": バランス、"opus": 高性能、"haiku": 高速、"fable": Claude Fable）
 ---@field prioritize_vibing_lsp boolean vibing-nvim LSPツールを優先（true: Serena等の汎用LSPより優先、false: システムプロンプトを挿入しない、デフォルト: true）
+---@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）
 
 ---@class Vibing.NodeConfig
 ---Node.js実行ファイル設定
@@ -223,6 +224,7 @@ M.defaults = {
     default_mode = "code",
     default_model = "sonnet",
     prioritize_vibing_lsp = true,
+    setting_sources = { "user", "project", "local" },
   },
   chat = {
     window = {

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -7,7 +7,28 @@ local worktree_constants = require("vibing.core.constants.worktree")
 
 local M = {}
 
+local DEFAULT_SETTING_SOURCES = { "user", "project", "local" }
+
 local cached_claude_path = nil
+
+--- Resolve the `--setting-sources` list, falling back to the default when config
+--- is missing, malformed, or contains non-string/empty entries.
+--- @param config Vibing.Config
+--- @return string[]
+local function resolve_setting_sources(config)
+  local setting_sources = config.agent and config.agent.setting_sources
+  if type(setting_sources) ~= "table" or #setting_sources == 0 then
+    return DEFAULT_SETTING_SOURCES
+  end
+
+  for _, source in ipairs(setting_sources) do
+    if type(source) ~= "string" or source == "" then
+      return DEFAULT_SETTING_SOURCES
+    end
+  end
+
+  return setting_sources
+end
 
 --- Resolve model name to CLI-compatible format
 --- @param opts Vibing.AdapterOpts
@@ -209,7 +230,7 @@ function M.build(prompt, opts, session_id, config, settings_path, handle_id, rpc
   table.insert(cmd, table.concat(system_prompt_lines, "\n"))
 
   table.insert(cmd, "--setting-sources")
-  table.insert(cmd, "user,project,local")
+  table.insert(cmd, table.concat(resolve_setting_sources(config), ","))
 
   -- Build prompt with context prefix (only for new sessions, not resume)
   local full_prompt = prompt

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -8,11 +8,12 @@ local worktree_constants = require("vibing.core.constants.worktree")
 local M = {}
 
 local DEFAULT_SETTING_SOURCES = { "user", "project", "local" }
+local VALID_SETTING_SOURCES = { user = true, project = true, ["local"] = true }
 
 local cached_claude_path = nil
 
 --- Resolve the `--setting-sources` list, falling back to the default when config
---- is missing, malformed, or contains non-string/empty entries.
+--- is missing, malformed, or contains entries outside `user`/`project`/`local`.
 --- @param config Vibing.Config
 --- @return string[]
 local function resolve_setting_sources(config)
@@ -22,7 +23,7 @@ local function resolve_setting_sources(config)
   end
 
   for _, source in ipairs(setting_sources) do
-    if type(source) ~= "string" or source == "" then
+    if type(source) ~= "string" or not VALID_SETTING_SOURCES[source] then
       return DEFAULT_SETTING_SOURCES
     end
   end

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -113,4 +113,49 @@ describe("cli_command_builder", function()
       assert.is_true(allowed:find("mcp__plugin_vibing-nvim_vibing-nvim__*", 1, true) ~= nil)
     end)
   end)
+
+  describe("--setting-sources", function()
+    it("defaults to user,project,local when config.agent.setting_sources is not set", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local idx = find_flag(cmd, "--setting-sources")
+      assert.is_not_nil(idx)
+      assert.equals("user,project,local", cmd[idx + 1])
+    end)
+
+    it("uses config.agent.setting_sources when provided", function()
+      local config = { agent = { setting_sources = { "project", "local" } } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      local idx = find_flag(cmd, "--setting-sources")
+      assert.is_not_nil(idx)
+      assert.equals("project,local", cmd[idx + 1])
+    end)
+
+    it("falls back to the default when setting_sources is not a table", function()
+      local config = { agent = { setting_sources = "project" } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      local idx = find_flag(cmd, "--setting-sources")
+      assert.equals("user,project,local", cmd[idx + 1])
+    end)
+
+    it("falls back to the default when setting_sources is an empty table", function()
+      local config = { agent = { setting_sources = {} } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      local idx = find_flag(cmd, "--setting-sources")
+      assert.equals("user,project,local", cmd[idx + 1])
+    end)
+
+    it("falls back to the default when setting_sources contains a non-string element", function()
+      local config = { agent = { setting_sources = { "project", 42 } } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      local idx = find_flag(cmd, "--setting-sources")
+      assert.equals("user,project,local", cmd[idx + 1])
+    end)
+
+    it("falls back to the default when setting_sources contains an empty string element", function()
+      local config = { agent = { setting_sources = { "project", "" } } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      local idx = find_flag(cmd, "--setting-sources")
+      assert.equals("user,project,local", cmd[idx + 1])
+    end)
+  end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -157,5 +157,12 @@ describe("cli_command_builder", function()
       local idx = find_flag(cmd, "--setting-sources")
       assert.equals("user,project,local", cmd[idx + 1])
     end)
+
+    it("falls back to the default when setting_sources contains an unsupported source name", function()
+      local config = { agent = { setting_sources = { "project", "workspace" } } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      local idx = find_flag(cmd, "--setting-sources")
+      assert.equals("user,project,local", cmd[idx + 1])
+    end)
   end)
 end)


### PR DESCRIPTION
## 概要

- `cli_command_builder.lua` でハードコードされていた `--setting-sources user,project,local` を設定項目化しました
- `config.agent.setting_sources`（デフォルト: `{ "user", "project", "local" }`、後方互換）を追加
- 不正な値（table以外、空配列、非文字列要素、空文字要素）が指定された場合は安全にデフォルトへフォールバックします
- 例えば `{ "project", "local" }` を指定すると、ユーザーのグローバルCLAUDE.mdや個人MCPサーバーを毎セッション読み込まずに済み、固定トークンコストを削減できます

## 変更ファイル

- `lua/vibing/config.lua`: `Vibing.AgentConfig` に `setting_sources` フィールドを追加、デフォルト値を設定
- `lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua`: `resolve_setting_sources()` を追加し、config からカンマ結合した値を `--setting-sources` に渡す
- `tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua`: デフォルト値・カスタム値・不正値のフォールバックをカバーするテストを追加
- `README.md`: Agent Settings セクションに設定例を追記

## テスト計画

- [x] `pnpm run check`（luac構文チェック）
- [x] `pnpm run test:lua`（全テストパス、`cli_command_builder_spec.lua` に追加した6件含む）

fixes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for selecting which setting sources are passed to the Claude CLI.
  * Defaults to `user`, `project`, and `local` sources.
  * Custom source lists are supported, with automatic fallback to the default when invalid or empty values are provided.

* **Documentation**
  * Documented the new `agent.setting_sources` configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->