### PR TITLE
fix: repair vibing-nvim Claude Code plugin MCP server registration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace-manifest.json",
-  "name": "vibing-nvim",
+  "name": "vibing",
   "owner": {
     "name": "shabaraba",
     "url": "https://github.com/shabaraba"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,8 +11,8 @@
   "keywords": ["neovim", "nvim", "mcp", "lsp", "editor"],
   "mcpServers": {
     "vibing-nvim": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/bin/run.mjs"],
+      "command": "sh",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/bin/run.sh"],
       "env": {
         "VIBING_RPC_TIMEOUT": "30000"
       }

--- a/README.ja.md
+++ b/README.ja.md
@@ -175,7 +175,7 @@ vibing.nvimは[Claude Codeプラグイン](https://code.claude.com/docs/en/plugi
 
 ```text
 /plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing-nvim
+/plugin install vibing-nvim@vibing
 ```
 
 いずれの方法でも、`vibing-nvim` MCPサーバー（下記で説明する`mcp__vibing-nvim__*`と同じツール群）に
@@ -192,8 +192,8 @@ Neovimを起動しておく必要はあります。
 **アンインストール：**
 
 ```text
-/plugin uninstall vibing-nvim@vibing-nvim
-/plugin marketplace remove vibing-nvim
+/plugin uninstall vibing-nvim@vibing
+/plugin marketplace remove vibing
 ```
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)を使用

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ user` for you on every build — nothing else to do.
 
 ```text
 /plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing-nvim
+/plugin install vibing-nvim@vibing
 ```
 
 Either way, this registers the `vibing-nvim` MCP server (same tools as `mcp__vibing-nvim__*`
@@ -211,8 +211,8 @@ anything to connect to.
 **Uninstalling:**
 
 ```text
-/plugin uninstall vibing-nvim@vibing-nvim
-/plugin marketplace remove vibing-nvim
+/plugin uninstall vibing-nvim@vibing
+/plugin marketplace remove vibing
 ```
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim)

--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -22,7 +22,7 @@ import { homedir } from 'os';
  * A resolved installed plugin: its registry id and on-disk install path.
  */
 export interface ResolvedPlugin {
-  /** Plugin identifier as it appears in installed_plugins.json, e.g. "vibing-nvim@vibing-nvim" */
+  /** Plugin identifier as it appears in installed_plugins.json, e.g. "vibing-nvim@vibing" */
   id: string;
   /** Absolute path to the plugin's installation directory */
   path: string;
@@ -154,7 +154,7 @@ async function loadEnabledPluginIds(): Promise<Set<string> | null> {
  * @example
  * ```typescript
  * const plugins = await resolveInstalledPlugins();
- * // Returns: [{ id: 'vibing-nvim@vibing-nvim', path: '/path/to/plugin' }, ...]
+ * // Returns: [{ id: 'vibing-nvim@vibing', path: '/path/to/plugin' }, ...]
  * ```
  */
 export async function resolveInstalledPlugins(): Promise<ResolvedPlugin[]> {

--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -82,7 +82,7 @@ async function parseSkillFrontmatter(
 
 /**
  * Derive a plugin's short name from its registry id, e.g.
- * "vibing-nvim@vibing-nvim" -> "vibing-nvim", "document-skills@anthropic-agent-skills" -> "document-skills".
+ * "vibing-nvim@vibing" -> "vibing-nvim", "document-skills@anthropic-agent-skills" -> "document-skills".
  * This is how Claude Code itself namespaces skill invocations ("plugin:skill"),
  * and it's reliable even for plugins nested in a marketplace repo that don't
  * ship their own .claude-plugin/plugin.json (e.g. document-skills).

--- a/build.sh
+++ b/build.sh
@@ -146,6 +146,13 @@ npm install --silent
 echo "[vibing.nvim] Building TypeScript..."
 npm run build --silent
 
+# Record the fingerprint run.mjs's self-build check compares against (same
+# algorithm, via bin/build-fingerprint.mjs), so the plugin cache's run.mjs
+# recognizes this build as fresh on first launch instead of running `npm ci`
+# over the node_modules symlink set up below and replacing it with a real
+# copy until the next build.sh run re-links it.
+"$NODE_EXECUTABLE" bin/write-fingerprint.mjs
+
 # Verify build succeeded
 if [ -f "dist/index.js" ]; then
     echo "[vibing.nvim] ✓ MCP server built successfully"
@@ -193,8 +200,8 @@ if [ -f "dist/index.js" ]; then
         # the migration window instead of two extra `claude` CLI spawns on every
         # future build forever.
         if echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='${OLD_PLUGIN_ID}')?0:1)" 2>/dev/null; then
-            claude plugin uninstall "$OLD_PLUGIN_ID" &> /dev/null || true
-            claude plugin marketplace remove "$OLD_MARKETPLACE_NAME" &> /dev/null || true
+            run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin uninstall "$OLD_PLUGIN_ID" &> /dev/null || true
+            run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace remove "$OLD_MARKETPLACE_NAME" &> /dev/null || true
             PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
         fi
 
@@ -284,8 +291,15 @@ if [ -f "dist/index.js" ]; then
         if [ -n "$PLUGIN_INSTALL_PATH" ]; then
             echo "[vibing.nvim] Syncing plugin cache with this checkout..."
             mkdir -p "$PLUGIN_INSTALL_PATH/mcp-server"
+            # A partial-copy failure here (permission errors, EDR/antivirus
+            # interference — the exact class of environment this sync exists
+            # to work around) must not abort the rest of build.sh under `set
+            # -e`, the way every other `claude plugin ...` call above already
+            # tolerates failure. Capture the status via `||` instead of
+            # letting a failing command be the tail of its own statement.
+            SYNC_STATUS=0
             if command -v rsync &> /dev/null; then
-                rsync -a --delete --exclude='.git' --exclude='/node_modules' --exclude='/mcp-server/node_modules' --exclude='/mcp-server/dist' "$SCRIPT_DIR/" "$PLUGIN_INSTALL_PATH/"
+                rsync -a --delete --exclude='.git' --exclude='/node_modules' --exclude='/mcp-server/node_modules' --exclude='/mcp-server/dist' "$SCRIPT_DIR/" "$PLUGIN_INSTALL_PATH/" || SYNC_STATUS=$?
             else
                 # Portable fallback without rsync. Copy each top-level entry
                 # individually and skip the excluded ones outright, rather than
@@ -301,15 +315,18 @@ if [ -f "dist/index.js" ]; then
                     [ "$name" = ".git" ] && continue
                     [ "$name" = "node_modules" ] && continue
                     [ "$name" = "mcp-server" ] && continue
-                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/"
+                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/" || SYNC_STATUS=$?
                 done
                 for entry in "$MCP_DIR"/* "$MCP_DIR"/.[!.]*; do
                     [ -e "$entry" ] || continue
                     name="$(basename "$entry")"
                     [ "$name" = "node_modules" ] && continue
                     [ "$name" = "dist" ] && continue
-                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/mcp-server/"
+                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/mcp-server/" || SYNC_STATUS=$?
                 done
+            fi
+            if [ "$SYNC_STATUS" -ne 0 ]; then
+                echo "[vibing.nvim] ⚠ Warning: plugin cache sync failed (exit $SYNC_STATUS); cache may be incomplete"
             fi
 
             # Unconditionally (re)point node_modules/dist at this live checkout's own

--- a/build.sh
+++ b/build.sh
@@ -110,11 +110,11 @@ fi
 # `command: "node"` fails with "Executable not found in $PATH" on any machine
 # where node is only installed through one of those. Written after the
 # directory check above so a missing mcp-server/ checkout fails with that
-# clear error instead of a raw redirect failure here.
-NODE_ABS_PATH="$(command -v "$NODE_EXECUTABLE" 2>/dev/null || true)"
-if [ -n "$NODE_ABS_PATH" ]; then
-    echo "$NODE_ABS_PATH" > "${MCP_DIR}/bin/.node-path"
-fi
+# clear error instead of a raw redirect failure here. `command -v` is
+# guaranteed to succeed here (the checks above already proved $NODE_EXECUTABLE
+# is either an executable absolute path or resolvable on PATH), so no extra
+# empty-value guard is needed around it.
+echo "$(command -v "$NODE_EXECUTABLE")" > "${MCP_DIR}/bin/.node-path"
 
 # Install root dependencies (Agent SDK, etc.)
 echo "[vibing.nvim] Installing root dependencies..."
@@ -157,7 +157,12 @@ if [ -f "dist/index.js" ]; then
     # RPC port, so it silently targets the wrong Neovim instance whenever more
     # than one is running (see cli_command_builder.lua's rpc_port handling).
     cd "$SCRIPT_DIR"
-    PLUGIN_INSTALL_HINT="claude plugin marketplace add $SCRIPT_DIR && claude plugin install vibing-nvim@vibing --scope user"
+    MARKETPLACE_NAME="vibing"
+    PLUGIN_ID="vibing-nvim@${MARKETPLACE_NAME}"
+    # Pre-rename identifiers, kept only for the one-time migration cleanup below.
+    OLD_MARKETPLACE_NAME="vibing-nvim"
+    OLD_PLUGIN_ID="vibing-nvim@${OLD_MARKETPLACE_NAME}"
+    PLUGIN_INSTALL_HINT="claude plugin marketplace add $SCRIPT_DIR && claude plugin install ${PLUGIN_ID} --scope user"
     if command -v claude &> /dev/null; then
         # Remove any legacy direct "vibing-nvim" mcpServers registration (e.g. from
         # `claude mcp add` predating the plugin-based install above, or a leftover
@@ -167,17 +172,31 @@ if [ -f "dist/index.js" ]; then
         # no-op when no such entry exists.
         claude mcp remove vibing-nvim --scope user &> /dev/null || true
 
+        # Fetch the installed-plugin list once up front and reuse it below for the
+        # migration-cleanup check, the already-installed check, and (after a
+        # refresh) the installPath lookup, instead of asking `claude` — slow on at
+        # least one real machine in this project's history — for the same data
+        # repeatedly. Re-fetched only after an operation that actually changes it
+        # (a fresh install, or the migration cleanup below).
+        PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
+
         # Remove the pre-rename "vibing-nvim" marketplace/plugin registration (this
         # marketplace was renamed to "vibing" so the plugin-scoped MCP tool prefix
-        # isn't mcp__plugin_vibing-nvim_vibing-nvim__* — see git history). `claude
-        # plugin marketplace add` on the same directory does not migrate an
-        # existing registration to the new name on its own, so without this an
-        # upgrading user would end up with both the old and new marketplace/plugin
-        # registered side by side — reintroducing the very duplicate-tool-name
-        # problem this rename fixed, just under two names instead of one. Ignore
-        # failure: a no-op once no one is left on the old name.
-        claude plugin uninstall vibing-nvim@vibing-nvim &> /dev/null || true
-        claude plugin marketplace remove vibing-nvim &> /dev/null || true
+        # isn't mcp__plugin_vibing-nvim_vibing-nvim__* — see git history), but only
+        # when there's actual evidence of it in the plugin list. `claude plugin
+        # marketplace add` on the same directory does not migrate an existing
+        # registration to the new name on its own, so without this an upgrading
+        # user would end up with both the old and new marketplace/plugin registered
+        # side by side — reintroducing the very duplicate-tool-name problem this
+        # rename fixed, just under two names instead of one. Gating on the list
+        # (rather than running unconditionally) keeps this a one-time cost during
+        # the migration window instead of two extra `claude` CLI spawns on every
+        # future build forever.
+        if echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='${OLD_PLUGIN_ID}')?0:1)" 2>/dev/null; then
+            claude plugin uninstall "$OLD_PLUGIN_ID" &> /dev/null || true
+            claude plugin marketplace remove "$OLD_MARKETPLACE_NAME" &> /dev/null || true
+            PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
+        fi
 
         # Capture output instead of streaming it directly so it can be printed
         # below only on failure, keeping successful (repeat) runs quiet.
@@ -197,7 +216,7 @@ if [ -f "dist/index.js" ]; then
         # Query installed state as JSON rather than grepping the human-readable table
         # (`claude plugin list`), whose "❯" marker/formatting is a display detail,
         # not a stable contract to match against.
-        elif run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='vibing-nvim@vibing')?0:1)" 2>/dev/null; then
+        elif echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='${PLUGIN_ID}')?0:1)" 2>/dev/null; then
             # Already installed: `claude plugin install` is a no-op here, so on repeat
             # runs (e.g. `:Lazy update` re-invoking this script) it won't pick up
             # skill/agent changes on its own. Explicitly refresh the marketplace
@@ -206,28 +225,31 @@ if [ -f "dist/index.js" ]; then
             # See the MARKETPLACE_ADD_STATUS comment above for why the fallback is
             # attached via `||` on the same line rather than a separate `STATUS=$?`.
             MARKETPLACE_UPDATE_STATUS=0
-            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update vibing 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
+            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update "$MARKETPLACE_NAME" 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
             PLUGIN_UPDATE_OUTPUT=""
             PLUGIN_UPDATE_STATUS=1
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ]; then
                 PLUGIN_UPDATE_STATUS=0
-                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update vibing-nvim@vibing 2>&1)" || PLUGIN_UPDATE_STATUS=$?
+                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update "$PLUGIN_ID" 2>&1)" || PLUGIN_UPDATE_STATUS=$?
             fi
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ] && [ $PLUGIN_UPDATE_STATUS -eq 0 ]; then
                 echo "[vibing.nvim] ✓ Synced vibing-nvim plugin cache (restart Claude Code to apply)"
             elif [ $MARKETPLACE_UPDATE_STATUS -ne 0 ]; then
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin marketplace update' failed"
                 echo "$MARKETPLACE_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing && claude plugin update vibing-nvim@vibing"
+                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update $MARKETPLACE_NAME && claude plugin update $PLUGIN_ID"
             else
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin update' failed"
                 echo "$PLUGIN_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing && claude plugin update vibing-nvim@vibing"
+                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update $MARKETPLACE_NAME && claude plugin update $PLUGIN_ID"
             fi
         else
             echo "[vibing.nvim] Installing vibing-nvim as a Claude Code plugin (user scope)..."
-            if run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin install vibing-nvim@vibing --scope user; then
+            if run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin install "$PLUGIN_ID" --scope user; then
                 echo "[vibing.nvim] ✓ Installed vibing-nvim Claude Code plugin (scope: user)"
+                # The snapshot above predates this install, so it won't have an
+                # installPath for $PLUGIN_ID yet — refetch before using it below.
+                PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
             else
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin install' failed"
                 echo "[vibing.nvim] You can manually install by running: $PLUGIN_INSTALL_HINT"
@@ -253,9 +275,9 @@ if [ -f "dist/index.js" ]; then
         # doing it here would just as easily blow past lazy.nvim's own build-step
         # timeout; (2) a symlink means a later `npm run build` here is reflected
         # immediately without rerunning this sync.
-        PLUGIN_INSTALL_PATH="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null | "$NODE_EXECUTABLE" -e "
+        PLUGIN_INSTALL_PATH="$(echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "
           const plugins = JSON.parse(require('fs').readFileSync(0, 'utf8') || '[]');
-          const p = plugins.find((p) => p.id === 'vibing-nvim@vibing');
+          const p = plugins.find((p) => p.id === '${PLUGIN_ID}');
           process.stdout.write(p && p.installPath ? p.installPath : '');
         " 2>/dev/null)"
 

--- a/build.sh
+++ b/build.sh
@@ -96,6 +96,18 @@ if ! command -v npm &> /dev/null; then
     exit 1
 fi
 
+# Record the exact node binary resolved above so the Claude Code plugin's MCP
+# server launcher (mcp-server/bin/run.sh) can invoke it directly by absolute
+# path instead of relying on `node` being on PATH. Claude Code spawns
+# plugin-declared MCP server commands with a minimal PATH that doesn't
+# include version-manager shims (mise, nvm, volta, asdf, ...), so a bare
+# `command: "node"` fails with "Executable not found in $PATH" on any machine
+# where node is only installed through one of those.
+NODE_ABS_PATH="$(command -v "$NODE_EXECUTABLE" 2>/dev/null || true)"
+if [ -n "$NODE_ABS_PATH" ]; then
+    echo "$NODE_ABS_PATH" > "${MCP_DIR}/bin/.node-path"
+fi
+
 # Check if MCP directory exists
 if [ ! -d "$MCP_DIR" ]; then
     echo "[vibing.nvim] Error: MCP server directory not found: $MCP_DIR"
@@ -143,7 +155,7 @@ if [ -f "dist/index.js" ]; then
     # RPC port, so it silently targets the wrong Neovim instance whenever more
     # than one is running (see cli_command_builder.lua's rpc_port handling).
     cd "$SCRIPT_DIR"
-    PLUGIN_INSTALL_HINT="claude plugin marketplace add $SCRIPT_DIR && claude plugin install vibing-nvim@vibing-nvim --scope user"
+    PLUGIN_INSTALL_HINT="claude plugin marketplace add $SCRIPT_DIR && claude plugin install vibing-nvim@vibing --scope user"
     if command -v claude &> /dev/null; then
         # Remove any legacy direct "vibing-nvim" mcpServers registration (e.g. from
         # `claude mcp add` predating the plugin-based install above, or a leftover
@@ -171,7 +183,7 @@ if [ -f "dist/index.js" ]; then
         # Query installed state as JSON rather than grepping the human-readable table
         # (`claude plugin list`), whose "❯" marker/formatting is a display detail,
         # not a stable contract to match against.
-        elif run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='vibing-nvim@vibing-nvim')?0:1)" 2>/dev/null; then
+        elif run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='vibing-nvim@vibing')?0:1)" 2>/dev/null; then
             # Already installed: `claude plugin install` is a no-op here, so on repeat
             # runs (e.g. `:Lazy update` re-invoking this script) it won't pick up
             # skill/agent changes on its own. Explicitly refresh the marketplace
@@ -180,31 +192,85 @@ if [ -f "dist/index.js" ]; then
             # See the MARKETPLACE_ADD_STATUS comment above for why the fallback is
             # attached via `||` on the same line rather than a separate `STATUS=$?`.
             MARKETPLACE_UPDATE_STATUS=0
-            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update vibing-nvim 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
+            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update vibing 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
             PLUGIN_UPDATE_OUTPUT=""
             PLUGIN_UPDATE_STATUS=1
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ]; then
                 PLUGIN_UPDATE_STATUS=0
-                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update vibing-nvim@vibing-nvim 2>&1)" || PLUGIN_UPDATE_STATUS=$?
+                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update vibing-nvim@vibing 2>&1)" || PLUGIN_UPDATE_STATUS=$?
             fi
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ] && [ $PLUGIN_UPDATE_STATUS -eq 0 ]; then
                 echo "[vibing.nvim] ✓ Synced vibing-nvim plugin cache (restart Claude Code to apply)"
             elif [ $MARKETPLACE_UPDATE_STATUS -ne 0 ]; then
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin marketplace update' failed"
                 echo "$MARKETPLACE_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing-nvim && claude plugin update vibing-nvim@vibing-nvim"
+                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing && claude plugin update vibing-nvim@vibing"
             else
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin update' failed"
                 echo "$PLUGIN_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing-nvim && claude plugin update vibing-nvim@vibing-nvim"
+                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing && claude plugin update vibing-nvim@vibing"
             fi
         else
             echo "[vibing.nvim] Installing vibing-nvim as a Claude Code plugin (user scope)..."
-            if run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin install vibing-nvim@vibing-nvim --scope user; then
+            if run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin install vibing-nvim@vibing --scope user; then
                 echo "[vibing.nvim] ✓ Installed vibing-nvim Claude Code plugin (scope: user)"
             else
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin install' failed"
                 echo "[vibing.nvim] You can manually install by running: $PLUGIN_INSTALL_HINT"
+            fi
+        fi
+
+        # `claude plugin install`/`update` above can report success while leaving an
+        # incomplete cache snapshot behind: on machines where copying many small
+        # files is slow (observed with real-time antivirus/EDR scanning on a
+        # corporate-managed Mac), the CLI's own copy step can silently stop partway
+        # while still updating its bookkeeping as if it finished. `claude plugin
+        # update` also treats a matching git commit SHA as "already up to date" and
+        # never re-copies — which, for a "directory"-source (dev-mode) plugin whose
+        # whole point is tracking uncommitted local edits, means it silently skips
+        # syncing on every single build.sh run where HEAD hasn't moved. So sync this
+        # checkout's tracked files into the cache directly on every run, rather than
+        # only when detected as broken.
+        #
+        # mcp-server/node_modules and mcp-server/dist are symlinked into the cache
+        # rather than copied, for two reasons: (1) rsync/cp copying node_modules'
+        # thousands of small files is exactly the kind of slow-on-this-machine
+        # operation that produced the incomplete snapshot in the first place, and
+        # doing it here would just as easily blow past lazy.nvim's own build-step
+        # timeout; (2) a symlink means a later `npm run build` here is reflected
+        # immediately without rerunning this sync.
+        PLUGIN_INSTALL_PATH="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null | "$NODE_EXECUTABLE" -e "
+          const plugins = JSON.parse(require('fs').readFileSync(0, 'utf8') || '[]');
+          const p = plugins.find((p) => p.id === 'vibing-nvim@vibing');
+          process.stdout.write(p && p.installPath ? p.installPath : '');
+        " 2>/dev/null)"
+
+        if [ -n "$PLUGIN_INSTALL_PATH" ]; then
+            echo "[vibing.nvim] Syncing plugin cache with this checkout..."
+            mkdir -p "$PLUGIN_INSTALL_PATH/mcp-server"
+            if command -v rsync &> /dev/null; then
+                rsync -a --delete --exclude='.git' --exclude='/node_modules' --exclude='/mcp-server/node_modules' --exclude='/mcp-server/dist' "$SCRIPT_DIR/" "$PLUGIN_INSTALL_PATH/"
+            else
+                cp -R "$SCRIPT_DIR/." "$PLUGIN_INSTALL_PATH/"
+                rm -rf "$PLUGIN_INSTALL_PATH/node_modules" "$PLUGIN_INSTALL_PATH/.git" "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" "$PLUGIN_INSTALL_PATH/mcp-server/dist"
+            fi
+
+            # Unconditionally (re)point node_modules/dist at this live checkout's own
+            # build output rather than only when missing: an earlier run of this
+            # script, or an earlier version of it, may have left a real (now stale)
+            # copy behind instead of a symlink, and `ln -sfn` is instant either way so
+            # there's no cost to always re-asserting it.
+            if [ -d "$PLUGIN_INSTALL_PATH/mcp-server" ]; then
+                [ -L "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" ] || rm -rf "$PLUGIN_INSTALL_PATH/mcp-server/node_modules"
+                [ -L "$PLUGIN_INSTALL_PATH/mcp-server/dist" ] || rm -rf "$PLUGIN_INSTALL_PATH/mcp-server/dist"
+                ln -sfn "$MCP_DIR/node_modules" "$PLUGIN_INSTALL_PATH/mcp-server/node_modules"
+                ln -sfn "$MCP_DIR/dist" "$PLUGIN_INSTALL_PATH/mcp-server/dist"
+            fi
+
+            if [ -f "$PLUGIN_INSTALL_PATH/mcp-server/bin/run.mjs" ] && [ -d "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" ]; then
+                echo "[vibing.nvim] ✓ Plugin cache OK (restart Claude Code to apply any changes)"
+            else
+                echo "[vibing.nvim] ✗ Repair failed; mcp-server/ still incomplete under $PLUGIN_INSTALL_PATH"
             fi
         fi
     else

--- a/build.sh
+++ b/build.sh
@@ -96,22 +96,24 @@ if ! command -v npm &> /dev/null; then
     exit 1
 fi
 
+# Check if MCP directory exists
+if [ ! -d "$MCP_DIR" ]; then
+    echo "[vibing.nvim] Error: MCP server directory not found: $MCP_DIR"
+    exit 1
+fi
+
 # Record the exact node binary resolved above so the Claude Code plugin's MCP
 # server launcher (mcp-server/bin/run.sh) can invoke it directly by absolute
 # path instead of relying on `node` being on PATH. Claude Code spawns
 # plugin-declared MCP server commands with a minimal PATH that doesn't
 # include version-manager shims (mise, nvm, volta, asdf, ...), so a bare
 # `command: "node"` fails with "Executable not found in $PATH" on any machine
-# where node is only installed through one of those.
+# where node is only installed through one of those. Written after the
+# directory check above so a missing mcp-server/ checkout fails with that
+# clear error instead of a raw redirect failure here.
 NODE_ABS_PATH="$(command -v "$NODE_EXECUTABLE" 2>/dev/null || true)"
 if [ -n "$NODE_ABS_PATH" ]; then
     echo "$NODE_ABS_PATH" > "${MCP_DIR}/bin/.node-path"
-fi
-
-# Check if MCP directory exists
-if [ ! -d "$MCP_DIR" ]; then
-    echo "[vibing.nvim] Error: MCP server directory not found: $MCP_DIR"
-    exit 1
 fi
 
 # Install root dependencies (Agent SDK, etc.)
@@ -164,6 +166,18 @@ if [ -f "dist/index.js" ]; then
         # must not coexist with the plugin registration. Ignore failure: this is a
         # no-op when no such entry exists.
         claude mcp remove vibing-nvim --scope user &> /dev/null || true
+
+        # Remove the pre-rename "vibing-nvim" marketplace/plugin registration (this
+        # marketplace was renamed to "vibing" so the plugin-scoped MCP tool prefix
+        # isn't mcp__plugin_vibing-nvim_vibing-nvim__* — see git history). `claude
+        # plugin marketplace add` on the same directory does not migrate an
+        # existing registration to the new name on its own, so without this an
+        # upgrading user would end up with both the old and new marketplace/plugin
+        # registered side by side — reintroducing the very duplicate-tool-name
+        # problem this rename fixed, just under two names instead of one. Ignore
+        # failure: a no-op once no one is left on the old name.
+        claude plugin uninstall vibing-nvim@vibing-nvim &> /dev/null || true
+        claude plugin marketplace remove vibing-nvim &> /dev/null || true
 
         # Capture output instead of streaming it directly so it can be printed
         # below only on failure, keeping successful (repeat) runs quiet.
@@ -251,8 +265,29 @@ if [ -f "dist/index.js" ]; then
             if command -v rsync &> /dev/null; then
                 rsync -a --delete --exclude='.git' --exclude='/node_modules' --exclude='/mcp-server/node_modules' --exclude='/mcp-server/dist' "$SCRIPT_DIR/" "$PLUGIN_INSTALL_PATH/"
             else
-                cp -R "$SCRIPT_DIR/." "$PLUGIN_INSTALL_PATH/"
-                rm -rf "$PLUGIN_INSTALL_PATH/node_modules" "$PLUGIN_INSTALL_PATH/.git" "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" "$PLUGIN_INSTALL_PATH/mcp-server/dist"
+                # Portable fallback without rsync. Copy each top-level entry
+                # individually and skip the excluded ones outright, rather than
+                # `cp -R` the whole tree and `rm -rf` them after: on a repeat run,
+                # the destination's mcp-server/node_modules and mcp-server/dist are
+                # already symlinks back into this very checkout (from the symlink
+                # step below), and `cp -R` landing on an existing symlink follows it
+                # — copying this checkout's node_modules into itself through the
+                # link — instead of replacing it.
+                for entry in "$SCRIPT_DIR"/* "$SCRIPT_DIR"/.[!.]*; do
+                    [ -e "$entry" ] || continue
+                    name="$(basename "$entry")"
+                    [ "$name" = ".git" ] && continue
+                    [ "$name" = "node_modules" ] && continue
+                    [ "$name" = "mcp-server" ] && continue
+                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/"
+                done
+                for entry in "$MCP_DIR"/* "$MCP_DIR"/.[!.]*; do
+                    [ -e "$entry" ] || continue
+                    name="$(basename "$entry")"
+                    [ "$name" = "node_modules" ] && continue
+                    [ "$name" = "dist" ] && continue
+                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/mcp-server/"
+                done
             fi
 
             # Unconditionally (re)point node_modules/dist at this live checkout's own

--- a/docs/lazy-setup-example.lua
+++ b/docs/lazy-setup-example.lua
@@ -2,7 +2,7 @@
 -- Place this in ~/.config/nvim/lua/plugins/vibing.lua
 --
 -- MCP server registration is exclusively via the Claude Code plugin marketplace
--- (`claude plugin install vibing-nvim@vibing-nvim`), which build.sh installs automatically.
+-- (`claude plugin install vibing-nvim@vibing`), which build.sh installs automatically.
 -- There is no separate ~/.claude.json registration path: that route can only ever hardcode a
 -- single default RPC port, so it silently targets the wrong Neovim instance whenever more than
 -- one is running.

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -39,6 +39,18 @@ for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
   M.ALWAYS_ALLOWED_TOOLS_MAP[tool] = true
 end
 
+---vibing-nvim自身が提供するMCPツールの許可パターン。プレーンなユーザーレベルMCPサーバー登録
+---（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*、
+---このリポジトリが.claude-plugin/marketplace.jsonで出荷する"vibing"マーケットプレイス名前提）の
+---両方に対応する。can_use_tool.M.is_vibing_nvim_mcp_tool側はサフィックスマッチでマーケットプレイス名
+---に依存しないが、Claude Code CLIの--allowedToolsゲート自体は具体的なプレフィックスを要求するため、
+---こちらは定数化のみで対応している。マーケットプレイス名を変更した場合はここを更新すること。
+---@type string[]
+M.VIBING_NVIM_MCP_TOOL_PATTERNS = {
+  "mcp__vibing-nvim__*",
+  "mcp__plugin_vibing_vibing-nvim__*",
+}
+
 ---lightweightなユーティリティ呼び出し（タイトル生成・要約等）で明示的に拒否するClaude Code CLIの
 ---組み込みツール名一覧。`--allowedTools ""`だけでは実際のツール実行をブロックできないことを
 ---実機検証で確認したため、`--disallowedTools`で個別に拒否する。新しいツールがCLIに追加された場合は

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -71,13 +71,15 @@ local function add_permission_args(cmd, opts)
   local allow_tools = vim.deepcopy(permissions_allow)
   -- The vibing-nvim MCP server may be registered either as a plain user-level MCP server
   -- (mcp__vibing-nvim__<tool>) or as a Claude Code plugin
-  -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing-nvim_vibing-nvim__<tool>).
-  -- Both patterns must be pre-approved here so the CLI's own --allowedTools gate doesn't block
-  -- calls before they ever reach vibing.nvim's PreToolUse hook, which already recognizes both
-  -- registration styles via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match).
+  -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing_vibing-nvim__<tool> for
+  -- the "vibing" marketplace this repo ships as .claude-plugin/marketplace.json). Both patterns
+  -- must be pre-approved here so the CLI's own --allowedTools gate doesn't block calls before they
+  -- ever reach vibing.nvim's PreToolUse hook, which already recognizes both registration styles
+  -- via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match, so it isn't tied to a specific
+  -- marketplace name).
   local always_allowed = vim.list_extend(
     vim.deepcopy(tools_constants.ALWAYS_ALLOWED_TOOLS),
-    { "mcp__vibing-nvim__*", "mcp__plugin_vibing-nvim_vibing-nvim__*" }
+    { "mcp__vibing-nvim__*", "mcp__plugin_vibing_vibing-nvim__*" }
   )
   for _, tool in ipairs(always_allowed) do
     if not vim.tbl_contains(allow_tools, tool) then
@@ -219,10 +221,14 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     table.insert(
       system_prompt_lines,
       "When you need the user to choose among options (single or multi-select), always call the "
-        .. "mcp__vibing-nvim__nvim_ask_user_question tool instead of asking in free text. Do not use "
-        .. "the native AskUserQuestion tool for this — it is unavailable in this environment. Pass "
-        .. "this turn's \"Current vibing.nvim chat buffer file\" path (given elsewhere in this "
-        .. "system prompt) as the chat_file_path argument."
+        .. "vibing-nvim MCP server's nvim_ask_user_question tool instead of asking in free text. Its "
+        .. "exact tool name depends on how vibing-nvim is registered — mcp__vibing-nvim__nvim_ask_user_question "
+        .. "for a plain user-level MCP server, or mcp__plugin_<marketplace>_vibing-nvim__nvim_ask_user_question "
+        .. "if installed as a Claude Code plugin — so search for a tool name ending in "
+        .. "\"nvim_ask_user_question\" if the plain form isn't available. Do not use the native "
+        .. "AskUserQuestion tool for this — it is unavailable in this environment. Pass this turn's "
+        .. "\"Current vibing.nvim chat buffer file\" path (given elsewhere in this system prompt) as "
+        .. "the chat_file_path argument."
     )
 
     if rpc_port then
@@ -230,9 +236,10 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         system_prompt_lines,
         "Your rpc_port for this turn is "
           .. tostring(rpc_port)
-          .. ". You MUST pass this exact value as the rpc_port argument on every "
-          .. "mcp__vibing-nvim__* tool call — never omit it or guess, since other unrelated Neovim "
-          .. "instances may be running and reachable on other ports."
+          .. ". You MUST pass this exact value as the rpc_port argument on every vibing-nvim MCP tool "
+          .. "call (tool names ending in \"nvim_*\", regardless of whether the prefix is "
+          .. "mcp__vibing-nvim__ or mcp__plugin_<marketplace>_vibing-nvim__) — never omit it or guess, "
+          .. "since other unrelated Neovim instances may be running and reachable on other ports."
       )
     end
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -69,17 +69,14 @@ local function add_permission_args(cmd, opts)
     permissions_allow = {}
   end
   local allow_tools = vim.deepcopy(permissions_allow)
-  -- The vibing-nvim MCP server may be registered either as a plain user-level MCP server
-  -- (mcp__vibing-nvim__<tool>) or as a Claude Code plugin
-  -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing_vibing-nvim__<tool> for
-  -- the "vibing" marketplace this repo ships as .claude-plugin/marketplace.json). Both patterns
-  -- must be pre-approved here so the CLI's own --allowedTools gate doesn't block calls before they
-  -- ever reach vibing.nvim's PreToolUse hook, which already recognizes both registration styles
-  -- via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match, so it isn't tied to a specific
-  -- marketplace name).
+  -- Both of vibing-nvim's own possible MCP registration styles (see
+  -- tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS) must be pre-approved here so the CLI's own
+  -- --allowedTools gate doesn't block calls before they ever reach vibing.nvim's PreToolUse hook,
+  -- which already recognizes both via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match, so it
+  -- isn't tied to a specific marketplace name).
   local always_allowed = vim.list_extend(
     vim.deepcopy(tools_constants.ALWAYS_ALLOWED_TOOLS),
-    { "mcp__vibing-nvim__*", "mcp__plugin_vibing_vibing-nvim__*" }
+    vim.deepcopy(tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS)
   )
   for _, tool in ipairs(always_allowed) do
     if not vim.tbl_contains(allow_tools, tool) then
@@ -220,15 +217,17 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     )
     table.insert(
       system_prompt_lines,
+      "vibing-nvim MCP tools may be registered as mcp__vibing-nvim__<tool> (a plain user-level MCP "
+        .. "server) or mcp__plugin_<marketplace>_vibing-nvim__<tool> (a Claude Code plugin) — search "
+        .. "for a tool name ending in the specific tool you need if the plain prefix isn't available."
+    )
+    table.insert(
+      system_prompt_lines,
       "When you need the user to choose among options (single or multi-select), always call the "
-        .. "vibing-nvim MCP server's nvim_ask_user_question tool instead of asking in free text. Its "
-        .. "exact tool name depends on how vibing-nvim is registered — mcp__vibing-nvim__nvim_ask_user_question "
-        .. "for a plain user-level MCP server, or mcp__plugin_<marketplace>_vibing-nvim__nvim_ask_user_question "
-        .. "if installed as a Claude Code plugin — so search for a tool name ending in "
-        .. "\"nvim_ask_user_question\" if the plain form isn't available. Do not use the native "
-        .. "AskUserQuestion tool for this — it is unavailable in this environment. Pass this turn's "
-        .. "\"Current vibing.nvim chat buffer file\" path (given elsewhere in this system prompt) as "
-        .. "the chat_file_path argument."
+        .. "vibing-nvim MCP server's nvim_ask_user_question tool instead of asking in free text. Do "
+        .. "not use the native AskUserQuestion tool for this — it is unavailable in this environment. "
+        .. "Pass this turn's \"Current vibing.nvim chat buffer file\" path (given elsewhere in this "
+        .. "system prompt) as the chat_file_path argument."
     )
 
     if rpc_port then
@@ -237,9 +236,8 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         "Your rpc_port for this turn is "
           .. tostring(rpc_port)
           .. ". You MUST pass this exact value as the rpc_port argument on every vibing-nvim MCP tool "
-          .. "call (tool names ending in \"nvim_*\", regardless of whether the prefix is "
-          .. "mcp__vibing-nvim__ or mcp__plugin_<marketplace>_vibing-nvim__) — never omit it or guess, "
-          .. "since other unrelated Neovim instances may be running and reachable on other ports."
+          .. "call — never omit it or guess, since other unrelated Neovim instances may be running and "
+          .. "reachable on other ports."
       )
     end
 

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -48,7 +48,7 @@ local TOOL_NAMES = {
   "WebFetch",
   "Skill",
   "mcp__vibing-nvim__*",
-  "mcp__plugin_vibing-nvim_vibing-nvim__*",
+  "mcp__plugin_vibing_vibing-nvim__*",
   "mcp__chrome-devtools__*",
   "mcp__context7__*",
   "mcp__serena__*",

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -1,6 +1,8 @@
 ---@class Vibing.FrontmatterProvider
 ---Provider for YAML frontmatter completion items
 ---@module "vibing.infrastructure.completion.providers.frontmatter"
+local tools_constants = require("vibing.core.constants.tools")
+
 local M = {}
 
 ---Enum values for frontmatter fields
@@ -47,13 +49,12 @@ local TOOL_NAMES = {
   "WebSearch",
   "WebFetch",
   "Skill",
-  "mcp__vibing-nvim__*",
-  "mcp__plugin_vibing_vibing-nvim__*",
   "mcp__chrome-devtools__*",
   "mcp__context7__*",
   "mcp__serena__*",
   "mcp__lapras__*",
 }
+vim.list_extend(TOOL_NAMES, tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS)
 
 ---Get enum values for a field
 ---@param field string Field name (agent, permissions_mode, ...)

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -243,8 +243,9 @@ function M.can_use_tool(tool_name, input, config)
 
     -- Handle vibing-nvim MCP tools. The vibing-nvim MCP server may be registered either as a
     -- plain user-level MCP server (mcp__vibing-nvim__<tool>) or as a Claude Code plugin
-    -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing-nvim_vibing-nvim__<tool>).
-    -- Match on suffix so both registration styles are recognized identically.
+    -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing_vibing-nvim__<tool>).
+    -- Match on suffix so both registration styles are recognized identically, regardless of
+    -- marketplace name.
     if M.is_vibing_nvim_mcp_tool(tool_name) then
       if config.mcp_enabled then
         return allow(input)

--- a/lua/vibing/install.lua
+++ b/lua/vibing/install.lua
@@ -25,7 +25,7 @@ end
 local function plugin_install_message(plugin_root)
   return "Register vibing-nvim as a Claude Code plugin by running: claude plugin marketplace add "
     .. plugin_root
-    .. " && claude plugin install vibing-nvim@vibing-nvim --scope user"
+    .. " && claude plugin install vibing-nvim@vibing --scope user"
 end
 
 ---Check if command exists

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.log
 .DS_Store
+bin/.node-path

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -40,7 +40,7 @@ and no separate build step (the server builds itself on first launch).
 
 ```text
 /plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing-nvim
+/plugin install vibing-nvim@vibing
 ```
 
 See the plugin manifest at `../.claude-plugin/plugin.json`. The manual steps below remain useful
@@ -53,8 +53,8 @@ or your own fork/clone).
 To uninstall:
 
 ```text
-/plugin uninstall vibing-nvim@vibing-nvim
-/plugin marketplace remove vibing-nvim
+/plugin uninstall vibing-nvim@vibing
+/plugin marketplace remove vibing
 ```
 
 **Auto-build mechanism:** `mcp-server/bin/run.mjs` hashes `package.json`, `package-lock.json`,

--- a/mcp-server/bin/build-fingerprint.mjs
+++ b/mcp-server/bin/build-fingerprint.mjs
@@ -1,0 +1,38 @@
+/**
+ * Shared build-fingerprint logic for the vibing-nvim MCP server launcher.
+ *
+ * Used by both run.mjs (to decide whether a self-build is needed) and
+ * write-fingerprint.mjs (invoked by build.sh right after its own build, so
+ * that run.mjs sees that build as fresh instead of re-running `npm ci` over
+ * the node_modules symlink build.sh sets up in the plugin cache).
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createHash } from 'node:crypto';
+
+const IGNORED_FILE_PATTERN = /(?:^\.DS_Store$|\.sw[op]$|~$|\.tmp$)/;
+
+function listFilesRecursive(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (IGNORED_FILE_PATTERN.test(entry.name)) return [];
+    const full = join(dir, entry.name);
+    return entry.isDirectory() ? listFilesRecursive(full) : [full];
+  });
+}
+
+export function computeFingerprint(mcpDir) {
+  const hash = createHash('sha256');
+  const inputs = ['package.json', 'package-lock.json', 'tsconfig.json']
+    .map((f) => join(mcpDir, f))
+    .filter(existsSync)
+    .concat(listFilesRecursive(join(mcpDir, 'src')).sort());
+  for (const file of inputs) {
+    hash.update(relative(mcpDir, file));
+    hash.update(readFileSync(file));
+  }
+  return hash.digest('hex');
+}
+
+export function fingerprintFilePath(mcpDir) {
+  return join(mcpDir, 'dist', '.build-fingerprint');
+}

--- a/mcp-server/bin/run.mjs
+++ b/mcp-server/bin/run.mjs
@@ -17,39 +17,16 @@
  * CLAUDE_PLUGIN_ROOT — only add this plugin's marketplace from a source you
  * trust (see the "Trust note" in mcp-server/README.md).
  */
-import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { spawnSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, relative } from 'node:path';
-import { createHash } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { computeFingerprint, fingerprintFilePath } from './build-fingerprint.mjs';
 
 const mcpDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const distEntry = join(mcpDir, 'dist', 'index.js');
 const nodeModulesDir = join(mcpDir, 'node_modules');
-const fingerprintFile = join(mcpDir, 'dist', '.build-fingerprint');
-
-const IGNORED_FILE_PATTERN = /(?:^\.DS_Store$|\.sw[op]$|~$|\.tmp$)/;
-
-function listFilesRecursive(dir) {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    if (IGNORED_FILE_PATTERN.test(entry.name)) return [];
-    const full = join(dir, entry.name);
-    return entry.isDirectory() ? listFilesRecursive(full) : [full];
-  });
-}
-
-function computeFingerprint() {
-  const hash = createHash('sha256');
-  const inputs = ['package.json', 'package-lock.json', 'tsconfig.json']
-    .map((f) => join(mcpDir, f))
-    .filter(existsSync)
-    .concat(listFilesRecursive(join(mcpDir, 'src')).sort());
-  for (const file of inputs) {
-    hash.update(relative(mcpDir, file));
-    hash.update(readFileSync(file));
-  }
-  return hash.digest('hex');
-}
+const fingerprintFile = fingerprintFilePath(mcpDir);
 
 function isBuildStale(fingerprint) {
   if (!existsSync(distEntry) || !existsSync(nodeModulesDir) || !existsSync(fingerprintFile)) {
@@ -71,7 +48,7 @@ function run(command, args) {
   }
 }
 
-const fingerprint = computeFingerprint();
+const fingerprint = computeFingerprint(mcpDir);
 if (isBuildStale(fingerprint)) {
   console.error('[vibing-nvim] Building MCP server...');
   // Drop any existing fingerprint up front so a build that fails partway

--- a/mcp-server/bin/run.sh
+++ b/mcp-server/bin/run.sh
@@ -18,32 +18,46 @@
 DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 NODE_BIN="$(cat "$DIR/.node-path" 2>/dev/null || true)"
 
-if [ ! -x "$NODE_BIN" ]; then
-  if command -v node >/dev/null 2>&1; then
-    NODE_BIN="$(command -v node)"
-  else
-    for candidate in \
-      "$HOME/.local/share/mise/shims/node" \
-      "$HOME/.asdf/shims/node" \
-      "$HOME/.volta/bin/node" \
-      /opt/homebrew/bin/node \
-      /usr/local/bin/node \
-      /usr/bin/node
-    do
-      if [ -x "$candidate" ]; then
-        NODE_BIN="$candidate"
-        break
-      fi
-    done
-    if [ ! -x "$NODE_BIN" ]; then
-      # nvm has no fixed shim path (each version lives in its own directory);
-      # take the lexically-last match as a reasonable guess at the newest one.
-      for candidate in "$HOME"/.nvm/versions/node/*/bin/node; do
-        [ -x "$candidate" ] && NODE_BIN="$candidate"
-      done
-    fi
-  fi
+if [ ! -x "$NODE_BIN" ] && command -v node >/dev/null 2>&1; then
+  NODE_BIN="$(command -v node)"
 fi
 
-[ -x "$NODE_BIN" ] || NODE_BIN="node"
+if [ ! -x "$NODE_BIN" ]; then
+  for candidate in \
+    "$HOME/.local/share/mise/shims/node" \
+    "$HOME/.asdf/shims/node" \
+    "$HOME/.volta/bin/node" \
+    /opt/homebrew/bin/node \
+    /usr/local/bin/node \
+    /usr/bin/node
+  do
+    if [ -x "$candidate" ]; then
+      NODE_BIN="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ ! -x "$NODE_BIN" ]; then
+  # nvm has no fixed shim path (each version lives in its own directory); take
+  # the lexically-last match as a reasonable guess at the newest one.
+  for candidate in "$HOME"/.nvm/versions/node/*/bin/node; do
+    [ -x "$candidate" ] && NODE_BIN="$candidate"
+  done
+fi
+
+if [ ! -x "$NODE_BIN" ]; then
+  echo "vibing-nvim MCP server: no working node executable found." >&2
+  echo "Run ./build.sh once from the plugin checkout to record one, or set VIBING_NODE_EXECUTABLE and re-run it." >&2
+  exit 1
+fi
+
+# Also put node's own directory on PATH (not just exec it by absolute path):
+# run.mjs's self-build step shells out to `npm`, which hits the exact same
+# "not on Claude Code's minimal PATH" problem this launcher exists to solve.
+# npm ships alongside node in every installation method above, so this is
+# free once NODE_BIN is known.
+PATH="$(dirname "$NODE_BIN"):$PATH"
+export PATH
+
 exec "$NODE_BIN" "$DIR/run.mjs" "$@"

--- a/mcp-server/bin/run.sh
+++ b/mcp-server/bin/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Launcher for the vibing-nvim MCP server, invoked by Claude Code via the
+# `command`/`args` declared in ../../.claude-plugin/plugin.json.
+#
+# Claude Code spawns plugin-declared MCP server commands with a minimal PATH
+# that does not include version-manager shims (mise, nvm, volta, asdf, ...),
+# so a bare `command: "node"` fails with "Executable not found in $PATH" on
+# any machine where node is only installed through one of those (not through
+# an OS-default location like /usr/local/bin or /opt/homebrew/bin). build.sh
+# records the exact node binary it resolved (and used to build this plugin)
+# into .node-path; invoke that directly by absolute path so this launcher
+# does not depend on PATH at all. Falls back to a bare `node` PATH lookup for
+# a fresh checkout that hasn't been built yet.
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+NODE_BIN="$(cat "$DIR/.node-path" 2>/dev/null || true)"
+[ -x "$NODE_BIN" ] || NODE_BIN="node"
+exec "$NODE_BIN" "$DIR/run.mjs" "$@"

--- a/mcp-server/bin/run.sh
+++ b/mcp-server/bin/run.sh
@@ -9,9 +9,41 @@
 # an OS-default location like /usr/local/bin or /opt/homebrew/bin). build.sh
 # records the exact node binary it resolved (and used to build this plugin)
 # into .node-path; invoke that directly by absolute path so this launcher
-# does not depend on PATH at all. Falls back to a bare `node` PATH lookup for
-# a fresh checkout that hasn't been built yet.
-DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+# does not depend on PATH at all.
+#
+# .node-path is gitignored (machine-specific), so a manual `/plugin install`
+# that never ran build.sh won't have it. In that case, fall back to a bare
+# PATH lookup, then to common version-manager install locations that a
+# minimal PATH wouldn't include either.
+DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 NODE_BIN="$(cat "$DIR/.node-path" 2>/dev/null || true)"
+
+if [ ! -x "$NODE_BIN" ]; then
+  if command -v node >/dev/null 2>&1; then
+    NODE_BIN="$(command -v node)"
+  else
+    for candidate in \
+      "$HOME/.local/share/mise/shims/node" \
+      "$HOME/.asdf/shims/node" \
+      "$HOME/.volta/bin/node" \
+      /opt/homebrew/bin/node \
+      /usr/local/bin/node \
+      /usr/bin/node
+    do
+      if [ -x "$candidate" ]; then
+        NODE_BIN="$candidate"
+        break
+      fi
+    done
+    if [ ! -x "$NODE_BIN" ]; then
+      # nvm has no fixed shim path (each version lives in its own directory);
+      # take the lexically-last match as a reasonable guess at the newest one.
+      for candidate in "$HOME"/.nvm/versions/node/*/bin/node; do
+        [ -x "$candidate" ] && NODE_BIN="$candidate"
+      done
+    fi
+  fi
+fi
+
 [ -x "$NODE_BIN" ] || NODE_BIN="node"
 exec "$NODE_BIN" "$DIR/run.mjs" "$@"

--- a/mcp-server/bin/write-fingerprint.mjs
+++ b/mcp-server/bin/write-fingerprint.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/**
+ * Records dist/.build-fingerprint for the checkout build.sh just built.
+ *
+ * Without this, run.mjs's self-build check never sees build.sh's `tsc` run
+ * as a valid build (that check only writes the fingerprint from run.mjs
+ * itself), so the first launch of the plugin-cache's run.mjs re-runs
+ * `npm ci` — which deletes and replaces the node_modules symlink build.sh
+ * set up in the cache with a real copy, defeating the point of the symlink
+ * until the next build.sh run re-links it.
+ */
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { computeFingerprint, fingerprintFilePath } from './build-fingerprint.mjs';
+
+const mcpDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+writeFileSync(fingerprintFilePath(mcpDir), computeFingerprint(mcpDir));

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -95,7 +95,8 @@ describe("cli_command_builder", function()
       assert.is_not_nil(idx)
       local prompt_text = cmd[idx + 1]
       assert.is_true(prompt_text:find("Your rpc_port for this turn is 9878", 1, true) ~= nil)
-      assert.is_true(prompt_text:find("mcp__vibing-nvim__*", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("mcp__vibing-nvim__", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("mcp__plugin_<marketplace>_vibing-nvim__", 1, true) ~= nil)
     end)
 
     it("omits the rpc_port line when rpc_port is not provided", function()
@@ -113,7 +114,7 @@ describe("cli_command_builder", function()
       assert.is_not_nil(idx)
       local allowed = cmd[idx + 1]
       assert.is_true(allowed:find("mcp__vibing-nvim__*", 1, true) ~= nil)
-      assert.is_true(allowed:find("mcp__plugin_vibing-nvim_vibing-nvim__*", 1, true) ~= nil)
+      assert.is_true(allowed:find("mcp__plugin_vibing_vibing-nvim__*", 1, true) ~= nil)
     end)
   end)
 

--- a/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
+++ b/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
@@ -80,8 +80,8 @@ describe("can_use_tool", function()
     local tool_names = {
       -- Registered as a plain user-level MCP server
       "mcp__vibing-nvim__nvim_get_buffer",
-      -- Registered as a Claude Code plugin (marketplace + plugin name both "vibing-nvim")
-      "mcp__plugin_vibing-nvim_vibing-nvim__nvim_get_buffer",
+      -- Registered as a Claude Code plugin (marketplace "vibing", plugin "vibing-nvim")
+      "mcp__plugin_vibing_vibing-nvim__nvim_get_buffer",
     }
 
     for _, tool_name in ipairs(tool_names) do
@@ -124,7 +124,7 @@ describe("can_use_tool", function()
     it("matches a specific tool regardless of registration namespace", function()
       assert.is_true(
         can_use_tool.is_vibing_nvim_mcp_tool(
-          "mcp__plugin_vibing-nvim_vibing-nvim__nvim_ask_user_question",
+          "mcp__plugin_vibing_vibing-nvim__nvim_ask_user_question",
           "nvim_ask_user_question"
         )
       )
@@ -136,7 +136,7 @@ describe("can_use_tool", function()
     it("does not match a different vibing-nvim tool", function()
       assert.is_false(
         can_use_tool.is_vibing_nvim_mcp_tool(
-          "mcp__plugin_vibing-nvim_vibing-nvim__nvim_get_buffer",
+          "mcp__plugin_vibing_vibing-nvim__nvim_get_buffer",
           "nvim_ask_user_question"
         )
       )


### PR DESCRIPTION
## Summary

- `build.sh`が毎回このチェックアウトの内容をClaude Codeのプラグインキャッシュへrsyncするように変更。`claude plugin update`はgitのコミットハッシュが変わらないと「最新」と判定してしまい、未コミットのローカル変更を静かに無視してキャッシュへ同期しない（`mcp-server/`ディレクトリごと欠落するケースを実際に確認）。`mcp-server/node_modules`・`mcp-server/dist`はコピーではなくシンボリックリンクにして、大量の小さいファイルのコピーによるタイムアウトを回避
- `mcp-server/bin/run.sh`ランチャーを追加し、build.shが記録した絶対パスのnodeを直接execするように変更。Claude CodeはプラグインのMCPサーバーをmise/nvmなどのバージョン管理シムを含まない最小限のPATHで起動するため、nodeがOS標準の場所に無い環境では従来の`command: "node"`指定では起動に失敗していた
- マーケットプレイス名を`vibing-nvim`から`vibing`に変更し、プラグイン経由登録時のツール名重複（`mcp__plugin_vibing-nvim_vibing-nvim__*`）を解消
- システムプロンプト内でハードコードしていた単一のMCPツール名/プレフィックスの記述をやめ、登録方式（プレーン/プラグイン経由）の両方に触れた上でモデルに該当ツールを検索させる形に変更（実際に存在しないツール名を鵜呑みにして「使えます」と誤答する問題があったため）

## Test plan

- [x] `pnpm run test:lua` で全テストパス（`cli_command_builder_spec.lua`のシステムプロンプト検証・許可ツールリスト検証、`can_use_tool_spec.lua`のMCPツール名マッチングを含む）
- [x] `bash build.sh`を実行し、プラグインキャッシュに`mcp-server/`一式・`.node-path`・シンボリックリンクが正しく作成されることを確認
- [x] PATHを意図的に空にした状態で`sh mcp-server/bin/run.sh`経由でMCPハンドシェイク（initialize/tools/list）が正常に完了することを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a reliable MCP server launcher that detects available Node.js installations and forwards command-line arguments.
- Added build fingerprinting to support dependable MCP updates and cache verification.

## Bug Fixes
- Corrected Claude Code marketplace and plugin naming from `vibing-nvim` to `vibing`.
- Improved recognition and permissions for direct and marketplace-installed MCP tools.
- Enhanced plugin cache synchronization during installation and updates.

## Documentation
- Updated installation, uninstallation, marketplace, and setup examples to use the corrected plugin identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->