### PR TITLE
docs: remove obsolete config items from README

### DIFF
--- a/.claude/rules/configuration.md
+++ b/.claude/rules/configuration.md
@@ -1,13 +1,14 @@
 # Configuration
 
 The full user-facing configuration reference (every `setup()` field, window positions, permission
-rule examples, daily summary, etc.) lives in `README.md` → `## 📚 Configuration Reference` and in
+rule examples, daily summary, etc.) lives in `docs/configuration.md` and in
 `lua/vibing/config.lua` (defaults + type annotations) — read those instead of duplicating the
-field list here.
+field list here. `README.md` keeps only a short "commonly tweaked options" block that links to
+`docs/configuration.md`.
 
 ## Where Things Live
 
-- Full option list & defaults: `README.md` → `## 📚 Configuration Reference`
+- Full option list & defaults: `docs/configuration.md`
 - Mote (diff tool) setup, session storage layout, and troubleshooting: `docs/MIGRATION_MOTE.md`
 - Defaults and type annotations: `lua/vibing/config.lua`
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,19 +4,19 @@
 
 # vibing.nvim
 
-**Neovim用のインテリジェントAIコードアシスタント**
+**Neovim のためのインテリジェント AI コードアシスタント**
 
 [![CI](https://github.com/shabaraba/vibing.nvim/actions/workflows/ci.yml/badge.svg)](https://github.com/shabaraba/vibing.nvim/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Release](https://img.shields.io/github/v/release/shabaraba/vibing.nvim)](https://github.com/shabaraba/vibing.nvim/releases)
 
-Agent SDKを通じて**Claude AI**をシームレスに統合し、エディタ内で直接、
-インテリジェントなチャット会話を提供する強力なNeovimプラグインです。
+**Claude** と **Codex** を CLI バックエンドとして統合し、コンテキストを理解した
+AI チャットをエディタ内で直接利用できる Neovim プラグイン。
 
 [English](./README.md) | 日本語
 
 [機能](#-機能) • [インストール](#-インストール) • [使い方](#-使い方) •
-[設定例](#️-設定例) • [コントリビューション](#-コントリビューション)
+[設定](#️-設定) • [コントリビュート](#-コントリビュート)
 
 </div>
 
@@ -24,674 +24,253 @@ Agent SDKを通じて**Claude AI**をシームレスに統合し、エディタ�
 
 ## 目次
 
-- [なぜvibing.nvimなのか？](#-なぜvibingnvimなのか)
 - [機能](#-機能)
-- [他のプラグインとの違い](#-他のプラグインとの違い)
 - [インストール](#-インストール)
+- [クイックスタート](#-クイックスタート)
 - [使い方](#-使い方)
-- [設定例](#️-設定例)
-- [設定リファレンス](#-設定リファレンス)
+- [設定](#️-設定)
 - [チャットファイル形式](#-チャットファイル形式)
 - [アーキテクチャ](#️-アーキテクチャ)
 - [FAQ](#-faq)
-- [コントリビューション](#-コントリビューション)
+- [コントリビュート](#-コントリビュート)
 - [ライセンス](#-ライセンス)
 - [リンク](#-リンク)
 
-## 💡 なぜvibing.nvimなのか？
-
-vibing.nvimは、NeovimにおけるAI支援コーディングに対して、根本的に異なるアプローチを取っています。
-
-### エージェント・ファーストなアーキテクチャ
-
-従来のチャットベースAIプラグインがLLMに静的なコンテキストを送信するのとは異なり、
-vibing.nvimはAgent SDKとMCP統合を通じて、ClaudeにNeovimインスタンスへの**直接アクセス**を与えます。
-
-これにより、Claudeは以下のことが可能になります：
-
-- **コードベースを自律的に探索** - 手動でコンテキストを設定することなく、ファイルをナビゲートし、シンボルを検索し、プロジェクト構造を理解
-- **リアルタイムなエディタ状態へのアクセス** - LSP診断、シンボル定義、参照をオンデマンドでクエリ
-- **Neovimコマンドの実行** - ワークフローの一部としてエディタ操作を実行
-- **会話の継続性を維持** - `.vibing`ファイルに完全なコンテキストを保存してセッションを再開
-
-### Claudeのために設計
-
-vibing.nvimは、公式Agent SDKを活用してClaude専用に構築されており、
-Claude Code CLIと同じ機能をNeovim内で直接提供します。
-この焦点を絞ったアプローチにより、マルチプロバイダープラグインでは実現できない深い統合が可能になります。
-
-### 並行セッション
-
-ブロックせずに複数のタスクを同時進行：
-
-- **複数のチャットウィンドウ** - それぞれ独立したセッションで別々の会話を開く
-- **待ち時間なし** - 別のチャットが処理中でも新しいチャットを開始
-
-ワークフロー例：
-
-```vim
-:VibingChat  " チャット1で認証問題をデバッグ
-:VibingChat  " チャット2で新機能を設計
-```
-
-すべてのセッションは適切な競合管理のもと独立して実行されます。
-
 ## ✨ 機能
 
-### 🤖 Neovimをエージェントツールとして活用
+静的なコンテキストを LLM に送るだけのチャットプラグインと異なり、vibing.nvim は
+CLI バックエンドと MCP 統合を通じて、AI に**実行中の Neovim インスタンスへの直接アクセス**を
+提供します。
 
-ClaudeはMCPを介して実行中のNeovimインスタンスと直接対話できます：
+- **🤖 Neovim をエージェントのツールに** — MCP 経由で AI がバッファの読み書き、コマンド実行、
+  LSP クエリ(診断・定義・参照・シンボル)を*実行中の*エディタに対して行える
+- **🔀 マルチバックエンド** — Claude CLI(`claude -p --output-format stream-json`)または
+  Codex CLI(`codex exec --json`)。`adapter` 設定でグローバルに、チャットごとには
+  frontmatter の `agent` フィールドで切り替え
+- **💾 ファイルベースのセッション永続化** — チャットは `.vibing/chat/` 配下の YAML frontmatter
+  付き Markdown ファイル。持ち運び可能・再開可能(CLI セッション状態を完全復元)・監査可能・
+  バージョン管理可能
+- **🔀 並行セッション** — 複数の独立したチャットを同時実行。あるチャットの処理中でも新しい
+  チャットを開始できる
+- **🛡️ きめ細かい権限制御** — ツールごとの allow/deny/ask リスト、機密ファイル向けの
+  パスベースルール、Bash コマンドパターン、対話的な Permission Builder UI
+- **📊 diff ビューア** — 変更ファイル上で `gd` を押すと before/after の diff を表示。
+  デフォルトはリクエスト単位のパッチ追跡で、[mote](https://github.com/shabaraba/mote)
+  スナップショットバックエンド(利用可能なら自動選択)を使うと Bash 経由のファイル変更も
+  捕捉できる
+- **🎯 スマートコンテキスト** — 手動追加、oil.nvim、ビジュアル選択からファイルをコンテキストへ
+- **🌍 多言語対応** — AI 応答の言語をチャットごとに設定可能
 
-- バッファの読み書きをプログラマティックに実行
-- ExコマンドとLuaコードの実行
-- LSPによる診断、定義、参照、シンボルのクエリ
-- プロジェクト内のファイルシステムのナビゲート
+### 他の選択肢を検討すべきケース
 
-### 💾 ファイルベースのセッション永続化
+- ローカル/オフラインモデル(Ollama 等)が必要
+- 最小限の依存関係を好む(vibing.nvim は MCP サーバーのため Node.js が必要)
+- 大きなコミュニティを持つ実績あるプラグインが欲しい(私たちはまだ成長中です!)
 
-各会話はYAMLフロントマター付きの`.vibing`ファイルとして保存されます：
-
-- **ポータブル** - チームメイトやマシン間で会話を共有
-- **再開可能** - 完全なSDKセッション状態で中断したところから正確に続行
-- **監査可能** - すべての設定（モデル、モード、権限）がファイル内で可視化
-- **バージョン管理可能** - AI支援による変更をGitで追跡
-
-### 🛡️ きめ細かい権限システム
-
-Claudeができることを細かく制御：
-
-- 特定のツールの許可/拒否（Read、Edit、Write、Bashなど）
-- センシティブファイルのパスベースルール
-- シェル操作のコマンドパターンマッチング
-- インタラクティブな権限ビルダーUI
-
-### 📋 Accept/Reject機能付き差分プレビュー
-
-すべてのコード修正に対するTelescope風の差分プレビュー：
-
-- 各変更ファイルの視覚的な差分表示
-- Gitベースのrevertによるすべて承認/すべて拒否
-- 複数の変更ファイル間のナビゲート
-- チャットモードで動作
-
-### 🔀 並行セッションサポート
-
-複数のAIタスクを同時に実行：
-
-- **独立したチャットセッション** - 各チャットウィンドウが独自の会話とセッションIDを維持
-- **並列ワークフロー** - 1つのチャットでデバッグしながら別のチャットで機能を設計
-
-### その他の機能
-
-- **💬 インタラクティブなチャットインターフェース** - Claude AIとのシームレスなチャットウィンドウ、デフォルトで現在のバッファに開く
-- **📝 自然言語コマンド** - あらゆるコード変換にカスタム指示を使用
-- **🔧 スラッシュコマンド** - コンテキスト管理、権限、設定のためのチャット内コマンド
-- **🎯 スマートコンテキスト** - 開いているバッファからの自動ファイルコンテキスト検出と手動追加
-- **🌍 多言語サポート** - AIレスポンスの言語を設定可能
-- **📊 差分ビューアー** - AI編集ファイルの視覚的な差分表示（`gd`キーバインド）
-- **⚙️ 高度な設定可能性** - 柔軟なモード、モデル、権限、UI設定
-
-## 🔄 他のプラグインとの違い
-
-AIコーディングプラグインは、それぞれ異なるニーズに対応します。vibing.nvimの位置づけは以下の通りです：
-
-### vibing.nvimが最適な場合：
-
-- Claudeを主要なAIアシスタントとして使用している
-- AIに自律的にコードベースをナビゲートして理解させたい
-- 永続的で共有可能な会話履歴が必要
-- きめ細かい権限制御を好む
-- 複数のAIタスクを同時進行したい
-- NeovimからClaude Code CLIの機能を使いたい
-
-### 代替手段を検討すべき場合：
-
-- 複数のLLMプロバイダー（OpenAI、Ollamaなど）のサポートが必要
-- 最小限の依存関係を好む（vibing.nvimはNode.jsが必要）
-- 大規模コミュニティを持つ実績あるプラグインを求めている（私たちはまだ成長中です！）
-
-### 補完的な使用
-
-vibing.nvimは深いClaude統合に焦点を当てています。以下の用途には他のツールも併用できます：
-
-- クイック補完（GitHub Copilot、Codeium）
-- ローカル/オフラインモデル（Ollamaベースのプラグイン）
-- プロバイダー非依存のワークフロー
+vibing.nvim は補完プラグイン(Copilot、Codeium)や他のチャットプラグインと競合しません。
 
 ## 📦 インストール
 
-### Claude Codeプラグイン（MCP + スキル + エージェント）
+### 前提条件
 
-vibing.nvimは[Claude Codeプラグイン](https://code.claude.com/docs/en/plugins)としても配布されています。
-`vibing-nvim` MCPサーバーに加えて、Neovim対応のスキルと読み取り専用のナビゲーション用サブエージェントを
-まとめてバンドルしており、`~/.claude.json`を手動編集する必要はありません。
+- **Neovim** 0.10+(`vim.system()` を使用)
+- **Node.js** 18+(MCP サーバー用)
+- AI CLI バックエンドを最低1つ:
+  - **Claude CLI**(`claude`)— `npm install -g @anthropic-ai/claude-code`
+  - **Codex CLI**(`codex`)— `npm install -g @openai/codex`
 
-**自動インストール：** `build = "./build.sh"`（後述）でインストールしていて、`claude` CLIが
-`PATH`上にある場合、`build.sh`がビルドの度に`claude plugin marketplace add` +
-`claude plugin install ... --scope user`を自動実行します。他に何もする必要はありません。
-
-**手動インストール：** 自分でインストールする場合（`build.sh`を実行しない場合や、別のマシンで
-インストールする場合など）：
-
-```text
-/plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing-nvim
-```
-
-いずれの方法でも、`vibing-nvim` MCPサーバー（下記で説明する`mcp__vibing-nvim__*`と同じツール群）に
-加えて、`nvim-context`・`nvim-lsp-navigation` スキル（Neovimインスタンスに接続されている場合、grepよりも
-ライブなバッファ/ウィンドウ/カーソル状態の読み取りとLSPナビゲーションを優先させる）、`nvim-navigator`
-サブエージェント（`@vibing-nvim:nvim-navigator`で読み取り専用のコードナビゲーションを実行）が
-インストールされます。
-
-バンドルされたMCPサーバーは初回起動時に自身をビルド（`npm install && npm run build`）するため、
-MCPサーバー自体に別途ビルド手順は不要です。これはNeovim側の`build.sh`（後述、プラグインの他のネイティブ
-部分のビルドに引き続き必要）とは独立しています。MCPツールが接続する対象として、`mcp = { enabled = true }`（デフォルト）で
-Neovimを起動しておく必要はあります。
-
-**アンインストール：**
-
-```text
-/plugin uninstall vibing-nvim@vibing-nvim
-/plugin marketplace remove vibing-nvim
-```
-
-### [lazy.nvim](https://github.com/folke/lazy.nvim)を使用
+### [lazy.nvim](https://github.com/folke/lazy.nvim) を使う場合
 
 ```lua
 {
   "shabaraba/vibing.nvim",
   dependencies = {
-    -- オプション：ファイルブラウザ統合用
-    "stevearc/oil.nvim",
+    "stevearc/oil.nvim",  -- オプション: ファイルブラウザ統合
   },
-  build = "./build.sh",  -- Neovim統合用MCPサーバーをビルド
-  config = function()
-    require("vibing").setup({
-      -- デフォルト設定
-      chat = {
-        window = {
-          position = "current",  -- "current" | "right" | "left" | "float"
-          width = 0.4,
-          border = "rounded",
-        },
-        auto_context = true,
-        save_location_type = "project",  -- "project" | "user" | "custom"
-        context_position = "append",  -- "prepend" | "append"
-      },
-      agent = {
-        default_mode = "code",  -- "code" | "plan" | "explore"
-        default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
-        prioritize_vibing_lsp = true,  -- vibing-nvim LSPツールを優先（デフォルト：true）
-      },
-      permissions = {
-        mode = "acceptEdits",  -- "default" | "acceptEdits" | "bypassPermissions"
-        allow = { "Read", "Edit", "Write", "Glob", "Grep" },
-        deny = { "Bash" },
-        rules = {},  -- オプション：きめ細かい権限ルール
-      },
-      preview = {
-        enabled = false,  -- 差分プレビューUIを有効化（Git必須）
-      },
-      language = nil,  -- オプション："ja" | "en" | { default = "ja", chat = "ja" }
-    })
-  end,
-}
-```
-
-### [packer.nvim](https://github.com/wbthomason/packer.nvim)を使用
-
-```lua
-use {
-  "shabaraba/vibing.nvim",
-  run = "./build.sh",  -- Neovim統合用MCPサーバーをビルド
+  build = "./build.sh",  -- MCP サーバーのビルドと Claude Code プラグインの登録
   config = function()
     require("vibing").setup()
   end,
 }
 ```
 
-## 🚀 使い方
+`setup()` に渡せるオプションは[設定](#️-設定)を参照してください。
 
-### ユーザーコマンド
-
-| コマンド                       | 説明                                                                                         |
-| ------------------------------ | -------------------------------------------------------------------------------------------- |
-| `:VibingChat [position\|file]` | オプションの位置（current\|right\|left）で新しいチャットを作成、または保存したファイルを開く |
-| `:VibingToggleChat`            | 既存のチャットウィンドウを切り替え（現在の会話を保持）                                       |
-| `:VibingSlashCommands`         | チャット内でスラッシュコマンドピッカーを表示                                                 |
-| `:VibingContext [path]`        | コンテキストにファイルを追加（またはパスがない場合oil.nvimから）                             |
-| `:VibingClearContext`          | すべてのコンテキストをクリア                                                                 |
-| `:VibingCancel`                | 現在のリクエストをキャンセル                                                                 |
-
-**コマンドのセマンティクス：**
-
-- **`:VibingChat`** - 常に新しいチャットウィンドウを作成します。オプションで位置（`current`、`right`、`left`）を指定してウィンドウ配置を制御できます。
-  - `:VibingChat` - 設定のデフォルト位置を使用して新しいチャット
-  - `:VibingChat current` - 現在のウィンドウに新しいチャット
-  - `:VibingChat right` - 右分割に新しいチャット
-  - `:VibingChat left` - 左分割に新しいチャット
-  - `:VibingChat path/to/file.vibing` - 保存したチャットファイルを開く
-- **`:VibingToggleChat`** - 現在の会話を表示/非表示にします。既存のチャット状態を保持します。
-
-### プレビューUI
-
-設定で`preview.enabled = true`が設定されている場合、チャットでのコード変更後にTelescope風のプレビューUIを表示します（Gitリポジトリ必須）：
-
-**レイアウト：**
-
-チャットモード（2パネル）：
-
-```text
-┌──────────────┬──────────────────────────────────────┐
-│ Files (3)    │ Diff Preview                         │
-│  > src/a.lua │  @@ -10,5 +10,8 @@                   │
-│    src/b.lua │  -old line                           │
-│    tests/*.lua  +new line                           │
-└──────────────┴──────────────────────────────────────┘
-```
-
-**キーバインディング：**
-
-- `j`/`k` - カーソルを上下に移動（通常のNeovimナビゲーション）
-- `<Enter>` - カーソル位置のファイルを選択（Filesウィンドウ内）
-- `<Tab>` - 次のウィンドウにサイクル（Files → Diff → Response → Files）
-- `<Shift-Tab>` - 前のウィンドウにサイクル
-- `a` - すべての変更を承認（プレビューを閉じて変更を保持）
-- `r` - すべての変更を拒否（`git checkout HEAD`を使用してすべてのファイルを元に戻す）
-- `q`/`Esc` - プレビューを閉じる（変更を保持）
-
-**機能：**
-
-- レスポンシブレイアウト（横幅 ≥120列で水平、<120列で垂直）
-- Delta統合による強化された差分ハイライト（利用可能な場合）
-- 複数の変更ファイル間のナビゲート
-- 個別またはすべての変更を承認/拒否
-- Gitベースの元に戻す機能
-
-### スラッシュコマンド（チャット内）
-
-| コマンド                      | 説明                                                                   |
-| ----------------------------- | ---------------------------------------------------------------------- |
-| `/context <file>`             | コンテキストにファイルを追加                                           |
-| `/clear`                      | コンテキストをクリア                                                   |
-| `/save`                       | 現在のチャットを保存                                                   |
-| `/summarize`                  | 会話を要約                                                             |
-| `/model <model>`              | AIモデルを設定（opus/sonnet/haiku/fable）                              |
-| `/permissions` または `/perm` | インタラクティブな権限ビルダー - ツールの許可/拒否ルールを設定         |
-| `/allow [tool]`               | 許可リストにツールを追加、引数なしで現在のリストを表示                 |
-| `/deny [tool]`                | 拒否リストにツールを追加、引数なしで現在のリストを表示                 |
-| `/permission [mode]`          | 権限モードを設定（default/acceptEdits/bypassPermissions/plan/dontAsk） |
-
-### チャットキーバインディング
-
-チャットバッファ内では、以下のキーバインディングが使用できます：
-
-| キー | 説明                                                                              |
-| ---- | --------------------------------------------------------------------------------- |
-| `gd` | カーソル下のファイルの差分を表示（Modified Filesセクション内）                    |
-| `gf` | カーソル下のファイルを開く（Modified Filesセクション内）                          |
-| `gp` | **すべての変更ファイルをプレビュー** - Telescope風のプレビューUIを開く（Git必須） |
-| `q`  | チャットウィンドウを閉じる                                                        |
-
-**すべての変更ファイルをプレビュー（`gp`）：**
-
-Claudeがチャットセッションで複数のファイルを変更した場合、チャットバッファ内の任意の場所で`gp`を押すと、
-すべての変更ファイルを一度に表示するプレビューUIが開きます。これにより、Accept/Reject機能が提供されます：
-
-- `j`/`k`でファイル間をナビゲート
-- `a`を押してすべての変更を承認
-- `r`を押してすべての変更を拒否して元に戻す（`git checkout HEAD`経由）
-- `q`を押してプレビューを終了
-
-## ⚙️ 設定例
-
-### 基本セットアップ
+### [packer.nvim](https://github.com/wbthomason/packer.nvim) を使う場合
 
 ```lua
-require("vibing").setup()
-```
-
-設定を提供しない場合、以下の**デフォルト権限**が適用されます：
-
-```lua
-permissions = {
-  mode = "acceptEdits",  -- ファイル編集を自動承認、他のツールは確認
-  allow = {
-    "Read",    -- ファイルを読む
-    "Edit",    -- ファイルを編集
-    "Write",   -- 新しいファイルを書く
-    "Glob",    -- パターンでファイルを検索
-    "Grep",    -- ファイル内容を検索
-    "Skill",   -- スキルを使用（スラッシュコマンドとワークフロー）
-  },
-  deny = {
-    "Bash",    -- シェルコマンドをブロック（セキュリティ）
-  },
-}
-```
-
-これらのデフォルトは、新しいチャットファイルを作成する際の**テンプレート**として使用されます。
-各チャットファイルのフロントマターには独自の権限が含まれ、実行時に使用されます。
-
-### カスタム設定
-
-```lua
-require("vibing").setup({
-  chat = {
-    window = {
-      position = "float",
-      width = 0.6,
-      border = "single",
-    },
-    save_location_type = "user",  -- グローバルチャット履歴
-  },
-  agent = {
-    default_mode = "plan",  -- プランニングモードで開始
-    default_model = "opus",  -- 最も能力の高いモデルを使用
-  },
-  permissions = {
-    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "WebSearch" },
-    deny = {},  -- すべてのツールを許可
-  },
-  preview = {
-    enabled = true,  -- 差分プレビューUIを有効化
-  },
-  keymaps = {
-    send = "<C-CR>",  -- カスタム送信キー
-    cancel = "<C-c>",
-    add_context = "<C-a>",
-  },
-})
-```
-
-### プロジェクト固有の設定
-
-```lua
--- チャットをプロジェクトディレクトリに保存
-require("vibing").setup({
-  chat = {
-    save_location_type = "project",  -- プロジェクトルートの.vibing/chat/
-  },
-})
-```
-
-### カスタム保存場所
-
-```lua
-require("vibing").setup({
-  chat = {
-    save_location_type = "custom",
-    save_dir = "~/my-ai-chats/vibing/",
-  },
-})
-```
-
-### きめ細かい権限ルール
-
-```lua
-require("vibing").setup({
-  permissions = {
-    mode = "default",  -- 毎回確認を求める
-    rules = {
-      -- 特定のパスの読み取りを許可
-      {
-        tools = { "Read" },
-        paths = { "src/**", "tests/**" },
-        action = "allow",
-      },
-      -- 重要なファイルへの書き込みを拒否
-      {
-        tools = { "Write", "Edit" },
-        paths = { ".env", "*.secret" },
-        action = "deny",
-        message = "機密ファイルは変更できません",
-      },
-      -- 特定のnpmコマンドのみ許可
-      {
-        tools = { "Bash" },
-        commands = { "npm", "yarn" },
-        action = "allow",
-      },
-      -- 危険なbashパターンを拒否
-      {
-        tools = { "Bash" },
-        patterns = { "^rm -rf", "^sudo" },
-        action = "deny",
-        message = "危険なコマンドがブロックされました",
-      },
-    },
-  },
-})
-```
-
-### 多言語設定
-
-```lua
-require("vibing").setup({
-  -- シンプル：すべてのレスポンスを日本語で
-  language = "ja",
-
-  -- 高度：コンテキストごとに異なる言語
-  -- language = {
-  --   default = "ja",
-  --   chat = "ja",     -- チャットは日本語
-  -- },
-})
-```
-
-## 📚 設定リファレンス
-
-すべての設定オプションの完全なリファレンス：
-
-### Agent設定
-
-Claude Agent SDKの動作を制御：
-
-```lua
-agent = {
-  default_mode = "code",    -- デフォルト実行モード
-                            -- "code": 直接実装
-                            -- "plan": まず計画してから実装
-                            -- "explore": コードベースを探索・分析
-
-  default_model = "sonnet", -- デフォルトClaudeモデル
-                            -- "sonnet": バランス型（推奨）
-                            -- "opus": 最も能力が高い
-                            -- "haiku": 最速
-
-  prioritize_vibing_lsp = true,  -- vibing-nvim LSPツールを優先
-                                 -- true: vibing-nvim LSPを使用（実行中のNeovimに接続）
-                                 -- false: 汎用LSPツール（例：Serena）を許可
-                                 -- デフォルト：true
-}
-```
-
-### Chat設定
-
-チャットウィンドウとセッション設定：
-
-```lua
-chat = {
-  window = {
-    position = "current",  -- ウィンドウ位置
-                          -- "current": 現在のウィンドウに開く
-                          -- "right": 右垂直分割
-                          -- "left": 左垂直分割
-                          -- "float": フローティングウィンドウ
-
-    width = 0.4,          -- ウィンドウ幅（0-1: 比率、>1: 絶対列数）
-    border = "rounded",   -- ボーダースタイル："rounded" | "single" | "double" | "none"
-  },
-
-  auto_context = true,     -- 開いているバッファを自動的にコンテキストに追加
-
-  save_location_type = "project",  -- チャットファイルの保存場所
-                                   -- "project": プロジェクトルートの.vibing/chat/
-                                   -- "user": ~/.local/share/nvim/vibing/chats/
-                                   -- "custom": save_dirパスを使用
-
-  save_dir = "~/.local/share/nvim/vibing/chats",  -- save_location_type="custom"の場合に使用
-
-  context_position = "append",  -- 新しいコンテキストファイルを追加する場所
-                               -- "append": コンテキストリストの末尾に追加
-                               -- "prepend": 先頭に追加
-}
-```
-
-### Permissions（権限）
-
-Claudeが使用できるツールを制御。詳細な例については[きめ細かい権限ルール](#きめ細かい権限ルール)を参照してください。
-
-```lua
-permissions = {
-  mode = "acceptEdits",  -- 権限モード
-                        -- "default": 毎回確認を求める
-                        -- "acceptEdits": Edit/Writeを自動承認（推奨）
-                        -- "bypassPermissions": すべてを自動承認（慎重に使用）
-                        -- "plan": 読み取り専用の計画モード（ツール実行なし）
-                        -- "dontAsk": プロンプトの代わりに拒否
-
-  allow = {              -- 許可するツール（空 = 拒否されたもの以外すべて許可）
-    "Read",              -- ファイルを読む
-    "Edit",              -- 既存ファイルを編集
-    "Write",             -- 新しいファイルを作成
-    "Glob",              -- パターンでファイルを検索
-    "Grep",              -- ファイル内容を検索
-    -- "Bash",           -- シェルコマンドを実行（セキュリティリスク）
-    -- "WebSearch",      -- Webを検索
-    -- "WebFetch",       -- Webページを取得
-  },
-
-  deny = {               -- 拒否するツール（allowより優先）
-    "Bash",              -- デフォルトでシェルコマンドをブロック
-  },
-
-  rules = {},            -- 高度：きめ細かい権限ルール
-                        -- きめ細かい権限ルールセクションを参照
-}
-```
-
-### Keymaps（キーマップ）
-
-チャットバッファのキーバインディング：
-
-```lua
-keymaps = {
-  send = "<CR>",         -- メッセージを送信
-  cancel = "<C-c>",      -- 現在のリクエストをキャンセル
-  add_context = "<C-a>", -- コンテキストにファイルを追加
-  open_diff = "gd",      -- ファイルパス上で差分ビューアーを開く
-  open_file = "gf",      -- ファイルパス上でファイルを開く
-}
-```
-
-### Preview設定
-
-チャット用の差分プレビューUIを設定：
-
-```lua
-preview = {
-  enabled = false,  -- Telescope風の差分プレビューUIを有効化
-                    -- Gitリポジトリが必要
-                    -- コード変更後にAccept/Reject UIを表示
-                    -- git diffとgit checkoutを使用して元に戻す
-                    -- チャット（gpキー）で動作
-}
-```
-
-### UI設定
-
-UIの外観と動作を設定：
-
-```lua
-ui = {
-  wrap = "on",  -- 行の折り返し動作
-                -- "nvim": Neovimのデフォルトを尊重（ラップ設定を変更しない）
-                -- "on": wrap + linebreakを有効化（チャット可読性のため推奨）
-                -- "off": 行の折り返しを無効化
-
-  tool_result_display = "compact",  -- ツール実行結果の表示モード
-                                    -- "none": ツール結果を表示しない
-                                    -- "compact": 最初の100文字のみ表示（デフォルト）
-                                    -- "full": 完全なツール出力を表示
-
-  gradient = {
-    enabled = true,  -- AIレスポンス中のグラデーションアニメーションを有効化
-    colors = {
-      "#cc3300",  -- 開始色（オレンジ、vibing.nvimロゴに合わせて）
-      "#fffe00",  -- 終了色（黄色、vibing.nvimロゴに合わせて）
-    },
-    interval = 100,  -- アニメーション更新間隔（ミリ秒）
-  },
-}
-```
-
-### MCP（Model Context Protocol）
-
-ClaudeによるNeovimの直接制御を有効化。MCPサーバーの登録は上記の「Claude Codeプラグイン」経由のみを
-サポートしている（`build.sh`が自動でインストールする）。独立した`~/.claude.json`への登録経路は存在
-しない——その経路はデフォルトポートを1つしかハードコードできず、複数のNeovimインスタンスが起動している
-場合に誤ったインスタンスへサイレントに接続してしまうため。
-
-```lua
-mcp = {
-  enabled = true,   -- MCP統合を有効化
-  rpc_port = 9876,  -- RPCサーバーポート
-}
-```
-
-**lazy.nvim推奨設定：**
-
-```lua
-{
+use {
   "shabaraba/vibing.nvim",
-  build = "./build.sh",
+  run = "./build.sh",
   config = function()
-    require("vibing").setup({
-      mcp = { enabled = true },
-    })
+    require("vibing").setup()
   end,
 }
 ```
 
-### Language（言語）
+### Claude Code プラグイン(MCP + スキル + エージェント)
 
-AIレスポンスの言語を設定：
+vibing.nvim は [Claude Code プラグイン](https://code.claude.com/docs/en/plugins)としても配布
+されており、`vibing-nvim` MCP サーバー・Neovim 対応スキル・読み取り専用ナビゲーション
+サブエージェントが同梱されます。`~/.claude.json` の手動編集は不要です。
 
-```lua
--- シンプル：すべてのレスポンスを1つの言語で
-language = "ja"  -- または "en"、"fr"など
+**自動:** 上記のように `build = "./build.sh"` でインストールし、`claude` CLI が `PATH` に
+あれば、ビルドのたびに `build.sh` が `claude plugin marketplace add` +
+`claude plugin install ... --scope user` を実行します。追加作業はありません。
 
--- 高度：コンテキストごとに異なる言語
-language = {
-  default = "ja",  -- デフォルト言語
-  chat = "ja",     -- チャットウィンドウのレスポンス
-}
+**手動:** 自分でインストールする場合(`build.sh` を実行しない場合や別マシンなど):
+
+```text
+/plugin marketplace add shabaraba/vibing.nvim
+/plugin install vibing-nvim@vibing-nvim
 ```
 
-### Remote Control（リモート制御）
+いずれの方法でも、`vibing-nvim` MCP サーバー(実行中の Neovim へのバッファ/ウィンドウ/
+カーソルアクセス・Ex コマンド・LSP クエリを `mcp__vibing-nvim__*` ツールとして提供)、
+同梱スキル(`nvim-context`、`nvim-lsp-navigation`、`vibing-chat-recall`、
+`vibing-chat-search`、および worktree ワークフローの
+`vibing-worktree-{list,create,attach,run,finish}`)、`nvim-navigator` サブエージェント
+(`@vibing-nvim:nvim-navigator` による読み取り専用コードナビゲーション)が登録されます。
 
-テストと開発用（高度）：
+同梱 MCP サーバーは初回起動時(およびソース変更時)に自動でビルドされるため、MCP サーバー
+自体の個別ビルドは不要です。MCP ツールの接続先として、`mcp = { enabled = true }`(デフォルト)
+の Neovim が起動している必要があります。
+
+**アンインストール:**
+
+```text
+/plugin uninstall vibing-nvim@vibing-nvim
+/plugin marketplace remove vibing-nvim
+```
+
+## 🚀 クイックスタート
+
+```vim
+:VibingChat        " 新しいチャットを開く
+```
+
+`## User` ヘッダの下にメッセージを書き、ノーマルモードで `<CR>` を押すと送信されます。
+AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエストをキャンセルできます。
+チャットは通常の Markdown バッファなので、他のファイルと同様に保存・検索・編集できます。
+
+## 🚀 使い方
+
+### ユーザーコマンド
+
+| コマンド | 説明 |
+| --- | --- |
+| `:VibingChat [position\|file]` | 新規チャット作成。位置指定(current\|right\|left\|top\|bottom\|back)または保存済みファイルを開く |
+| `:VibingToggleChat` | 既存チャットウィンドウの表示切り替え(会話を保持) |
+| `:VibingChatFork [position]` | 現在のチャットをフォーク(会話を分岐) |
+| `:VibingSlashCommands` | スラッシュコマンドピッカーを表示 |
+| `:VibingSetFileTitle` | AI がタイトルを生成しチャットファイルをリネーム |
+| `:VibingSummarize` | チャット履歴の AI 要約を生成してバッファに挿入 |
+| `:VibingDeleteChats [--unrenamed]` | チャットファイルを削除(--unrenamed で未リネームのファイルを一括削除) |
+| `:VibingContext [path]` | コンテキスト追加: oil.nvim のエントリ、ビジュアル選択(range)、パス引数、引数なしなら現在のバッファ |
+| `:VibingClearContext` | コンテキストを全クリア |
+| `:VibingCancel` | 実行中のリクエストをキャンセル |
+| `:VibingReloadCommands` | カスタムスラッシュコマンドと補完候補を再読み込み |
+| `:VibingCopyUnsentUserHeader` | `## User <!-- unsent -->` をクリップボードにコピー |
+| `:VibingDailySummary [YYYY-MM-DD]` | プロジェクトのチャットから日報を生成(デフォルト: 今日) |
+| `:VibingDailySummaryAll [YYYY-MM-DD]` | すべてのチャットから日報を生成(デフォルト: 今日) |
+| `:VibingCleanMote` | チャットを削除せずに mote オブジェクトをクリーンアップ |
+| `:VibingMoteDir [dir]` | チャットの mote 追跡対象ディレクトリを追加(`mote_dirs` frontmatter。デフォルト: cwd) |
+
+**コマンドの補足:**
+
+- **`:VibingChat`** — 常に新規チャットを作成。位置
+  (`current` / `right` / `left` / `top` / `bottom` / `back`)または保存済みチャットファイルの
+  パスを指定できます。
+- **`:VibingChatFork`** — 現在の会話をフォークして別方向に分岐(同じ位置指定を受け付けます)。
+- **`:VibingToggleChat`** — 現在の会話の表示/非表示を切り替え(状態は保持)。
+- **worktree のライフサイクル** — 同梱の
+  `vibing-worktree-{list,create,attach,run,finish}` Claude Code スキルが自然言語
+  (「worktree に切り出して」など)で処理します。エディタコマンドはありません。
+
+### スラッシュコマンド(チャット内)
+
+| コマンド | 説明 |
+| --- | --- |
+| `/context <file>` | ファイルをコンテキストに追加 |
+| `/clear` | コンテキストをクリア |
+| `/save` | 現在のチャットを保存 |
+| `/summarize` | 会話を要約 |
+| `/model <model>` | AI モデルを設定(opus/sonnet/haiku/fable) |
+| `/help` | 利用可能なスラッシュコマンドを表示 |
+| `/permissions` or `/perm` | 対話的 Permission Builder — ツールの allow/deny ルールを設定 |
+| `/allow [tool]` | allow リストに追加(`-tool` で削除)。引数なしで現在のリストを表示 |
+| `/deny [tool]` | deny リストに追加(`-tool` で削除)。引数なしで現在のリストを表示 |
+| `/ask [tool]` | 使用前に確認するツールを追加(`-tool` で削除)。引数なしで現在のリストを表示 |
+| `/permission [mode]` | 権限モードを設定(default/acceptEdits/bypassPermissions/plan/dontAsk/auto) |
+| `/new-session` | セッションをリセットして新規開始 |
+
+`/allow`・`/deny`・`/ask` は `Bash(git:*)`、`Read(src/**/*.ts)`、`WebFetch(github.com)` の
+ような粒度指定パターンも受け付けます。
+
+### チャットのキーバインド
+
+チャットバッファでは以下のキーバインドが使えます(`q` 以外は `keymaps` 設定で変更可能 —
+[設定](#️-設定)参照):
+
+| キー | 説明 |
+| --- | --- |
+| `<CR>` | メッセージ送信(ノーマルモード) |
+| `<C-c>` | 実行中のリクエストをキャンセル |
+| `<C-a>` | ファイルをコンテキストに追加 |
+| `gd` | カーソル下のファイルの diff 表示(Modified Files セクション内) |
+| `gf` | カーソル下のファイルを開く(Modified Files セクションほかチャット内のパス) |
+| `gx` | カーソル行の URL をブラウザで開く |
+| `q` | チャットウィンドウを閉じる |
+
+## ⚙️ 設定
+
+`require("vibing").setup()` はそのままで動作します。よく変更されるオプション:
 
 ```lua
-remote = {
-  socket_path = nil,   -- NVIM環境変数から自動検出
-  auto_detect = true,  -- リモート制御検出を有効化
-}
+require("vibing").setup({
+  adapter = "claude",              -- "claude" | "codex"
+  chat = {
+    window = {
+      position = "current",        -- "current" | "right" | "left" | "top" | "bottom" | "back" | "float"
+      width = 0.4,                 -- 画面幅に対する比率(0-1)
+    },
+    save_location_type = "project", -- "project" | "user" | "custom"
+  },
+  agent = {
+    default_model = "sonnet",      -- "sonnet" | "opus" | "haiku" | "fable"
+  },
+  permissions = {
+    mode = "acceptEdits",          -- "default" | "acceptEdits" | "plan" | "auto" | "dontAsk" | "bypassPermissions"
+    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "StructuredOutput" },
+    deny = { "Bash" },
+  },
+  language = nil,                  -- 例: "ja"、または { default = "ja", chat = "ja" }
+})
 ```
+
+上記のデフォルト権限は、新規チャットファイル作成時の**テンプレート**として使われます。実行時に
+適用されるのは各チャットファイルの frontmatter に記録された権限です。
+
+**完全なリファレンス:** すべてのオプション(ウィンドウ詳細、UI/グラデーション/ツールマーカー、
+diff バックエンド、粒度の細かい権限ルール、MCP、Node.js 実行ファイル、日報など)は
+[docs/configuration.md](./docs/configuration.md)(英語)を参照してください。
 
 ## 📝 チャットファイル形式
 
-チャットはセッション再開と設定のためにYAMLフロントマター付きMarkdownとして保存されます：
+チャットは YAML frontmatter 付きの Markdown ファイル(デフォルトで
+`.vibing/chat/chat-<timestamp>-....md`)として保存され、セッション再開と設定の記録に
+使われます:
 
 ```yaml
 ---
 vibing.nvim: true
-session_id: <sdk-session-id>
+session_id: <cli-session-id>
 created_at: 2024-01-01T12:00:00
+working_dir: .vibing/worktrees/feature-x  # オプション: 作業ディレクトリ(git ルートからの相対パス)
+agent: claude  # claude | codex(このチャットに限りグローバルの adapter 設定を上書き)
+mode: code  # code | plan | explore
 model: sonnet  # sonnet | opus | haiku | fable
-permissions_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk
+permission_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk | auto
 permissions_allow:
   - Read
   - Edit
@@ -700,164 +279,109 @@ permissions_allow:
   - Grep
 permissions_deny:
   - Bash
-language: ja  # オプション：AIレスポンスのデフォルト言語
+permissions_ask: []
+language: ja  # オプション: AI 応答のデフォルト言語
 ---
 # Vibing Chat
 
 ## User
 
-こんにちは、Claude！
+Hello, Claude!
 
 ## Assistant
 
-こんにちは！今日はどのようにお手伝いできますか？
+Hello! How can I help you today?
 ```
 
-**主な機能：**
+**ポイント:**
 
-- **セッション再開**：`session_id`を使用して自動的に会話を再開
-- **設定追跡**：透明性のためにモード、モデル、権限を記録
-- **言語サポート**：オプションの`language`フィールドでセッション全体で一貫したAIレスポンス言語を確保
-- **監査可能性**：すべての権限がフロントマターで可視化
+- **セッション再開** — 保存済みチャットを開き直すと `session_id` で会話を再開
+- **フォーク追跡** — フォークされたチャットは最初の応答まで `forked_from` フィールドを保持
+- **監査可能性** — モデル・モード・権限がすべて frontmatter で確認できる
+- **言語サポート** — オプションの `language` フィールドで AI 応答言語を固定
 
 ## 🏗️ アーキテクチャ
 
-詳細なアーキテクチャドキュメントについては、[CLAUDE.md](./CLAUDE.md)を参照してください。
-
-### 高レベル概要
+詳細なアーキテクチャドキュメントは [CLAUDE.md](./CLAUDE.md) を参照してください。
 
 ```mermaid
 graph TB
-    subgraph Neovim["Neovimプロセス"]
-        Plugin["vibing.nvim<br/>(Luaプラグイン)"]
-        Buffer["チャットバッファ<br/>(.vibingファイル)<br/>- Markdown + YAML<br/>- セッションメタデータ<br/>- 権限設定"]
-        RPC["RPCサーバー<br/>(非同期TCP)"]
+    subgraph Neovim["Neovim Process"]
+        Plugin["vibing.nvim<br/>(Lua Plugin)"]
+        Buffer["Chat Buffer<br/>(.vibing/chat/*.md)<br/>- Markdown + YAML<br/>- Session metadata<br/>- Permission settings"]
+        RPC["RPC Server<br/>(Async TCP)"]
 
-        Plugin -->|管理| Buffer
-        Plugin -->|使用| RPC
+        Plugin -->|manages| Buffer
+        Plugin -->|uses| RPC
     end
 
-    subgraph Backend["Node.jsバックエンド"]
-        SDK["Claude Agent SDK<br/>- ツール実行<br/>- セッション管理<br/>- ストリーミングレスポンス"]
-        MCP["MCPサーバー<br/>- バッファ操作<br/>- LSPクエリ<br/>- コマンド実行<br/>- ファイルシステムアクセス"]
-
-        SDK -->|制御| MCP
+    subgraph MCP["Node.js MCP Server"]
+        MCPServer["MCP Server<br/>- Buffer operations<br/>- LSP queries<br/>- Command execution"]
     end
 
-    RPC <-->|JSON-RPC| MCP
-    Plugin -->|起動・通信<br/>JSON Lines| SDK
+    subgraph AI["AI CLI Backends"]
+        Claude["Claude CLI<br/>(claude -p --output-format stream-json)"]
+        Codex["Codex CLI<br/>(codex exec --json)"]
+    end
 
-    style Neovim fill:#e1f5ff
-    style Backend fill:#fff4e1
-    style Plugin fill:#bbdefb
-    style SDK fill:#ffe0b2
+    RPC <-->|JSON-RPC| MCPServer
+    Plugin -->|spawns & communicates<br/>JSON Lines| Claude
+    Plugin -->|spawns & communicates<br/>JSON Lines| Codex
 ```
 
-### 従来のアプローチとの違い
-
-| 側面             | 従来のREST API        | vibing.nvim (Agent SDK)                |
-| ---------------- | --------------------- | -------------------------------------- |
-| コンテキスト     | 手動で組み立て        | エージェントがオンデマンドでリクエスト |
-| エディタアクセス | なし（fire & forget） | 完全な双方向MCP                        |
-| セッション状態   | プラグインが管理      | 再開サポート付きSDK                    |
-| ツール実行       | プラグインが実装      | SDK標準ツール                          |
-| 機能             | プラグインに制限      | MCPで拡張可能                          |
-
-**主要コンポーネント：**
-
-- **Agent SDK統合** - JSON Lines経由で通信するNode.jsラッパー
-- **MCPサーバー** - Claudeに直接Neovim制御を提供
-- **コンテキストシステム** - 自動および手動のファイルコンテキスト管理
-- **セッション永続化** - 完全な履歴で会話を再開
-
-### ディレクトリ構造
-
-vibing.nvimは、Neovimプラグイン（Lua）とNode.jsバックエンド（Agent SDK/MCP）を組み合わせたハイブリッドプロジェクトです。
-この構造は、Neovimプラグインの慣例とNode.jsエコシステムの標準の両方に従っています。
-
-**Neovimプラグイン（Neovimランタイムに必要）：**
-
-- `lua/` - プラグイン実装（Luaモジュール）
-- `plugin/` - 自動ロードされるプラグインエントリーポイント
-- `doc/` - ヘルプドキュメント（`:help vibing`）
-- `ftplugin/` - `.vibing`チャットファイル用のファイルタイプ固有設定
-
-**Node.jsバックエンド：**
-
-- `bin/` - Agent SDK用実行可能ラッパー
-- `mcp-server/` - Neovim制御用MCP統合サーバー
-- `tests/` - テストスイート（LuaとNode.jsのテスト）
-- `package.json` - Node.js依存関係とスクリプト
-
-**ドキュメント：**
-
-- `README.md` - メインユーザードキュメント
-- `CLAUDE.md` - AI開発ガイドラインとアーキテクチャ詳細
-- `docs/` - 開発者ガイド（アダプター開発、パフォーマンス、例）
-- `CONTRIBUTING.md` - コントリビューションガイド
-
-**開発設定：**
-
-- `.editorconfig`、`.prettierrc` - コードスタイルの一貫性
-- `eslint.config.mjs` - リント設定
-- `.github/` - CI/CDワークフローとissueテンプレート
-- `build.sh` - MCPサーバー用ビルドスクリプト
+| 観点 | 従来の REST API | vibing.nvim(CLI アダプター) |
+| --- | --- | --- |
+| コンテキスト | 手動で組み立て | MCP: エージェントが随時要求 |
+| エディタアクセス | なし(fire & forget) | MCP による完全な双方向アクセス |
+| セッション状態 | プラグインが管理 | CLI セッションを resume |
+| ツール実行 | プラグインが実装 | CLI ネイティブツール |
 
 ## ❓ FAQ
 
-### なぜClaude専用なのか？他のプロバイダーをサポートしないのはなぜ？
+### どの AI バックエンドに対応していますか?
 
-vibing.nvimは、単純なチャット以上の機能を提供するClaude Agent SDKを使用しています：
+- **Claude CLI**(`claude -p --output-format stream-json`)— Claude Code のフル機能
+- **Codex CLI**(`codex exec --json`)— OpenAI Codex バックエンド
 
-- 組み込みツール実行フレームワーク
-- セッション永続化と再開
-- エディタ制御のためのMCP統合
+setup の `adapter = "claude"|"codex"` でグローバルに、チャットファイルの frontmatter に
+`agent: claude` / `agent: codex` を書けばチャット単位で切り替えられます。
 
-これらの機能はClaudeのアーキテクチャに固有のものです。他のプロバイダーをサポートすることは、次のいずれかを意味します：
+### なぜ Node.js が必要なのですか?
 
-- これらの機能を失う、または
-- ゼロから再実装する
+MCP サーバーに必要です。MCP サーバーは実行中の Neovim インスタンスへの直接アクセス
+(バッファ読み書き・LSP クエリ・コマンド実行)を AI に提供します。AI CLI バイナリ
+(`claude`、`codex`)自体は別途インストールします。
 
-私たちは幅よりも深さを選びました。
+### Claude Code CLI と比べてどうですか?
 
-### なぜNode.jsが必要なのか？
+vibing.nvim は Claude Code CLI と同等の機能を Neovim に統合したものです:
 
-Claude Agent SDKはTypeScript/JavaScriptライブラリです。Luaバインディングを作成することも可能ですが、
-Node.jsを直接使用することで以下が保証されます：
+- 内部では同じ `claude` CLI を使用
+- MCP でエディタを制御(CLI はターミナルを、vibing は Neovim を制御)
+- OpenAI ワークフロー向けに Codex バックエンドも選択可能
 
-- 完全なSDK互換性
-- 新しいSDK機能への即座のアクセス
-- 信頼性の高いMCPサーバー実装
+「Neovim ユーザーのための Claude Code(または Codex)」と考えてください。
 
-### Claude Code CLIと比較してどうか？
+### 他の AI プラグインと併用できますか?
 
-vibing.nvimは、Claude Code CLIと同様の機能をNeovimに統合して提供します：
+はい。vibing.nvim は補完プラグイン(Copilot、Codeium)や他のチャットプラグインと競合しません。
+深い対話には vibing.nvim を、素早い補完や別プロバイダーには他のツールを使い分けられます。
 
-- 同じAgent SDKを基盤として使用
-- 同じツール実行モデル
-- エディタ制御のためのMCP（CLIはターミナルを制御、vibingはNeovimを制御）
+## 🤝 コントリビュート
 
-「Neovimユーザー向けのClaude Code」と考えてください。
-
-### vibing.nvimを他のAIプラグインと併用できるか？
-
-はい。vibing.nvimは補完プラグイン（Copilot、Codeium）や他のチャットプラグインと競合しません。
-深いClaude対話にはvibing.nvimを使用し、クイック補完や異なるプロバイダーには他のツールを使用してください。
-
-## 🤝 コントリビューション
-
-コントリビューションを歓迎します！issueやプルリクエストをお気軽に提出してください。
+コントリビューションを歓迎します! [CONTRIBUTING.md](./CONTRIBUTING.md) を参照の上、
+Issue や Pull Request をお気軽にどうぞ。
 
 ## 📄 ライセンス
 
-MITライセンス - 詳細はLICENSEファイルを参照
+MIT License — 詳細は LICENSE ファイルを参照してください。
 
 ## 🔗 リンク
 
 - [Claude AI](https://claude.ai)
-- [Claude Agent SDK](https://github.com/anthropics/anthropic-sdk-typescript)
-- [GitHubリポジトリ](https://github.com/shabaraba/vibing.nvim)
+- [Codex CLI](https://github.com/openai/codex)
+- [GitHub リポジトリ](https://github.com/shabaraba/vibing.nvim)
 
 ---
 
-Made with ❤️ using Claude Code
+Made with ❤️ using Claude Code!

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,9 +55,9 @@ CLI バックエンドと MCP 統合を通じて、AI に**実行中の Neovim �
 - **🛡️ きめ細かい権限制御** — ツールごとの allow/deny/ask リスト、機密ファイル向けの
   パスベースルール、Bash コマンドパターン、対話的な Permission Builder UI
 - **📊 diff ビューア** — 変更ファイル上で `gd` を押すと before/after の diff を表示。
-  デフォルトはリクエスト単位のパッチ追跡で、[mote](https://github.com/shabaraba/mote)
-  スナップショットバックエンド(利用可能なら自動選択)を使うと Bash 経由のファイル変更も
-  捕捉できる
+  デフォルトはリクエスト単位のパッチ追跡で、opt-in の [mote](https://github.com/shabaraba/mote)
+  スナップショットバックエンド(`diff.tool = "mote"` または `:VibingMoteDir`)を使うと
+  Bash 経由のファイル変更も捕捉できる
 - **🎯 スマートコンテキスト** — 手動追加、oil.nvim、ビジュアル選択からファイルをコンテキストへ
 - **🌍 多言語対応** — AI 応答の言語をチャットごとに設定可能
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -157,24 +157,24 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 
 ### ユーザーコマンド
 
-| コマンド | 説明 |
-| --- | --- |
-| `:VibingChat [position\|file]` | 新規チャット作成。位置指定(current\|right\|left\|top\|bottom\|back)または保存済みファイルを開く |
-| `:VibingToggleChat` | 既存チャットウィンドウの表示切り替え(会話を保持) |
-| `:VibingChatFork [position]` | 現在のチャットをフォーク(会話を分岐) |
-| `:VibingSlashCommands` | スラッシュコマンドピッカーを表示 |
-| `:VibingSetFileTitle` | AI がタイトルを生成しチャットファイルをリネーム |
-| `:VibingSummarize` | チャット履歴の AI 要約を生成してバッファに挿入 |
-| `:VibingDeleteChats [--unrenamed]` | チャットファイルを削除(--unrenamed で未リネームのファイルを一括削除) |
-| `:VibingContext [path]` | コンテキスト追加: oil.nvim のエントリ、ビジュアル選択(range)、パス引数、引数なしなら現在のバッファ |
-| `:VibingClearContext` | コンテキストを全クリア |
-| `:VibingCancel` | 実行中のリクエストをキャンセル |
-| `:VibingReloadCommands` | カスタムスラッシュコマンドと補完候補を再読み込み |
-| `:VibingCopyUnsentUserHeader` | `## User <!-- unsent -->` をクリップボードにコピー |
-| `:VibingDailySummary [YYYY-MM-DD]` | プロジェクトのチャットから日報を生成(デフォルト: 今日) |
-| `:VibingDailySummaryAll [YYYY-MM-DD]` | すべてのチャットから日報を生成(デフォルト: 今日) |
-| `:VibingCleanMote` | チャットを削除せずに mote オブジェクトをクリーンアップ |
-| `:VibingMoteDir [dir]` | チャットの mote 追跡対象ディレクトリを追加(`mote_dirs` frontmatter。デフォルト: cwd) |
+| コマンド                              | 説明                                                                                               |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `:VibingChat [position\|file]`        | 新規チャット作成。位置指定(current\|right\|left\|top\|bottom\|back)または保存済みファイルを開く    |
+| `:VibingToggleChat`                   | 既存チャットウィンドウの表示切り替え(会話を保持)                                                   |
+| `:VibingChatFork [position]`          | 現在のチャットをフォーク(会話を分岐)                                                               |
+| `:VibingSlashCommands`                | スラッシュコマンドピッカーを表示                                                                   |
+| `:VibingSetFileTitle`                 | AI がタイトルを生成しチャットファイルをリネーム                                                    |
+| `:VibingSummarize`                    | チャット履歴の AI 要約を生成してバッファに挿入                                                     |
+| `:VibingDeleteChats [--unrenamed]`    | チャットファイルを削除(--unrenamed で未リネームのファイルを一括削除)                               |
+| `:VibingContext [path]`               | コンテキスト追加: oil.nvim のエントリ、ビジュアル選択(range)、パス引数、引数なしなら現在のバッファ |
+| `:VibingClearContext`                 | コンテキストを全クリア                                                                             |
+| `:VibingCancel`                       | 実行中のリクエストをキャンセル                                                                     |
+| `:VibingReloadCommands`               | カスタムスラッシュコマンドと補完候補を再読み込み                                                   |
+| `:VibingCopyUnsentUserHeader`         | `## User <!-- unsent -->` をクリップボードにコピー                                                 |
+| `:VibingDailySummary [YYYY-MM-DD]`    | プロジェクトのチャットから日報を生成(デフォルト: 今日)                                             |
+| `:VibingDailySummaryAll [YYYY-MM-DD]` | すべてのチャットから日報を生成(デフォルト: 今日)                                                   |
+| `:VibingCleanMote`                    | チャットを削除せずに mote オブジェクトをクリーンアップ                                             |
+| `:VibingMoteDir [dir]`                | チャットの mote 追跡対象ディレクトリを追加(`mote_dirs` frontmatter。デフォルト: cwd)               |
 
 **コマンドの補足:**
 
@@ -189,20 +189,20 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 
 ### スラッシュコマンド(チャット内)
 
-| コマンド | 説明 |
-| --- | --- |
-| `/context <file>` | ファイルをコンテキストに追加 |
-| `/clear` | コンテキストをクリア |
-| `/save` | 現在のチャットを保存 |
-| `/summarize` | 会話を要約 |
-| `/model <model>` | AI モデルを設定(opus/sonnet/haiku/fable) |
-| `/help` | 利用可能なスラッシュコマンドを表示 |
-| `/permissions` or `/perm` | 対話的 Permission Builder — ツールの allow/deny ルールを設定 |
-| `/allow [tool]` | allow リストに追加(`-tool` で削除)。引数なしで現在のリストを表示 |
-| `/deny [tool]` | deny リストに追加(`-tool` で削除)。引数なしで現在のリストを表示 |
-| `/ask [tool]` | 使用前に確認するツールを追加(`-tool` で削除)。引数なしで現在のリストを表示 |
-| `/permission [mode]` | 権限モードを設定(default/acceptEdits/bypassPermissions/plan/dontAsk/auto) |
-| `/new-session` | セッションをリセットして新規開始 |
+| コマンド                  | 説明                                                                       |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `/context <file>`         | ファイルをコンテキストに追加                                               |
+| `/clear`                  | コンテキストをクリア                                                       |
+| `/save`                   | 現在のチャットを保存                                                       |
+| `/summarize`              | 会話を要約                                                                 |
+| `/model <model>`          | AI モデルを設定(opus/sonnet/haiku/fable)                                   |
+| `/help`                   | 利用可能なスラッシュコマンドを表示                                         |
+| `/permissions` or `/perm` | 対話的 Permission Builder — ツールの allow/deny ルールを設定               |
+| `/allow [tool]`           | allow リストに追加(`-tool` で削除)。引数なしで現在のリストを表示           |
+| `/deny [tool]`            | deny リストに追加(`-tool` で削除)。引数なしで現在のリストを表示            |
+| `/ask [tool]`             | 使用前に確認するツールを追加(`-tool` で削除)。引数なしで現在のリストを表示 |
+| `/permission [mode]`      | 権限モードを設定(default/acceptEdits/bypassPermissions/plan/dontAsk/auto)  |
+| `/new-session`            | セッションをリセットして新規開始                                           |
 
 `/allow`・`/deny`・`/ask` は `Bash(git:*)`、`Read(src/**/*.ts)`、`WebFetch(github.com)` の
 ような粒度指定パターンも受け付けます。
@@ -212,15 +212,15 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 チャットバッファでは以下のキーバインドが使えます(`q` 以外は `keymaps` 設定で変更可能 —
 [設定](#️-設定)参照):
 
-| キー | 説明 |
-| --- | --- |
-| `<CR>` | メッセージ送信(ノーマルモード) |
-| `<C-c>` | 実行中のリクエストをキャンセル |
-| `<C-a>` | ファイルをコンテキストに追加 |
-| `gd` | カーソル下のファイルの diff 表示(Modified Files セクション内) |
-| `gf` | カーソル下のファイルを開く(Modified Files セクションほかチャット内のパス) |
-| `gx` | カーソル行の URL をブラウザで開く |
-| `q` | チャットウィンドウを閉じる |
+| キー    | 説明                                                                      |
+| ------- | ------------------------------------------------------------------------- |
+| `<CR>`  | メッセージ送信(ノーマルモード)                                            |
+| `<C-c>` | 実行中のリクエストをキャンセル                                            |
+| `<C-a>` | ファイルをコンテキストに追加                                              |
+| `gd`    | カーソル下のファイルの diff 表示(Modified Files セクション内)             |
+| `gf`    | カーソル下のファイルを開く(Modified Files セクションほかチャット内のパス) |
+| `gx`    | カーソル行の URL をブラウザで開く                                         |
+| `q`     | チャットウィンドウを閉じる                                                |
 
 ## ⚙️ 設定
 
@@ -329,12 +329,12 @@ graph TB
     Plugin -->|spawns & communicates<br/>JSON Lines| Codex
 ```
 
-| 観点 | 従来の REST API | vibing.nvim(CLI アダプター) |
-| --- | --- | --- |
-| コンテキスト | 手動で組み立て | MCP: エージェントが随時要求 |
+| 観点             | 従来の REST API     | vibing.nvim(CLI アダプター)    |
+| ---------------- | ------------------- | ------------------------------ |
+| コンテキスト     | 手動で組み立て      | MCP: エージェントが随時要求    |
 | エディタアクセス | なし(fire & forget) | MCP による完全な双方向アクセス |
-| セッション状態 | プラグインが管理 | CLI セッションを resume |
-| ツール実行 | プラグインが実装 | CLI ネイティブツール |
+| セッション状態   | プラグインが管理    | CLI セッションを resume        |
+| ツール実行       | プラグインが実装    | CLI ネイティブツール           |
 
 ## ❓ FAQ
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ access to your Neovim instance** through CLI backends and MCP integration.
 - **🛡️ Granular permissions** — allow/deny/ask lists per tool, path-based rules for sensitive
   files, Bash command patterns, and an interactive Permission Builder UI
 - **📊 Diff viewer** — `gd` on a changed file shows a before/after diff; per-request patch
-  tracking by default, with an optional [mote](https://github.com/shabaraba/mote) snapshot
-  backend (used automatically when available) that also catches Bash-driven changes
+  tracking by default, with an opt-in [mote](https://github.com/shabaraba/mote) snapshot
+  backend (`diff.tool = "mote"` or `:VibingMoteDir`) that also catches Bash-driven changes
 - **🎯 Smart context** — add files manually, from oil.nvim, or from a visual selection
 - **🌍 Multi-language support** — configure the AI response language per chat
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Unlike chat plugins that send static context to an LLM, vibing.nvim gives the AI
 access to your Neovim instance** through CLI backends and MCP integration.
 
 - **🤖 Neovim as an agent tool** — via MCP, the AI reads and writes buffers, executes commands,
-  and queries LSP (diagnostics, definitions, references, symbols) in your *running* editor
+  and queries LSP (diagnostics, definitions, references, symbols) in your _running_ editor
 - **🔀 Multi-backend** — Claude CLI (`claude -p --output-format stream-json`) or Codex CLI
   (`codex exec --json`); switch globally via `adapter` or per-chat via the `agent` frontmatter
   field
@@ -187,20 +187,20 @@ buffers — save, search, and edit them like any other file.
 
 ### Slash Commands (in Chat)
 
-| Command                   | Description                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------ |
-| `/context <file>`         | Add file to context                                                            |
-| `/clear`                  | Clear context                                                                  |
-| `/save`                   | Save current chat                                                              |
-| `/summarize`              | Summarize conversation                                                         |
-| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                         |
-| `/help`                   | Show available slash commands                                                  |
-| `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules               |
-| `/allow [tool]`           | Add tool to allow list (`-tool` removes), or show current list if no args      |
-| `/deny [tool]`            | Add tool to deny list (`-tool` removes), or show current list if no args       |
-| `/ask [tool]`             | Ask before using tool (`-tool` removes), or show current list if no args       |
-| `/permission [mode]`      | Set permission mode (default/acceptEdits/bypassPermissions/plan/dontAsk/auto)  |
-| `/new-session`            | Reset session and start fresh                                                  |
+| Command                   | Description                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| `/context <file>`         | Add file to context                                                           |
+| `/clear`                  | Clear context                                                                 |
+| `/save`                   | Save current chat                                                             |
+| `/summarize`              | Summarize conversation                                                        |
+| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                        |
+| `/help`                   | Show available slash commands                                                 |
+| `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules              |
+| `/allow [tool]`           | Add tool to allow list (`-tool` removes), or show current list if no args     |
+| `/deny [tool]`            | Add tool to deny list (`-tool` removes), or show current list if no args      |
+| `/ask [tool]`             | Ask before using tool (`-tool` removes), or show current list if no args      |
+| `/permission [mode]`      | Set permission mode (default/acceptEdits/bypassPermissions/plan/dontAsk/auto) |
+| `/new-session`            | Reset session and start fresh                                                 |
 
 `/allow`, `/deny`, and `/ask` also accept granular patterns like `Bash(git:*)`,
 `Read(src/**/*.ts)`, and `WebFetch(github.com)`.

--- a/README.md
+++ b/README.md
@@ -113,15 +113,6 @@ Fine-grained control over what Claude can do:
 - Command pattern matching for shell operations
 - Interactive Permission Builder UI
 
-### 📋 Diff Preview with Accept/Reject
-
-Telescope-style diff preview for all code modifications:
-
-- Visual diff for each changed file
-- Accept all or reject all with Git-based revert
-- Navigate between multiple modified files
-- Works in chat mode
-
 ### 🔀 Concurrent Session Support
 
 Run multiple AI tasks simultaneously:
@@ -251,9 +242,6 @@ anything to connect to.
         deny = { "Bash" },
         rules = {},  -- Optional granular permission rules
       },
-      preview = {
-        enabled = false,  -- Enable diff preview UI (requires Git)
-      },
       language = nil,  -- Optional: "ja" | "en" | { default = "ja", chat = "ja" }
     })
   end,
@@ -338,19 +326,8 @@ In chat buffers, the following keybindings are available:
 | ---- | -------------------------------------------------------------------------------- |
 | `gd` | Show diff for file under cursor (in Modified Files section)                      |
 | `gf` | Open file under cursor (in Modified Files section)                               |
-| `gp` | **Preview all modified files** - Opens Telescope-style preview UI (requires Git) |
+| `gx` | Open URL on current line in browser                                              |
 | `q`  | Close chat window                                                                |
-
-**Preview All Modified Files (`gp`):**
-
-When Claude modifies multiple files in a chat session, press `gp` anywhere in the chat buffer to open
-the preview UI showing all modified files at once. This provides Accept/Reject
-functionality:
-
-- Navigate between files with `j`/`k`
-- Press `a` to accept all changes
-- Press `r` to reject and revert all changes (via `git checkout HEAD`)
-- Press `q` to quit preview
 
 ## ⚙️ Configuration Examples
 
@@ -401,9 +378,6 @@ require("vibing").setup({
   permissions = {
     allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "WebSearch" },
     deny = {},  -- Allow all tools
-  },
-  preview = {
-    enabled = true,  -- Enable diff preview UI
   },
   keymaps = {
     send = "<C-CR>",  -- Custom send key
@@ -701,20 +675,7 @@ keymaps = {
   add_context = "<C-a>", -- Add file to context
   open_diff = "gd",      -- Open diff viewer on file paths
   open_file = "gf",      -- Open file on file paths
-}
-```
-
-### Preview Settings
-
-Configure diff preview UI for chat:
-
-```lua
-preview = {
-  enabled = false,  -- Enable Telescope-style diff preview UI
-                    -- Requires Git repository
-                    -- Shows Accept/Reject UI after code modifications
-                    -- Uses git diff and git checkout for revert
-                    -- Works in chat (gp key)
+  open_url = "gx",       -- Open URL on current line in browser
 }
 ```
 
@@ -900,17 +861,6 @@ daily_summary = {
 | `VibingDailySummaryAll` | `search_dirs` if configured, otherwise default directories |
 
 Summary files are saved as `YYYY-MM-DD.md` with YAML frontmatter containing metadata (date, source files, total messages).
-
-### Remote Control
-
-For testing and development (advanced):
-
-```lua
-remote = {
-  socket_path = nil,   -- Auto-detect from NVIM env variable
-  auto_detect = true,  -- Enable remote control detection
-}
-```
 
 ## 📝 Chat File Format
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bringing intelligent, context-aware chat conversations directly into your editor
 English | [日本語](./README.ja.md)
 
 [Features](#-features) • [Installation](#-installation) • [Usage](#-usage) •
-[Configuration](#️-configuration-examples) • [Contributing](#-contributing)
+[Configuration](#️-configuration) • [Contributing](#-contributing)
 
 </div>
 
@@ -24,13 +24,11 @@ English | [日本語](./README.ja.md)
 
 ## Table of Contents
 
-- [Why vibing.nvim?](#-why-vibingnvim)
 - [Features](#-features)
-- [How It Differs](#-how-it-differs)
 - [Installation](#-installation)
+- [Quick Start](#-quick-start)
 - [Usage](#-usage)
-- [Configuration Examples](#️-configuration-examples)
-- [Configuration Reference](#-configuration-reference)
+- [Configuration](#️-configuration)
 - [Chat File Format](#-chat-file-format)
 - [Architecture](#️-architecture)
 - [FAQ](#-faq)
@@ -38,138 +36,76 @@ English | [日本語](./README.ja.md)
 - [License](#-license)
 - [Links](#-links)
 
-## 💡 Why vibing.nvim?
-
-vibing.nvim takes a fundamentally different approach to AI-assisted coding in Neovim.
-
-### CLI Adapter Architecture
-
-Unlike traditional chat-based AI plugins that send static context to an LLM, vibing.nvim gives AI
-**direct access to your Neovim instance** through CLI backends and MCP integration.
-
-This means the AI can:
-
-```markdown
-- **Autonomously explore your codebase** - Navigate files, search symbols, and understand
-  project structure without manual context setup
-- **Access real-time editor state** - Query LSP diagnostics, symbol definitions, and references
-  on demand
-- **Execute Neovim commands** - Perform editor operations as part of its workflow
-- **Maintain conversation continuity** - Resume sessions with full context preserved in
-  `.vibing` files
-```
-
-### Multi-Backend Support
-
-vibing.nvim supports multiple AI CLI backends with a unified interface:
-
-- **Claude CLI** (`claude -p --stream-json`) - Full Claude Code capabilities within Neovim
-- **Codex CLI** (`codex exec --json`) - OpenAI Codex backend for alternative AI workflows
-
-Switch backends globally via `adapter` config or per-chat via the `agent` frontmatter field.
-
-### Concurrent Sessions
-
-Work on multiple tasks simultaneously without blocking:
-
-- **Multiple chat windows** - Open separate conversations, each with its own independent session
-- **No waiting** - Start a new chat while another is still processing
-
-Example workflow:
-
-```vim
-:VibingChat  " Debug authentication issue in chat 1
-:VibingChat  " Design new feature in chat 2
-```
-
-All sessions run independently with proper conflict management.
-
 ## ✨ Features
 
-### 🤖 Neovim as an Agent Tool
+Unlike chat plugins that send static context to an LLM, vibing.nvim gives the AI **direct
+access to your Neovim instance** through CLI backends and MCP integration.
 
-Claude can directly interact with your running Neovim instance via MCP:
+- **🤖 Neovim as an agent tool** — via MCP, the AI reads and writes buffers, executes commands,
+  and queries LSP (diagnostics, definitions, references, symbols) in your *running* editor
+- **🔀 Multi-backend** — Claude CLI (`claude -p --output-format stream-json`) or Codex CLI
+  (`codex exec --json`); switch globally via `adapter` or per-chat via the `agent` frontmatter
+  field
+- **💾 File-based session persistence** — chats are plain Markdown files with YAML frontmatter
+  saved under `.vibing/chat/`: portable, resumable (full CLI session state), auditable, and
+  version-controllable
+- **🔀 Concurrent sessions** — run multiple independent chats simultaneously; start a new chat
+  while another is still processing
+- **🛡️ Granular permissions** — allow/deny/ask lists per tool, path-based rules for sensitive
+  files, Bash command patterns, and an interactive Permission Builder UI
+- **📊 Diff viewer** — `gd` on a changed file shows a before/after diff; per-request patch
+  tracking by default, with an optional [mote](https://github.com/shabaraba/mote) snapshot
+  backend (used automatically when available) that also catches Bash-driven changes
+- **🎯 Smart context** — add files manually, from oil.nvim, or from a visual selection
+- **🌍 Multi-language support** — configure the AI response language per chat
 
-- Read and write buffers programmatically
-- Execute Ex commands and Lua code
-- Query LSP for diagnostics, definitions, references, and symbols
-- Navigate the file system within your project
+### Consider alternatives if you
 
-### 💾 File-Based Session Persistence
-
-Each conversation is saved as a `.vibing` file with YAML frontmatter:
-
-- **Portable** - Share conversations with teammates or across machines
-- **Resumable** - Continue exactly where you left off with full SDK session state
-- **Auditable** - All settings (model, mode, permissions) are visible in the file
-- **Version-controllable** - Track AI-assisted changes in Git
-
-### 🛡️ Granular Permission System
-
-Fine-grained control over what Claude can do:
-
-- Allow/deny specific tools (Read, Edit, Write, Bash, etc.)
-- Path-based rules for sensitive files
-- Command pattern matching for shell operations
-- Interactive Permission Builder UI
-
-### 🔀 Concurrent Session Support
-
-Run multiple AI tasks simultaneously:
-
-- **Independent chat sessions** - Each chat window maintains its own conversation and session ID
-- **Parallel workflows** - Debug in one chat while designing features in another
-
-### Other Features
-
-- **💬 Interactive Chat Interface** - Seamless chat window with Claude AI, opens in current buffer by default
-- **🔧 Slash Commands** - In-chat commands for context management, permissions, and settings
-- **🎯 Smart Context** - Automatic file context detection from open buffers and manual additions
-- **🌍 Multi-language Support** - Configure language for chat
-- **📊 Diff Viewer** - Visual diff display for AI-edited files with `gd` keybinding
-  - Lightweight per-request patches by default: edited files are backed up before each write
-    and diffed in-process — accurate per-request diffs even with concurrent chats, with no
-    whole-tree scanning
-  - Optional [mote](https://github.com/shabaraba/mote) (fine-grained snapshot tool) backend
-    via `diff.tool = "mote"`
-- **⚙️ Highly Configurable** - Flexible modes, models, permissions, and UI settings
-
-## 🔄 How It Differs
-
-Different AI coding plugins serve different needs. Here's how vibing.nvim fits in:
-
-### vibing.nvim is ideal if you:
-
-- Use Claude or Codex as your AI assistant
-- Want the AI to autonomously navigate and understand your codebase
-- Need persistent, shareable conversation history
-- Prefer fine-grained permission controls
-- Want to work on multiple AI tasks concurrently
-- Want Claude Code / Codex CLI capabilities without leaving Neovim
-
-### Consider alternatives if you:
-
-- Need support for local/offline models (Ollama, etc.)
+- Need local/offline models (Ollama, etc.)
 - Prefer minimal dependencies (vibing.nvim requires Node.js for the MCP server)
-- Want a battle-tested plugin with large community (we're still growing!)
+- Want a battle-tested plugin with a large community (we're still growing!)
 
-### Complementary Usage
-
-vibing.nvim focuses on deep Claude integration. You might still use other tools for:
-
-- Quick completions (GitHub Copilot, Codeium)
-- Local/offline models (Ollama-based plugins)
-- Provider-agnostic workflows
+vibing.nvim doesn't conflict with completion plugins (Copilot, Codeium) or other chat plugins —
+they compose well.
 
 ## 📦 Installation
 
 ### Prerequisites
 
-- **Neovim** 0.9+
+- **Neovim** 0.10+ (uses `vim.system()`)
 - **Node.js** 18+ (for the MCP server)
 - At least one AI CLI backend:
-  - **Claude CLI** (`claude`) — Install via `npm install -g @anthropic-ai/claude-code`
-  - **Codex CLI** (`codex`) — Install via `npm install -g @openai/codex`
+  - **Claude CLI** (`claude`) — `npm install -g @anthropic-ai/claude-code`
+  - **Codex CLI** (`codex`) — `npm install -g @openai/codex`
+
+### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+  "shabaraba/vibing.nvim",
+  dependencies = {
+    "stevearc/oil.nvim",  -- Optional: file browser integration
+  },
+  build = "./build.sh",  -- Builds the MCP server and registers the Claude Code plugin
+  config = function()
+    require("vibing").setup()
+  end,
+}
+```
+
+See [Configuration](#️-configuration) for the options you can pass to `setup()`.
+
+### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
+
+```lua
+use {
+  "shabaraba/vibing.nvim",
+  run = "./build.sh",
+  config = function()
+    require("vibing").setup()
+  end,
+}
+```
 
 ### Claude Code Plugin (MCP + Skills + Agents)
 
@@ -177,8 +113,8 @@ vibing.nvim is also distributed as a [Claude Code plugin](https://code.claude.co
 which bundles the `vibing-nvim` MCP server together with Neovim-aware skills and a read-only
 navigation subagent — no manual `~/.claude.json` editing required.
 
-**Automatic:** if you install with `build = "./build.sh"` (see below) and have the `claude` CLI
-on your `PATH`, `build.sh` runs `claude plugin marketplace add` + `claude plugin install ... --scope
+**Automatic:** if you install with `build = "./build.sh"` (as above) and have the `claude` CLI on
+your `PATH`, `build.sh` runs `claude plugin marketplace add` + `claude plugin install ... --scope
 user` for you on every build — nothing else to do.
 
 **Manual:** to install it yourself (e.g. without running `build.sh`, or on a different machine):
@@ -188,16 +124,15 @@ user` for you on every build — nothing else to do.
 /plugin install vibing-nvim@vibing-nvim
 ```
 
-Either way, this registers the `vibing-nvim` MCP server (same tools as `mcp__vibing-nvim__*`
-described below), adds the `nvim-context` and `nvim-lsp-navigation` skills (teach Claude to read
-live buffer/window/cursor state and prefer LSP over grep when a Neovim instance is connected), and
-the `nvim-navigator` subagent (read-only code navigation via `@vibing-nvim:nvim-navigator`).
+Either way, this registers the `vibing-nvim` MCP server (buffer/window/cursor access, Ex commands,
+and LSP queries against the running Neovim instance, as `mcp__vibing-nvim__*` tools), the bundled
+skills (`nvim-context`, `nvim-lsp-navigation`, `vibing-chat-recall`, `vibing-chat-search`, and the
+`vibing-worktree-{list,create,attach,run,finish}` worktree workflow), and the `nvim-navigator`
+subagent (read-only code navigation via `@vibing-nvim:nvim-navigator`).
 
-The bundled MCP server builds itself (`npm install && npm run build`) on first launch, so no
-separate build step is needed for the MCP server itself — this is independent of the Neovim-side
-`build.sh`, which is still required to build the plugin's other native pieces (see below). You
-still need Neovim running with `mcp = { enabled = true }` (the default) for the MCP tools to have
-anything to connect to.
+The bundled MCP server builds itself on first launch (and whenever its sources change), so no
+separate build step is needed for the MCP server itself. You still need Neovim running with
+`mcp = { enabled = true }` (the default) for the MCP tools to have anything to connect to.
 
 **Uninstalling:**
 
@@ -206,674 +141,133 @@ anything to connect to.
 /plugin marketplace remove vibing-nvim
 ```
 
-### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+## 🚀 Quick Start
 
-```lua
-{
-  "shabaraba/vibing.nvim",
-  dependencies = {
-    -- Optional: for file browser integration
-    "stevearc/oil.nvim",
-  },
-  build = "./build.sh",  -- Builds MCP server for Neovim integration
-  config = function()
-    require("vibing").setup({
-      -- Default configuration
-      adapter = "claude",  -- "claude" | "codex" (global default; overridable per-chat via frontmatter)
-      chat = {
-        window = {
-          position = "current",  -- "current" | "right" | "left" | "top" | "bottom" | "back" | "float"
-          width = 0.4,
-          height = 0.4,
-          border = "rounded",
-        },
-        auto_context = true,
-        save_location_type = "project",  -- "project" | "user" | "custom"
-        context_position = "append",  -- "prepend" | "append"
-      },
-      agent = {
-        default_mode = "code",  -- "code" | "plan" | "explore"
-        default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
-        prioritize_vibing_lsp = true,  -- Prioritize vibing-nvim LSP tools (default: true)
-      },
-      permissions = {
-        mode = "acceptEdits",  -- "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk" | "auto"
-        allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill" },
-        deny = { "Bash" },
-        rules = {},  -- Optional granular permission rules
-      },
-      language = nil,  -- Optional: "ja" | "en" | { default = "ja", chat = "ja" }
-    })
-  end,
-}
+```vim
+:VibingChat        " Open a new chat
 ```
 
-### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
-
-```lua
-use {
-  "shabaraba/vibing.nvim",
-  run = "./build.sh",  -- Builds MCP server for Neovim integration
-  config = function()
-    require("vibing").setup()
-  end,
-}
-```
+Type your message under the `## User` header and press `<CR>` in normal mode to send. The AI
+responds in the same buffer; `<C-c>` cancels a running request. Chats are ordinary Markdown
+buffers — save, search, and edit them like any other file.
 
 ## 🚀 Usage
 
 ### User Commands
 
-| Command                               | Description                                                                                         |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `:VibingChat [position\|file]`        | Create new chat with optional position (current\|right\|left\|top\|bottom\|back) or open saved file |
-| `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                         |
-| `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                         |
-| `:VibingSlashCommands`                | Show slash command picker in chat                                                                   |
-| `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                              |
-| `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                          |
-| `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                   |
-| `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                   |
-| `:VibingClearContext`                 | Clear all context                                                                                   |
-| `:VibingCancel`                       | Cancel current request                                                                              |
-| `:VibingReloadCommands`               | Reload custom slash commands                                                                        |
-| `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                         |
-| `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                     |
-| `:VibingDailySummaryAll [YYYY-MM-DD]` | Generate daily summary from all chat files (default: today)                                         |
+| Command                               | Description                                                                                          |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `:VibingChat [position\|file]`        | Create new chat with optional position (current\|right\|left\|top\|bottom\|back) or open saved file  |
+| `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                          |
+| `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                          |
+| `:VibingSlashCommands`                | Show slash command picker in chat                                                                    |
+| `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                               |
+| `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                           |
+| `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                    |
+| `:VibingContext [path]`               | Add context: oil.nvim entry, visual selection (range), path argument, or current buffer when no args |
+| `:VibingClearContext`                 | Clear all context                                                                                    |
+| `:VibingCancel`                       | Cancel current request                                                                               |
+| `:VibingReloadCommands`               | Reload custom slash commands and completion candidates                                               |
+| `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                          |
+| `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                      |
+| `:VibingDailySummaryAll [YYYY-MM-DD]` | Generate daily summary from all chat files (default: today)                                          |
+| `:VibingCleanMote`                    | Clean mote objects for chat files without deleting the chats                                         |
+| `:VibingMoteDir [dir]`                | Add a directory to the chat's mote tracking (`mote_dirs` frontmatter; default: cwd)                  |
 
 **Command Semantics:**
 
-- **`:VibingChat`** - Always creates a fresh chat window. Optionally specify position to control window placement.
-  - `:VibingChat` - New chat using default position from config
-  - `:VibingChat current` - New chat in current window
-  - `:VibingChat right` - New chat in right split
-  - `:VibingChat left` - New chat in left split
-  - `:VibingChat top` - New chat in top split
-  - `:VibingChat bottom` - New chat in bottom split
-  - `:VibingChat back` - New chat as background buffer only (no window)
-  - `:VibingChat path/to/file.md` - Open saved chat file
-- **Worktree lifecycle** - Use the `vibing-worktree-{list,create,attach,run,finish}` Claude Code skills bundled with this plugin, entirely via natural language, to list/create/attach/run/finish git worktrees under `.vibing/worktrees/<branch>/`.
-- **`:VibingChatFork`** - Fork current chat conversation for branching in a different direction.
-- **`:VibingToggleChat`** - Use to show/hide your current conversation. Preserves the existing chat state.
+- **`:VibingChat`** — always creates a fresh chat. Optionally specify a position
+  (`current` / `right` / `left` / `top` / `bottom` / `back`) or a saved chat file path to reopen it.
+- **`:VibingChatFork`** — fork the current conversation to branch in a different direction
+  (accepts the same positions).
+- **`:VibingToggleChat`** — show/hide your current conversation, preserving its state.
+- **Worktree lifecycle** — handled by the bundled `vibing-worktree-{list,create,attach,run,finish}`
+  Claude Code skills entirely via natural language ("split this off into a worktree"), not by
+  editor commands.
 
 ### Slash Commands (in Chat)
 
-| Command                   | Description                                                              |
-| ------------------------- | ------------------------------------------------------------------------ |
-| `/context <file>`         | Add file to context                                                      |
-| `/clear`                  | Clear context                                                            |
-| `/save`                   | Save current chat                                                        |
-| `/summarize`              | Summarize conversation                                                   |
-| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                   |
-| `/help`                   | Show available slash commands                                            |
-| `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules         |
-| `/allow [tool]`           | Add tool to allow list, or show current list if no args                  |
-| `/deny [tool]`            | Add tool to deny list, or show current list if no args                   |
-| `/ask [tool]`             | Ask before using tool, or show current list if no args                   |
-| `/permission [mode]`      | Set permission mode (default/acceptEdits/bypassPermissions/plan/dontAsk) |
-| `/new-session`            | Reset session and start fresh                                            |
+| Command                   | Description                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `/context <file>`         | Add file to context                                                            |
+| `/clear`                  | Clear context                                                                  |
+| `/save`                   | Save current chat                                                              |
+| `/summarize`              | Summarize conversation                                                         |
+| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                         |
+| `/help`                   | Show available slash commands                                                  |
+| `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules               |
+| `/allow [tool]`           | Add tool to allow list (`-tool` removes), or show current list if no args      |
+| `/deny [tool]`            | Add tool to deny list (`-tool` removes), or show current list if no args       |
+| `/ask [tool]`             | Ask before using tool (`-tool` removes), or show current list if no args       |
+| `/permission [mode]`      | Set permission mode (default/acceptEdits/bypassPermissions/plan/dontAsk/auto)  |
+| `/new-session`            | Reset session and start fresh                                                  |
 
-Worktree lifecycle is handled by the `vibing-worktree-{list,create,attach,run,finish}` Claude
-Code skills bundled with this plugin, not by chat slash commands — see
-`skills/vibing-worktree-list/SKILL.md` and its sibling `-create`, `-attach`, `-run`, `-finish`
-skills.
+`/allow`, `/deny`, and `/ask` also accept granular patterns like `Bash(git:*)`,
+`Read(src/**/*.ts)`, and `WebFetch(github.com)`.
 
 ### Chat Keybindings
 
-In chat buffers, the following keybindings are available:
+In chat buffers (all except `q` are configurable via `keymaps` — see
+[Configuration](#️-configuration)):
 
-| Key  | Description                                                                      |
-| ---- | -------------------------------------------------------------------------------- |
-| `gd` | Show diff for file under cursor (in Modified Files section)                      |
-| `gf` | Open file under cursor (in Modified Files section)                               |
-| `gx` | Open URL on current line in browser                                              |
-| `q`  | Close chat window                                                                |
+| Key     | Description                                                              |
+| ------- | ------------------------------------------------------------------------ |
+| `<CR>`  | Send message (normal mode)                                               |
+| `<C-c>` | Cancel current request                                                   |
+| `<C-a>` | Add file to context                                                      |
+| `gd`    | Show diff for file under cursor (in Modified Files section)              |
+| `gf`    | Open file under cursor (Modified Files section, or any path in the chat) |
+| `gx`    | Open URL on current line in browser                                      |
+| `q`     | Close chat window                                                        |
 
-## ⚙️ Configuration Examples
+## ⚙️ Configuration
 
-### Basic Setup
-
-```lua
-require("vibing").setup()
-```
-
-If you don't provide any configuration, the following **default permissions** will be applied:
-
-```lua
-permissions = {
-  mode = "acceptEdits",  -- Auto-accept file edits, ask for other tools
-  allow = {
-    "Read",    -- Read files
-    "Edit",    -- Edit files
-    "Write",   -- Write new files
-    "Glob",    -- Search files by pattern
-    "Grep",    -- Search file contents
-    "Skill",   -- Use skills (slash commands and workflows)
-  },
-  deny = {
-    "Bash",    -- Block shell commands (security)
-  },
-}
-```
-
-These defaults are used as a **template** when creating new chat files. Each chat file's frontmatter
-contains its own permissions, which are used at runtime.
-
-### Custom Configuration
+`require("vibing").setup()` works out of the box. Commonly tweaked options:
 
 ```lua
 require("vibing").setup({
+  adapter = "claude",              -- "claude" | "codex"
   chat = {
     window = {
-      position = "float",
-      width = 0.6,
-      border = "single",
+      position = "current",        -- "current" | "right" | "left" | "top" | "bottom" | "back" | "float"
+      width = 0.4,                 -- screen-width ratio (0-1)
     },
-    save_location_type = "user",  -- Global chat history
+    save_location_type = "project", -- "project" | "user" | "custom"
   },
   agent = {
-    default_mode = "plan",  -- Start in planning mode
-    default_model = "opus",  -- Use most capable model
+    default_model = "sonnet",      -- "sonnet" | "opus" | "haiku" | "fable"
   },
   permissions = {
-    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "WebSearch" },
-    deny = {},  -- Allow all tools
+    mode = "acceptEdits",          -- "default" | "acceptEdits" | "plan" | "auto" | "dontAsk" | "bypassPermissions"
+    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "StructuredOutput" },
+    deny = { "Bash" },
   },
-  keymaps = {
-    send = "<C-CR>",  -- Custom send key
-    cancel = "<C-c>",
-    add_context = "<C-a>",
-  },
+  language = nil,                  -- e.g. "ja", or { default = "ja", chat = "ja" }
 })
 ```
 
-### Project-Specific Settings
-
-```lua
--- Store chats in project directory
-require("vibing").setup({
-  chat = {
-    save_location_type = "project",  -- .vibing/chat/ in project root
-  },
-})
-```
-
-### Custom Save Location
-
-```lua
-require("vibing").setup({
-  chat = {
-    save_location_type = "custom",
-    save_dir = "~/my-ai-chats/vibing/",
-  },
-})
-```
-
-### Granular Permission Rules
-
-```lua
-require("vibing").setup({
-  permissions = {
-    mode = "default",  -- Ask for confirmation each time
-    rules = {
-      -- Allow reading specific paths
-      {
-        tools = { "Read" },
-        paths = { "src/**", "tests/**" },
-        action = "allow",
-      },
-      -- Deny writing to critical files
-      {
-        tools = { "Write", "Edit" },
-        paths = { ".env", "*.secret" },
-        action = "deny",
-        message = "Cannot modify sensitive files",
-      },
-      -- Allow specific npm commands only
-      {
-        tools = { "Bash" },
-        commands = { "npm", "yarn" },
-        action = "allow",
-      },
-      -- Deny dangerous bash patterns
-      {
-        tools = { "Bash" },
-        patterns = { "^rm -rf", "^sudo" },
-        action = "deny",
-        message = "Dangerous command blocked",
-      },
-    },
-  },
-})
-```
-
-### Multi-language Configuration
-
-```lua
-require("vibing").setup({
-  -- Simple: All responses in Japanese
-  language = "ja",
-
-  -- Advanced: Per-context language
-  -- language = {
-  --   default = "ja",
-  --   chat = "ja",     -- Chat in Japanese
-  -- },
-})
-```
-
-### Daily Summary Configuration
-
-```lua
-require("vibing").setup({
-  daily_summary = {
-    save_dir = ".vibing/daily-reports/",  -- Custom save directory (relative path)
-    -- If not set, defaults to <chat_save_dir>/daily/
-  },
-})
-
--- Or use home directory with vim.fn.expand()
-require("vibing").setup({
-  daily_summary = {
-    save_dir = vim.fn.expand("~/Documents/vibing-daily/"),  -- Expand ~ to home directory
-  },
-})
-
--- Specify search directories for VibingDailySummaryAll
-require("vibing").setup({
-  daily_summary = {
-    search_dirs = {
-      "~/workspaces",  -- Recursively searches ALL .vibing files under this directory
-    },
-    -- When search_dirs is set, VibingDailySummaryAll searches ONLY these directories
-    -- Each directory is recursively searched for .vibing files
-    -- e.g., ~/workspaces/project-a/.vibing/chat/*.vibing will be found
-    -- ~ is automatically expanded to home directory
-    -- ⚠️ Warning: Large directories (e.g., ~/) may impact performance.
-    --            Use specific project directories for better performance.
-  },
-})
-```
-
-### Tool Markers Configuration
-
-Customize visual markers for tool execution with optional pattern matching:
-
-```lua
-require("vibing").setup({
-  ui = {
-    tool_markers = {
-      Task = "▶",           -- Task tool start marker
-      TaskComplete = "✓",   -- Task tool complete marker
-      default = "⏺",        -- Default marker for other tools
-
-      -- Simple string markers
-      Read = "📄",
-      Edit = "✏️",
-      Write = "📝",
-
-      -- Pattern matching for command-specific markers
-      Bash = {
-        default = "💻",     -- Default Bash marker
-        patterns = {
-          -- Package manager operations (supports npm/pnpm/yarn/bun)
-          ["^(npm|pnpm|yarn|bun) install"] = "📦⬇",
-          ["^(npm|pnpm|yarn|bun) run"] = "📦▶",
-
-          -- Git operations
-          ["^git (commit|push|pull)"] = "🌿📝",
-          ["^git checkout"] = "🌿🔀",
-
-          -- Docker operations
-          ["^docker (build|compose)"] = "🐳🔨",
-          ["^docker run"] = "🐳▶",
-
-          -- Build tools
-          ["^(cargo|go) build"] = "🔨",
-          ["^(cargo|go) test"] = "🧪",
-        }
-      },
-    },
-  },
-})
-```
-
-**Pattern Matching Features:**
-
-- Supports full JavaScript regex syntax
-- Patterns are evaluated in definition order (first match wins)
-- Invalid patterns are caught and logged to console
-- More specific patterns should be defined before general ones
-
-## 📚 Configuration Reference
-
-Complete reference of all configuration options:
-
-### Adapter Settings
-
-Select the AI CLI backend:
-
-```lua
-adapter = "claude",  -- Global backend adapter
-                     -- "claude": Use Claude CLI (claude -p --stream-json)
-                     -- "codex":  Use Codex CLI  (codex exec --json)
-                     -- Can be overridden per-chat via "agent" frontmatter field
-```
-
-### Agent Settings
-
-Controls AI agent behavior:
-
-```lua
-agent = {
-  default_mode = "code",    -- Default execution mode
-                            -- "code": Direct implementation
-                            -- "plan": Plan first, then implement
-                            -- "explore": Explore and analyze codebase
-
-  default_model = "sonnet", -- Default model
-                            -- "sonnet": Balanced (recommended)
-                            -- "opus": Most capable
-                            -- "haiku": Fastest
-
-  prioritize_vibing_lsp = true,  -- Prioritize vibing-nvim LSP tools
-                                 -- true: Use vibing-nvim LSP (connects to running Neovim)
-                                 -- false: Allow generic LSP tools (e.g., Serena)
-                                 -- Default: true
-
-  setting_sources = { "user", "project", "local" },  -- Sources passed to the CLI's
-                                 -- --setting-sources flag. Drop "user" to skip loading your
-                                 -- global CLAUDE.md on every chat, reducing fixed per-session
-                                 -- token cost. Note: this does not affect MCP server loading —
-                                 -- use --strict-mcp-config for that.
-                                 -- Default: { "user", "project", "local" }
-}
-```
-
-### Chat Settings
-
-Chat window and session configuration:
-
-```lua
-chat = {
-  window = {
-    position = "current",  -- Window position
-                          -- "current": Open in current window
-                          -- "right": Right vertical split
-                          -- "left": Left vertical split
-                          -- "top": Top horizontal split
-                          -- "bottom": Bottom horizontal split
-                          -- "back": Background buffer only (no window)
-                          -- "float": Floating window
-
-    width = 0.4,          -- Window width (0-1: ratio, >1: absolute columns)
-    height = 0.4,         -- Window height (0-1: ratio, >1: absolute rows, for top/bottom)
-    border = "rounded",   -- Border style: "rounded" | "single" | "double" | "none"
-  },
-
-  auto_context = true,     -- Automatically add open buffers to context
-
-  save_location_type = "project",  -- Chat file save location
-                                   -- "project": .vibing/chat/ in project root
-                                   -- "user": ~/.local/share/nvim/vibing/chats/
-                                   -- "custom": Use save_dir path
-
-  save_dir = "~/.local/share/nvim/vibing/chats",  -- Used when save_location_type="custom"
-
-  context_position = "append",  -- Where to add new context files
-                               -- "append": Add to end of context list
-                               -- "prepend": Add to beginning
-}
-```
-
-### Permissions
-
-Control what tools Claude can use. See [Granular Permission Rules](#granular-permission-rules) for
-detailed examples.
-
-```lua
-permissions = {
-  mode = "acceptEdits",  -- Permission mode
-                        -- "default": Ask for confirmation each time
-                        -- "acceptEdits": Auto-approve Edit/Write (recommended)
-                        -- "bypassPermissions": Auto-approve all (use with caution)
-                        -- "plan": Read-only planning mode (no tool execution)
-                        -- "dontAsk": Deny instead of prompting
-                        -- "auto": Automatic selection
-
-  allow = {              -- Tools to allow (empty = allow all except denied)
-    "Read",              -- Read files
-    "Edit",              -- Edit existing files
-    "Write",             -- Create new files
-    "Glob",              -- Search files by pattern
-    "Grep",              -- Search file contents
-    "Skill",             -- Use skills (slash commands and workflows)
-    -- "Bash",           -- Execute shell commands (security risk)
-    -- "WebSearch",      -- Search the web
-    -- "WebFetch",       -- Fetch web pages
-  },
-
-  deny = {               -- Tools to deny (takes precedence over allow)
-    "Bash",              -- Block shell commands by default
-  },
-
-  ask = {},              -- Tools requiring confirmation before use
-
-  rules = {},            -- Advanced: Granular permission rules
-                        -- See Granular Permission Rules section
-}
-```
-
-### Keymaps
-
-Chat buffer key bindings:
-
-```lua
-keymaps = {
-  send = "<CR>",         -- Send message
-  cancel = "<C-c>",      -- Cancel current request
-  add_context = "<C-a>", -- Add file to context
-  open_diff = "gd",      -- Open diff viewer on file paths
-  open_file = "gf",      -- Open file on file paths
-  open_url = "gx",       -- Open URL on current line in browser
-}
-```
-
-### UI Settings
-
-Configure UI appearance and behavior:
-
-```lua
-ui = {
-  wrap = "on",  -- Line wrapping behavior
-                -- "nvim": Respect Neovim defaults (don't modify wrap settings)
-                -- "on": Enable wrap + linebreak (recommended for chat readability)
-                -- "off": Disable line wrapping
-
-  tool_result_display = "compact",  -- Tool execution result display mode
-                                    -- "none": Don't show tool results
-                                    -- "compact": Show first 100 characters only (default)
-                                    -- "full": Show complete tool output
-
-  gradient = {
-    enabled = true,  -- Enable gradient animation during AI response
-    colors = {
-      "#cc3300",  -- Start color (orange, matching vibing.nvim logo)
-      "#fffe00",  -- End color (yellow, matching vibing.nvim logo)
-    },
-    interval = 100,  -- Animation update interval in milliseconds
-  },
-
-  tool_markers = {
-    Task = "▶",           -- Task tool start marker
-    TaskComplete = "✓",   -- Task tool complete marker
-    default = "⏺",        -- Default marker for other tools
-
-    -- Simple string markers (optional)
-    -- Read = "📄",
-    -- Edit = "✏️",
-    -- Write = "📝",
-
-    -- Pattern matching for command-specific markers (optional)
-    -- Supports full JavaScript regex syntax with grouping and alternation
-    -- Bash = {
-    --   default = "💻",
-    --   patterns = {
-    --     ["^(npm|pnpm|yarn|bun) install"] = "📦⬇",
-    --     ["^(npm|pnpm|yarn|bun) run"] = "📦▶",
-    --     ["^git (commit|push|pull)"] = "🌿📝",
-    --     ["^docker (build|compose)"] = "🐳🔨",
-    --   }
-    -- },
-  },
-}
-```
-
-### MCP (Model Context Protocol)
-
-Enable Claude to directly control Neovim. The MCP server is registered exclusively via the
-"Claude Code Plugin" install described above (installed automatically by `build.sh`) — there is
-no separate `~/.claude.json` registration path, since that route can only ever hardcode a single
-default RPC port and silently targets the wrong Neovim instance whenever more than one is running.
-
-```lua
-mcp = {
-  enabled = true,   -- Enable MCP integration
-  rpc_port = 9876,  -- RPC server port
-}
-```
-
-**Recommended for lazy.nvim:**
-
-```lua
-{
-  "shabaraba/vibing.nvim",
-  build = "./build.sh",
-  config = function()
-    require("vibing").setup({
-      mcp = { enabled = true },
-    })
-  end,
-}
-```
-
-### Node.js Executable
-
-Configure the Node.js executable used for the MCP server and internal scripts:
-
-```lua
-node = {
-  executable = "auto",  -- Node.js executable path
-                        -- "auto": Auto-detect from PATH (default)
-                        -- "/usr/bin/node": Explicit path to node binary
-                        -- "/usr/local/bin/bun": Use bun instead of node
-                        -- Can also be set via VIBING_NODE_EXECUTABLE env var
-
-  dev_mode = false,     -- Development mode for plugin development
-                        -- true: Run TypeScript scripts directly with bun (no build step)
-                        -- false: Use compiled JS from dist/ (default)
-}
-```
-
-**When to use this:**
-
-- **Custom Node.js location**: If node is not in your PATH
-- **Alternative runtime**: Use bun or another Node.js-compatible runtime
-- **Build environment**: Control which Node.js binary is used during `build.sh`
-
-**Build-time configuration:**
-
-During plugin installation (`build.sh`), you can set the `VIBING_NODE_EXECUTABLE` environment
-variable:
-
-```bash
-VIBING_NODE_EXECUTABLE=/usr/local/bin/bun ./build.sh
-```
-
-Or in your Lazy.nvim config:
-
-```lua
-{
-  "shabaraba/vibing.nvim",
-  build = "VIBING_NODE_EXECUTABLE=/usr/local/bin/bun ./build.sh",
-  config = function()
-    require("vibing").setup({
-      node = {
-        executable = "/usr/local/bin/bun",
-      },
-    })
-  end,
-}
-```
-
-### Language
-
-Configure AI response language:
-
-```lua
--- Simple: All responses in one language
-language = "ja"  -- or "en", "fr", etc.
-
--- Advanced: Per-context language
-language = {
-  default = "ja",  -- Default language
-  chat = "ja",     -- Chat window responses
-}
-```
-
-### Daily Summary
-
-Configure daily summary generation:
-
-```lua
-daily_summary = {
-  save_dir = nil,  -- Custom save directory for daily summaries
-                   -- nil: Auto-detect from chat save directory
-                   --      If chat_save_dir ends with "/chat/", uses "/daily/"
-                   --      Otherwise, appends "daily/" to chat_save_dir
-                   -- string: Custom path
-                   --      Relative: ".vibing/daily-reports/"
-                   --      Absolute: "/path/to/reports/"
-                   --      Home dir: vim.fn.expand("~/Documents/vibing-daily/")
-
-  search_dirs = nil,  -- Search directories for VibingDailySummaryAll
-                      -- nil: Use default directories (project/.vibing/chat, user data dir, custom save_dir)
-                      -- string[]: Parent directories to recursively search for .vibing files
-                      --           e.g., { "~/workspaces" } finds all .vibing files under ~/workspaces/
-                      --           ~ is automatically expanded
-                      -- ⚠️ Warning: Large directories (e.g., ~/) may impact performance.
-                      --            Use specific project directories for better performance.
-}
-```
-
-**Usage:**
-
-```vim
-:VibingDailySummary [YYYY-MM-DD]     " Generate summary from current project only
-:VibingDailySummaryAll [YYYY-MM-DD]  " Generate summary from all configured directories
-```
-
-**Command Differences:**
-
-| Command                 | Search Scope                                               |
-| ----------------------- | ---------------------------------------------------------- |
-| `VibingDailySummary`    | Current project's chat save directory only                 |
-| `VibingDailySummaryAll` | `search_dirs` if configured, otherwise default directories |
-
-Summary files are saved as `YYYY-MM-DD.md` with YAML frontmatter containing metadata (date, source files, total messages).
+The default permissions shown above are used as a **template** when creating new chat files; each
+chat file's frontmatter carries its own permissions, which are what's enforced at runtime.
+
+**Full reference:** every option (window details, UI/gradient/tool markers, diff backends,
+granular permission rules, MCP, Node.js executable, daily summary, ...) is documented in
+[docs/configuration.md](./docs/configuration.md).
 
 ## 📝 Chat File Format
 
-Chats are saved as Markdown with YAML frontmatter for session resumption and configuration:
+Chats are saved as Markdown files (`.vibing/chat/chat-<timestamp>-....md` by default) with YAML
+frontmatter for session resumption and configuration:
 
 ```yaml
 ---
 vibing.nvim: true
 session_id: <cli-session-id>
 created_at: 2024-01-01T12:00:00
+working_dir: .vibing/worktrees/feature-x  # Optional: working directory (relative to git root)
 agent: claude  # claude | codex (overrides global adapter setting for this chat)
+mode: code  # code | plan | explore
 model: sonnet  # sonnet | opus | haiku | fable
-permissions_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk
+permission_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk | auto
 permissions_allow:
   - Read
   - Edit
@@ -882,6 +276,7 @@ permissions_allow:
   - Grep
 permissions_deny:
   - Bash
+permissions_ask: []
 language: ja  # Optional: default language for AI responses
 ---
 # Vibing Chat
@@ -897,22 +292,20 @@ Hello! How can I help you today?
 
 **Key Features:**
 
-- **Session Resumption**: Automatically resumes conversation using `session_id`
-- **Configuration Tracking**: Records mode, model, and permissions for transparency
-- **Language Support**: Optional `language` field for consistent AI response language
-- **Auditability**: All permissions are visible in frontmatter
+- **Session Resumption** — reopening a saved chat resumes the conversation via `session_id`
+- **Fork tracking** — a forked chat carries a `forked_from` field until its first response
+- **Auditability** — model, mode, and permissions are all visible in frontmatter
+- **Language Support** — optional `language` field for consistent AI response language
 
 ## 🏗️ Architecture
 
 For detailed architecture documentation, see [CLAUDE.md](./CLAUDE.md).
 
-### High-Level Overview
-
 ```mermaid
 graph TB
     subgraph Neovim["Neovim Process"]
         Plugin["vibing.nvim<br/>(Lua Plugin)"]
-        Buffer["Chat Buffer<br/>(.vibing file)<br/>- Markdown + YAML<br/>- Session metadata<br/>- Permission settings"]
+        Buffer["Chat Buffer<br/>(.vibing/chat/*.md)<br/>- Markdown + YAML<br/>- Session metadata<br/>- Permission settings"]
         RPC["RPC Server<br/>(Async TCP)"]
 
         Plugin -->|manages| Buffer
@@ -920,27 +313,18 @@ graph TB
     end
 
     subgraph MCP["Node.js MCP Server"]
-        MCPServer["MCP Server<br/>- Buffer operations<br/>- LSP queries<br/>- Command execution<br/>- File system access"]
+        MCPServer["MCP Server<br/>- Buffer operations<br/>- LSP queries<br/>- Command execution"]
     end
 
     subgraph AI["AI CLI Backends"]
-        Claude["Claude CLI<br/>(claude -p --stream-json)"]
+        Claude["Claude CLI<br/>(claude -p --output-format stream-json)"]
         Codex["Codex CLI<br/>(codex exec --json)"]
     end
 
     RPC <-->|JSON-RPC| MCPServer
     Plugin -->|spawns & communicates<br/>JSON Lines| Claude
     Plugin -->|spawns & communicates<br/>JSON Lines| Codex
-
-    style Neovim fill:#e1f5ff
-    style MCP fill:#fff4e1
-    style AI fill:#e8f5e9
-    style Plugin fill:#bbdefb
-    style Claude fill:#ffe0b2
-    style Codex fill:#c8e6c9
 ```
-
-### How It Differs from Traditional Approaches
 
 | Aspect         | Traditional REST API | vibing.nvim (CLI Adapters)    |
 | -------------- | -------------------- | ----------------------------- |
@@ -948,63 +332,16 @@ graph TB
 | Editor Access  | None (fire & forget) | Full bidirectional MCP        |
 | Session State  | Plugin manages       | CLI session with resume       |
 | Tool Execution | Plugin implements    | CLI native tools              |
-| Capabilities   | Limited to plugin    | Extensible via MCP            |
-
-**Key Components:**
-
-- **CLI Adapters** - Direct execution of `claude` / `codex` CLI communicating via JSON Lines
-- **MCP Server** - Provides AI with direct Neovim control (buffers, LSP, commands)
-- **Context System** - Automatic and manual file context management
-- **Session Persistence** - Resume conversations with full history
-
-### Directory Structure
-
-vibing.nvim is a hybrid project combining Neovim plugin (Lua) and Node.js backend (Agent SDK/MCP).
-This structure follows both Neovim plugin conventions and Node.js ecosystem standards.
-
-**Neovim Plugin (required by Neovim runtime):**
-
-- `lua/` - Plugin implementation (Lua modules)
-- `plugin/` - Auto-loaded plugin entry point
-- `doc/` - Help documentation (`:help vibing`)
-- `ftplugin/` - Filetype-specific settings for `.vibing` chat files
-
-**Node.js Backend:**
-
-- `bin/` - Executable wrappers for Agent SDK
-- `mcp-server/` - MCP integration server for Neovim control
-- `tests/` - Test suite (Lua and Node.js tests)
-- `package.json` - Node.js dependencies and scripts
-
-**Documentation:**
-
-- `README.md` - Main user documentation
-- `CLAUDE.md` - AI development guidelines and architecture details
-- `docs/` - Developer guides (adapter development, performance, examples)
-- `CONTRIBUTING.md` - Contribution guide
-
-**Development Configuration:**
-
-- `.editorconfig`, `.prettierrc` - Code style consistency
-- `eslint.config.mjs` - Linting configuration
-- `.github/` - CI/CD workflows and issue templates
-- `build.sh` - Build script for MCP server
-
-## 🤝 Contributing
-
-Contributions are welcome! Please feel free to submit issues or pull requests.
 
 ## ❓ FAQ
 
 ### Which AI backends are supported?
 
-vibing.nvim currently supports:
-
-- **Claude CLI** (`claude -p --stream-json`) — Full Claude Code capabilities
+- **Claude CLI** (`claude -p --output-format stream-json`) — full Claude Code capabilities
 - **Codex CLI** (`codex exec --json`) — OpenAI Codex backend
 
-Switch backends globally with `adapter = "claude"|"codex"` in setup, or per-chat by adding
-`agent: claude` or `agent: codex` to a chat file's YAML frontmatter.
+Switch globally with `adapter = "claude"|"codex"` in setup, or per-chat by adding `agent: claude`
+or `agent: codex` to a chat file's YAML frontmatter.
 
 ### Why does it require Node.js?
 
@@ -1024,7 +361,14 @@ Think of it as "Claude Code (or Codex) for Neovim users."
 
 ### Can I use vibing.nvim alongside other AI plugins?
 
-Yes. vibing.nvim doesn't conflict with completion plugins (Copilot, Codeium) or other chat plugins. Use vibing.nvim for deep Claude interactions and other tools for quick completions or different providers.
+Yes. vibing.nvim doesn't conflict with completion plugins (Copilot, Codeium) or other chat
+plugins. Use vibing.nvim for deep Claude interactions and other tools for quick completions or
+different providers.
+
+## 🤝 Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md), and feel free to submit
+issues or pull requests.
 
 ## 📄 License
 

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -24,18 +24,22 @@
 
 ```lua
 require("vibing").setup({
-  adapter = "agent_sdk",
+  adapter = "claude",  -- "claude" | "codex"
   agent = {
-    mode = "command",
-    model = "claude-sonnet-4-5",
+    default_mode = "code",     -- "code" | "plan" | "explore"
+    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
   },
   chat = {
-    position = "right",
-    size = 80,
-    auto_context = false,
+    window = {
+      position = "right",  -- "current" | "right" | "left" | "top" | "bottom" | "back" | "float"
+      width = 0.4,         -- 画面幅に対する比率（0-1）
+    },
+    save_location_type = "project",
   },
 })
 ```
+
+全オプションは [docs/configuration.md](../docs/configuration.md) を参照してください。
 
 ### `vibing.get_adapter()`
 

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -409,13 +409,17 @@ require("vibing.context").clear()
 
 ```lua
 ---@class Vibing.Config
----@field adapter string アダプター名（"agent_sdk", "claude", "claude_acp"）
----@field cli_path string Claude CLI パス
----@field agent Vibing.AgentConfig Agent SDK設定
+---@field adapter "claude"|"codex" バックエンドアダプター選択
+---@field agent Vibing.AgentConfig エージェント設定（モード、モデル）
 ---@field chat Vibing.ChatConfig チャット設定
+---@field ui Vibing.UiConfig UI設定
 ---@field keymaps Vibing.KeymapConfig キーマップ設定
+---@field diff Vibing.DiffConfig diff表示設定
 ---@field permissions Vibing.PermissionsConfig 権限設定
----@field remote Vibing.RemoteConfig リモート制御設定
+---@field node Vibing.NodeConfig Node.js実行ファイル設定
+---@field mcp Vibing.McpConfig MCP統合設定
+---@field language string|Vibing.LanguageConfig? AI応答のデフォルト言語
+---@field daily_summary Vibing.DailySummaryConfig? Daily Summary機能設定
 ```
 
 ### `Vibing.AdapterOpts`

--- a/doc/tutorials/getting-started.md
+++ b/doc/tutorials/getting-started.md
@@ -13,14 +13,20 @@
 
 ## 前提条件
 
-- Neovim 0.10.0以降
-- Node.js 18以降（Agent SDK アダプター使用時）
-- Claude Code CLI（推奨）
+- Neovim 0.10.0以降（`vim.system()` を使用）
+- Node.js 18以降（MCP サーバー用）
+- AI CLI バックエンドを最低1つ:
+  - Claude CLI（推奨）
+  - Codex CLI
 
-### Claude Code CLI のインストール
+### CLI のインストール
 
 ```bash
-npm install -g @anthropics/claude-code
+# Claude CLI
+npm install -g @anthropic-ai/claude-code
+
+# Codex CLI（任意）
+npm install -g @openai/codex
 ```
 
 ## インストール
@@ -29,10 +35,11 @@ npm install -g @anthropics/claude-code
 
 ```lua
 {
-  "your-username/vibing.nvim",
+  "shabaraba/vibing.nvim",
   dependencies = {
-    "nvim-lua/plenary.nvim",
+    "stevearc/oil.nvim",  -- オプション: ファイルブラウザ統合
   },
+  build = "./build.sh",  -- MCP サーバーのビルドと Claude Code プラグインの登録
   config = function()
     require("vibing").setup()
   end,
@@ -43,26 +50,12 @@ npm install -g @anthropics/claude-code
 
 ```lua
 use {
-  "your-username/vibing.nvim",
-  requires = {
-    "nvim-lua/plenary.nvim",
-  },
+  "shabaraba/vibing.nvim",
+  run = "./build.sh",
   config = function()
     require("vibing").setup()
   end,
 }
-```
-
-### vim-plug
-
-```vim
-Plug 'nvim-lua/plenary.nvim'
-Plug 'your-username/vibing.nvim'
-```
-
-```lua
--- init.lua
-require("vibing").setup()
 ```
 
 ## 基本設定
@@ -79,30 +72,31 @@ require("vibing").setup()
 
 ```lua
 require("vibing").setup({
-  -- アダプター選択（agent_sdk推奨）
-  adapter = "agent_sdk",
+  adapter = "claude",  -- "claude" | "codex"
 
-  -- Agent SDK設定
+  -- エージェント設定
   agent = {
-    mode = "command",  -- commandモード（ツール使用なし）
-    model = "claude-sonnet-4-5",  -- 使用モデル
+    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
   },
 
   -- チャットウィンドウ設定
   chat = {
-    position = "right",  -- 右側に表示
-    size = 80,           -- 幅80カラム
-    auto_context = false,  -- 自動コンテキスト無効
-    location_type = "project",  -- プロジェクトディレクトリに保存
+    window = {
+      position = "right",  -- 右側に分割表示
+      width = 0.4,         -- 画面幅の40%
+    },
+    save_location_type = "project",  -- プロジェクトの .vibing/chat/ に保存
   },
 
   -- キーマップ設定
   keymaps = {
-    submit = "<C-CR>",  -- Ctrl+Enterで送信
-    cancel = "<C-c>",   -- Ctrl+Cでキャンセル
+    send = "<C-CR>",  -- Ctrl+Enterで送信（デフォルトは <CR>）
+    cancel = "<C-c>", -- Ctrl+Cでキャンセル
   },
 })
 ```
+
+全オプションは [docs/configuration.md](../../docs/configuration.md) を参照してください。
 
 ### カスタムキーマップ
 
@@ -127,8 +121,8 @@ vim.keymap.set("n", "<leader>cc", ":VibingChat<CR>", { desc = "Open chat" })
 ### メッセージを送信
 
 1. チャットウィンドウで `## User` セクションの下にメッセージを入力
-2. `<C-CR>`（Ctrl+Enter）で送信
-3. Claudeの応答が `## Assistant` セクションに表示されます
+2. ノーマルモードで `<CR>`（設定変更時は `keymaps.send` のキー）で送信
+3. AI の応答が `## Assistant` セクションに表示されます
 
 **例：**
 
@@ -144,13 +138,15 @@ Luaでクイックソートを実装してください。
 :w
 ```
 
-チャットは `.vibing/chat/` ディレクトリに自動保存されます。
+チャットは `.vibing/chat/` ディレクトリに Markdown ファイルとして保存されます。
 
 ### 保存したチャットを開く
 
 ```vim
-:VibingOpenChat .vibing/chat/quicksort-implementation.md
+:VibingChat .vibing/chat/chat-20260101-120000-xxxx.md
 ```
+
+保存済みチャットを開くと、frontmatter の `session_id` で会話が再開されます。
 
 ## コンテキストの活用
 
@@ -166,22 +162,12 @@ Luaでクイックソートを実装してください。
 :VibingContext
 ```
 
+ビジュアル選択した範囲だけを追加することもできます（選択して `:VibingContext`）。
+
 ### コンテキストをクリア
 
 ```vim
 :VibingClearContext
-```
-
-### 自動コンテキスト
-
-開いている全バッファを自動的にコンテキストに含めます：
-
-```lua
-require("vibing").setup({
-  chat = {
-    auto_context = true,
-  },
-})
 ```
 
 ### チャット内でコンテキストを指定
@@ -202,56 +188,39 @@ require("vibing").setup({
 
 **A**: 以下を確認してください：
 
-1. Claude Code CLIがインストールされているか: `claude --version`
-2. APIキーが設定されているか
+1. CLI がインストールされているか: `claude --version`（または `codex --version`）
+2. CLI のログイン・APIキーが設定されているか
 3. ネットワーク接続が正常か
-
-### Q: エラー "Adapter 'agent_sdk' not found"
-
-**A**: Agent SDKアダプターを使用するにはNode.jsが必要です。以下を確認：
-
-```bash
-node --version  # 18以降が必要
-```
-
-または、他のアダプターを使用：
-
-```lua
-require("vibing").setup({
-  adapter = "claude",  -- Claude CLIを直接使用
-})
-```
 
 ### Q: キーマップが動作しない
 
 **A**: 設定が正しく読み込まれているか確認：
 
-```lua
+```vim
 :lua print(vim.inspect(require("vibing").get_config()))
 ```
 
 ### Q: チャットファイルの保存場所を変更したい
 
-**A**: `location_type` を設定：
+**A**: `save_location_type` を設定：
 
 ```lua
 require("vibing").setup({
   chat = {
-    location_type = "custom",
-    custom_directory = "~/my-chats/",
+    save_location_type = "custom",
+    save_dir = "~/my-chats/",
   },
 })
 ```
 
-### Q: ストリーミングを無効にしたい
+### Q: Codex を使いたい
 
-**A**: 現在のところ、Agent SDKアダプターはストリーミング専用です。非ストリーミングが必要な場合は、`claude` アダプターを使用してください。
+**A**: グローバルには `adapter = "codex"`、チャット単位では frontmatter に `agent: codex` を指定します。
 
 ## 次のステップ
 
-- [API Reference](../api-reference.md) - 全APIの詳細
-- [Configuration Examples](../examples/configurations.md) - 様々な設定例
-- [Advanced Features](./advanced-features.md) - 高度な機能の活用
+- [Configuration Reference](../../docs/configuration.md) - 全設定オプションの詳細
+- [API Reference](../api-reference.md) - Lua API の詳細
 
 ## トラブルシューティング
 
@@ -261,16 +230,16 @@ require("vibing").setup({
 :messages
 ```
 
-### デバッグモード
+### ストリーミングのデバッグ
 
 ```lua
-vim.g.vibing_debug = true
+vim.g.vibing_debug_stream = true
 ```
 
 ### サポート
 
 問題が解決しない場合は、以下にissueを作成してください：
-https://github.com/your-username/vibing.nvim/issues
+https://github.com/shabaraba/vibing.nvim/issues
 
 **報告時に含めるべき情報：**
 

--- a/doc/tutorials/getting-started.md
+++ b/doc/tutorials/getting-started.md
@@ -114,7 +114,7 @@ vim.keymap.set("n", "<leader>cc", ":VibingChat<CR>", { desc = "Open chat" })
 
 または設定したキーマップで：
 
-```
+```text
 <leader>cc
 ```
 
@@ -239,7 +239,7 @@ vim.g.vibing_debug_stream = true
 ### サポート
 
 問題が解決しない場合は、以下にissueを作成してください：
-https://github.com/shabaraba/vibing.nvim/issues
+<https://github.com/shabaraba/vibing.nvim/issues>
 
 **報告時に含めるべき情報：**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,406 @@
+# Configuration Reference
+
+Complete reference for every `require("vibing").setup()` option. Defaults shown below match
+`lua/vibing/config.lua`.
+
+## Table of Contents
+
+- [Defaults at a Glance](#defaults-at-a-glance)
+- [Adapter](#adapter)
+- [Agent](#agent)
+- [Chat](#chat)
+- [UI](#ui)
+- [Keymaps](#keymaps)
+- [Diff](#diff)
+- [Permissions](#permissions)
+- [Granular Permission Rules](#granular-permission-rules)
+- [MCP](#mcp)
+- [Node.js Executable](#nodejs-executable)
+- [Language](#language)
+- [Daily Summary](#daily-summary)
+
+## Defaults at a Glance
+
+```lua
+require("vibing").setup({
+  adapter = "claude",
+  agent = {
+    default_mode = "code",
+    default_model = "sonnet",
+    utility_model = "haiku",
+    setting_sources = { "user", "project", "local" },
+  },
+  chat = {
+    window = {
+      position = "current",
+      width = 0.4,
+      height = 0.4,
+      border = "rounded",
+    },
+    save_location_type = "project",
+    save_dir = vim.fn.stdpath("data") .. "/vibing/chats",
+  },
+  ui = {
+    wrap = "on",
+    gradient = {
+      enabled = true,
+      colors = { "#cc3300", "#fffe00" },
+      interval = 100,
+    },
+    tool_result_display = "compact",
+    tool_markers = {
+      Task = "▶",
+      default = "⏺",
+    },
+  },
+  keymaps = {
+    send = "<CR>",
+    cancel = "<C-c>",
+    add_context = "<C-a>",
+    open_diff = "gd",
+    open_file = "gf",
+    open_url = "gx",
+  },
+  diff = {
+    tool = "auto",
+    mote = {
+      project = nil,
+      context_prefix = "vibing",
+    },
+  },
+  permissions = {
+    mode = "acceptEdits",
+    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "StructuredOutput" },
+    deny = { "Bash" },
+    ask = {},
+    rules = {},
+  },
+  node = {
+    executable = "auto",
+  },
+  mcp = {
+    enabled = true,
+    rpc_port = 9876,
+  },
+  language = nil,
+  daily_summary = {
+    save_dir = nil,
+    search_dirs = {},
+    file_finder_strategy = "auto",
+  },
+})
+```
+
+## Adapter
+
+```lua
+adapter = "claude",  -- Global backend adapter
+                     -- "claude": Claude CLI (claude -p --output-format stream-json)
+                     -- "codex":  Codex CLI  (codex exec --json)
+                     -- Overridable per-chat via the "agent" frontmatter field
+```
+
+## Agent
+
+```lua
+agent = {
+  default_mode = "code",    -- Recorded in each new chat's frontmatter as `mode`
+                            -- ("code" | "plan" | "explore"). Currently metadata only —
+                            -- it does not change runtime behavior.
+
+  default_model = "sonnet", -- Default model for new chats
+                            -- "sonnet": Balanced (recommended)
+                            -- "opus": Most capable
+                            -- "haiku": Fastest
+                            -- "fable": Claude Fable
+
+  utility_model = "haiku",  -- Model used for lightweight utility calls
+                            -- (AI title generation, chat summaries, daily summaries).
+                            -- Takes priority over the chat's model for those calls.
+
+  setting_sources = { "user", "project", "local" },
+                            -- Passed to the Claude CLI's --setting-sources flag.
+                            -- Drop "user" to skip loading your global CLAUDE.md on
+                            -- every chat, reducing fixed per-session token cost.
+                            -- Note: does not affect MCP server loading.
+}
+```
+
+## Chat
+
+```lua
+chat = {
+  window = {
+    position = "current",  -- "current": open in current window
+                           -- "right" / "left": vertical split
+                           -- "top" / "bottom": horizontal split
+                           -- "back": background buffer only (no window)
+                           -- "float": floating window
+
+    width = 0.4,           -- Screen-width ratio (0-1). Applied to right/left splits
+                           -- and floating windows. Always interpreted as a ratio —
+                           -- absolute column counts are not supported.
+
+    height = 0.4,          -- Screen-height ratio (0-1). Applied to top/bottom splits
+                           -- only. Floating windows use a fixed 0.8 screen ratio.
+
+    border = "rounded",    -- Border for position = "float" only (any nvim_open_win
+                           -- border spec). Split windows have no border.
+  },
+
+  save_location_type = "project",  -- Chat file save location
+                                   -- "project": .vibing/chat/ in project root
+                                   -- "user": stdpath("data") .. "/vibing/chats"
+                                   -- "custom": use save_dir
+
+  save_dir = vim.fn.stdpath("data") .. "/vibing/chats",  -- Used when save_location_type = "custom"
+}
+```
+
+Chat files are created as Markdown (`chat-<timestamp>-....md`) inside the save location.
+
+## UI
+
+```lua
+ui = {
+  wrap = "on",  -- "nvim": respect Neovim defaults (don't touch wrap settings)
+                -- "on": enable wrap + linebreak (recommended for chat readability)
+                -- "off": disable line wrapping
+
+  tool_result_display = "compact",  -- "none": don't show tool results
+                                    -- "compact": first 100 characters only (default)
+                                    -- "full": complete tool output
+
+  gradient = {
+    enabled = true,   -- Animate line numbers while the AI is responding
+    colors = { "#cc3300", "#fffe00" },  -- Exactly 2 hex colors: { start, end }
+    interval = 100,   -- Animation update interval (ms)
+  },
+
+  tool_markers = {
+    Task = "▶",      -- Marker for the Task tool
+    default = "⏺",   -- Default marker for all other tools
+
+    -- Per-tool string markers (optional):
+    -- Read = "📄",
+    -- Edit = "✏️",
+    -- Bash = "💻",
+  },
+}
+```
+
+A `tool_markers` entry may also be a table with a `default` key (e.g.
+`Bash = { default = "💻" }`); only the `default` key is used.
+
+## Keymaps
+
+Chat-buffer key bindings (all six are configurable; `q` to close the window is fixed):
+
+```lua
+keymaps = {
+  send = "<CR>",         -- Send message
+  cancel = "<C-c>",      -- Cancel current request
+  add_context = "<C-a>", -- Add file to context
+  open_diff = "gd",      -- Open diff viewer on file paths
+  open_file = "gf",      -- Open file on file paths
+  open_url = "gx",       -- Open URL on current line in browser
+}
+```
+
+## Diff
+
+Selects the strategy used by the `gd` diff viewer:
+
+```lua
+diff = {
+  tool = "auto",  -- "auto": use mote when available, otherwise per-request patches
+                  -- "git":  per-request patches (vim.diff-based, no external process)
+                  -- "mote": mote snapshots (catches Bash-driven file changes too)
+  mote = {
+    project = nil,              -- Project name (nil = auto-detect from git repo name)
+    context_prefix = "vibing",  -- Prefix for mote context names
+  },
+}
+```
+
+With per-request patches, edited files are backed up before each write and stored as patches
+under `.vibing/patches/`; Bash-driven file changes are only captured by the mote backend. See
+[MIGRATION_MOTE.md](./MIGRATION_MOTE.md) for mote setup details.
+
+## Permissions
+
+```lua
+permissions = {
+  mode = "acceptEdits",  -- Permission mode
+                         -- "default": ask for confirmation each time
+                         -- "acceptEdits": auto-approve Edit/Write (recommended)
+                         -- "plan": forwarded to the CLI as --permission-mode plan
+                         --         (read-only planning enforced by the CLI itself)
+                         -- "auto": approve everything not matched by the deny
+                         --         list / deny rules
+                         -- "dontAsk": deny instead of prompting
+                         -- "bypassPermissions": auto-approve all (use with caution)
+
+  allow = {              -- Tools to allow (empty = allow all except denied)
+    "Read", "Edit", "Write", "Glob", "Grep", "Skill", "StructuredOutput",
+  },
+
+  deny = { "Bash" },     -- Tools to deny (takes precedence over allow)
+
+  ask = {},              -- Tools requiring confirmation before each use
+
+  rules = {},            -- Granular rules — see next section
+}
+```
+
+Valid tool names: `Read`, `Edit`, `Write`, `Bash`, `Glob`, `Grep`, `WebSearch`, `WebFetch`,
+`Skill`, `StructuredOutput`. Bash command patterns (`Bash(git:*)`) and MCP tool names
+(`mcp__server__tool`) are also accepted in the lists.
+
+Two built-in behaviors to be aware of:
+
+- `Read`, `Skill`, and `StructuredOutput` are **always allowed** regardless of the allow list
+  (they can still be blocked via `deny`).
+- `Skill` is automatically appended to `allow` unless you put it in `deny` or `ask`.
+
+## Granular Permission Rules
+
+Fine-grained control based on tool inputs:
+
+```lua
+permissions = {
+  mode = "default",
+  rules = {
+    -- Allow reading specific paths
+    { tools = { "Read" }, paths = { "src/**", "tests/**" }, action = "allow" },
+
+    -- Deny writes to sensitive files, with a custom message
+    {
+      tools = { "Write", "Edit" },
+      paths = { ".env", "*.secret" },
+      action = "deny",
+      message = "Cannot modify sensitive files",
+    },
+
+    -- Allow specific Bash commands (exact base-command match)
+    { tools = { "Bash" }, commands = { "npm", "yarn" }, action = "allow" },
+
+    -- Deny dangerous Bash command patterns (Lua patterns — escape "-" as "%-")
+    { tools = { "Bash" }, patterns = { "^rm %-rf", "^sudo" }, action = "deny" },
+
+    -- Restrict web fetches to specific domains
+    { tools = { "WebFetch" }, domains = { "github.com", "*.npmjs.com" }, action = "allow" },
+  },
+}
+```
+
+Field reference:
+
+| Field | Applies to | Matching |
+| --- | --- | --- |
+| `tools` | any | Exact tool-name match |
+| `paths` | tools whose input has a file path (Read/Write/Edit/...) | Glob: `*` (single dir), `**` (recursive); paths are normalized to absolute, symlink-resolved form first |
+| `commands` | `Bash` only | Exact match against the base command (first word) |
+| `patterns` | `Bash` only | **Lua patterns**, not regex — escape `-` as `%-` (e.g. `"^rm %-rf"`). Patterns longer than 500 chars are ignored |
+| `domains` | `WebFetch` only | Domain match with `*.` wildcard support |
+| `action` | — | `"allow"` or `"deny"` |
+| `message` | — | Shown when a `deny` rule blocks a call |
+
+Evaluation notes:
+
+- Rules are evaluated **after** the tool-level `allow`/`ask` lists.
+- Any matching `deny` rule blocks immediately and beats every `allow` rule.
+- A rule whose condition doesn't apply to the tool's input (e.g. `paths` on a `Bash` call)
+  is skipped.
+
+## MCP
+
+Enables the RPC server that the bundled `vibing-nvim` MCP server connects to (see the README's
+Installation section for how the MCP server itself is installed via the Claude Code plugin):
+
+```lua
+mcp = {
+  enabled = true,   -- Start the Neovim-side RPC server
+  rpc_port = 9876,  -- RPC server port
+}
+```
+
+## Node.js Executable
+
+```lua
+node = {
+  executable = "auto",  -- "auto": detect from PATH (default)
+                        -- or an explicit path, e.g. "/usr/local/bin/node"
+                        -- (bun and other Node-compatible runtimes work too)
+}
+```
+
+During plugin installation (`build.sh`), the `VIBING_NODE_EXECUTABLE` environment variable
+controls which binary is used for the build:
+
+```bash
+VIBING_NODE_EXECUTABLE=/usr/local/bin/bun ./build.sh
+```
+
+Or in your lazy.nvim spec:
+
+```lua
+{
+  "shabaraba/vibing.nvim",
+  build = "VIBING_NODE_EXECUTABLE=/usr/local/bin/bun ./build.sh",
+  config = function()
+    require("vibing").setup({
+      node = { executable = "/usr/local/bin/bun" },
+    })
+  end,
+}
+```
+
+## Language
+
+Configure AI response language:
+
+```lua
+-- Simple: all responses in one language
+language = "ja"  -- "ja", "en", "zh", "ko", "fr", "de", "es", ...
+
+-- Advanced: per-context language
+language = {
+  default = "ja",  -- Default language
+  chat = "ja",     -- Chat responses (falls back to default)
+}
+```
+
+## Daily Summary
+
+Settings for `:VibingDailySummary` / `:VibingDailySummaryAll`:
+
+```lua
+daily_summary = {
+  save_dir = nil,  -- nil: auto-detect from the chat save directory
+                   --      (".../chat/" becomes ".../daily/", otherwise "daily/" is appended)
+                   -- string: custom path (relative, absolute, or vim.fn.expand("~/..."))
+
+  search_dirs = {},  -- Directories for :VibingDailySummaryAll
+                     -- {} (default): search the standard locations (project .vibing/chat,
+                     --     user data dir, custom save_dir)
+                     -- { "~/workspaces" }: search ONLY the listed directories.
+                     --     Each entry is scanned for `.vibing` directories (max depth 5,
+                     --     skipping node_modules/.git/build/dist) and chat files are
+                     --     collected from their chat/ subdirectories.
+
+  file_finder_strategy = "auto",  -- File search backend
+                                  -- "auto": pick the best available tool
+                                  -- "fd" | "find" | "locate" | "ripgrep": force one
+}
+```
+
+**Usage:**
+
+```vim
+:VibingDailySummary [YYYY-MM-DD]     " Current project's chats only (default: today)
+:VibingDailySummaryAll [YYYY-MM-DD]  " search_dirs if configured, otherwise default locations
+```
+
+Summary files are saved as `YYYY-MM-DD.md` with YAML frontmatter (date, source files, total
+messages).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,13 +209,22 @@ keymaps = {
 
 ## Diff
 
-Selects the strategy used by the `gd` diff viewer:
+How diffs work by default (regardless of `diff.tool`): when a write tool (Write / Edit /
+MultiEdit / NotebookEdit) is approved, the target file's pre-edit content is backed up at
+PreToolUse-hook time; when the response completes, a git-style patch is generated in-process
+with `vim.diff()` (no external commands, no tree scanning) and stored under `.vibing/patches/`.
+`gd` on a changed file shows that patch first.
+
+`diff.tool` controls two things: whether mote snapshots are also taken, and what `gd` falls
+back to when no patch file exists for the file (e.g. changes made via Bash, or reopening an
+old chat):
 
 ```lua
 diff = {
-  tool = "auto",  -- "auto" / "git": per-request patches (vim.diff-based, no external
-                  --                 process) — these two currently behave the same
-                  -- "mote": mote snapshots (catches Bash-driven file changes too)
+  tool = "auto",  -- "auto" / "git": no mote; fallback viewer is `git diff`
+                  --                 (these two currently behave the same)
+                  -- "mote": take mote snapshots and fall back to mote diff
+                  --         (catches Bash-driven file changes too)
   mote = {
     project = nil,              -- Project name (nil = auto-detect from git repo name)
     context_prefix = "vibing",  -- Prefix for mote context names
@@ -223,11 +232,9 @@ diff = {
 }
 ```
 
-mote is **opt-in**: it is used only when `tool = "mote"` is set explicitly, or when a chat has
+mote is **opt-in**: it runs only when `tool = "mote"` is set explicitly, or when a chat has
 `mote_dirs` in its frontmatter (added via `:VibingMoteDir` — those directories use mote
-regardless of `tool`). Otherwise edited files are backed up before each write and stored as
-patches under `.vibing/patches/`; Bash-driven file changes are only captured by the mote
-backend. See [MIGRATION_MOTE.md](./MIGRATION_MOTE.md) for mote setup details.
+regardless of `tool`). See [MIGRATION_MOTE.md](./MIGRATION_MOTE.md) for mote setup details.
 
 ## Permissions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,8 +213,8 @@ Selects the strategy used by the `gd` diff viewer:
 
 ```lua
 diff = {
-  tool = "auto",  -- "auto": use mote when available, otherwise per-request patches
-                  -- "git":  per-request patches (vim.diff-based, no external process)
+  tool = "auto",  -- "auto" / "git": per-request patches (vim.diff-based, no external
+                  --                 process) — these two currently behave the same
                   -- "mote": mote snapshots (catches Bash-driven file changes too)
   mote = {
     project = nil,              -- Project name (nil = auto-detect from git repo name)
@@ -223,9 +223,11 @@ diff = {
 }
 ```
 
-With per-request patches, edited files are backed up before each write and stored as patches
-under `.vibing/patches/`; Bash-driven file changes are only captured by the mote backend. See
-[MIGRATION_MOTE.md](./MIGRATION_MOTE.md) for mote setup details.
+mote is **opt-in**: it is used only when `tool = "mote"` is set explicitly, or when a chat has
+`mote_dirs` in its frontmatter (added via `:VibingMoteDir` — those directories use mote
+regardless of `tool`). Otherwise edited files are backed up before each write and stored as
+patches under `.vibing/patches/`; Bash-driven file changes are only captured by the mote
+backend. See [MIGRATION_MOTE.md](./MIGRATION_MOTE.md) for mote setup details.
 
 ## Permissions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,15 +298,15 @@ permissions = {
 
 Field reference:
 
-| Field | Applies to | Matching |
-| --- | --- | --- |
-| `tools` | any | Exact tool-name match |
-| `paths` | tools whose input has a file path (Read/Write/Edit/...) | Glob: `*` (single dir), `**` (recursive); paths are normalized to absolute, symlink-resolved form first |
-| `commands` | `Bash` only | Exact match against the base command (first word) |
-| `patterns` | `Bash` only | **Lua patterns**, not regex — escape `-` as `%-` (e.g. `"^rm %-rf"`). Patterns longer than 500 chars are ignored |
-| `domains` | `WebFetch` only | Domain match with `*.` wildcard support |
-| `action` | — | `"allow"` or `"deny"` |
-| `message` | — | Shown when a `deny` rule blocks a call |
+| Field      | Applies to                                              | Matching                                                                                                         |
+| ---------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `tools`    | any                                                     | Exact tool-name match                                                                                            |
+| `paths`    | tools whose input has a file path (Read/Write/Edit/...) | Glob: `*` (single dir), `**` (recursive); paths are normalized to absolute, symlink-resolved form first          |
+| `commands` | `Bash` only                                             | Exact match against the base command (first word)                                                                |
+| `patterns` | `Bash` only                                             | **Lua patterns**, not regex — escape `-` as `%-` (e.g. `"^rm %-rf"`). Patterns longer than 500 chars are ignored |
+| `domains`  | `WebFetch` only                                         | Domain match with `*.` wildcard support                                                                          |
+| `action`   | —                                                       | `"allow"` or `"deny"`                                                                                            |
+| `message`  | —                                                       | Shown when a `deny` rule blocks a call                                                                           |
 
 Evaluation notes:
 

--- a/docs/mcp-setup-example.md
+++ b/docs/mcp-setup-example.md
@@ -298,5 +298,5 @@ Configure separate MCP servers in `~/.claude.json`:
 ## References
 
 - [MCP Server README](../mcp-server/README.md)
-- [vibing.nvim Configuration](../README.md#configuration)
+- [vibing.nvim Configuration](./configuration.md)
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/)

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -7,7 +7,7 @@
 ---@class Vibing.DiffConfig
 ---diff表示設定
 ---ファイル変更のdiff表示に使用するツールを制御
----@field tool "git"|"mote"|"auto" 使用するdiffツール（"git": git diff、"mote": mote diff、"auto": mote優先で自動選択）
+---@field tool "git"|"mote"|"auto" 使用するdiffツール（"auto"/"git": リクエスト単位パッチのgit diff表示、"mote": mote diff。moteはopt-inで、"mote"明示またはチャットのmote_dirs指定時のみ使用）
 ---@field mote Vibing.MoteConfig mote固有の設定
 
 ---@class Vibing.GradientConfig


### PR DESCRIPTION
Remove documentation for features/config that no longer exist in the code:

- `preview = { enabled }` config block (lazy.nvim example, Custom
  Configuration example, and the Preview Settings reference section):
  no `preview` field exists in lua/vibing/config.lua and nothing in
  the codebase reads it
- `gp` (Preview All Modified Files) keybinding and its feature section:
  removed from keymap_handler.lua in favor of `gd` per-file diffs
- "Diff Preview with Accept/Reject" feature section describing the
  removed Telescope-style preview UI
- `remote = { socket_path, auto_detect }` reference section: no such
  config exists anywhere in the plugin

Also document the existing `gx` / `keymaps.open_url` binding, which
was implemented but missing from the keybindings table and keymaps
reference.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012oeSEwW4BBgRAtTKCbWRGw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the English and Japanese documentation with Quick Start, setup, usage, architecture, FAQ, and contributing guidance.
  * Added a complete configuration reference, including UI, permissions, MCP, language, Node.js, diff, and daily-summary options.
  * Documented Claude CLI and Codex CLI support, worktree workflows, bundled skills, `gx` URL opening, and `permissions_ask` frontmatter.
  * Updated API reference and MCP setup links to reflect current configuration options.
  * Removed obsolete diff-preview, remote-control, and legacy configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->