### PR TITLE
fix: address review findings on per-request diff tracking

### DIFF
--- a/.claude/rules/configuration.md
+++ b/.claude/rules/configuration.md
@@ -31,7 +31,8 @@ require("vibing").setup({
   diff = {
     tool = "auto",  -- "git" | "mote" | "auto"
     -- "auto"/"git": Lightweight per-request diff (default). Files touched by
-    --   Write/Edit/NotebookEdit are backed up at PreToolUse time and diffed after the response — no
+    --   Write/Edit/MultiEdit/NotebookEdit are backed up at PreToolUse time and diffed after the
+    --   response — no
     --   whole-tree scanning, no external processes. `gd` falls back to git diff when no
     --   patch file is found.
     -- "mote": Opt-in mote snapshot tracking (requires mote v0.2.4+:
@@ -142,7 +143,7 @@ require("vibing").setup({
 ## Per-Request Diff Tracking (Default)
 
 By default (`diff.tool = "auto"` or `"git"`), vibing.nvim tracks per-request changes without
-mote: when Claude is about to run Write/Edit/NotebookEdit, the PreToolUse hook backs up the
+mote: when Claude is about to run Write/Edit/MultiEdit/NotebookEdit, the PreToolUse hook backs up the
 target file's pre-edit content, and after the response a git-style patch is generated with
 `vim.diff()` (built-in xdiff, no external processes). Patches are stored under
 `.vibing/patches/` and referenced from the chat buffer via `<!-- patch: ... -->` comments, so

--- a/.claude/rules/configuration.md
+++ b/.claude/rules/configuration.md
@@ -30,8 +30,8 @@ require("vibing").setup({
   },
   diff = {
     tool = "auto",  -- "git" | "mote" | "auto"
-    -- "auto"/"git": Lightweight per-request diff (default). Files touched by Write/Edit are
-    --   backed up at PreToolUse time and diffed with vim.diff() after the response — no
+    -- "auto"/"git": Lightweight per-request diff (default). Files touched by
+    --   Write/Edit/NotebookEdit are backed up at PreToolUse time and diffed after the response — no
     --   whole-tree scanning, no external processes. `gd` falls back to git diff when no
     --   patch file is found.
     -- "mote": Opt-in mote snapshot tracking (requires mote v0.2.4+:

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -129,7 +129,7 @@ function M.execute(adapter, callbacks, message, config)
       language = lang_code,
       cwd = session_cwd,
       on_tool_use = function(tool, file_path, _command)
-        if (tool == "Write" or tool == "Edit" or tool == "NotebookEdit") and file_path then
+        if (tool == "Write" or tool == "Edit" or tool == "MultiEdit" or tool == "NotebookEdit") and file_path then
           modified_file_paths[file_path] = true
         elseif tool == "FileChange" and file_path then
           -- Codex adapter reports comma-joined paths
@@ -308,12 +308,24 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
         diff_timeout_timer = nil
       end
       RequestDiff.clear(handle_id_for_diff)
-      -- moteのignore設定等でdiffから漏れたファイルも、ツールイベントで検知した分は必ず一覧に載せる
+      -- moteのignore設定等でdiffから漏れたファイルも、ツールイベントで検知した分は必ず一覧に載せる。
+      -- mote出力はmc.cwd相対パスなので、絶対パスに直して重複判定し、追加分は絶対パスで載せる
+      -- （BufferReloadがNeovimのcwd基準で誤解決しないように）
       for path in pairs(modified_file_paths or {}) do
-        local rel = vim.fn.fnamemodify(path, ":.")
-        if not seen_files[rel] and not seen_files[path] then
-          seen_files[rel] = true
-          table.insert(all_files, rel)
+        local abs = vim.fn.fnamemodify(path, ":p")
+        local dup = seen_files[path] or seen_files[abs]
+        if not dup then
+          for _, mc in ipairs(active_configs) do
+            local base = vim.fn.fnamemodify(mc.cwd or vim.fn.getcwd(), ":p"):gsub("/$", "")
+            if abs:sub(1, #base + 1) == base .. "/" and seen_files[abs:sub(#base + 2)] then
+              dup = true
+              break
+            end
+          end
+        end
+        if not dup then
+          seen_files[abs] = true
+          table.insert(all_files, abs)
         end
       end
       if #all_files > 0 then

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -291,9 +291,8 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
   local handle_id_for_diff = incoming_handle_id or (callbacks.get_handle_id and callbacks.get_handle_id())
 
   if #active_configs > 0 and has_file_changes then
-    -- 全configから変更ファイルを収集し、重複排除して出力
-    local all_files = {}
-    local seen_files = {}
+    -- 各configの変更ファイルを収集し、finalizeで絶対パスに正規化・重複排除して出力
+    local mote_batches = {}
     local patch_paths = {}
     local remaining = #active_configs
     local timestamp = os.date("%Y%m%d_%H%M%S")
@@ -308,32 +307,18 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
         diff_timeout_timer = nil
       end
       RequestDiff.clear(handle_id_for_diff)
-      -- moteのignore設定等でdiffから漏れたファイルも、ツールイベントで検知した分は必ず一覧に載せる。
-      -- mote出力はmc.cwd相対パスなので、絶対パスに直して重複判定し、追加分は絶対パスで載せる
-      -- （BufferReloadがNeovimのcwd基準で誤解決しないように）
-      for path in pairs(modified_file_paths or {}) do
-        local abs = vim.fn.fnamemodify(path, ":p")
-        local dup = seen_files[path] or seen_files[abs]
-        if not dup then
-          for _, mc in ipairs(active_configs) do
-            local base = vim.fn.fnamemodify(mc.cwd or vim.fn.getcwd(), ":p"):gsub("/$", "")
-            if abs:sub(1, #base + 1) == base .. "/" and seen_files[abs:sub(#base + 2)] then
-              dup = true
-              break
-            end
-          end
-        end
-        if not dup then
-          seen_files[abs] = true
-          table.insert(all_files, abs)
-        end
-      end
+      -- moteの結果（mc.cwd相対）とツールイベントのパスを絶対パスに正規化して統合。
+      -- 別mote_dirsの同名相対パスの衝突や、Neovim cwdと異なる作業ディレクトリでの
+      -- 誤ったバッファリロードを防ぐ。moteのignore設定等でdiffから漏れたファイルも
+      -- ツールイベントで検知した分は必ず一覧に載る
+      local all_files = M._merge_modified_files(mote_batches, modified_file_paths)
       if #all_files > 0 then
         BufferReload.reload_files(all_files)
         local MAX_DISPLAY = 50
         local file_lines = {}
         for i = 1, math.min(#all_files, MAX_DISPLAY) do
-          table.insert(file_lines, all_files[i])
+          -- 表示はNeovim cwd相対（cwd外なら絶対パスのまま）、リロードは絶対パス
+          table.insert(file_lines, vim.fn.fnamemodify(all_files[i], ":."))
         end
         if #all_files > MAX_DISPLAY then
           table.insert(file_lines, string.format("... (%d more)", #all_files - MAX_DISPLAY))
@@ -354,12 +339,7 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
     for _, mc in ipairs(active_configs) do
       MoteDiff.get_changed_files(mc, function(success, files, err)
         if success and files then
-          for _, f in ipairs(files) do
-            if not seen_files[f] then
-              seen_files[f] = true
-              table.insert(all_files, f)
-            end
-          end
+          table.insert(mote_batches, { base = mc.cwd or vim.fn.getcwd(), files = files })
         elseif not success then
           vim.notify("[vibing] Failed to get changed files: " .. (err or "Unknown error"), vim.log.levels.WARN)
         end
@@ -394,6 +374,40 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
 
   -- NOTE: clear_handle_id() は呼ばない
   -- 次のsend_message()時にkillすることで、ゾンビプロセス対策になる
+end
+
+---moteの変更ファイル結果とツールイベントのパスを絶対パスに正規化して統合する
+---moteは各configのcwd相対パスを返すため、そのまま扱うと別mote_dirsの同名ファイルが
+---重複排除で潰れたり、Neovim cwd基準の誤ったリロードが起きる
+---@param mote_batches {base: string, files: string[]}[] mote configごとの結果（baseはそのconfigのcwd）
+---@param modified_file_paths table<string, boolean>|nil ツールイベントで検知した変更ファイル
+---@return string[] 重複排除済みの絶対パス一覧
+function M._merge_modified_files(mote_batches, modified_file_paths)
+  local seen = {}
+  local out = {}
+  local function add(abs)
+    if not seen[abs] then
+      seen[abs] = true
+      table.insert(out, abs)
+    end
+  end
+
+  for _, batch in ipairs(mote_batches or {}) do
+    local base = vim.fn.fnamemodify(batch.base, ":p"):gsub("/$", "")
+    for _, f in ipairs(batch.files or {}) do
+      if f:sub(1, 1) == "/" then
+        add(f)
+      else
+        add(base .. "/" .. f)
+      end
+    end
+  end
+
+  for path in pairs(modified_file_paths or {}) do
+    add(vim.fn.fnamemodify(path, ":p"))
+  end
+
+  return out
 end
 
 ---リクエスト単位diff（軽量パス）のModified Files出力とpatch生成

--- a/lua/vibing/core/utils/diff_selector.lua
+++ b/lua/vibing/core/utils/diff_selector.lua
@@ -114,8 +114,10 @@ function M.show_diff(file_path, session_id, cwd, mote_dirs)
   local mote_config = vim.deepcopy(config.diff.mote)
   local context_prefix = mote_config.context_prefix or "vibing"
 
-  if matched_mote_dir and tool ~= "mote" then
-    -- VibingMoteDirでopt-inされたディレクトリ: 送信時と同じディレクトリ単位コンテキストを使う
+  if matched_mote_dir then
+    -- VibingMoteDirで指定されたディレクトリ配下: 送信時（_create_session_mote_configs）は
+    -- diff.toolの値に関係なくmote_dirs優先でディレクトリ単位コンテキストにスナップショットを
+    -- 書くため、表示側も同じコンテキストを使う（tool = "mote" 併用時も含む）
     mote_config.project = mote_config.project or MoteDiff.get_project_name(matched_mote_dir)
     mote_config.context = MoteDiff.build_context_name_from_path(context_prefix, matched_mote_dir)
     mote_config.cwd = matched_mote_dir

--- a/lua/vibing/core/utils/diff_selector.lua
+++ b/lua/vibing/core/utils/diff_selector.lua
@@ -70,6 +70,8 @@ local function show_git_diff(file_path)
 end
 
 ---file_pathを含むmote_dirを探す
+---ファイルパス（gdの対象）を想定しており、mote_dirそのものを指すパスは
+---配下のファイルではないため意図的にマッチさせない
 ---@param file_path string 絶対パス
 ---@param mote_dirs string[]|nil チャットのmote_dirs frontmatter
 ---@return string|nil マッチした追跡ディレクトリ（絶対パス）
@@ -82,6 +84,12 @@ local function find_mote_dir(file_path, mote_dirs)
     end
   end
   return nil
+end
+
+-- テスト用エクスポート
+M._find_mote_dir = find_mote_dir
+M._show_git_diff = function(file_path)
+  return show_git_diff(file_path)
 end
 
 ---ファイルのdiffを表示

--- a/lua/vibing/core/utils/diff_selector.lua
+++ b/lua/vibing/core/utils/diff_selector.lua
@@ -29,16 +29,30 @@ local function show_diff_buffer(output)
   })
 end
 
----ファイルのgit diffを表示（HEADとの比較）
+---ファイルのgit diffを表示
+---追跡済みならHEAD（無ければindex）との比較、未追跡・リポジトリ外なら
+---git diff --no-index /dev/null でファイル全体を新規追加として表示する
 ---@param file_path string ファイルパス（絶対パス）
 local function show_git_diff(file_path)
   local abs = vim.fn.fnamemodify(file_path, ":p")
   local dir = vim.fn.fnamemodify(abs, ":h")
 
-  local result = vim.system({ "git", "diff", "HEAD", "--", abs }, { cwd = dir, text = true }):wait()
-  if result.code ~= 0 then
-    -- HEADが無い場合（初回コミット前など）はworking treeのdiffにフォールバック
-    result = vim.system({ "git", "diff", "--", abs }, { cwd = dir, text = true }):wait()
+  local tracked = vim.system({ "git", "ls-files", "--error-unmatch", "--", abs }, { cwd = dir, text = true }):wait()
+
+  local result
+  if tracked.code == 0 then
+    result = vim.system({ "git", "diff", "HEAD", "--", abs }, { cwd = dir, text = true }):wait()
+    if result.code ~= 0 then
+      -- HEADが無い場合（初回コミット前）はindexとの比較にフォールバック
+      result = vim.system({ "git", "diff", "--cached", "--", abs }, { cwd = dir, text = true }):wait()
+    end
+  else
+    -- 未追跡ファイル・リポジトリ外: /dev/nullと比較して全体を新規として表示
+    -- （--no-indexは差分ありで終了コード1を返すので正常扱い）
+    result = vim.system({ "git", "diff", "--no-index", "--", "/dev/null", abs }, { cwd = dir, text = true }):wait()
+    if result.code == 1 then
+      result.code = 0
+    end
   end
 
   if result.code ~= 0 then
@@ -55,34 +69,59 @@ local function show_git_diff(file_path)
   show_diff_buffer(output)
 end
 
+---file_pathを含むmote_dirを探す
+---@param file_path string 絶対パス
+---@param mote_dirs string[]|nil チャットのmote_dirs frontmatter
+---@return string|nil マッチした追跡ディレクトリ（絶対パス）
+local function find_mote_dir(file_path, mote_dirs)
+  local abs = vim.fn.fnamemodify(file_path, ":p")
+  for _, dir in ipairs(mote_dirs or {}) do
+    local base = vim.fn.fnamemodify(dir, ":p"):gsub("/$", "")
+    if abs:sub(1, #base + 1) == base .. "/" then
+      return base
+    end
+  end
+  return nil
+end
+
 ---ファイルのdiffを表示
----patchファイルが見つからない場合のフォールバック。diff.tool = "mote" のときだけmoteを使い、
+---patchファイルが見つからない場合のフォールバック。送信時のバックエンド選択と同じ規則で、
+---diff.tool = "mote" またはチャットのmote_dirsが対象ファイルをカバーする場合はmote、
 ---それ以外（"auto" / "git"）はgit diffで表示する。
 ---@param file_path string ファイルパス（絶対パス）
 ---@param session_id? string セッションID（未使用、互換性のため保持）
 ---@param cwd? string 作業ディレクトリ（frontmatterのworking_dirから算出、worktree判定用）
-function M.show_diff(file_path, session_id, cwd)
+---@param mote_dirs? string[] チャットのmote_dirs frontmatter（VibingMoteDirで指定）
+function M.show_diff(file_path, session_id, cwd, mote_dirs)
   local config = require("vibing.config").get()
   local tool = config.diff and config.diff.tool or "auto"
 
-  if tool ~= "mote" then
+  local matched_mote_dir = find_mote_dir(file_path, mote_dirs)
+  if tool ~= "mote" and not matched_mote_dir then
     show_git_diff(file_path)
     return
   end
 
   local MoteDiff = require("vibing.core.utils.mote_diff")
   local mote_config = vim.deepcopy(config.diff.mote)
-
-  -- Normalize cwd to absolute path
-  local abs_cwd = cwd and vim.fn.fnamemodify(cwd, ":p") or nil
-
-  -- mote v0.2.4: --project/--context APIを使用
-  mote_config.project = mote_config.project or MoteDiff.get_project_name(abs_cwd)
   local context_prefix = mote_config.context_prefix or "vibing"
-  mote_config.context = MoteDiff.build_context_name(context_prefix, abs_cwd)
 
-  if abs_cwd then
-    mote_config.cwd = abs_cwd
+  if matched_mote_dir and tool ~= "mote" then
+    -- VibingMoteDirでopt-inされたディレクトリ: 送信時と同じディレクトリ単位コンテキストを使う
+    mote_config.project = mote_config.project or MoteDiff.get_project_name(matched_mote_dir)
+    mote_config.context = MoteDiff.build_context_name_from_path(context_prefix, matched_mote_dir)
+    mote_config.cwd = matched_mote_dir
+  else
+    -- Normalize cwd to absolute path
+    local abs_cwd = cwd and vim.fn.fnamemodify(cwd, ":p") or nil
+
+    -- mote v0.2.4: --project/--context APIを使用
+    mote_config.project = mote_config.project or MoteDiff.get_project_name(abs_cwd)
+    mote_config.context = MoteDiff.build_context_name(context_prefix, abs_cwd)
+
+    if abs_cwd then
+      mote_config.cwd = abs_cwd
+    end
   end
 
   MoteDiff.show_diff(file_path, mote_config)

--- a/lua/vibing/core/utils/request_diff.lua
+++ b/lua/vibing/core/utils/request_diff.lua
@@ -53,15 +53,16 @@ end
 
 ---@param abs string 絶対パス
 ---@param base string|nil 基準ディレクトリ（絶対パス）
----@return string base配下なら相対パス、そうでなければ絶対パスのまま
+---@return string rel base配下なら相対パス、そうでなければ絶対パスのまま
+---@return boolean under_base base配下だったか
 local function to_rel(abs, base)
   if base and base ~= "" then
     local prefix = base:sub(-1) == "/" and base or (base .. "/")
     if abs:sub(1, #prefix) == prefix then
-      return abs:sub(#prefix + 1)
+      return abs:sub(#prefix + 1), true
     end
   end
-  return abs
+  return abs, false
 end
 
 ---TTL超過した放置セッション（キャンセルされたリクエスト等）を破棄
@@ -133,31 +134,64 @@ function M.capture(handle_id, tool_name, tool_input)
   table.insert(s.order, abs)
 end
 
+---git diff --no-index で2ファイル間のhunk部分（@@以降）を取得
+---vim.diff()と違い「\ No newline at end of file」マーカーを正しく出力するため、
+---末尾改行がないファイルはこちらで比較する（git apply --reverse での復元が保証される）
+---@param old_path string 比較元（存在しない側は "/dev/null"）
+---@param new_path string 比較先（存在しない側は "/dev/null"）
+---@return string|nil hunks（差分がない/取得できない場合nil）
+local function git_no_index_hunks(old_path, new_path)
+  local result = vim
+    .system({ "git", "diff", "--no-index", "--", old_path, new_path }, { text = true })
+    :wait()
+  -- --no-index は差分ありで終了コード1を返す
+  if result.code ~= 0 and result.code ~= 1 then
+    return nil
+  end
+  local output = result.stdout or ""
+  local hunk_start = output:find("\n@@", 1, true)
+  if not hunk_start then
+    return nil
+  end
+  return output:sub(hunk_start + 1)
+end
+
 ---1ファイル分のdiffセクションを生成
 ---@param rel string 相対パス
+---@param entry Vibing.RequestDiff.Entry 退避情報
+---@param abs string 絶対パス（現在のファイル）
 ---@param before string|nil 変更前内容（nil=ファイルが存在しなかった）
 ---@param after string|nil 変更後内容（nil=ファイルが削除された）
----@return string|nil diffセクション（変更がなければnil）
-local function build_file_section(rel, before, after)
+---@return string|nil diffセクション（変更がない/patch化できない場合nil）
+local function build_file_section(rel, entry, abs, before, after)
   local before_text = before or ""
   local after_text = after or ""
   if before_text == after_text then
     return nil
   end
 
-  local header = string.format("diff --git a/%s b/%s", rel, rel)
-  local old_label = before and ("a/" .. rel) or "/dev/null"
-  local new_label = after and ("b/" .. rel) or "/dev/null"
-
+  -- バイナリはgit applyで復元できるpatchにならないため、一覧のみでdiffセクションは作らない
   if before_text:find("\0", 1, true) or after_text:find("\0", 1, true) then
-    return string.format("%s\nBinary files %s and %s differ", header, old_label, new_label)
+    return nil
   end
 
-  local hunks = vim.diff(before_text, after_text, { result_type = "unified", ctxlen = 3 })
+  local hunks
+  local missing_trailing_newline = (before and before ~= "" and not before:match("\n$"))
+    or (after and after ~= "" and not after:match("\n$"))
+  if missing_trailing_newline then
+    local old_path = (before and entry.backup_path) or "/dev/null"
+    local new_path = after and abs or "/dev/null"
+    hunks = git_no_index_hunks(old_path, new_path)
+  else
+    hunks = vim.diff(before_text, after_text, { result_type = "unified", ctxlen = 3 })
+  end
   if not hunks or hunks == "" then
     return nil
   end
 
+  local header = string.format("diff --git a/%s b/%s", rel, rel)
+  local old_label = before and ("a/" .. rel) or "/dev/null"
+  local new_label = after and ("b/" .. rel) or "/dev/null"
   return string.format("%s\n--- %s\n+++ %s\n%s", header, old_label, new_label, hunks:gsub("\n$", ""))
 end
 
@@ -184,13 +218,18 @@ function M.generate(handle_id, base_dir, extra_paths)
         before = read_file(entry.backup_path)
       end
       local after = read_file(abs)
-      local rel = to_rel(abs, base_dir)
-      local section = build_file_section(rel, before, after)
-      if section then
+      local rel, under_base = to_rel(abs, base_dir)
+      local changed = (before or "") ~= (after or "")
+      -- base_dir外のファイルはgit apply（cwd=base_dir、-p1）で復元できるpatchにならないため、
+      -- 一覧にのみ載せてdiffセクションは作らない（バイナリも同様、build_file_section内で除外）
+      local section = under_base and build_file_section(rel, entry, abs, before, after) or nil
+      if section or changed then
         seen[abs] = true
         table.insert(files, rel)
         table.insert(abs_files, abs)
-        table.insert(sections, section)
+        if section then
+          table.insert(sections, section)
+        end
       end
     end
   end
@@ -200,7 +239,8 @@ function M.generate(handle_id, base_dir, extra_paths)
     local abs = vim.fn.fnamemodify(path, ":p")
     if not seen[abs] and not (s and s.files[abs]) then
       seen[abs] = true
-      table.insert(files, to_rel(abs, base_dir))
+      local rel = to_rel(abs, base_dir)
+      table.insert(files, rel)
       table.insert(abs_files, abs)
     end
   end

--- a/lua/vibing/presentation/chat/modules/keymap_handler.lua
+++ b/lua/vibing/presentation/chat/modules/keymap_handler.lua
@@ -57,16 +57,25 @@ function M.setup(buf, callbacks, keymaps)
         -- patchファイルから該当ファイルのdiffを表示
         PatchViewer.show(session_id, patch_filename, file_path)
       else
-        -- patchがない場合は設定に基づいてdiffツールを選択
-        -- session_idを渡してセッション専用のmote storageを使用
+        -- patchがない場合は送信時と同じ規則でdiffバックエンドを選択
+        -- （diff.tool = "mote" またはmote_dirs該当ならmote、それ以外はgit diff）
         local DiffSelector = require("vibing.core.utils.diff_selector")
-        -- cwdをfrontmatterのworking_dirから取得
+        -- cwd・mote_dirsをチャットのfrontmatterから取得
         local cwd = nil
+        local mote_dirs = nil
         local chat_buf = view.get_chat_buffer(buf)
         if chat_buf then
           cwd = chat_buf:get_cwd()
+          local frontmatter = chat_buf:parse_frontmatter()
+          mote_dirs = frontmatter and frontmatter.mote_dirs
+          if type(mote_dirs) == "string" then
+            mote_dirs = { mote_dirs }
+          end
+          if (not mote_dirs or #mote_dirs == 0) and frontmatter and frontmatter.mote_cwd then
+            mote_dirs = { frontmatter.mote_cwd }
+          end
         end
-        DiffSelector.show_diff(file_path, session_id, cwd)
+        DiffSelector.show_diff(file_path, session_id, cwd, mote_dirs)
       end
     end, { buffer = buf, desc = "Open diff for file under cursor" })
 

--- a/lua/vibing/ui/patch_viewer/revert.lua
+++ b/lua/vibing/ui/patch_viewer/revert.lua
@@ -117,6 +117,19 @@ local function revert_one(ctx, file)
   return restore_file(ctx.context_dir, ctx.snapshot_id, file)
 end
 
+---patch内の相対パスをバッファリロード用に解決する
+---request_diff形式のpatchはbase_dir相対（git applyがcwd=base_dirで動くため）なので、
+---Neovimのcwdと異なっていても正しいファイルをリロードできるよう絶対パスに直す
+---@param ctx Vibing.PatchViewer.RevertContext
+---@param file string patch内の相対パス
+---@return string リロードに使うパス
+local function resolve_reload_path(ctx, file)
+  if ctx.kind == "request_diff" and ctx.base_dir and file:sub(1, 1) ~= "/" then
+    return ctx.base_dir .. "/" .. file
+  end
+  return file
+end
+
 ---@param _ string
 ---@param patch_filename string
 ---@param selected_file string
@@ -138,7 +151,7 @@ function M.revert_single_file(_, patch_filename, selected_file)
   end
 
   local BufferReload = require("vibing.core.utils.buffer_reload")
-  BufferReload.reload_files({ selected_file })
+  BufferReload.reload_files({ resolve_reload_path(ctx, selected_file) })
 
   vim.notify(string.format("Reverted %s", selected_file), vim.log.levels.INFO)
   return true
@@ -173,7 +186,7 @@ function M.revert_all_files(_, patch_filename)
   end
 
   M._report_results(files, failed_files, success_count)
-  M._reload_successful_files(files, failed_files, success_count)
+  M._reload_successful_files(files, failed_files, success_count, ctx)
 
   return success_count > 0
 end
@@ -185,7 +198,7 @@ function M._report_results(files, failed_files, success_count)
   if #failed_files > 0 then
     local error_msg = string.format("Reverted %d/%d files. Failed files:\n", success_count, #files)
     for _, failure in ipairs(failed_files) do
-      error_msg = error_msg .. string.format("  - %s: %s\n", failure.file, failure.error)
+      error_msg = error_msg .. string.format("  - %s: %s\n", failure.file, failure.error or "unknown error")
     end
     vim.notify(error_msg, vim.log.levels.WARN)
   else
@@ -196,7 +209,8 @@ end
 ---@param files string[]
 ---@param failed_files { file: string, error: string? }[]
 ---@param success_count number
-function M._reload_successful_files(files, failed_files, success_count)
+---@param ctx Vibing.PatchViewer.RevertContext|nil
+function M._reload_successful_files(files, failed_files, success_count, ctx)
   if success_count == 0 then
     return
   end
@@ -209,7 +223,7 @@ function M._reload_successful_files(files, failed_files, success_count)
   local success_files = {}
   for _, file in ipairs(files) do
     if not failed_set[file] then
-      table.insert(success_files, file)
+      table.insert(success_files, ctx and resolve_reload_path(ctx, file) or file)
     end
   end
 

--- a/tests/lua/application/chat/send_message_spec.lua
+++ b/tests/lua/application/chat/send_message_spec.lua
@@ -1,54 +1,50 @@
 local SendMessage = require("vibing.application.chat.send_message")
 
-describe("send_message", function()
-  describe("execute", function()
-    it("propagates the sending chat buffer's file path as opts.chat_file_path", function()
-      local buf = vim.api.nvim_create_buf(false, true)
-      local file_path = vim.fn.tempname() .. ".md"
-      vim.api.nvim_buf_set_name(buf, file_path)
+describe("send_message._merge_modified_files", function()
+  it("resolves mote-relative paths against each batch's own base", function()
+    local result = SendMessage._merge_modified_files({
+      { base = "/repo/workspaces/app-a", files = { "src/main.lua" } },
+      { base = "/repo/workspaces/app-b", files = { "src/main.lua" } },
+    }, nil)
 
-      local callbacks = {
-        get_bufnr = function()
-          return buf
-        end,
-        get_session_id = function()
-          return "test-session"
-        end,
-        parse_frontmatter = function()
-          return {}
-        end,
-        extract_conversation = function()
-          return {}
-        end,
-        update_filename_from_message = function(_) end,
-        start_response = function() end,
-        get_session_allow = function()
-          return {}
-        end,
-        get_session_deny = function()
-          return {}
-        end,
-        add_user_section = function() end,
-      }
+    -- 別mote_dirsの同名相対パスが衝突せず両方残ること
+    assert.same({
+      "/repo/workspaces/app-a/src/main.lua",
+      "/repo/workspaces/app-b/src/main.lua",
+    }, result)
+  end)
 
-      local captured = {}
-      local adapter = {
-        supports = function(_, _feature)
-          return false
-        end,
-        execute = function(_, prompt, opts)
-          captured.opts = opts
-          captured.prompt = prompt
-          return { content = "ok" }
-        end,
-      }
+  it("keeps absolute mote paths as-is", function()
+    local result = SendMessage._merge_modified_files({
+      { base = "/repo", files = { "/repo/src/a.lua", "src/b.lua" } },
+    }, nil)
 
-      SendMessage.execute(adapter, callbacks, "hello", {})
+    assert.same({ "/repo/src/a.lua", "/repo/src/b.lua" }, result)
+  end)
 
-      assert.is_not_nil(captured.opts)
-      assert.equals(vim.api.nvim_buf_get_name(buf), captured.opts.chat_file_path)
+  it("unions tool-event paths and dedupes against mote results", function()
+    local result = SendMessage._merge_modified_files({
+      { base = "/repo", files = { "src/a.lua" } },
+    }, {
+      ["/repo/src/a.lua"] = true,
+      ["/repo/src/only-tool-event.lua"] = true,
+    })
 
-      vim.api.nvim_buf_delete(buf, { force = true })
-    end)
+    assert.equals(2, #result)
+    assert.equals("/repo/src/a.lua", result[1])
+    assert.equals("/repo/src/only-tool-event.lua", result[2])
+  end)
+
+  it("handles empty inputs", function()
+    assert.same({}, SendMessage._merge_modified_files({}, nil))
+    assert.same({}, SendMessage._merge_modified_files(nil, {}))
+  end)
+
+  it("strips trailing slashes from batch bases", function()
+    local result = SendMessage._merge_modified_files({
+      { base = "/repo/dir/", files = { "x.lua" } },
+    }, nil)
+
+    assert.same({ "/repo/dir/x.lua" }, result)
   end)
 end)

--- a/tests/lua/application/chat/send_message_spec.lua
+++ b/tests/lua/application/chat/send_message_spec.lua
@@ -1,50 +1,103 @@
 local SendMessage = require("vibing.application.chat.send_message")
 
-describe("send_message._merge_modified_files", function()
-  it("resolves mote-relative paths against each batch's own base", function()
-    local result = SendMessage._merge_modified_files({
-      { base = "/repo/workspaces/app-a", files = { "src/main.lua" } },
-      { base = "/repo/workspaces/app-b", files = { "src/main.lua" } },
-    }, nil)
+describe("send_message", function()
+  describe("execute", function()
+    it("propagates the sending chat buffer's file path as opts.chat_file_path", function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      local file_path = vim.fn.tempname() .. ".md"
+      vim.api.nvim_buf_set_name(buf, file_path)
 
-    -- 別mote_dirsの同名相対パスが衝突せず両方残ること
-    assert.same({
-      "/repo/workspaces/app-a/src/main.lua",
-      "/repo/workspaces/app-b/src/main.lua",
-    }, result)
+      local callbacks = {
+        get_bufnr = function()
+          return buf
+        end,
+        get_session_id = function()
+          return "test-session"
+        end,
+        parse_frontmatter = function()
+          return {}
+        end,
+        extract_conversation = function()
+          return {}
+        end,
+        update_filename_from_message = function(_) end,
+        start_response = function() end,
+        get_session_allow = function()
+          return {}
+        end,
+        get_session_deny = function()
+          return {}
+        end,
+        add_user_section = function() end,
+      }
+
+      local captured = {}
+      local adapter = {
+        supports = function(_, _feature)
+          return false
+        end,
+        execute = function(_, prompt, opts)
+          captured.opts = opts
+          captured.prompt = prompt
+          return { content = "ok" }
+        end,
+      }
+
+      SendMessage.execute(adapter, callbacks, "hello", {})
+
+      assert.is_not_nil(captured.opts)
+      assert.equals(vim.api.nvim_buf_get_name(buf), captured.opts.chat_file_path)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
   end)
 
-  it("keeps absolute mote paths as-is", function()
-    local result = SendMessage._merge_modified_files({
-      { base = "/repo", files = { "/repo/src/a.lua", "src/b.lua" } },
-    }, nil)
+  describe("_merge_modified_files", function()
+    it("resolves mote-relative paths against each batch's own base", function()
+      local result = SendMessage._merge_modified_files({
+        { base = "/repo/workspaces/app-a", files = { "src/main.lua" } },
+        { base = "/repo/workspaces/app-b", files = { "src/main.lua" } },
+      }, nil)
 
-    assert.same({ "/repo/src/a.lua", "/repo/src/b.lua" }, result)
-  end)
+      -- 別mote_dirsの同名相対パスが衝突せず両方残ること
+      assert.same({
+        "/repo/workspaces/app-a/src/main.lua",
+        "/repo/workspaces/app-b/src/main.lua",
+      }, result)
+    end)
 
-  it("unions tool-event paths and dedupes against mote results", function()
-    local result = SendMessage._merge_modified_files({
-      { base = "/repo", files = { "src/a.lua" } },
-    }, {
-      ["/repo/src/a.lua"] = true,
-      ["/repo/src/only-tool-event.lua"] = true,
-    })
+    it("keeps absolute mote paths as-is", function()
+      local result = SendMessage._merge_modified_files({
+        { base = "/repo", files = { "/repo/src/a.lua", "src/b.lua" } },
+      }, nil)
 
-    assert.equals(2, #result)
-    assert.equals("/repo/src/a.lua", result[1])
-    assert.equals("/repo/src/only-tool-event.lua", result[2])
-  end)
+      assert.same({ "/repo/src/a.lua", "/repo/src/b.lua" }, result)
+    end)
 
-  it("handles empty inputs", function()
-    assert.same({}, SendMessage._merge_modified_files({}, nil))
-    assert.same({}, SendMessage._merge_modified_files(nil, {}))
-  end)
+    it("unions tool-event paths and dedupes against mote results", function()
+      local result = SendMessage._merge_modified_files({
+        { base = "/repo", files = { "src/a.lua" } },
+      }, {
+        ["/repo/src/a.lua"] = true,
+        ["/repo/src/only-tool-event.lua"] = true,
+      })
 
-  it("strips trailing slashes from batch bases", function()
-    local result = SendMessage._merge_modified_files({
-      { base = "/repo/dir/", files = { "x.lua" } },
-    }, nil)
+      assert.equals(2, #result)
+      assert.equals("/repo/src/a.lua", result[1])
+      assert.equals("/repo/src/only-tool-event.lua", result[2])
+    end)
 
-    assert.same({ "/repo/dir/x.lua" }, result)
+    it("handles empty inputs", function()
+      assert.same({}, SendMessage._merge_modified_files({}, nil))
+      assert.same({}, SendMessage._merge_modified_files(nil, {}))
+    end)
+
+    it("strips trailing slashes from batch bases", function()
+      local result = SendMessage._merge_modified_files({
+        { base = "/repo/dir/", files = { "x.lua" } },
+      }, nil)
+
+      assert.same({ "/repo/dir/x.lua" }, result)
+    end)
   end)
 end)

--- a/tests/lua/core/utils/diff_selector_spec.lua
+++ b/tests/lua/core/utils/diff_selector_spec.lua
@@ -1,0 +1,137 @@
+local DiffSelector = require("vibing.core.utils.diff_selector")
+
+describe("diff_selector", function()
+  describe("_find_mote_dir", function()
+    it("returns the mote_dir containing the file", function()
+      local dir = DiffSelector._find_mote_dir("/repo/workspaces/app/src/main.lua", {
+        "/repo/workspaces/other",
+        "/repo/workspaces/app",
+      })
+      assert.equals("/repo/workspaces/app", dir)
+    end)
+
+    it("returns nil when no mote_dir contains the file", function()
+      assert.is_nil(DiffSelector._find_mote_dir("/elsewhere/file.lua", { "/repo/workspaces/app" }))
+    end)
+
+    it("returns nil for empty or missing mote_dirs", function()
+      assert.is_nil(DiffSelector._find_mote_dir("/repo/file.lua", {}))
+      assert.is_nil(DiffSelector._find_mote_dir("/repo/file.lua", nil))
+    end)
+
+    it("does not match a path prefix that is not a directory boundary", function()
+      assert.is_nil(DiffSelector._find_mote_dir("/repo/workspaces/app-extra/file.lua", { "/repo/workspaces/app" }))
+    end)
+
+    it("does not match the mote_dir itself (files only, by design)", function()
+      assert.is_nil(DiffSelector._find_mote_dir("/repo/workspaces/app", { "/repo/workspaces/app" }))
+    end)
+
+    it("normalizes trailing slashes on mote_dirs", function()
+      local dir = DiffSelector._find_mote_dir("/repo/workspaces/app/file.lua", { "/repo/workspaces/app/" })
+      assert.equals("/repo/workspaces/app", dir)
+    end)
+  end)
+
+  describe("_show_git_diff", function()
+    local repo_dir
+    local notify_messages
+    local original_notify
+
+    local function write_file(path, content)
+      local f = assert(io.open(path, "w"))
+      f:write(content)
+      f:close()
+    end
+
+    local function git(args)
+      local cmd = { "git" }
+      vim.list_extend(cmd, args)
+      local result = vim.system(cmd, { cwd = repo_dir, text = true }):wait()
+      assert.equals(0, result.code, result.stderr)
+    end
+
+    ---現在のウィンドウに表示されたdiffバッファの内容を返す
+    local function current_diff_buffer_text()
+      local buf = vim.api.nvim_get_current_buf()
+      if vim.bo[buf].filetype ~= "diff" then
+        return nil
+      end
+      return table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
+    end
+
+    before_each(function()
+      repo_dir = vim.fn.tempname()
+      vim.fn.mkdir(repo_dir, "p")
+      repo_dir = vim.fn.fnamemodify(repo_dir, ":p"):gsub("/$", "")
+      git({ "init", "-q" })
+      git({ "config", "user.email", "test@example.com" })
+      git({ "config", "user.name", "test" })
+
+      notify_messages = {}
+      original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notify_messages, { msg = msg, level = level })
+      end
+    end)
+
+    after_each(function()
+      vim.notify = original_notify
+      vim.cmd("only")
+      vim.fn.delete(repo_dir, "rf")
+    end)
+
+    it("shows HEAD diff for a tracked modified file", function()
+      local file = repo_dir .. "/tracked.txt"
+      write_file(file, "before\n")
+      git({ "add", "." })
+      git({ "commit", "-q", "-m", "init" })
+      write_file(file, "after\n")
+
+      DiffSelector._show_git_diff(file)
+
+      local text = current_diff_buffer_text()
+      assert.is_truthy(text)
+      assert.is_truthy(text:find("-before", 1, true))
+      assert.is_truthy(text:find("+after", 1, true))
+    end)
+
+    it("shows the whole file as new for an untracked file", function()
+      local file = repo_dir .. "/untracked.txt"
+      write_file(file, "brand new\n")
+
+      DiffSelector._show_git_diff(file)
+
+      local text = current_diff_buffer_text()
+      assert.is_truthy(text)
+      assert.is_truthy(text:find("+brand new", 1, true))
+      assert.is_truthy(text:find("/dev/null", 1, true))
+    end)
+
+    it("falls back to the index diff for a staged file before the first commit", function()
+      local file = repo_dir .. "/staged.txt"
+      write_file(file, "staged content\n")
+      git({ "add", "." })
+
+      DiffSelector._show_git_diff(file)
+
+      local text = current_diff_buffer_text()
+      assert.is_truthy(text)
+      assert.is_truthy(text:find("+staged content", 1, true))
+    end)
+
+    it("notifies instead of opening a window when there are no changes", function()
+      local file = repo_dir .. "/clean.txt"
+      write_file(file, "committed\n")
+      git({ "add", "." })
+      git({ "commit", "-q", "-m", "init" })
+
+      local win_count_before = #vim.api.nvim_list_wins()
+      DiffSelector._show_git_diff(file)
+
+      assert.equals(win_count_before, #vim.api.nvim_list_wins())
+      assert.equals(1, #notify_messages)
+      assert.is_truthy(notify_messages[1].msg:find("No changes to show", 1, true))
+    end)
+  end)
+end)

--- a/tests/lua/core/utils/diff_selector_spec.lua
+++ b/tests/lua/core/utils/diff_selector_spec.lua
@@ -33,6 +33,82 @@ describe("diff_selector", function()
     end)
   end)
 
+  describe("show_diff mote context selection", function()
+    local Config = require("vibing.config")
+    local original_get
+    local original_mote_diff
+    local captured
+
+    ---MoteDiffをスタブし、show_diffに渡されたconfigをキャプチャする
+    local function stub_mote_diff()
+      captured = {}
+      original_mote_diff = package.loaded["vibing.core.utils.mote_diff"]
+      package.loaded["vibing.core.utils.mote_diff"] = {
+        get_project_name = function()
+          return "test-project"
+        end,
+        build_context_name = function(prefix, cwd)
+          return prefix .. "-session-context"
+        end,
+        build_context_name_from_path = function(prefix, path)
+          return prefix .. "-dir-context"
+        end,
+        show_diff = function(_, mote_config)
+          captured.mote_config = mote_config
+        end,
+      }
+    end
+
+    local function stub_config(tool)
+      original_get = Config.get
+      Config.get = function()
+        return { diff = { tool = tool, mote = { context_prefix = "vibing" } } }
+      end
+    end
+
+    after_each(function()
+      if original_get then
+        Config.get = original_get
+        original_get = nil
+      end
+      if original_mote_diff ~= nil then
+        package.loaded["vibing.core.utils.mote_diff"] = original_mote_diff
+        original_mote_diff = nil
+      end
+    end)
+
+    it("uses the per-dir context when the file is under a mote_dir, even with tool = mote", function()
+      -- 送信時（_create_session_mote_configs）はmote_dirs優先でディレクトリ単位コンテキストに
+      -- スナップショットを書くため、tool = "mote" 併用時も表示側は同じコンテキストを使うこと
+      stub_config("mote")
+      stub_mote_diff()
+
+      DiffSelector.show_diff("/repo/workspaces/app/src/x.lua", nil, "/repo", { "/repo/workspaces/app" })
+
+      assert.equals("vibing-dir-context", captured.mote_config.context)
+      assert.equals("/repo/workspaces/app", captured.mote_config.cwd)
+    end)
+
+    it("uses the session-cwd context with tool = mote and no matching mote_dir", function()
+      stub_config("mote")
+      stub_mote_diff()
+
+      DiffSelector.show_diff("/repo/src/x.lua", nil, "/repo", nil)
+
+      assert.equals("vibing-session-context", captured.mote_config.context)
+    end)
+
+    it("uses the per-dir context when a mote_dir matches under tool = auto", function()
+      stub_config("auto")
+      stub_mote_diff()
+
+      DiffSelector.show_diff("/repo/workspaces/app/src/x.lua", nil, "/repo", { "/repo/workspaces/app" })
+
+      assert.equals("vibing-dir-context", captured.mote_config.context)
+      assert.equals("/repo/workspaces/app", captured.mote_config.cwd)
+    end)
+  end)
+
   describe("_show_git_diff", function()
     local repo_dir
     local notify_messages

--- a/tests/lua/core/utils/request_diff_spec.lua
+++ b/tests/lua/core/utils/request_diff_spec.lua
@@ -155,6 +155,56 @@ describe("request_diff", function()
       RequestDiff.clear(other_handle)
     end)
 
+    it("lists files outside base_dir without a diff section", function()
+      local outside_dir = vim.fn.tempname()
+      vim.fn.mkdir(outside_dir, "p")
+      outside_dir = vim.fn.fnamemodify(outside_dir, ":p"):gsub("/$", "")
+      local outside = outside_dir .. "/outside.txt"
+      write_file(outside, "a\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = outside })
+      write_file(outside, "b\n")
+
+      local files, abs_files, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+
+      assert.same({ outside }, files)
+      assert.same({ outside }, abs_files)
+      assert.is_nil(patch)
+
+      vim.fn.delete(outside_dir, "rf")
+    end)
+
+    it("lists binary files without a diff section", function()
+      local file = tmp_dir .. "/bin.dat"
+      write_file(file, "a\0b")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      write_file(file, "c\0d")
+
+      local files, _, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+
+      assert.same({ "bin.dat" }, files)
+      assert.is_nil(patch)
+    end)
+
+    it("handles files without trailing newlines so reverse-apply restores them exactly", function()
+      local file = tmp_dir .. "/no-newline.txt"
+      write_file(file, "one\ntwo")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      write_file(file, "one\nTWO")
+
+      local _, _, patch = RequestDiff.generate(handle_id, tmp_dir, nil)
+      assert.is_truthy(patch)
+      assert.is_truthy(patch:find("No newline at end of file", 1, true))
+
+      local patch_file = tmp_dir .. "/nn.patch"
+      local parser = require("vibing.ui.patch_viewer.parser")
+      write_file(patch_file, parser.extract_file_diff(patch, "no-newline.txt") .. "\n")
+      local result = vim
+        .system({ "git", "apply", "--reverse", "--whitespace=nowarn", patch_file }, { cwd = tmp_dir, text = true })
+        :wait()
+      assert.equals(0, result.code, result.stderr)
+      assert.equals("one\ntwo", read_file(file))
+    end)
+
     it("is compatible with the patch viewer parser and git apply --reverse", function()
       local file = tmp_dir .. "/roundtrip.txt"
       write_file(file, "one\ntwo\nthree\n")


### PR DESCRIPTION
# Pull Request

## Summary

Follow-up to #479 addressing the CodeRabbit review comments that were posted before the merge. Fixes real bugs in the per-request diff mechanism (MultiEdit handling, revert reload paths, no-trailing-newline patches) and hardens the patch/diff fallbacks.

## Changes

- Record `MultiEdit` in the tool-event filter so a MultiEdit-only request keeps its captured baseline and produces a patch
- Exclude out-of-base and binary files from patch sections (list-only) so `git apply --reverse` never receives unresolvable paths or stanzas
- Generate hunks via `git diff --no-index` when either side lacks a trailing newline, preserving the `\ No newline at end of file` marker so reverse-apply restores content byte-exactly
- Resolve reverted request-diff files against the patch `base_dir` before buffer reload (session cwd may differ from Neovim cwd)
- Normalize tool-event paths to absolute in the mote finalize union to avoid duplicate Modified Files entries and wrong-relative reloads
- Honor a chat's `mote_dirs` frontmatter in the `gd` fallback backend selection, matching send-time behavior
- Handle untracked files and unborn `HEAD` in the git diff fallback (`git diff --no-index /dev/null`, `git diff --cached`)
- Guard nil error messages in the revert failure report
- Mention `NotebookEdit` in the configuration example

One review suggestion was intentionally not taken: session_id-scoped mote contexts would contradict the by-design worktree-shared contexts (per-request isolation comes from baselines/patches); the stale comment implying session-scoped storage was corrected instead.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [ ] Tested locally in Neovim
- [ ] Ran `npm run validate`
- [ ] Ran `npm run lint`
- [ ] Ran `npm run format:check`
- [ ] Tested with multiple configurations
- [x] Manual testing completed

Ran the full plenary suite headlessly (all specs green; the request_diff spec now covers 15 cases including a `git apply --reverse` byte-exact restore of a file without a trailing newline, out-of-base list-only handling, and binary list-only handling).

### Test Environment

- **Neovim version**: NVIM v0.10.4
- **Operating System**: Linux (Ubuntu-based CI container)
- **Node.js version**: not applicable (Lua-only changes)

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [x] Code comments added/updated (if applicable)

`.claude/rules/configuration.md` example updated to mention `NotebookEdit`.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

Relates to #479

## Screenshots / Videos

Not applicable.

## Additional Context

The base branch CI on `main` is currently red at the #479 merge commit due to a GitHub Actions incident (`Failed to resolve action download info. Error: Service Unavailable` during job setup), not a code failure. Merging this PR will trigger a fresh `main` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4B6op2dqo9byF2gUdiCgw

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4B6op2dqo9byF2gUdiCgw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded change tracking to include multi-file edits and notebook updates.
  - Improved diff selection across configured directories, untracked files, and files outside the current workspace.
  - Added support for displaying changes without trailing newlines while suppressing binary patch content.

- **Bug Fixes**
  - File reloads and reversions now consistently resolve paths and handle missing error details.
  - Changed files remain visible even when a patch cannot be generated.

- **Documentation**
  - Updated documentation to reflect notebook edit tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->