### PR TITLE
feat: lightweight per-request diff tracking without mote snapshots

### DIFF
--- a/.claude/rules/configuration.md
+++ b/.claude/rules/configuration.md
@@ -30,9 +30,13 @@ require("vibing").setup({
   },
   diff = {
     tool = "auto",  -- "git" | "mote" | "auto"
-    -- "git": Always use git diff
-    -- "mote": Always use mote diff (requires mote v0.2.4+: https://github.com/shabaraba/mote)
-    -- "auto": Use mote if available and initialized, otherwise fallback to git
+    -- "auto"/"git": Lightweight per-request diff (default). Files touched by Write/Edit are
+    --   backed up at PreToolUse time and diffed with vim.diff() after the response — no
+    --   whole-tree scanning, no external processes. `gd` falls back to git diff when no
+    --   patch file is found.
+    -- "mote": Opt-in mote snapshot tracking (requires mote v0.2.4+:
+    --   https://github.com/shabaraba/mote). Also catches Bash-driven file changes, at the
+    --   cost of snapshotting the whole tracked tree on every request.
     mote = {
       project = nil,  -- Project name (nil = auto-detect from git repo name)
       context_prefix = "vibing",  -- Context name prefix (default: "vibing")
@@ -135,9 +139,25 @@ require("vibing").setup({
 })
 ```
 
-## Mote Integration
+## Per-Request Diff Tracking (Default)
 
-vibing.nvim uses mote for displaying file changes and tracking modifications.
+By default (`diff.tool = "auto"` or `"git"`), vibing.nvim tracks per-request changes without
+mote: when Claude is about to run Write/Edit/NotebookEdit, the PreToolUse hook backs up the
+target file's pre-edit content, and after the response a git-style patch is generated with
+`vim.diff()` (built-in xdiff, no external processes). Patches are stored under
+`.vibing/patches/` and referenced from the chat buffer via `<!-- patch: ... -->` comments, so
+`gd` and patch revert work per request and per chat buffer — concurrent chats never mix
+diffs, and cost scales with the number of files actually touched (not the tree size, which
+matters for virtual-monorepo setups with many workspaces).
+
+Limitation: files changed via Bash commands are listed in Modified Files (when reported by
+tool events) but have no diff section. Use mote mode if you need Bash-driven changes tracked.
+
+## Mote Integration (Opt-In)
+
+vibing.nvim can alternatively use mote for displaying file changes and tracking
+modifications. Mote snapshots run only when `diff.tool = "mote"` is set explicitly, or when a
+chat has `mote_dirs` in its frontmatter (via `:VibingMoteDir`).
 
 [mote](https://github.com/shabaraba/mote) is a fine-grained snapshot management tool that provides richer diff capabilities than git. It tracks changes at a more granular level than git commits.
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,11 @@ Run multiple AI tasks simultaneously:
 - **🎯 Smart Context** - Automatic file context detection from open buffers and manual additions
 - **🌍 Multi-language Support** - Configure language for chat
 - **📊 Diff Viewer** - Visual diff display for AI-edited files with `gd` keybinding
-  - Supports both `git diff` and [mote](https://github.com/shabaraba/mote) (fine-grained snapshot tool)
-  - Auto-detection: Uses mote if available, fallback to git
+  - Lightweight per-request patches by default: edited files are backed up before each write
+    and diffed in-process — accurate per-request diffs even with concurrent chats, with no
+    whole-tree scanning
+  - Optional [mote](https://github.com/shabaraba/mote) (fine-grained snapshot tool) backend
+    via `diff.tool = "mote"`
 - **⚙️ Highly Configurable** - Flexible modes, models, permissions, and UI settings
 
 ## 🔄 How It Differs

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -69,7 +69,14 @@ function M.execute(adapter, callbacks, message, config)
   if (not mote_dirs or #mote_dirs == 0) and frontmatter and frontmatter.mote_cwd then
     mote_dirs = { frontmatter.mote_cwd }
   end
-  local mote_configs = M._create_session_mote_configs(config, callbacks.get_session_id(), bufnr, session_cwd, mote_dirs)
+  -- moteはopt-in: diff.tool = "mote" 明示か、mote_dirs指定時のみスナップショットを取る。
+  -- デフォルトはPreToolUseフックで変更前ファイルだけを退避する軽量なリクエスト単位diff
+  -- （request_diff.lua）を使うため、全ツリースキャンやmoteプロセスは発生しない。
+  local use_mote = (config.diff and config.diff.tool == "mote") or (mote_dirs and #mote_dirs > 0)
+  local mote_configs = {}
+  if use_mote then
+    mote_configs = M._create_session_mote_configs(config, callbacks.get_session_id(), bufnr, session_cwd, mote_dirs)
+  end
 
   -- 実際のメッセージ送信処理（mote初期化後に呼び出される）
   local function do_send()
@@ -213,9 +220,12 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
   -- キャンセル済みの古いリクエストが遅れて完了した場合、現在アクティブなハンドルIDと
   -- 一致しないレスポンスは無視する（新しいリクエストの結果を上書きさせない）
   local incoming_handle_id = response._handle_id
+  local RequestDiff = require("vibing.core.utils.request_diff")
   if incoming_handle_id and callbacks.get_handle_id then
     local current_handle_id = callbacks.get_handle_id()
     if current_handle_id and incoming_handle_id ~= current_handle_id then
+      -- このリクエストは破棄されるので、対応するバックアップも破棄
+      RequestDiff.clear(incoming_handle_id)
       return
     end
   end
@@ -262,7 +272,7 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
     callbacks.clear_forked_from()
   end
 
-  -- mote統合: 有効なconfigが1つでもあればModified Files出力とpatch生成
+  -- mote統合（opt-in時のみ）: 有効なconfigが1つでもあればModified Files出力とpatch生成
   local MoteDiff = require("vibing.core.utils.mote_diff")
 
   -- セッション開始時のスナップショットIDをベースラインとして各configに設定
@@ -276,8 +286,9 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
     end
   end
 
-  -- Write/Editで実際にファイルが変更された場合のみmote diffを実行
+  -- Write/Editで実際にファイルが変更された場合のみdiff処理を実行
   local has_file_changes = next(modified_file_paths or {}) ~= nil
+  local handle_id_for_diff = incoming_handle_id or (callbacks.get_handle_id and callbacks.get_handle_id())
 
   if #active_configs > 0 and has_file_changes then
     -- 全configから変更ファイルを収集し、重複排除して出力
@@ -295,6 +306,15 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
       if diff_timeout_timer then
         vim.fn.timer_stop(diff_timeout_timer)
         diff_timeout_timer = nil
+      end
+      RequestDiff.clear(handle_id_for_diff)
+      -- moteのignore設定等でdiffから漏れたファイルも、ツールイベントで検知した分は必ず一覧に載せる
+      for path in pairs(modified_file_paths or {}) do
+        local rel = vim.fn.fnamemodify(path, ":.")
+        if not seen_files[rel] and not seen_files[path] then
+          seen_files[rel] = true
+          table.insert(all_files, rel)
+        end
       end
       if #all_files > 0 then
         BufferReload.reload_files(all_files)
@@ -351,12 +371,65 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
         end
       end)
     end
+  elseif has_file_changes then
+    -- 軽量パス（デフォルト）: PreToolUseフックで退避した変更前内容からpatchを生成。
+    -- 外部プロセスを使わず、触ったファイル数分のvim.diff()だけで完結する。
+    M._finalize_request_diff(callbacks, handle_id_for_diff, modified_file_paths)
   else
+    RequestDiff.clear(handle_id_for_diff)
     callbacks.add_user_section()
   end
 
   -- NOTE: clear_handle_id() は呼ばない
   -- 次のsend_message()時にkillすることで、ゾンビプロセス対策になる
+end
+
+---リクエスト単位diff（軽量パス）のModified Files出力とpatch生成
+---@param callbacks Vibing.ChatCallbacks
+---@param handle_id string|nil リクエストのハンドルID
+---@param modified_file_paths table<string, boolean> ツールイベントで検知した変更ファイル
+function M._finalize_request_diff(callbacks, handle_id, modified_file_paths)
+  local RequestDiff = require("vibing.core.utils.request_diff")
+  local Git = require("vibing.core.utils.git")
+
+  local session_cwd = callbacks.get_cwd and callbacks.get_cwd() or nil
+  local base_dir = session_cwd or Git.get_root(nil) or vim.fn.getcwd()
+  base_dir = vim.fn.fnamemodify(base_dir, ":p"):gsub("/$", "")
+
+  local files, abs_files, patch_content = RequestDiff.generate(handle_id, base_dir, modified_file_paths)
+  RequestDiff.clear(handle_id)
+
+  if #files > 0 then
+    BufferReload.reload_files(abs_files)
+    local MAX_DISPLAY = 50
+    local file_lines = {}
+    for i = 1, math.min(#files, MAX_DISPLAY) do
+      table.insert(file_lines, files[i])
+    end
+    if #files > MAX_DISPLAY then
+      table.insert(file_lines, string.format("... (%d more)", #files - MAX_DISPLAY))
+    end
+    callbacks.append_chunk("\n\n### Modified Files\n\n" .. table.concat(file_lines, "\n") .. "\n")
+  end
+
+  if patch_content then
+    local patch_dir = base_dir .. "/.vibing/patches"
+    vim.fn.mkdir(patch_dir, "p")
+    local suffix = tostring(handle_id or ""):gsub("%W", ""):sub(-6)
+    local patch_path = string.format("%s/%s_%s.patch", patch_dir, os.date("%Y%m%d_%H%M%S"), suffix)
+    local f = io.open(patch_path, "w")
+    if f then
+      f:write(patch_content)
+      f:close()
+      callbacks.append_chunk("\n<!-- patch: " .. patch_path .. " -->\n")
+    else
+      vim.notify("[vibing] Failed to write patch file: " .. patch_path, vim.log.levels.WARN)
+    end
+  end
+
+  vim.schedule(function()
+    callbacks.add_user_section()
+  end)
 end
 
 ---セッション固有のmote設定を作成（単一dir用）

--- a/lua/vibing/core/utils/diff_selector.lua
+++ b/lua/vibing/core/utils/diff_selector.lua
@@ -1,13 +1,75 @@
 ---@class Vibing.Utils.DiffSelector
----mote diffの表示を管理
+---patchファイルが見つからない場合のdiff表示フォールバックを管理
 local M = {}
 
----ファイルのdiffを表示（moteを使用）
+---diff内容をスクラッチバッファに表示
+---@param output string diff出力
+local function show_diff_buffer(output)
+  local Factory = require("vibing.infrastructure.ui.factory")
+  local buf = Factory.create_buffer({
+    buftype = "nofile",
+    bufhidden = "wipe",
+    filetype = "diff",
+    modifiable = true,
+  })
+
+  local lines = vim.split(output, "\n")
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+
+  vim.cmd("vsplit")
+  vim.api.nvim_win_set_buf(0, buf)
+
+  vim.keymap.set("n", "q", function()
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end, {
+    buffer = buf,
+    noremap = true,
+    silent = true,
+  })
+end
+
+---ファイルのgit diffを表示（HEADとの比較）
+---@param file_path string ファイルパス（絶対パス）
+local function show_git_diff(file_path)
+  local abs = vim.fn.fnamemodify(file_path, ":p")
+  local dir = vim.fn.fnamemodify(abs, ":h")
+
+  local result = vim.system({ "git", "diff", "HEAD", "--", abs }, { cwd = dir, text = true }):wait()
+  if result.code ~= 0 then
+    -- HEADが無い場合（初回コミット前など）はworking treeのdiffにフォールバック
+    result = vim.system({ "git", "diff", "--", abs }, { cwd = dir, text = true }):wait()
+  end
+
+  if result.code ~= 0 then
+    vim.notify("[vibing] git diff failed: " .. vim.trim(result.stderr or ""), vim.log.levels.ERROR)
+    return
+  end
+
+  local output = result.stdout or ""
+  if output == "" or output:match("^%s*$") then
+    vim.notify("[vibing] No changes to show", vim.log.levels.INFO)
+    return
+  end
+
+  show_diff_buffer(output)
+end
+
+---ファイルのdiffを表示
+---patchファイルが見つからない場合のフォールバック。diff.tool = "mote" のときだけmoteを使い、
+---それ以外（"auto" / "git"）はgit diffで表示する。
 ---@param file_path string ファイルパス（絶対パス）
 ---@param session_id? string セッションID（未使用、互換性のため保持）
 ---@param cwd? string 作業ディレクトリ（frontmatterのworking_dirから算出、worktree判定用）
 function M.show_diff(file_path, session_id, cwd)
   local config = require("vibing.config").get()
+  local tool = config.diff and config.diff.tool or "auto"
+
+  if tool ~= "mote" then
+    show_git_diff(file_path)
+    return
+  end
+
   local MoteDiff = require("vibing.core.utils.mote_diff")
   local mote_config = vim.deepcopy(config.diff.mote)
 

--- a/lua/vibing/core/utils/request_diff.lua
+++ b/lua/vibing/core/utils/request_diff.lua
@@ -1,0 +1,248 @@
+---@class Vibing.Utils.RequestDiff
+---リクエスト単位の軽量diff機構
+---
+---PreToolUseフックの時点（ツール実行前）で、Write/Edit系ツールが対象とするファイルの
+---「変更前」内容だけをtmpに退避し、レスポンス完了時に退避内容と現在の内容を
+---vim.diff()（組み込みxdiff）で比較してgit形式のpatchを生成する。
+---
+---moteのような全ツリースキャンを一切行わないため、コストは
+---「そのリクエストで実際に触ったファイル数」にのみ比例する。
+---バックアップはhandle_id（リクエスト）単位で管理されるので、
+---並行するチャットバッファ間で差分が混ざることもない。
+local M = {}
+
+local uv = vim.uv or vim.loop
+
+---@class Vibing.RequestDiff.Entry
+---@field existed boolean 退避時点でファイルが存在したか
+---@field backup_path string|nil 退避先パス（existed=falseの場合nil）
+
+---@class Vibing.RequestDiff.Session
+---@field dir string|nil バックアップディレクトリ
+---@field count number 退避ファイルの連番
+---@field created number セッション作成時刻（os.time）
+---@field files table<string, Vibing.RequestDiff.Entry> 絶対パス→退避情報
+---@field order string[] 退避順の絶対パスリスト
+
+---handle_idごとの退避状態
+---@type table<string, Vibing.RequestDiff.Session>
+local sessions = {}
+
+---ツール名→tool_input内のファイルパスキー
+local TOOL_PATH_KEYS = {
+  Write = "file_path",
+  Edit = "file_path",
+  MultiEdit = "file_path",
+  NotebookEdit = "notebook_path",
+}
+
+---キャンセル等でclearされなかったセッションの掃除用TTL（秒）
+local SESSION_TTL_SEC = 3600
+
+---@param path string
+---@return string|nil
+local function read_file(path)
+  local f = io.open(path, "rb")
+  if not f then
+    return nil
+  end
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+
+---@param abs string 絶対パス
+---@param base string|nil 基準ディレクトリ（絶対パス）
+---@return string base配下なら相対パス、そうでなければ絶対パスのまま
+local function to_rel(abs, base)
+  if base and base ~= "" then
+    local prefix = base:sub(-1) == "/" and base or (base .. "/")
+    if abs:sub(1, #prefix) == prefix then
+      return abs:sub(#prefix + 1)
+    end
+  end
+  return abs
+end
+
+---TTL超過した放置セッション（キャンセルされたリクエスト等）を破棄
+local function sweep_stale()
+  local now = os.time()
+  for handle_id, s in pairs(sessions) do
+    if now - s.created > SESSION_TTL_SEC then
+      if s.dir then
+        vim.fn.delete(s.dir, "rf")
+      end
+      sessions[handle_id] = nil
+    end
+  end
+end
+
+---ツール実行前にファイル内容を退避する（PreToolUseフックの許可パスから呼ぶ）
+---同一リクエスト内で同じファイルが複数回編集されても、最初の退避
+---（=リクエスト開始時点の状態）を保持する。
+---@param handle_id string|nil リクエストのハンドルID
+---@param tool_name string ツール名
+---@param tool_input table ツール入力
+function M.capture(handle_id, tool_name, tool_input)
+  if not handle_id or handle_id == "" then
+    return
+  end
+  local path_key = TOOL_PATH_KEYS[tool_name]
+  if not path_key or type(tool_input) ~= "table" then
+    return
+  end
+  local path = tool_input[path_key]
+  if type(path) ~= "string" or path == "" then
+    return
+  end
+
+  sweep_stale()
+
+  local abs = vim.fn.fnamemodify(path, ":p")
+  local s = sessions[handle_id]
+  if not s then
+    s = { dir = nil, count = 0, created = os.time(), files = {}, order = {} }
+    sessions[handle_id] = s
+  end
+  if s.files[abs] then
+    return
+  end
+
+  local stat = uv.fs_stat(abs)
+  if not stat then
+    s.files[abs] = { existed = false }
+    table.insert(s.order, abs)
+    return
+  end
+  if stat.type ~= "file" then
+    return
+  end
+
+  if not s.dir then
+    s.dir = vim.fn.tempname() .. ".vibing-reqdiff"
+    vim.fn.mkdir(s.dir, "p")
+  end
+  s.count = s.count + 1
+  local backup_path = string.format("%s/%d", s.dir, s.count)
+  local ok = uv.fs_copyfile(abs, backup_path)
+  if not ok then
+    -- 退避に失敗したファイルはdiff対象から外す（一覧には extra_paths 経由で載る）
+    return
+  end
+  s.files[abs] = { existed = true, backup_path = backup_path }
+  table.insert(s.order, abs)
+end
+
+---1ファイル分のdiffセクションを生成
+---@param rel string 相対パス
+---@param before string|nil 変更前内容（nil=ファイルが存在しなかった）
+---@param after string|nil 変更後内容（nil=ファイルが削除された）
+---@return string|nil diffセクション（変更がなければnil）
+local function build_file_section(rel, before, after)
+  local before_text = before or ""
+  local after_text = after or ""
+  if before_text == after_text then
+    return nil
+  end
+
+  local header = string.format("diff --git a/%s b/%s", rel, rel)
+  local old_label = before and ("a/" .. rel) or "/dev/null"
+  local new_label = after and ("b/" .. rel) or "/dev/null"
+
+  if before_text:find("\0", 1, true) or after_text:find("\0", 1, true) then
+    return string.format("%s\nBinary files %s and %s differ", header, old_label, new_label)
+  end
+
+  local hunks = vim.diff(before_text, after_text, { result_type = "unified", ctxlen = 3 })
+  if not hunks or hunks == "" then
+    return nil
+  end
+
+  return string.format("%s\n--- %s\n+++ %s\n%s", header, old_label, new_label, hunks:gsub("\n$", ""))
+end
+
+---リクエストの差分を生成する
+---@param handle_id string|nil リクエストのハンドルID
+---@param base_dir string patch内パスの基準ディレクトリ（絶対パス）
+---@param extra_paths table<string, boolean>|nil ツールイベント由来の変更ファイル（絶対/相対パス→true）。
+---  フックで退避できなかったファイルもModified Files一覧には必ず含めるための補完。
+---@return string[] files 変更ファイルの相対パス一覧（表示用）
+---@return string[] abs_files 変更ファイルの絶対パス一覧（バッファリロード用）
+---@return string|nil patch_content patch内容（diffを1つも生成できなければnil）
+function M.generate(handle_id, base_dir, extra_paths)
+  local files = {}
+  local abs_files = {}
+  local sections = {}
+  local seen = {}
+
+  local s = handle_id and sessions[handle_id] or nil
+  if s then
+    for _, abs in ipairs(s.order) do
+      local entry = s.files[abs]
+      local before = nil
+      if entry.existed and entry.backup_path then
+        before = read_file(entry.backup_path)
+      end
+      local after = read_file(abs)
+      local rel = to_rel(abs, base_dir)
+      local section = build_file_section(rel, before, after)
+      if section then
+        seen[abs] = true
+        table.insert(files, rel)
+        table.insert(abs_files, abs)
+        table.insert(sections, section)
+      end
+    end
+  end
+
+  -- フックを通らなかった変更ファイル（退避なし）も一覧にだけは載せる
+  for path in pairs(extra_paths or {}) do
+    local abs = vim.fn.fnamemodify(path, ":p")
+    if not seen[abs] and not (s and s.files[abs]) then
+      seen[abs] = true
+      table.insert(files, to_rel(abs, base_dir))
+      table.insert(abs_files, abs)
+    end
+  end
+
+  local patch_content = nil
+  if #sections > 0 then
+    patch_content = string.format(
+      "# vibing-request-diff base: %s\n%s\n",
+      base_dir,
+      table.concat(sections, "\n")
+    )
+  end
+
+  return files, abs_files, patch_content
+end
+
+---リクエストのバックアップを破棄する（レスポンス処理の最後に必ず呼ぶ）
+---@param handle_id string|nil
+function M.clear(handle_id)
+  if not handle_id then
+    return
+  end
+  local s = sessions[handle_id]
+  if not s then
+    return
+  end
+  if s.dir then
+    vim.fn.delete(s.dir, "rf")
+  end
+  sessions[handle_id] = nil
+end
+
+---テスト用: 退避済みかどうか
+---@param handle_id string
+---@param path string
+---@return boolean
+function M.has_capture(handle_id, path)
+  local s = sessions[handle_id]
+  if not s then
+    return false
+  end
+  return s.files[vim.fn.fnamemodify(path, ":p")] ~= nil
+end
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -225,6 +225,18 @@ function M.check_tool_permission(params)
   local result = can_use_tool_mod.can_use_tool(tool_name, tool_input, perm_config)
 
   if result.behavior == "allow" then
+    -- ツールが実行される前（=レスポンスを書いてフックのブロックを解く前）に、
+    -- 対象ファイルの「変更前」内容を退避する。リクエスト単位diffのベースラインになる。
+    -- 退避の失敗が許可判断を壊さないよう pcall で保護する。
+    pcall(function()
+      local effective_handle = handle_id
+      if not effective_handle then
+        local registry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
+        local stream = registry.get(nil)
+        effective_handle = stream and stream.handle_id
+      end
+      require("vibing.core.utils.request_diff").capture(effective_handle, tool_name, tool_input)
+    end)
     write_hook_response(request_id, true)
     return { status = "allowed" }
   elseif result.behavior == "deny" then

--- a/lua/vibing/ui/patch_viewer/parser.lua
+++ b/lua/vibing/ui/patch_viewer/parser.lua
@@ -91,6 +91,13 @@ function M.extract_file_diff(patch_content, target_file)
   return table.concat(result, "\n")
 end
 
+---request_diff.luaが生成したpatchの基準ディレクトリを抽出
+---@param patch_content string
+---@return string?
+function M.extract_base_dir(patch_content)
+  return patch_content:match("^# vibing%-request%-diff base: ([^\n]+)")
+end
+
 ---@param patch_content string
 ---@return string?
 function M.extract_snapshot_id(patch_content)

--- a/lua/vibing/ui/patch_viewer/revert.lua
+++ b/lua/vibing/ui/patch_viewer/revert.lua
@@ -27,37 +27,94 @@ local function restore_file(context_dir, snapshot_id, file)
   return true, nil
 end
 
+---request_diff形式のpatch（git形式）の1ファイル分diffをリバース適用して変更を取り消す
+---@param base_dir string patch内パスの基準ディレクトリ
+---@param file_diff string 対象ファイルのdiffセクション
+---@return boolean success
+---@return string? error_message
+local function reverse_apply(base_dir, file_diff)
+  local tmp = vim.fn.tempname()
+  local f = io.open(tmp, "w")
+  if not f then
+    return false, "Failed to create temp file"
+  end
+  f:write(file_diff)
+  if not file_diff:match("\n$") then
+    f:write("\n")
+  end
+  f:close()
+
+  local result = vim
+    .system({ "git", "apply", "--reverse", "--whitespace=nowarn", tmp }, { cwd = base_dir, text = true })
+    :wait()
+  os.remove(tmp)
+
+  if result.code ~= 0 then
+    return false, vim.trim(result.stderr or "")
+  end
+  return true, nil
+end
+
+---@class Vibing.PatchViewer.RevertContext
+---@field kind "mote"|"request_diff"
+---@field snapshot_id string? moteスナップショットID（kind="mote"）
+---@field context_dir string? moteコンテキストディレクトリ（kind="mote"）
+---@field base_dir string? patch基準ディレクトリ（kind="request_diff"）
+---@field patch_content string
+
 ---@param patch_filename string
----@return string? snapshot_id
----@return string? context_dir
+---@return Vibing.PatchViewer.RevertContext? ctx
 ---@return string? error
 local function prepare_revert(patch_filename)
   local patch_path = parser.resolve_patch_path(patch_filename)
   if not patch_path then
-    return nil, nil, "Patch file not found: " .. patch_filename
+    return nil, "Patch file not found: " .. patch_filename
   end
 
   local patch_content = parser.read_patch_file(patch_path)
   if not patch_content then
-    return nil, nil, "Failed to read patch file: " .. patch_filename
+    return nil, "Failed to read patch file: " .. patch_filename
   end
 
+  -- request_diff形式（git形式patch + baseヘッダ）: git applyでリバース適用できる
+  local base_dir = parser.extract_base_dir(patch_content)
+  if base_dir then
+    return { kind = "request_diff", base_dir = base_dir, patch_content = patch_content }, nil
+  end
+
+  -- mote形式: スナップショットからrestoreする
   local snapshot_id = parser.extract_snapshot_id(patch_content)
   if not snapshot_id then
-    return nil, nil, "Failed to extract snapshot ID from patch"
+    return nil, "Failed to extract snapshot ID from patch"
   end
 
   local context_dir = parser.extract_context_dir(patch_path)
   if not context_dir then
-    return nil, nil, "Failed to extract context directory from patch path"
+    return nil, "Failed to extract context directory from patch path"
   end
 
   local Binary = require("vibing.core.utils.mote.binary")
   if not Binary.is_available() then
-    return nil, nil, "mote binary not found. Cannot revert patch."
+    return nil, "mote binary not found. Cannot revert patch."
   end
 
-  return snapshot_id, context_dir, nil
+  return { kind = "mote", snapshot_id = snapshot_id, context_dir = context_dir, patch_content = patch_content }, nil
+end
+
+---patch形式に応じて1ファイルを差し戻す
+---@param ctx Vibing.PatchViewer.RevertContext
+---@param file string
+---@return boolean success
+---@return string? error_message
+local function revert_one(ctx, file)
+  if ctx.kind == "request_diff" then
+    local file_diff = parser.extract_file_diff(ctx.patch_content, file)
+    if not file_diff then
+      return false, "No diff found in patch for: " .. file
+    end
+    return reverse_apply(ctx.base_dir, file_diff)
+  end
+  return restore_file(ctx.context_dir, ctx.snapshot_id, file)
 end
 
 ---@param _ string
@@ -65,13 +122,13 @@ end
 ---@param selected_file string
 ---@return boolean
 function M.revert_single_file(_, patch_filename, selected_file)
-  local snapshot_id, context_dir, err = prepare_revert(patch_filename)
-  if err then
+  local ctx, err = prepare_revert(patch_filename)
+  if not ctx then
     vim.notify(err, vim.log.levels.ERROR)
     return false
   end
 
-  local success, error_msg = restore_file(context_dir, snapshot_id, selected_file)
+  local success, error_msg = revert_one(ctx, selected_file)
   if not success then
     vim.notify(
       string.format("Failed to revert %s:\n%s", selected_file, error_msg or ""),
@@ -83,7 +140,7 @@ function M.revert_single_file(_, patch_filename, selected_file)
   local BufferReload = require("vibing.core.utils.buffer_reload")
   BufferReload.reload_files({ selected_file })
 
-  vim.notify(string.format("Reverted %s to snapshot %s", selected_file, snapshot_id), vim.log.levels.INFO)
+  vim.notify(string.format("Reverted %s", selected_file), vim.log.levels.INFO)
   return true
 end
 
@@ -91,15 +148,13 @@ end
 ---@param patch_filename string
 ---@return boolean
 function M.revert_all_files(_, patch_filename)
-  local snapshot_id, context_dir, err = prepare_revert(patch_filename)
-  if err then
+  local ctx, err = prepare_revert(patch_filename)
+  if not ctx then
     vim.notify(err, vim.log.levels.ERROR)
     return false
   end
 
-  local patch_path = parser.resolve_patch_path(patch_filename)
-  local patch_content = parser.read_patch_file(patch_path)
-  local files = parser.extract_files(patch_content)
+  local files = parser.extract_files(ctx.patch_content)
   if #files == 0 then
     vim.notify("No files to revert", vim.log.levels.WARN)
     return false
@@ -109,7 +164,7 @@ function M.revert_all_files(_, patch_filename)
   local success_count = 0
 
   for _, file in ipairs(files) do
-    local success, error_msg = restore_file(context_dir, snapshot_id, file)
+    local success, error_msg = revert_one(ctx, file)
     if not success then
       table.insert(failed_files, { file = file, error = error_msg })
     else
@@ -117,7 +172,7 @@ function M.revert_all_files(_, patch_filename)
     end
   end
 
-  M._report_results(files, failed_files, success_count, snapshot_id)
+  M._report_results(files, failed_files, success_count)
   M._reload_successful_files(files, failed_files, success_count)
 
   return success_count > 0
@@ -126,8 +181,7 @@ end
 ---@param files string[]
 ---@param failed_files { file: string, error: string? }[]
 ---@param success_count number
----@param snapshot_id string
-function M._report_results(files, failed_files, success_count, snapshot_id)
+function M._report_results(files, failed_files, success_count)
   if #failed_files > 0 then
     local error_msg = string.format("Reverted %d/%d files. Failed files:\n", success_count, #files)
     for _, failure in ipairs(failed_files) do
@@ -135,7 +189,7 @@ function M._report_results(files, failed_files, success_count, snapshot_id)
     end
     vim.notify(error_msg, vim.log.levels.WARN)
   else
-    vim.notify(string.format("Reverted all %d file(s) to snapshot %s", #files, snapshot_id), vim.log.levels.INFO)
+    vim.notify(string.format("Reverted all %d file(s)", #files), vim.log.levels.INFO)
   end
 end
 

--- a/tests/lua/core/utils/request_diff_spec.lua
+++ b/tests/lua/core/utils/request_diff_spec.lua
@@ -1,0 +1,194 @@
+local RequestDiff = require("vibing.core.utils.request_diff")
+
+describe("request_diff", function()
+  local tmp_dir
+  local handle_id
+
+  local function write_file(path, content)
+    local f = assert(io.open(path, "w"))
+    f:write(content)
+    f:close()
+  end
+
+  local function read_file(path)
+    local f = io.open(path, "r")
+    if not f then
+      return nil
+    end
+    local content = f:read("*a")
+    f:close()
+    return content
+  end
+
+  before_each(function()
+    tmp_dir = vim.fn.tempname()
+    vim.fn.mkdir(tmp_dir, "p")
+    tmp_dir = vim.fn.fnamemodify(tmp_dir, ":p"):gsub("/$", "")
+    handle_id = "test-handle-" .. tostring(math.random(100000))
+  end)
+
+  after_each(function()
+    RequestDiff.clear(handle_id)
+    vim.fn.delete(tmp_dir, "rf")
+  end)
+
+  describe("capture", function()
+    it("captures the pre-edit content of an existing file", function()
+      local file = tmp_dir .. "/a.txt"
+      write_file(file, "before\n")
+
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      assert.is_true(RequestDiff.has_capture(handle_id, file))
+    end)
+
+    it("records non-existent files so Write shows as a new file", function()
+      local file = tmp_dir .. "/new.txt"
+      RequestDiff.capture(handle_id, "Write", { file_path = file })
+      assert.is_true(RequestDiff.has_capture(handle_id, file))
+    end)
+
+    it("ignores tools that do not modify files", function()
+      RequestDiff.capture(handle_id, "Read", { file_path = tmp_dir .. "/a.txt" })
+      assert.is_false(RequestDiff.has_capture(handle_id, tmp_dir .. "/a.txt"))
+    end)
+
+    it("ignores missing handle_id", function()
+      local file = tmp_dir .. "/a.txt"
+      write_file(file, "x\n")
+      RequestDiff.capture(nil, "Edit", { file_path = file })
+      -- 何も起きない（エラーにならない）ことだけ確認
+    end)
+
+    it("keeps the first backup when the same file is edited twice", function()
+      local file = tmp_dir .. "/a.txt"
+      write_file(file, "original\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+
+      write_file(file, "intermediate\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+
+      write_file(file, "final\n")
+      local _, _, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+      assert.is_truthy(patch)
+      assert.is_truthy(patch:find("-original", 1, true))
+      assert.is_truthy(patch:find("+final", 1, true))
+      assert.is_falsy(patch:find("intermediate", 1, true))
+    end)
+  end)
+
+  describe("generate", function()
+    it("produces a git-style patch for a modified file", function()
+      local file = tmp_dir .. "/mod.txt"
+      write_file(file, "line1\nline2\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      write_file(file, "line1\nchanged\n")
+
+      local files, abs_files, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+
+      assert.same({ "mod.txt" }, files)
+      assert.same({ file }, abs_files)
+      assert.is_truthy(patch:find("# vibing-request-diff base: " .. tmp_dir, 1, true))
+      assert.is_truthy(patch:find("diff --git a/mod.txt b/mod.txt", 1, true))
+      assert.is_truthy(patch:find("--- a/mod.txt", 1, true))
+      assert.is_truthy(patch:find("+++ b/mod.txt", 1, true))
+      assert.is_truthy(patch:find("-line2", 1, true))
+      assert.is_truthy(patch:find("+changed", 1, true))
+    end)
+
+    it("produces a /dev/null header for newly created files", function()
+      local file = tmp_dir .. "/created.txt"
+      RequestDiff.capture(handle_id, "Write", { file_path = file })
+      write_file(file, "hello\n")
+
+      local files, _, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+
+      assert.same({ "created.txt" }, files)
+      assert.is_truthy(patch:find("--- /dev/null", 1, true))
+      assert.is_truthy(patch:find("+++ b/created.txt", 1, true))
+      assert.is_truthy(patch:find("+hello", 1, true))
+    end)
+
+    it("skips files whose content did not change", function()
+      local file = tmp_dir .. "/same.txt"
+      write_file(file, "unchanged\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+
+      local files, _, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+      assert.same({}, files)
+      assert.is_nil(patch)
+    end)
+
+    it("lists uncaptured extra paths without a diff section", function()
+      local captured = tmp_dir .. "/captured.txt"
+      write_file(captured, "a\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = captured })
+      write_file(captured, "b\n")
+
+      local extra = tmp_dir .. "/bash-touched.txt"
+      write_file(extra, "x\n")
+
+      local files, _, patch = RequestDiff.generate(handle_id, tmp_dir, { [extra] = true })
+
+      assert.same({ "captured.txt", "bash-touched.txt" }, files)
+      assert.is_truthy(patch:find("diff --git a/captured.txt", 1, true))
+      assert.is_falsy(patch:find("bash-touched.txt", 1, true))
+    end)
+
+    it("keeps requests isolated per handle_id", function()
+      local other_handle = handle_id .. "-other"
+      local file_a = tmp_dir .. "/a.txt"
+      local file_b = tmp_dir .. "/b.txt"
+      write_file(file_a, "a\n")
+      write_file(file_b, "b\n")
+
+      RequestDiff.capture(handle_id, "Edit", { file_path = file_a })
+      RequestDiff.capture(other_handle, "Edit", { file_path = file_b })
+      write_file(file_a, "a2\n")
+      write_file(file_b, "b2\n")
+
+      local files_a = RequestDiff.generate(handle_id, tmp_dir, nil)
+      local files_b = RequestDiff.generate(other_handle, tmp_dir, nil)
+
+      assert.same({ "a.txt" }, files_a)
+      assert.same({ "b.txt" }, files_b)
+
+      RequestDiff.clear(other_handle)
+    end)
+
+    it("is compatible with the patch viewer parser and git apply --reverse", function()
+      local file = tmp_dir .. "/roundtrip.txt"
+      write_file(file, "one\ntwo\nthree\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      write_file(file, "one\nTWO\nthree\n")
+
+      local _, _, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+      local parser = require("vibing.ui.patch_viewer.parser")
+
+      assert.equals(tmp_dir, parser.extract_base_dir(patch))
+      local listed = parser.extract_files(patch)
+      assert.same({ "roundtrip.txt" }, listed)
+
+      local file_diff = parser.extract_file_diff(patch, "roundtrip.txt")
+      assert.is_truthy(file_diff)
+
+      -- リバース適用で変更前の内容に戻ること
+      local patch_file = tmp_dir .. "/x.patch"
+      write_file(patch_file, file_diff .. "\n")
+      local result = vim
+        .system({ "git", "apply", "--reverse", "--whitespace=nowarn", patch_file }, { cwd = tmp_dir, text = true })
+        :wait()
+      assert.equals(0, result.code, result.stderr)
+      assert.equals("one\ntwo\nthree\n", read_file(file))
+    end)
+  end)
+
+  describe("clear", function()
+    it("removes backups for the handle", function()
+      local file = tmp_dir .. "/a.txt"
+      write_file(file, "a\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      RequestDiff.clear(handle_id)
+      assert.is_false(RequestDiff.has_capture(handle_id, file))
+    end)
+  end)
+end)


### PR DESCRIPTION
Replace the default whole-tree mote snapshot flow with a per-request
mechanism that scales with the number of files actually touched:

- New request_diff.lua backs up Write/Edit/NotebookEdit targets at
  PreToolUse time (before the tool runs) keyed by handle_id, then
  generates a git-style patch with vim.diff() when the response
  completes. No external processes, no tree scanning, and concurrent
  chat buffers can never contaminate each other's diffs.
- The PreToolUse permission handler captures the pre-edit content on
  its allow path, so the baseline is exact even mid-request.
- send_message.lua now runs mote only when diff.tool = "mote" or the
  chat has mote_dirs frontmatter; the lightweight path is the default.
  Modified Files always includes tool-event-reported paths so files
  missed by the diff backend are still listed.
- Patch viewer revert supports the new git-style patches via
  git apply --reverse; mote patches keep the snapshot restore path.
- gd fallback (no patch comment found) now shows git diff unless
  diff.tool = "mote".

This fixes runaway mote object growth in virtual-monorepo setups where
Neovim runs at the monorepo root and every request snapshotted all
workspace worktrees.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4B6op2dqo9byF2gUdiCgw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-level diff tracking for file changes, supporting concurrent chats and newly created or deleted files.
  * Diff viewing now uses Git-based patches by default and opens results in a read-only split view.
  * Added support for reverting request-generated patches across one or multiple files.
  * Existing Mote-based diffs remain available as an explicit configuration option.

* **Documentation**
  * Updated configuration and feature documentation to explain diff behavior, backups, storage, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->