### PR TITLE
fix: prevent set -e from silently aborting build.sh on a claude plugin timeout

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -155,8 +155,15 @@ if [ -f "dist/index.js" ]; then
 
         # Capture output instead of streaming it directly so it can be printed
         # below only on failure, keeping successful (repeat) runs quiet.
-        MARKETPLACE_ADD_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace add "$SCRIPT_DIR" 2>&1)"
-        MARKETPLACE_ADD_STATUS=$?
+        # `... || STATUS=$?` (rather than a bare `STATUS=$?` on the next line) is
+        # required under `set -e`: a plain `VAR="$(cmd)"` assignment fails the
+        # *script* the moment cmd's timeout/error trips a non-zero exit, before
+        # the "if $STATUS -ne 0" fallback below ever runs. A command is exempt
+        # from set -e only when it isn't the final element of a && / || list, so
+        # attaching the fallback via `||` on the same line keeps the assignment's
+        # own failure from aborting the script while still capturing its status.
+        MARKETPLACE_ADD_STATUS=0
+        MARKETPLACE_ADD_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace add "$SCRIPT_DIR" 2>&1)" || MARKETPLACE_ADD_STATUS=$?
         if [ $MARKETPLACE_ADD_STATUS -ne 0 ]; then
             echo "[vibing.nvim] ⚠ Warning: 'claude plugin marketplace add' failed"
             echo "$MARKETPLACE_ADD_OUTPUT"
@@ -170,13 +177,15 @@ if [ -f "dist/index.js" ]; then
             # skill/agent changes on its own. Explicitly refresh the marketplace
             # pointer and re-sync the cached plugin snapshot to the current commit.
             echo "[vibing.nvim] vibing-nvim plugin already installed; refreshing cache..."
-            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update vibing-nvim 2>&1)"
-            MARKETPLACE_UPDATE_STATUS=$?
+            # See the MARKETPLACE_ADD_STATUS comment above for why the fallback is
+            # attached via `||` on the same line rather than a separate `STATUS=$?`.
+            MARKETPLACE_UPDATE_STATUS=0
+            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update vibing-nvim 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
             PLUGIN_UPDATE_OUTPUT=""
             PLUGIN_UPDATE_STATUS=1
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ]; then
-                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update vibing-nvim@vibing-nvim 2>&1)"
-                PLUGIN_UPDATE_STATUS=$?
+                PLUGIN_UPDATE_STATUS=0
+                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update vibing-nvim@vibing-nvim 2>&1)" || PLUGIN_UPDATE_STATUS=$?
             fi
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ] && [ $PLUGIN_UPDATE_STATUS -eq 0 ]; then
                 echo "[vibing.nvim] ✓ Synced vibing-nvim plugin cache (restart Claude Code to apply)"


### PR DESCRIPTION
## 背景

#480 で `claude plugin marketplace update`/`install` 等をタイムアウトで保護したが、実機で再現テストしたところ、タイムアウトが発火した際に `build.sh` 自体が「途中で無言で終了する」新しい不具合があることが分かった。

## 原因

```sh
MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout ... claude plugin marketplace update vibing-nvim 2>&1)"
MARKETPLACE_UPDATE_STATUS=$?
```

`build.sh` は `set -e` を有効にしている。`VAR="$(cmd)"` という代入文は、`cmd`（コマンド置換内の最後のコマンド）が非ゼロを返した瞬間、代入文それ自体の終了コードとして伝播し、`set -e` によりスクリプト全体が即座に終了する。これは、直後の `MARKETPLACE_UPDATE_STATUS=$?` や、その後の `if [ $MARKETPLACE_UPDATE_STATUS -ne 0 ]` によるフォールバック処理に到達する前に発生する。

`claude plugin marketplace add/update`・`claude plugin update` はこのパターンで書かれていたため、実際にタイムアウトが起きるとフォールバックの警告メッセージを出さずに `build.sh` が非ゼロ終了コードで落ちてしまう。

### 実機再現

```sh
$ ./build.sh
...
[vibing.nvim] vibing-nvim plugin already installed; refreshing cache...
=== EXIT_CODE=137 elapsed=105s ===
```

`run_with_timeout` 経由で `sleep 999` を実行させて `set -e` 配下で同じ構造を再現したところ、想定通り `set -e` によってスクリプトが即終了することを確認した。

## 修正

`VAR="$(cmd)"` と `STATUS=$?` を分離するのではなく、`VAR="$(cmd)" || STATUS=$?` の形にして同じ行内で失敗を処理する。bashの `set -e` は `&&`/`||` リストの「最後の要素以外」のコマンドの失敗では発火しないため、この形にすることで代入自体の失敗ではスクリプトを止めずに、意図したステータスハンドリング（既存の警告分岐）に正しく到達できる。

対象:
- `MARKETPLACE_ADD_OUTPUT` / `MARKETPLACE_ADD_STATUS`
- `MARKETPLACE_UPDATE_OUTPUT` / `MARKETPLACE_UPDATE_STATUS`
- `PLUGIN_UPDATE_OUTPUT` / `PLUGIN_UPDATE_STATUS`

（`claude plugin list --json | node -e ...` のパイプと `claude plugin install` の `if` 内呼び出しは、`if`/`elif` の条件式内にあるため元々 `set -e` の影響を受けず対応不要。）

## テスト

- `bash -n build.sh` / `/bin/bash -n build.sh` で構文チェック
- 該当関数のみ抽出し、`set -e` 下で `run_with_timeout ... sleep 999` を修正前/修正後の書き方で実行し、修正前は無言で落ちる（`outer exit: 137`）・修正後はステータスを捕捉して継続する（`outer exit: 0`）ことを確認
- `./build.sh` をフルで実行し、正常系で最後まで完走して `exit 0` になることを確認