### PR TITLE
fix: remove per-turn handle_id from system prompt to preserve prompt cache

### DIFF
--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -101,7 +101,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   local rpc_server = require("vibing.infrastructure.rpc.server")
   local rpc_port = rpc_server.get_port()
 
-  local cmd = CLICommandBuilder.build(prompt, opts, session_id, self.config, settings_path, handle_id, rpc_port)
+  local cmd = CLICommandBuilder.build(prompt, opts, session_id, self.config, settings_path, rpc_port)
   local output = {}
   local error_output = {}
 
@@ -148,6 +148,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
 
   ActiveStreamRegistry.register({
     handle_id = handle_id,
+    chat_file_path = opts.chat_file_path,
     adapter = self,
     on_insert_choices = opts.on_insert_choices,
     on_approval_required = opts.on_approval_required,

--- a/lua/vibing/infrastructure/adapter/modules/active_stream_registry.lua
+++ b/lua/vibing/infrastructure/adapter/modules/active_stream_registry.lua
@@ -6,6 +6,9 @@ local M = {}
 
 --- @class ActiveStreamEntry
 --- @field handle_id string
+--- @field chat_file_path? string Stable per-turn value (the "Current vibing.nvim chat buffer
+---   file" line embedded in the system prompt) used to route nvim_ask_user_question calls without
+---   a per-turn handle_id, which would otherwise defeat Anthropic's prompt cache (see issue #469).
 --- @field adapter table ClaudeCLI adapter reference
 --- @field on_insert_choices? fun(questions: table)
 --- @field on_approval_required? fun(tool: string, input: table, options: table, hook_request_id?: string)
@@ -44,6 +47,26 @@ function M.get(handle_id)
     return only_entry
   end
   return nil
+end
+
+--- Get an active stream entry by chat_file_path — the stable value embedded in the system prompt
+--- (see cli_command_builder.lua), used to route mcp__vibing-nvim__nvim_ask_user_question calls
+--- instead of a per-turn handle_id (see M module docstring, issue #469). Unlike M.get(), a
+--- non-matching chat_file_path still falls back to the sole registered stream rather than
+--- returning nil, since a mid-turn `:VibingSetFileTitle` rename can legitimately desync the path
+--- the model was given from the buffer's current path — safe only because there's no other
+--- candidate to confuse it with.
+--- @param chat_file_path string|nil
+--- @return ActiveStreamEntry|nil
+function M.get_by_chat_file_path(chat_file_path)
+  if chat_file_path and chat_file_path ~= "" then
+    for _, entry in pairs(streams) do
+      if entry.chat_file_path == chat_file_path then
+        return entry
+      end
+    end
+  end
+  return M.get(nil)
 end
 
 return M

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -117,17 +117,13 @@ end
 --- @param session_id string|nil Session ID for resumption
 --- @param config Vibing.Config Plugin config
 --- @param settings_path string|nil Path to hook settings file
---- @param handle_id string|nil This turn's stream handle id, embedded in the system prompt so the
----   model can echo it back on nvim_ask_user_question calls (see ActiveStreamRegistry) — it can't
----   reach the vibing-nvim MCP server via env, since the MCP client only forwards a fixed env
----   whitelist plus the server's static registration config, never the CLI process's own env.
 --- @param rpc_port number|nil This Neovim instance's RPC server port, embedded in the system
 ---   prompt so the model can echo it back on every vibing-nvim MCP tool call. The MCP server's
 ---   registration hardcodes a single default port (see `.claude-plugin/plugin.json`), so without
 ---   this it silently targets whichever unrelated Neovim instance happens to be bound to that
 ---   port when more than one is running.
 --- @return string[] Command array for vim.system()
-function M.build(prompt, opts, session_id, config, settings_path, handle_id, rpc_port)
+function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
   if not cached_claude_path then
     cached_claude_path = vim.fn.exepath("claude")
     if cached_claude_path == "" then
@@ -161,25 +157,21 @@ function M.build(prompt, opts, session_id, config, settings_path, handle_id, rpc
     table.insert(cmd, settings_path)
   end
 
-  -- System prompt additions (worktree convention + chat file path + optional language)
+  -- System prompt additions (worktree convention + chat file path + optional language). This
+  -- entire block must stay byte-for-byte identical across turns of the same conversation —
+  -- Anthropic's prompt cache matches on a forward-prefix basis (tools -> system -> messages), so
+  -- any per-turn value here (e.g. a freshly generated handle_id) would invalidate the cached
+  -- system+history prefix on every single turn. See issue #469.
   local system_prompt_lines = {
     "When creating a git worktree for isolated work, place it under "
       .. worktree_constants.DIR
       .. "<branch-name>/ at the repository root.",
     "When you need the user to choose among options (single or multi-select), always call the "
       .. "mcp__vibing-nvim__nvim_ask_user_question tool instead of asking in free text. Do not use "
-      .. "the native AskUserQuestion tool for this — it is unavailable in this environment.",
+      .. "the native AskUserQuestion tool for this — it is unavailable in this environment. Pass "
+      .. "this turn's \"Current vibing.nvim chat buffer file\" path (given elsewhere in this "
+      .. "system prompt) as the chat_file_path argument.",
   }
-
-  if handle_id then
-    table.insert(
-      system_prompt_lines,
-      'Your handle_id for this turn is "'
-        .. handle_id
-        .. '". When calling mcp__vibing-nvim__nvim_ask_user_question, you MUST pass this exact '
-        .. "value as the handle_id argument."
-    )
-  end
 
   if rpc_port then
     table.insert(

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -249,20 +249,20 @@ end
 --- no hook/deny plumbing here — just cancel the in-flight turn and show the same choice-list UI.
 --- The killed turn means this RPC's return value is never seen by the model; the user's next
 --- chat message (a fresh `--resume`d turn) delivers their answer instead.
---- @param params {handle_id: string?, questions: table[]}
+--- @param params {chat_file_path: string?, questions: table[]}
 --- @return table RPC response
 function M.ask_user_question(params)
   if not params or not params.questions then
     return { status = "error", reason = "Missing questions" }
   end
 
-  local handle_id = params.handle_id
-  if handle_id == "" then
-    handle_id = nil
+  local chat_file_path = params.chat_file_path
+  if chat_file_path == "" then
+    chat_file_path = nil
   end
 
   local registry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
-  local stream = registry.get(handle_id)
+  local stream = registry.get_by_chat_file_path(chat_file_path)
   if not stream then
     return {
       status = "error",

--- a/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/mcp-server/src/__tests__/chat-tools.test.ts
@@ -31,17 +31,17 @@ describe('chat tools (worktree redesign)', () => {
     expect(typeof handlers.nvim_chat_send_message).toBe('function');
   });
 
-  it('registers nvim_ask_user_question with handle_id, rpc_port, and questions all required', () => {
+  it('registers nvim_ask_user_question with chat_file_path, rpc_port, and questions all required', () => {
     const tool = allTools.find((t) => t.name === 'nvim_ask_user_question');
     expect(tool).toBeDefined();
     const inputSchema = tool?.inputSchema as {
       required?: string[];
       properties: Record<string, unknown>;
     };
-    expect(inputSchema.required).toContain('handle_id');
+    expect(inputSchema.required).toContain('chat_file_path');
     expect(inputSchema.required).toContain('rpc_port');
     expect(inputSchema.required).toContain('questions');
-    expect(inputSchema.properties.handle_id).toBeDefined();
+    expect(inputSchema.properties.chat_file_path).toBeDefined();
     expect(inputSchema.properties.rpc_port).toBeDefined();
     expect(inputSchema.properties.questions).toBeDefined();
   });
@@ -57,25 +57,25 @@ describe('chat tools (worktree redesign)', () => {
     expect(typeof handlers.nvim_ask_user_question).toBe('function');
   });
 
-  it('nvim_ask_user_question calls the ask_user_question RPC with handle_id and rpc_port passed as arguments', async () => {
+  it('nvim_ask_user_question calls the ask_user_question RPC with chat_file_path and rpc_port passed as arguments', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ status: 'ok' });
 
     const questions = [{ question: 'Which?', options: [{ label: 'A' }] }];
     const result = await handlers.nvim_ask_user_question({
-      handle_id: 'handle-123',
+      chat_file_path: '/tmp/chat-test.md',
       rpc_port: 9878,
       questions,
     });
 
     expect(rpc.callNeovim).toHaveBeenCalledWith(
       'ask_user_question',
-      { handle_id: 'handle-123', questions },
+      { chat_file_path: '/tmp/chat-test.md', questions },
       9878
     );
     expect(result.isError).toBeUndefined();
   });
 
-  it('nvim_ask_user_question rejects a call missing handle_id instead of silently guessing', async () => {
+  it('nvim_ask_user_question rejects a call missing chat_file_path instead of silently guessing', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ status: 'ok' });
 
     await expect(
@@ -92,7 +92,7 @@ describe('chat tools (worktree redesign)', () => {
 
     await expect(
       handlers.nvim_ask_user_question({
-        handle_id: 'handle-123',
+        chat_file_path: '/tmp/chat-test.md',
         questions: [{ question: 'Which?', options: [{ label: 'A' }] }],
       })
     ).rejects.toThrow();
@@ -103,7 +103,7 @@ describe('chat tools (worktree redesign)', () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ status: 'error', reason: 'no active chat' });
 
     const result = await handlers.nvim_ask_user_question({
-      handle_id: 'handle-123',
+      chat_file_path: '/tmp/chat-test.md',
       rpc_port: 9878,
       questions: [{ question: 'Which?', options: [{ label: 'A' }] }],
     });

--- a/mcp-server/src/handlers/chat.ts
+++ b/mcp-server/src/handlers/chat.ts
@@ -26,7 +26,7 @@ export async function handleChatSendMessage(args: any): Promise<any> {
 }
 
 const askUserQuestionArgsSchema = z.object({
-  handle_id: z.string(),
+  chat_file_path: z.string(),
   questions: z.array(z.any()),
   rpc_port: z.number(),
 });
@@ -41,19 +41,20 @@ const askUserQuestionArgsSchema = z.object({
  * so this handler's return value is never actually seen by the model. The user's next message in
  * that buffer (a fresh `--resume`d turn) IS the answer to this call.
  *
- * `handle_id` and `rpc_port` correlate the call to the right chat buffer/Neovim instance when
+ * `chat_file_path` and `rpc_port` correlate the call to the right chat buffer/Neovim instance when
  * multiple are active concurrently. Both are required tool arguments rather than sourced from env
  * vars: the MCP client (per the `@modelcontextprotocol/sdk` stdio transport) only forwards a fixed
  * OS-level env whitelist plus whatever is statically configured in the server's registration (see
  * `.claude-plugin/plugin.json`), so per-turn/per-instance values set on the parent `claude` CLI
  * process's env can never reach this MCP server subprocess. Instead, `cli_command_builder.lua`
  * embeds the real values into the turn's system prompt and instructs the model to echo them back
- * here.
+ * here. `chat_file_path` (unlike a per-turn handle_id) is stable across turns of the same
+ * conversation, so it doesn't defeat Anthropic's prompt cache — see issue #469.
  */
 export async function handleAskUserQuestion(args: any): Promise<any> {
-  const { handle_id, questions, rpc_port } = askUserQuestionArgsSchema.parse(args);
+  const { chat_file_path, questions, rpc_port } = askUserQuestionArgsSchema.parse(args);
 
-  const result = await callNeovim('ask_user_question', { handle_id, questions }, rpc_port);
+  const result = await callNeovim('ask_user_question', { chat_file_path, questions }, rpc_port);
 
   if (result?.status !== 'ok') {
     return {

--- a/mcp-server/src/tools/chat.ts
+++ b/mcp-server/src/tools/chat.ts
@@ -43,16 +43,17 @@ export const chatTools: Tool[] = [
       "(deleting unwanted options) and sends it. Your NEXT invocation's prompt IS the user's answer " +
       'to this question, delivered as a fresh turn — treat it as such rather than waiting for a ' +
       'tool response. ' +
-      'You MUST pass handle_id using the exact value given to you in your system prompt for this ' +
-      'turn — it identifies which chat buffer to render the question in.',
+      'You MUST pass chat_file_path using the exact "Current vibing.nvim chat buffer file" value ' +
+      'given to you in your system prompt — it identifies which chat buffer to render the ' +
+      'question in.',
     inputSchema: {
       type: 'object',
       properties: withRpcPort({
-        handle_id: {
+        chat_file_path: {
           type: 'string',
           description:
-            'The exact handle_id value given to you in your system prompt for this turn. Required ' +
-            'to associate this question with the correct chat buffer.',
+            'The exact "Current vibing.nvim chat buffer file" path given to you in your system ' +
+            'prompt. Required to associate this question with the correct chat buffer.',
         },
         questions: {
           type: 'array',
@@ -91,7 +92,7 @@ export const chatTools: Tool[] = [
           },
         },
       }),
-      required: requireRpcPort(['handle_id', 'questions']),
+      required: requireRpcPort(['chat_file_path', 'questions']),
     },
   },
 ];

--- a/tests/lua/infrastructure/adapter/modules/active_stream_registry_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/active_stream_registry_spec.lua
@@ -90,4 +90,42 @@ describe("active_stream_registry", function()
       assert.is_nil(registry.get(nil))
     end)
   end)
+
+  describe("get_by_chat_file_path", function()
+    it("returns the entry whose chat_file_path matches, even with several concurrent streams", function()
+      local registry = fresh_registry()
+      registry.register({ handle_id = "a", chat_file_path = "/tmp/chat-a.md", adapter = {} })
+      registry.register({ handle_id = "b", chat_file_path = "/tmp/chat-b.md", adapter = {} })
+
+      local stream = registry.get_by_chat_file_path("/tmp/chat-b.md")
+      assert.is_not_nil(stream)
+      assert.equals("b", stream.handle_id)
+    end)
+
+    it("falls back to the sole stream when chat_file_path is nil", function()
+      local registry = fresh_registry()
+      registry.register({ handle_id = "only", chat_file_path = "/tmp/chat-only.md", adapter = {} })
+
+      local stream = registry.get_by_chat_file_path(nil)
+      assert.is_not_nil(stream)
+      assert.equals("only", stream.handle_id)
+    end)
+
+    it("falls back to the sole stream when chat_file_path doesn't match any entry (e.g. mid-turn rename)", function()
+      local registry = fresh_registry()
+      registry.register({ handle_id = "only", chat_file_path = "/tmp/old-name.md", adapter = {} })
+
+      local stream = registry.get_by_chat_file_path("/tmp/new-name.md")
+      assert.is_not_nil(stream)
+      assert.equals("only", stream.handle_id)
+    end)
+
+    it("returns nil on mismatch when multiple streams are registered (avoids guessing)", function()
+      local registry = fresh_registry()
+      registry.register({ handle_id = "a", chat_file_path = "/tmp/chat-a.md", adapter = {} })
+      registry.register({ handle_id = "b", chat_file_path = "/tmp/chat-b.md", adapter = {} })
+
+      assert.is_nil(registry.get_by_chat_file_path("/tmp/unknown.md"))
+    end)
+  end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -70,24 +70,27 @@ describe("cli_command_builder", function()
       assert.is_nil(prompt_text:find("Current vibing.nvim chat buffer file:", 1, true))
     end)
 
-    it("embeds the handle_id and instructs the model to echo it back on nvim_ask_user_question", function()
-      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil, "abc123_456")
+    it("instructs the model to pass chat_file_path on nvim_ask_user_question, without any per-turn id", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
       local idx = find_flag(cmd, "--append-system-prompt")
       assert.is_not_nil(idx)
       local prompt_text = cmd[idx + 1]
-      assert.is_true(prompt_text:find('Your handle_id for this turn is "abc123_456"', 1, true) ~= nil)
       assert.is_true(prompt_text:find("nvim_ask_user_question", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("chat_file_path argument", 1, true) ~= nil)
     end)
 
-    it("omits the handle_id line when handle_id is not provided", function()
-      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
-      local idx = find_flag(cmd, "--append-system-prompt")
-      local prompt_text = cmd[idx + 1]
-      assert.is_nil(prompt_text:find("Your handle_id for this turn is", 1, true))
+    it("never embeds a handle_id, so the same conversation's system prompt is byte-identical across turns", function()
+      local opts = { chat_file_path = "/tmp/chat-test.md" }
+      local cmd1 = cli_command_builder.build("hello", opts, nil, {}, nil, 9878)
+      local cmd2 = cli_command_builder.build("hello again", opts, "session-1", {}, nil, 9878)
+      local idx1 = find_flag(cmd1, "--append-system-prompt")
+      local idx2 = find_flag(cmd2, "--append-system-prompt")
+      assert.equals(cmd1[idx1 + 1], cmd2[idx2 + 1])
+      assert.is_nil(cmd1[idx1 + 1]:find("handle_id", 1, true))
     end)
 
     it("embeds the rpc_port and instructs the model to echo it back on every vibing-nvim MCP call", function()
-      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil, nil, 9878)
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil, 9878)
       local idx = find_flag(cmd, "--append-system-prompt")
       assert.is_not_nil(idx)
       local prompt_text = cmd[idx + 1]


### PR DESCRIPTION
## 背景

`handle_id` は `stream()` 呼び出しごとに `hrtime + random` で新規生成され、`--append-system-prompt` に埋め込まれていた。Anthropic APIのプロンプトキャッシュは `tools → system → messages` の**前方一致**なので、systemが1バイトでも変わるとsystem以降(=会話履歴全体)のキャッシュが毎ターン無効化され、通常価格の0.1倍で読めるはずのキャッシュが、フルプライス+キャッシュ書き込み(1.25倍)で再処理されていた(fixes #469)。

`handle_id` を必要としていたのは `mcp__vibing-nvim__nvim_ask_user_question` のルーティングのみ(PreToolUseフックは別途 `VIBING_HANDLE_ID` 環境変数経由で受け取っており影響なし)。

## 変更内容

- `lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua`: システムプロンプトから `handle_id` の行を削除。`nvim_ask_user_question` の呼び出し指示文を、既存の安定値である `chat_file_path`(「Current vibing.nvim chat buffer file」)を渡すよう変更。`M.build()` の `handle_id` 引数も削除。
- `lua/vibing/infrastructure/adapter/modules/active_stream_registry.lua`: エントリに `chat_file_path` フィールドを追加。新たに `get_by_chat_file_path()` を追加し、chat_file_path から解決できるようにした。不一致時(実行中の `:VibingSetFileTitle` によるリネーム等)は既存の「単一ストリームならキーなしで解決」フォールバックに落とす。`handle_id` による解決(`M.get()`)はPreToolUseフック用・キャンセル用としてそのまま存続。
- `lua/vibing/infrastructure/adapter/claude_cli.lua`: レジストリ登録時に `opts.chat_file_path` を渡すよう変更。
- `mcp-server/src/tools/chat.ts` / `mcp-server/src/handlers/chat.ts`: `nvim_ask_user_question` のスキーマ・ハンドラを `handle_id` → `chat_file_path` に変更。
- `lua/vibing/infrastructure/rpc/handlers/permission.lua`: `M.ask_user_question` が `params.chat_file_path` を受け取り `registry.get_by_chat_file_path()` で解決するよう変更。
- 上記に合わせて `tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua`、`tests/lua/infrastructure/adapter/modules/active_stream_registry_spec.lua`、`mcp-server/src/__tests__/chat-tools.test.ts` を更新。`active_stream_registry_spec.lua` には `get_by_chat_file_path` のフォールバック・不一致ケースのテストを追加。

`rpc_port`・言語・worktree規約・`chat_file_path` の各行は元々ターン間で不変なので、`handle_id` さえ除去すれば `--append-system-prompt` の内容全体が会話を通じて完全に安定する。

## 検証結果

- `pnpm run check`(Lua構文チェック): 成功
- `pnpm run lint`(ESLint): 成功
- `pnpm run build`: 成功(root)。`mcp-server` は npm(`package-lock.json`)ベースの別パッケージのため、`mcp-server` ディレクトリで `pnpm install --ignore-workspace && pnpm run build`(`tsc`)を実行し成功を確認。
- `mcp-server` の `pnpm run test`(vitest): 122件全てパス
- `pnpm run test:lua`: 今回変更した `cli_command_builder_spec.lua`(9件)・`active_stream_registry_spec.lua`(11件)は2回の実行いずれも全件パス。ただし全体の `test:lua` 実行自体は、他のworktreeで並行実行中の別セッションのE2Eテストが同じRPCポート範囲を食い合っていることが原因の "all ports are in use" エラーで途中終了しており(このリポジトリのコード変更とは無関係な環境要因)、`tests/e2e/*.lua` の一部が実行し切れていない。関連する `tests/e2e/nvim_ask_user_question_spec.lua` はコード上ロジック変更なし(handle_idの直接参照なし)。

fixes #469