### PR TITLE
feat: auto-resume chats when a usage limit resets

### DIFF
--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -14,6 +14,8 @@
 | `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                   |
 | `:VibingClearContext`                 | Clear all context                                                                                   |
 | `:VibingCancel`                       | Cancel current request                                                                              |
+| `:VibingPendingResumes`               | List chats waiting on a usage limit reset                                                           |
+| `:VibingCancelResume [all]`           | Cancel the pending auto-resume for this chat (or every one with `all`)                              |
 | `:VibingReloadCommands`               | Reload custom slash commands                                                                        |
 | `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                         |
 | `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                     |

--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -1,5 +1,27 @@
 # Features
 
+## Auto-Resume on Usage Limit
+
+When a turn is rejected because the plan's usage limit is exhausted, vibing.nvim can park the chat
+and send a single continuation message once the limit resets. Opt-in via
+`agent.auto_resume_on_limit.enabled` (default `false` — it spends tokens unattended).
+
+Detection merges three signals in `lua/vibing/core/utils/rate_limit.lua`: the CLI's
+`rate_limit_event` stream line (the **only** source of `resetsAt`), the `StopFailure` hook filtered
+to `error_type = rate_limit` (confirms the turn died, no timestamp), and the error text as a
+fallback. None of these payload shapes is officially documented, so every field is optional and a
+schema change degrades the feature instead of breaking the stream.
+
+Pending resumes persist to `.vibing/pending-resume.json` and are re-armed on `setup()`, since a
+five-hour reset usually outlives the Neovim session. Safeguards: `max_retries` (default 1) per
+limit hit, never overwriting an unsent `## User` message, and an 8-day sanity ceiling on the reset
+timestamp. Concurrently parked chats all fire at once by design. See `docs/configuration.md` →
+"Auto-Resume on Usage Limit".
+
+**Implementation:** `application/chat/auto_resume.lua` (scheduler),
+`infrastructure/storage/pending_resume.lua` (persistence),
+`infrastructure/rpc/handlers/rate_limit.lua` (StopFailure receiver), `bin/hooks/stop-failure.sh`.
+
 ## Message Timestamps
 
 Chat messages include timestamps in their headers (`## 2025-12-28 14:30:00 User`) for chronology

--- a/bin/hooks/stop-failure.sh
+++ b/bin/hooks/stop-failure.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# vibing.nvim StopFailure hook
+#
+# Fires when a turn ends because of an API error. Unlike pre-tool-use.sh this hook has no
+# decision power at all — Claude Code ignores its exit code and output — so it is pure
+# fire-and-forget: drop the payload where Neovim can read it, poke the RPC server, and get out
+# of the way without waiting for a response.
+#
+# Always exits 0. A failure here must never look like a tool denial.
+
+debug_log() {
+  [ -n "$VIBING_DEBUG" ] && echo "$(date) [stop-failure] $1" >> "/tmp/vibing-hook-debug.log"
+}
+
+INPUT=$(cat)
+PORT="${VIBING_NVIM_RPC_PORT}"
+
+debug_log "fired, PID=$$, PORT=${PORT:-UNSET}"
+
+# No RPC port = not running inside vibing.nvim, nothing to report to.
+if [ -z "$PORT" ]; then
+  exit 0
+fi
+
+REQUEST_ID="$(date +%s)-$$-$RANDOM"
+COMM_DIR="/tmp/vibing-hook-${PORT}"
+mkdir -p "$COMM_DIR" 2>/dev/null
+
+REQ_FILE="$COMM_DIR/${REQUEST_ID}.fail"
+
+# Write payload file (atomic via rename) so the RPC server never reads a partial JSON document.
+printf '%s' "$INPUT" > "${REQ_FILE}.tmp"
+mv "${REQ_FILE}.tmp" "$REQ_FILE"
+
+# Identifies which chat buffer's stream this failure belongs to (see ActiveStreamRegistry).
+# Restricted to [A-Za-z0-9_] since it's interpolated directly into the JSON request below.
+HANDLE_ID="${VIBING_HANDLE_ID//[^A-Za-z0-9_]/}"
+
+printf '{"method":"stop_failure","id":1,"params":{"request_id":"%s","handle_id":"%s"}}\n' "$REQUEST_ID" "$HANDLE_ID" \
+  | nc -w 1 127.0.0.1 "$PORT" >/dev/null 2>&1
+debug_log "notified nvim (status=$?), request_id=$REQUEST_ID"
+
+exit 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ require("vibing").setup({
     default_model = "sonnet",
     utility_model = "haiku",
     setting_sources = { "user", "project", "local" },
+    auto_resume_on_limit = { enabled = false, max_retries = 1 },
   },
   chat = {
     window = {
@@ -123,8 +124,58 @@ agent = {
                             -- Drop "user" to skip loading your global CLAUDE.md on
                             -- every chat, reducing fixed per-session token cost.
                             -- Note: does not affect MCP server loading.
+
+  auto_resume_on_limit = {  -- Resume a chat automatically once a usage limit resets
+    enabled = false,        -- Opt-in: this spends tokens with nobody watching
+    max_retries = 1,        -- Auto-resumes allowed per limit hit
+    prompt = "Continue from where you left off.",
+    fallback_delay_sec = 300, -- Used only when no reset timestamp was reported
+    grace_sec = 10,         -- Added to the reset time to avoid firing on the boundary
+  },
 }
 ```
+
+### Auto-Resume on Usage Limit
+
+When a turn is rejected because the plan's usage limit is exhausted, vibing.nvim can park the
+chat, wait for the reset, and send a single continuation message so the conversation carries on
+by itself.
+
+```lua
+require("vibing").setup({
+  agent = {
+    auto_resume_on_limit = {
+      enabled = true,
+      max_retries = 1,
+      prompt = "Continue from where you left off.",
+    },
+  },
+})
+```
+
+**How the limit is detected.** Three independent signals feed one decision
+(`lua/vibing/core/utils/rate_limit.lua`):
+
+| Signal                                 | Carries reset time | Role                                     |
+| -------------------------------------- | ------------------ | ---------------------------------------- |
+| `rate_limit_event` on the CLI's stdout | Yes (`resetsAt`)   | Primary — supplies when to wake up       |
+| `StopFailure` hook (`rate_limit`)      | No                 | Confirms the turn actually died          |
+| Error text of the failed run           | No                 | Fallback if either payload shape changes |
+
+The reset timestamp is the only thing that makes scheduling possible, and it arrives solely on the
+stream event. If it is missing, `fallback_delay_sec` is used instead — bounded in practice by
+`max_retries`.
+
+**Persistence.** A five-hour limit resets hours away and a weekly limit days away, so pending
+resumes are written to `<project root>/.vibing/pending-resume.json` and re-armed at startup. A
+resume still requires Neovim to be running when the timer fires; nothing happens while the editor
+is closed, but a chat parked before a restart is picked up after it.
+
+**Safeguards.** Auto-resume never overwrites an unsent message you left in the chat, stops after
+`max_retries` limit hits in a row, and refuses reset timestamps more than 8 days out (a sign the
+payload was misread). Several parked chats all resume at once, which is intentional — a reset
+hands back a full quota, and concurrent chats are normal usage. Inspect and control pending
+resumes with `:VibingPendingResumes` and `:VibingCancelResume`.
 
 ## Chat
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,11 @@ resumes are written to `<project root>/.vibing/pending-resume.json` and re-armed
 resume still requires Neovim to be running when the timer fires; nothing happens while the editor
 is closed, but a chat parked before a restart is picked up after it.
 
+Each chat's entry is stored under the project that owns its **chat file**, not Neovim's current
+directory, so a `:cd` or a worktree-backed chat cannot lose a pending resume. Startup recovery and
+`:VibingPendingResumes` are still scoped to the project Neovim was opened in — resumes for a
+different project are picked up when you open Neovim there.
+
 **Safeguards.** Auto-resume never overwrites an unsent message you left in the chat, stops after
 `max_retries` limit hits in a row, and refuses reset timestamps more than 8 days out (a sign the
 payload was misread). Several parked chats all resume at once, which is intentional — a reset

--- a/lua/vibing/application/chat/auto_resume.lua
+++ b/lua/vibing/application/chat/auto_resume.lua
@@ -1,0 +1,363 @@
+--- Automatic continuation after a usage limit resets
+---
+--- When a turn is rejected because the plan's usage limit is exhausted, the CLI reports the
+--- Unix timestamp at which the limit lifts. This module parks the chat, waits for that moment,
+--- and sends a single continuation message so the conversation picks up where it stopped.
+---
+--- Deliberately conservative, because every path here spends tokens without a human present:
+---   * opt-in (`agent.auto_resume_on_limit.enabled`, default false)
+---   * a retry budget per limit hit (`max_retries`, default 1)
+---   * never overwrites text the user has already typed into the pending `## User` section
+---   * resumes are staggered so several parked chats don't all fire into the same fresh quota
+---
+--- @module vibing.application.chat.auto_resume
+
+local PendingResume = require("vibing.infrastructure.storage.pending_resume")
+local RateLimit = require("vibing.core.utils.rate_limit")
+
+local M = {}
+
+--- Refuse to schedule further out than this. A reset timestamp beyond it means the payload was
+--- misread (wrong unit, wrong field), and a timer armed for months is worse than no feature.
+local MAX_DELAY_SEC = 8 * 24 * 60 * 60
+
+--- Active timers keyed by chat file path, so re-parking a chat replaces its timer instead of
+--- stacking a second one that would double-send.
+--- @type table<string, userdata>
+local timers = {}
+
+--- @return table
+local function get_options()
+  local config = require("vibing.config").get()
+  local agent = config.agent or {}
+  return agent.auto_resume_on_limit or {}
+end
+
+--- @param path string
+local function stop_timer(path)
+  local timer = timers[path]
+  if timer then
+    pcall(function()
+      timer:stop()
+      timer:close()
+    end)
+    timers[path] = nil
+  end
+end
+
+--- Seconds to wait before resuming a parked chat.
+--- @param entry Vibing.PendingResume
+--- @param opts table
+--- @return number|nil delay_sec, string|nil reason_when_nil
+local function compute_delay(entry, opts)
+  local now = os.time()
+
+  if not entry.resets_at then
+    -- No reset timestamp anywhere in the payload. Rather than give up (which would make the
+    -- whole feature dead weight if the undocumented event shape changes), fall back to a fixed
+    -- delay — bounded in practice by max_retries.
+    return opts.fallback_delay_sec or 300
+  end
+
+  local delay = entry.resets_at + (opts.grace_sec or 10) - now
+  if delay > MAX_DELAY_SEC then
+    return nil, string.format("reset time is %d days away; ignoring as implausible", math.floor(delay / 86400))
+  end
+  -- Already past (e.g. Neovim was closed across the whole window): resume promptly, not instantly,
+  -- so startup has settled before a request goes out.
+  return math.max(delay, 3)
+end
+
+--- Locate the ChatBuffer for a chat file, loading the file into a buffer if needed.
+--- After a restart the chat is usually not open, so a resume that only worked for already-open
+--- buffers would miss exactly the case persistence exists for.
+--- @param chat_file_path string
+--- @return table|nil chat_buffer, string|nil error
+local function resolve_chat_buffer(chat_file_path)
+  if vim.fn.filereadable(chat_file_path) == 0 then
+    return nil, "chat file no longer exists"
+  end
+
+  local view = require("vibing.presentation.chat.view")
+
+  local bufnr = vim.fn.bufnr(chat_file_path)
+  if bufnr == -1 then
+    bufnr = vim.fn.bufadd(chat_file_path)
+  end
+  if bufnr == 0 or bufnr == -1 then
+    return nil, "could not create a buffer for the chat file"
+  end
+  vim.fn.bufload(bufnr)
+
+  local chat_buf = view.get_chat_buffer(bufnr)
+  if not chat_buf then
+    local ok, attached = pcall(view.attach_to_buffer, bufnr, chat_file_path)
+    if not ok or not attached then
+      return nil, "could not attach the chat buffer"
+    end
+    chat_buf = attached
+  end
+
+  return chat_buf, nil
+end
+
+--- Drop the trailing empty `## User` section left behind by the failed turn, so the continuation
+--- doesn't land under a second, orphaned header.
+--- @param bufnr number
+local function trim_empty_trailing_user_section(bufnr)
+  local Timestamp = require("vibing.core.utils.timestamp")
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+  local header_idx = nil
+  for i = #lines, 1, -1 do
+    if Timestamp.is_header(lines[i]) then
+      header_idx = i
+      break
+    end
+  end
+  if not header_idx or Timestamp.extract_role(lines[header_idx]) ~= "user" then
+    return
+  end
+
+  for i = header_idx + 1, #lines do
+    if vim.trim(lines[i]) ~= "" then
+      return -- section has content; leave it alone
+    end
+  end
+
+  vim.api.nvim_buf_set_lines(bufnr, header_idx - 1, -1, false, {})
+end
+
+--- Send the continuation message for a parked chat.
+--- @param chat_file_path string
+--- @param entry Vibing.PendingResume
+local function fire(chat_file_path, entry)
+  stop_timer(chat_file_path)
+
+  local opts = get_options()
+  if not opts.enabled then
+    return
+  end
+
+  -- Re-read the store: the user may have cancelled, or answered the chat manually, between
+  -- scheduling and now.
+  local current = PendingResume.get(chat_file_path)
+  if not current then
+    return
+  end
+
+  local chat_buf, err = resolve_chat_buffer(chat_file_path)
+  if not chat_buf then
+    PendingResume.remove(chat_file_path)
+    vim.notify(
+      string.format("[vibing] Auto-resume skipped for %s: %s", vim.fn.fnamemodify(chat_file_path, ":t"), err),
+      vim.log.levels.WARN
+    )
+    return
+  end
+
+  if chat_buf:is_sending() then
+    PendingResume.remove(chat_file_path)
+    return
+  end
+
+  -- The user typed something into the pending section while the chat was parked. Their message
+  -- is the one that should be sent, by them — not silently prefixed by ours.
+  local typed = chat_buf:extract_user_message()
+  if typed and vim.trim(typed) ~= "" then
+    PendingResume.remove(chat_file_path)
+    vim.notify(
+      string.format(
+        "[vibing] Auto-resume skipped for %s: an unsent message is waiting in the chat",
+        vim.fn.fnamemodify(chat_file_path, ":t")
+      ),
+      vim.log.levels.INFO
+    )
+    return
+  end
+
+  current.retry_count = (current.retry_count or 0) + 1
+  PendingResume.put(current)
+
+  local bufnr = chat_buf:get_buffer()
+  trim_empty_trailing_user_section(bufnr)
+
+  local prompt = opts.prompt or "Continue from where you left off."
+  local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+  local ok, send_err = pcall(ProgrammaticSender.send, bufnr, prompt)
+  if not ok then
+    PendingResume.remove(chat_file_path)
+    vim.notify("[vibing] Auto-resume failed: " .. tostring(send_err), vim.log.levels.WARN)
+    return
+  end
+
+  vim.notify(
+    string.format("[vibing] Usage limit reset - resumed %s", vim.fn.fnamemodify(chat_file_path, ":t")),
+    vim.log.levels.INFO
+  )
+end
+
+--- Arm a timer for a parked chat.
+--- Several chats parked on the same window all fire at once, which is deliberate: a reset hands
+--- back a full quota, and vibing.nvim already runs concurrent chats during normal use.
+--- @param entry Vibing.PendingResume
+--- @param opts table
+local function schedule(entry, opts)
+  local path = entry.chat_file_path
+  stop_timer(path)
+
+  local delay_sec, reason = compute_delay(entry, opts)
+  if not delay_sec then
+    PendingResume.remove(path)
+    vim.notify("[vibing] Auto-resume not scheduled: " .. tostring(reason), vim.log.levels.WARN)
+    return
+  end
+
+  local delay_ms = delay_sec * 1000
+  local timer = vim.loop.new_timer()
+  if not timer then
+    vim.notify("[vibing] Auto-resume not scheduled: no timer available", vim.log.levels.WARN)
+    return
+  end
+  timers[path] = timer
+  timer:start(
+    delay_ms,
+    0,
+    vim.schedule_wrap(function()
+      fire(path, entry)
+    end)
+  )
+
+  vim.notify(
+    string.format(
+      "[vibing] Usage limit hit - %s will resume in %s",
+      vim.fn.fnamemodify(path, ":t"),
+      M.format_duration(math.floor(delay_ms / 1000))
+    ),
+    vim.log.levels.INFO
+  )
+end
+
+--- Format a second count as a short human-readable duration
+--- @param seconds number
+--- @return string
+function M.format_duration(seconds)
+  if seconds < 60 then
+    return seconds .. "s"
+  end
+  local minutes = math.floor(seconds / 60)
+  if minutes < 60 then
+    return minutes .. "m"
+  end
+  return string.format("%dh%02dm", math.floor(minutes / 60), minutes % 60)
+end
+
+--- Called when a response comes back rejected by a usage limit.
+--- @param chat_file_path string|nil
+--- @param info Vibing.RateLimitInfo
+function M.on_rate_limited(chat_file_path, info)
+  local opts = get_options()
+
+  if not chat_file_path or chat_file_path == "" then
+    return
+  end
+
+  if not opts.enabled then
+    vim.notify(
+      "[vibing] Usage limit reached (" .. RateLimit.describe(info) .. ")",
+      vim.log.levels.WARN
+    )
+    return
+  end
+
+  local existing = PendingResume.get(chat_file_path)
+  local retry_count = existing and existing.retry_count or 0
+  local max_retries = opts.max_retries or 1
+
+  if retry_count >= max_retries then
+    PendingResume.remove(chat_file_path)
+    vim.notify(
+      string.format(
+        "[vibing] Usage limit reached again after %d auto-resume(s) - giving up on %s",
+        retry_count,
+        vim.fn.fnamemodify(chat_file_path, ":t")
+      ),
+      vim.log.levels.WARN
+    )
+    return
+  end
+
+  local entry = {
+    chat_file_path = chat_file_path,
+    resets_at = info.resets_at,
+    limit_type = info.limit_type,
+    retry_count = retry_count,
+    recorded_at = os.time(),
+  }
+  PendingResume.put(entry)
+  schedule(entry, opts)
+end
+
+--- Called when a chat completes without hitting a limit, clearing its retry budget.
+--- @param chat_file_path string|nil
+function M.on_success(chat_file_path)
+  if not chat_file_path or chat_file_path == "" then
+    return
+  end
+  if not PendingResume.get(chat_file_path) then
+    return
+  end
+  stop_timer(chat_file_path)
+  PendingResume.remove(chat_file_path)
+end
+
+--- Cancel a pending resume (user-initiated)
+--- @param chat_file_path string|nil When nil, cancels every pending resume
+--- @return number cancelled_count
+function M.cancel(chat_file_path)
+  if chat_file_path then
+    stop_timer(chat_file_path)
+    local existed = PendingResume.get(chat_file_path) ~= nil
+    PendingResume.remove(chat_file_path)
+    return existed and 1 or 0
+  end
+
+  local entries = PendingResume.load()
+  local count = 0
+  for path, _ in pairs(entries) do
+    stop_timer(path)
+    count = count + 1
+  end
+  PendingResume.clear()
+  return count
+end
+
+--- List pending resumes (for :VibingPendingResumes)
+--- @return Vibing.PendingResume[]
+function M.list()
+  local out = {}
+  for _, entry in pairs(PendingResume.load()) do
+    table.insert(out, entry)
+  end
+  table.sort(out, function(a, b)
+    return (a.resets_at or math.huge) < (b.resets_at or math.huge)
+  end)
+  return out
+end
+
+--- Re-arm timers for chats parked before Neovim was restarted.
+--- Called once at startup; safe to call again (each chat's timer is replaced, not stacked).
+function M.restore()
+  local opts = get_options()
+  if not opts.enabled then
+    return
+  end
+
+  for _, entry in pairs(PendingResume.load()) do
+    if entry.chat_file_path then
+      schedule(entry, opts)
+    end
+  end
+end
+
+return M

--- a/lua/vibing/application/chat/auto_resume.lua
+++ b/lua/vibing/application/chat/auto_resume.lua
@@ -46,6 +46,9 @@ local function stop_timer(path)
 end
 
 --- Seconds to wait before resuming a parked chat.
+--- Exposed as M._compute_delay for tests: it is the pure core of the safety limits (8-day sanity
+--- ceiling, fallback delay, past-reset clamp) and would otherwise only be reachable through a
+--- libuv timer.
 --- @param entry Vibing.PendingResume
 --- @param opts table
 --- @return number|nil delay_sec, string|nil reason_when_nil
@@ -136,6 +139,9 @@ local function fire(chat_file_path, entry)
 
   local opts = get_options()
   if not opts.enabled then
+    -- The feature was switched off while this chat was parked. Drop the entry rather than leave
+    -- it in the store, where :VibingPendingResumes would list a resume that can never fire.
+    PendingResume.remove(chat_file_path)
     return
   end
 
@@ -239,15 +245,21 @@ local function schedule(entry, opts)
     end)
   )
 
+  -- Say so when the delay is a guess. A bare "will resume in 5m" reads as a known reset time,
+  -- but for a five-hour or weekly limit the fallback will almost certainly be rejected again.
+  local qualifier = entry.resets_at and "" or " (no reset time reported; this is a fallback retry)"
   vim.notify(
     string.format(
-      "[vibing] Usage limit hit - %s will resume in %s",
+      "[vibing] Usage limit hit - %s will resume in %s%s",
       vim.fn.fnamemodify(path, ":t"),
-      M.format_duration(math.floor(delay_ms / 1000))
+      M.format_duration(math.floor(delay_ms / 1000)),
+      qualifier
     ),
     vim.log.levels.INFO
   )
 end
+
+M._compute_delay = compute_delay
 
 --- Format a second count as a short human-readable duration
 --- @param seconds number

--- a/lua/vibing/application/chat/auto_resume.lua
+++ b/lua/vibing/application/chat/auto_resume.lua
@@ -8,7 +8,7 @@
 ---   * opt-in (`agent.auto_resume_on_limit.enabled`, default false)
 ---   * a retry budget per limit hit (`max_retries`, default 1)
 ---   * never overwrites text the user has already typed into the pending `## User` section
----   * resumes are staggered so several parked chats don't all fire into the same fresh quota
+---   * an entry is marked in_flight before sending, so a restart can't replay it for free
 ---
 --- @module vibing.application.chat.auto_resume
 

--- a/lua/vibing/application/chat/auto_resume.lua
+++ b/lua/vibing/application/chat/auto_resume.lua
@@ -146,6 +146,13 @@ local function fire(chat_file_path, entry)
     return
   end
 
+  -- Defence in depth. on_rate_limited() is the usual budget gate, but a resume can also reach
+  -- here straight from restore(), which never consults it.
+  if (current.retry_count or 0) >= (opts.max_retries or 1) then
+    PendingResume.remove(chat_file_path)
+    return
+  end
+
   local chat_buf, err = resolve_chat_buffer(chat_file_path)
   if not chat_buf then
     PendingResume.remove(chat_file_path)
@@ -176,7 +183,11 @@ local function fire(chat_file_path, entry)
     return
   end
 
+  -- Mark the request in flight *before* sending. If Neovim dies between here and the response,
+  -- restore() must not treat this entry as still-waiting and send a second automatic request —
+  -- the retry budget is only consulted when a limit is observed, not when a timer fires.
   current.retry_count = (current.retry_count or 0) + 1
+  current.state = "in_flight"
   PendingResume.put(current)
 
   local bufnr = chat_buf:get_buffer()
@@ -293,6 +304,7 @@ function M.on_rate_limited(chat_file_path, info)
     limit_type = info.limit_type,
     retry_count = retry_count,
     recorded_at = os.time(),
+    state = "waiting",
   }
   PendingResume.put(entry)
   schedule(entry, opts)
@@ -354,7 +366,11 @@ function M.restore()
   end
 
   for _, entry in pairs(PendingResume.load()) do
-    if entry.chat_file_path then
+    -- Only re-arm chats still waiting on a reset. An "in_flight" entry was already sent by a
+    -- previous session whose outcome we never saw; re-sending it would spend a second request
+    -- outside the retry budget. The entry is kept (not deleted) so its retry_count still counts
+    -- against max_retries if that chat hits the limit again.
+    if entry.chat_file_path and (entry.state or "waiting") == "waiting" then
       schedule(entry, opts)
     end
   end

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -250,6 +250,16 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
     return
   end
 
+  -- 使用量リミットで弾かれた場合はリセット時刻まで待って自動継続する（opt-in）。
+  -- リミット以外で正常終了したときはリトライ budget をクリアする。
+  local AutoResume = require("vibing.application.chat.auto_resume")
+  local chat_file_path = (bufnr and vim.api.nvim_buf_is_valid(bufnr)) and vim.api.nvim_buf_get_name(bufnr) or nil
+  if response._rate_limit_info then
+    pcall(AutoResume.on_rate_limited, chat_file_path, response._rate_limit_info)
+  elseif not response.error then
+    pcall(AutoResume.on_success, chat_file_path)
+  end
+
   if response.error then
     callbacks.append_chunk("\n\n**Error:** " .. response.error)
 

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -227,6 +227,20 @@ M.defaults = {
     prioritize_vibing_lsp = true,
     utility_model = "haiku",
     setting_sources = { "user", "project", "local" },
+    -- 使用量リミットで応答が弾かれたとき、リセット時刻を待って自動で継続リクエストを送る。
+    -- 無人でトークンを消費するため既定は無効。
+    auto_resume_on_limit = {
+      enabled = false,
+      -- 1回のリミットヒットにつき許可する自動再送の回数。
+      -- 再送がまたリミットに当たった時点で打ち切られる。
+      max_retries = 1,
+      -- 再送する継続プロンプト。セッションはresumeされるので文脈の再説明は不要。
+      prompt = "Continue from where you left off.",
+      -- リセット時刻が取得できなかった場合の待ち時間（秒）。
+      fallback_delay_sec = 300,
+      -- リセット時刻からの上乗せ秒数。境界ぴったりで再送して弾かれるのを防ぐ。
+      grace_sec = 10,
+    },
   },
   chat = {
     window = {

--- a/lua/vibing/core/utils/rate_limit.lua
+++ b/lua/vibing/core/utils/rate_limit.lua
@@ -1,0 +1,190 @@
+--- Rate limit detection and normalization
+---
+--- The Claude CLI reports usage limits through three independent channels, none of which is
+--- officially documented (see anthropics/claude-code#24596). This module normalizes all of them
+--- into a single shape so callers never depend on a particular payload spelling:
+---
+---   1. `rate_limit_event` on the stream-json stdout — the only channel that carries the reset
+---      timestamp, so it is the primary source.
+---   2. The `StopFailure` hook with `error_type = "rate_limit"` — fires when the turn actually
+---      died, but carries no reset time.
+---   3. The error text of a failed run — last-resort fallback if both of the above change shape.
+---
+--- @module vibing.core.utils.rate_limit
+
+local M = {}
+
+--- Statuses that mean the request was actually rejected, as opposed to a remaining-quota warning
+--- emitted mid-turn. Anything not listed here is treated as informational.
+local REJECTED_STATUSES = {
+  rejected = true,
+  blocked = true,
+  exceeded = true,
+}
+
+--- Substrings that identify a usage/rate limit in a free-form error message. Matched
+--- case-insensitively against the whole error text.
+local ERROR_TEXT_PATTERNS = {
+  "usage limit",
+  "rate limit",
+  "rate_limit",
+  "too many requests",
+}
+
+--- @class Vibing.RateLimitInfo
+--- @field rejected boolean Whether the request was actually turned away
+--- @field resets_at number|nil Unix timestamp in seconds
+--- @field limit_type string|nil e.g. "five_hour", "weekly"
+--- @field status string|nil Raw status string, kept for diagnostics
+--- @field source string Which channel detected it ("stream_event"|"hook"|"error_text")
+--- @field raw table|nil Original payload, kept for debug logging
+
+--- Coerce a timestamp to Unix seconds.
+--- The CLI emits seconds today, but a millisecond value would be silently ~50000x too far in the
+--- future and schedule a resume that never fires, so normalize instead of trusting the unit.
+--- @param value any
+--- @return number|nil
+local function to_unix_seconds(value)
+  local n = tonumber(value)
+  if not n or n <= 0 then
+    return nil
+  end
+  -- Any plausible "seconds" value is < 1e12 until the year 33658; anything above is milliseconds.
+  if n > 1e12 then
+    n = n / 1000
+  end
+  return math.floor(n)
+end
+
+--- Read the first present key from a table, accepting both camelCase and snake_case spellings.
+--- @param tbl table
+--- @param ... string
+--- @return any
+local function pick(tbl, ...)
+  for _, key in ipairs({ ... }) do
+    if tbl[key] ~= nil then
+      return tbl[key]
+    end
+  end
+  return nil
+end
+
+--- Normalize a raw `rate_limit_event` payload.
+--- Every field is optional: an unrecognized payload still yields a usable (if reset-less) result
+--- rather than an error, so a schema change degrades the feature instead of breaking the stream.
+--- @param msg table Decoded `rate_limit_event` JSON line
+--- @return Vibing.RateLimitInfo|nil
+function M.from_event(msg)
+  if type(msg) ~= "table" then
+    return nil
+  end
+
+  local info = pick(msg, "rate_limit_info", "rateLimitInfo")
+  if type(info) ~= "table" then
+    -- Some builds may inline the fields on the event itself.
+    info = msg
+  end
+
+  local status = pick(info, "status", "rateLimitStatus")
+  local overage_status = pick(info, "overageStatus", "overage_status")
+
+  return {
+    rejected = REJECTED_STATUSES[tostring(status):lower()] == true
+      or REJECTED_STATUSES[tostring(overage_status):lower()] == true,
+    resets_at = to_unix_seconds(pick(info, "resetsAt", "resets_at", "resetAt", "reset_at")),
+    limit_type = pick(info, "rateLimitType", "rate_limit_type", "limitType"),
+    status = status and tostring(status) or nil,
+    source = "stream_event",
+    raw = info,
+  }
+end
+
+--- Build info from a `StopFailure` hook payload.
+--- The hook fires only when the turn actually died, so a `rate_limit` error_type is authoritative
+--- about rejection — but it carries no reset timestamp.
+--- @param hook_input table Decoded hook stdin JSON
+--- @return Vibing.RateLimitInfo|nil
+function M.from_hook(hook_input)
+  if type(hook_input) ~= "table" then
+    return nil
+  end
+
+  local error_type = pick(hook_input, "error_type", "errorType")
+  if tostring(error_type):lower() ~= "rate_limit" then
+    return nil
+  end
+
+  return {
+    rejected = true,
+    resets_at = to_unix_seconds(pick(hook_input, "resets_at", "resetsAt", "retry_after_epoch")),
+    limit_type = pick(hook_input, "rate_limit_type", "rateLimitType"),
+    status = "rate_limit",
+    source = "hook",
+    raw = hook_input,
+  }
+end
+
+--- Last-resort detection from a free-form error string.
+--- @param text string|nil
+--- @return Vibing.RateLimitInfo|nil
+function M.from_error_text(text)
+  if type(text) ~= "string" or text == "" then
+    return nil
+  end
+
+  local lower = text:lower()
+  for _, pattern in ipairs(ERROR_TEXT_PATTERNS) do
+    if lower:find(pattern, 1, true) then
+      return {
+        rejected = true,
+        resets_at = nil,
+        limit_type = nil,
+        status = "error_text",
+        source = "error_text",
+        raw = nil,
+      }
+    end
+  end
+  return nil
+end
+
+--- Merge detections from several channels into the single best answer.
+--- Rejection is a logical OR (any channel claiming rejection wins), while `resets_at` takes the
+--- first channel that actually supplies one — in practice always the stream event.
+--- @param ... Vibing.RateLimitInfo|nil
+--- @return Vibing.RateLimitInfo|nil
+function M.merge(...)
+  local merged = nil
+  for _, info in ipairs({ ... }) do
+    if info then
+      if not merged then
+        merged = vim.deepcopy(info)
+      else
+        merged.rejected = merged.rejected or info.rejected
+        merged.resets_at = merged.resets_at or info.resets_at
+        merged.limit_type = merged.limit_type or info.limit_type
+        if info.source and not merged.source:find(info.source, 1, true) then
+          merged.source = merged.source .. "+" .. info.source
+        end
+      end
+    end
+  end
+  return merged
+end
+
+--- Human-readable description for notifications.
+--- @param info Vibing.RateLimitInfo
+--- @return string
+function M.describe(info)
+  local parts = {}
+  table.insert(parts, info.limit_type and ("limit=" .. tostring(info.limit_type)) or "limit=unknown")
+  if info.resets_at then
+    table.insert(parts, "resets at " .. os.date("%Y-%m-%d %H:%M:%S", info.resets_at))
+  else
+    table.insert(parts, "reset time unknown")
+  end
+  table.insert(parts, "via " .. info.source)
+  return table.concat(parts, ", ")
+end
+
+return M

--- a/lua/vibing/core/utils/rate_limit.lua
+++ b/lua/vibing/core/utils/rate_limit.lua
@@ -151,11 +151,18 @@ end
 --- Merge detections from several channels into the single best answer.
 --- Rejection is a logical OR (any channel claiming rejection wins), while `resets_at` takes the
 --- first channel that actually supplies one — in practice always the stream event.
+---
+--- Iterates by argument count rather than with ipairs: callers routinely pass nil for channels
+--- that reported nothing (a turn with no rate_limit_event is the common case), and ipairs stops
+--- at the first nil hole — which silently discarded every later channel, including a
+--- hook-only detection.
 --- @param ... Vibing.RateLimitInfo|nil
 --- @return Vibing.RateLimitInfo|nil
 function M.merge(...)
+  local args = { ... }
   local merged = nil
-  for _, info in ipairs({ ... }) do
+  for i = 1, select("#", ...) do
+    local info = args[i]
     if info then
       if not merged then
         merged = vim.deepcopy(info)

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -170,6 +170,21 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
         vim.fn.timer_stop(timeout_timer)
         timeout_timer = nil
       end
+
+      -- Combine every channel that can report a usage limit. Only the stream event carries a
+      -- reset timestamp; the StopFailure hook confirms the turn actually died; the error text is
+      -- the fallback if either payload shape changes. See core/utils/rate_limit.lua.
+      local RateLimit = require("vibing.core.utils.rate_limit")
+      local rate_limit_handler = require("vibing.infrastructure.rpc.handlers.rate_limit")
+      local merged = RateLimit.merge(
+        event_context.rateLimitInfo,
+        rate_limit_handler.take_failure(handle_id),
+        response.error and RateLimit.from_error_text(tostring(response.error)) or nil
+      )
+      if merged and merged.rejected then
+        response._rate_limit_info = merged
+      end
+
       on_done(response)
     end
   end

--- a/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
@@ -229,9 +229,10 @@ end
 
 --- Handle "rate_limit_event" (usage limit status)
 --- Emitted mid-stream both as a remaining-quota warning and when a request is actually turned
---- away; only the latter carries a reset timestamp worth acting on. Warnings are recorded but
---- never override an earlier rejection, so a trailing warning can't mask the rejection that
---- ended the turn.
+--- away. Events are merged rather than replaced, because the two facts we need can arrive on
+--- different events: a warning may carry `resetsAt` while the rejection that ends the turn omits
+--- it. Merging newest-first keeps a fresher reset time while never losing a known one, and
+--- rejection stays sticky so a trailing warning can't mask it.
 ---
 --- Recorded on the context synchronously rather than dispatched through a callback: processLine
 --- already runs inside vim.schedule, and deferring by another tick could land after the process
@@ -244,10 +245,7 @@ local function handle_rate_limit_event(msg, context)
   end
 
   local previous = context.rateLimitInfo
-  if previous and previous.rejected and not info.rejected then
-    return
-  end
-  context.rateLimitInfo = info
+  context.rateLimitInfo = previous and RateLimit.merge(info, previous) or info
 end
 
 --- Event handler dispatch table

--- a/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
@@ -227,6 +227,29 @@ local function handle_text_event(msg, context)
   end
 end
 
+--- Handle "rate_limit_event" (usage limit status)
+--- Emitted mid-stream both as a remaining-quota warning and when a request is actually turned
+--- away; only the latter carries a reset timestamp worth acting on. Warnings are recorded but
+--- never override an earlier rejection, so a trailing warning can't mask the rejection that
+--- ended the turn.
+---
+--- Recorded on the context synchronously rather than dispatched through a callback: processLine
+--- already runs inside vim.schedule, and deferring by another tick could land after the process
+--- exit handler has already built the response, silently dropping the reset timestamp.
+local function handle_rate_limit_event(msg, context)
+  local RateLimit = require("vibing.core.utils.rate_limit")
+  local info = RateLimit.from_event(msg)
+  if not info then
+    return
+  end
+
+  local previous = context.rateLimitInfo
+  if previous and previous.rejected and not info.rejected then
+    return
+  end
+  context.rateLimitInfo = info
+end
+
 --- Event handler dispatch table
 local event_handlers = {
   system = function(msg, context)
@@ -253,7 +276,8 @@ local event_handlers = {
     handle_text_event(msg, context)
     return true
   end,
-  rate_limit_event = function()
+  rate_limit_event = function(msg, context)
+    handle_rate_limit_event(msg, context)
     return true
   end,
 }

--- a/lua/vibing/infrastructure/hooks/settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/settings_generator.lua
@@ -4,19 +4,30 @@
 
 local M = {}
 
---- Get the path to the hook script
+--- Resolve a bundled hook script by file name
+--- @param name string File name under bin/hooks/
 --- @return string
-function M.get_hook_script_path()
+local function hook_script_path(name)
   local source = debug.getinfo(1, "S").source:sub(2)
   local plugin_root = vim.fn.fnamemodify(source, ":h:h:h:h:h")
-  return plugin_root .. "/bin/hooks/pre-tool-use.sh"
+  return plugin_root .. "/bin/hooks/" .. name
+end
+
+--- Get the path to the PreToolUse hook script
+--- @return string
+function M.get_hook_script_path()
+  return hook_script_path("pre-tool-use.sh")
+end
+
+--- Get the path to the StopFailure hook script
+--- @return string
+function M.get_stop_failure_script_path()
+  return hook_script_path("stop-failure.sh")
 end
 
 --- Generate settings table with hook configuration
 --- @return table
 function M.generate()
-  local hook_script = M.get_hook_script_path()
-
   return {
     hooks = {
       PreToolUse = {
@@ -25,8 +36,24 @@ function M.generate()
           hooks = {
             {
               type = "command",
-              command = hook_script,
+              command = M.get_hook_script_path(),
               timeout = 120,
+            },
+          },
+        },
+      },
+      -- StopFailure fires when a turn dies from an API error. The matcher filters on error type,
+      -- and only rate_limit is actionable — the rest (overloaded, billing_error, ...) have no
+      -- reset time to wait for. The hook cannot block or alter anything; it exists purely so the
+      -- auto-resume scheduler learns the turn died rather than completed.
+      StopFailure = {
+        {
+          matcher = "rate_limit",
+          hooks = {
+            {
+              type = "command",
+              command = M.get_stop_failure_script_path(),
+              timeout = 10,
             },
           },
         },

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -8,6 +8,7 @@ local lsp = require("vibing.infrastructure.rpc.handlers.lsp")
 local execute = require("vibing.infrastructure.rpc.handlers.execute")
 local message = require("vibing.infrastructure.rpc.handlers.message")
 local permission = require("vibing.infrastructure.rpc.handlers.permission")
+local rate_limit = require("vibing.infrastructure.rpc.handlers.rate_limit")
 
 -- Export all handlers
 M.buf_get_lines = buffer.buf_get_lines
@@ -45,5 +46,7 @@ M.send_message = message.send_message
 
 M.check_tool_permission = permission.check_tool_permission
 M.ask_user_question = permission.ask_user_question
+
+M.stop_failure = rate_limit.stop_failure
 
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/rate_limit.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/rate_limit.lua
@@ -14,14 +14,14 @@ local M = {}
 --- Parsed failures awaiting pickup by wrapped_on_done, keyed by handle_id.
 --- Keyed rather than a single slot so concurrent chats can't consume each other's failure — the
 --- same class of bug ActiveStreamRegistry exists to prevent.
+---
+--- A failure that arrives without a handle_id is dropped rather than parked in a shared slot:
+--- whichever stream finished first would consume it, and mislabelling a healthy concurrent chat
+--- as rate-limited would auto-resume it for no reason. claude_cli.lua always exports
+--- VIBING_HANDLE_ID, so this is a real defect if it ever happens — and the stream-json
+--- `rate_limit_event`, not this hook, is the primary detection channel anyway.
 --- @type table<string, Vibing.RateLimitInfo>
 local pending_failures = {}
-
---- Failures that arrived without a usable handle_id. Keyed lookups can't reach these, so they are
---- consumed by whichever stream finishes first — only correct because a missing handle_id already
---- means we cannot tell the streams apart.
---- @type Vibing.RateLimitInfo|nil
-local unkeyed_failure = nil
 
 --- Get the communication directory for the current RPC port
 --- @return string
@@ -64,12 +64,16 @@ function M.stop_failure(params)
     return { status = "ignored", reason = "not a rate limit" }
   end
 
-  if handle_id then
-    pending_failures[handle_id] = info
-  else
-    unkeyed_failure = info
+  if not handle_id then
+    vim.notify(
+      "[vibing] StopFailure hook reported a rate limit without a handle_id; ignoring it "
+        .. "rather than risk attributing it to the wrong chat",
+      vim.log.levels.WARN
+    )
+    return { status = "ignored", reason = "missing handle_id" }
   end
 
+  pending_failures[handle_id] = info
   return { status = "ok" }
 end
 
@@ -79,25 +83,17 @@ end
 --- @param handle_id string|nil
 --- @return Vibing.RateLimitInfo|nil
 function M.take_failure(handle_id)
-  local info = handle_id and pending_failures[handle_id] or nil
-  if info then
-    pending_failures[handle_id] = nil
-    return info
+  if not handle_id then
+    return nil
   end
-
-  if unkeyed_failure then
-    info = unkeyed_failure
-    unkeyed_failure = nil
-    return info
-  end
-
-  return nil
+  local info = pending_failures[handle_id]
+  pending_failures[handle_id] = nil
+  return info
 end
 
 --- Drop all recorded failures (test helper / session reset)
 function M.reset()
   pending_failures = {}
-  unkeyed_failure = nil
 end
 
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/rate_limit.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/rate_limit.lua
@@ -1,0 +1,103 @@
+--- RPC handler for the StopFailure hook
+---
+--- Receives the "this turn died from an API error" signal that the CLI cannot express on its
+--- stdout stream. The hook has no decision power, so this handler writes no response file and
+--- the hook process never waits for one — it only parks the parsed result until the adapter's
+--- on_done runs and merges it with what the stream reported (see claude_cli.lua).
+---
+--- @module vibing.infrastructure.rpc.handlers.rate_limit
+
+local RateLimit = require("vibing.core.utils.rate_limit")
+
+local M = {}
+
+--- Parsed failures awaiting pickup by wrapped_on_done, keyed by handle_id.
+--- Keyed rather than a single slot so concurrent chats can't consume each other's failure — the
+--- same class of bug ActiveStreamRegistry exists to prevent.
+--- @type table<string, Vibing.RateLimitInfo>
+local pending_failures = {}
+
+--- Failures that arrived without a usable handle_id. Keyed lookups can't reach these, so they are
+--- consumed by whichever stream finishes first — only correct because a missing handle_id already
+--- means we cannot tell the streams apart.
+--- @type Vibing.RateLimitInfo|nil
+local unkeyed_failure = nil
+
+--- Get the communication directory for the current RPC port
+--- @return string
+local function get_comm_dir()
+  local rpc_server = require("vibing.infrastructure.rpc.server")
+  local port = rpc_server.get_port()
+  return "/tmp/vibing-hook-" .. tostring(port or 0)
+end
+
+--- Handle a stop_failure notification from bin/hooks/stop-failure.sh
+--- @param params {request_id: string, handle_id: string?}
+--- @return table RPC response (consumed by nobody; the hook does not wait for it)
+function M.stop_failure(params)
+  if not params or not params.request_id then
+    return { status = "error", reason = "Missing request_id" }
+  end
+
+  local handle_id = params.handle_id
+  if handle_id == "" then
+    handle_id = nil
+  end
+
+  local req_file = get_comm_dir() .. "/" .. params.request_id .. ".fail"
+  local f = io.open(req_file, "r")
+  if not f then
+    return { status = "ignored", reason = "payload file not found" }
+  end
+  local content = f:read("*a")
+  f:close()
+  os.remove(req_file)
+
+  local ok, hook_input = pcall(vim.json.decode, content)
+  if not ok or type(hook_input) ~= "table" then
+    return { status = "ignored", reason = "invalid payload JSON" }
+  end
+
+  local info = RateLimit.from_hook(hook_input)
+  if not info then
+    -- Some other API error (overloaded, billing, ...). Not something auto-resume can act on.
+    return { status = "ignored", reason = "not a rate limit" }
+  end
+
+  if handle_id then
+    pending_failures[handle_id] = info
+  else
+    unkeyed_failure = info
+  end
+
+  return { status = "ok" }
+end
+
+--- Consume the recorded failure for a handle, if any.
+--- Consuming (rather than peeking) guarantees a stale failure can't leak into the next turn of
+--- the same chat and trigger a resume for a request that actually succeeded.
+--- @param handle_id string|nil
+--- @return Vibing.RateLimitInfo|nil
+function M.take_failure(handle_id)
+  local info = handle_id and pending_failures[handle_id] or nil
+  if info then
+    pending_failures[handle_id] = nil
+    return info
+  end
+
+  if unkeyed_failure then
+    info = unkeyed_failure
+    unkeyed_failure = nil
+    return info
+  end
+
+  return nil
+end
+
+--- Drop all recorded failures (test helper / session reset)
+function M.reset()
+  pending_failures = {}
+  unkeyed_failure = nil
+end
+
+return M

--- a/lua/vibing/infrastructure/storage/pending_resume.lua
+++ b/lua/vibing/infrastructure/storage/pending_resume.lua
@@ -17,6 +17,9 @@ local M = {}
 --- @field limit_type string|nil e.g. "five_hour"
 --- @field retry_count number How many auto-resumes have already been spent on this limit hit
 --- @field recorded_at number Unix seconds when the limit was first observed
+--- @field state "waiting"|"in_flight" "waiting" until the continuation is actually sent. Only
+---   "waiting" entries are re-armed on startup, so a session that died mid-request cannot have
+---   its resume replayed for free by the next one.
 
 --- Resolve the store path for a working directory
 --- @param cwd? string

--- a/lua/vibing/infrastructure/storage/pending_resume.lua
+++ b/lua/vibing/infrastructure/storage/pending_resume.lua
@@ -21,12 +21,49 @@ local M = {}
 ---   "waiting" entries are re-armed on startup, so a session that died mid-request cannot have
 ---   its resume replayed for free by the next one.
 
+--- Memoized `git rev-parse` results, keyed by the directory asked about.
+--- A single fire()/on_rate_limited() call does several get/put/remove round trips, and each one
+--- would otherwise spawn a synchronous subprocess on the main thread.
+--- @type table<string, string|false>
+local root_cache = {}
+
+--- @param dir string|nil
+--- @return string|nil
+local function git_root_cached(dir)
+  local key = dir or "<cwd>"
+  local cached = root_cache[key]
+  if cached ~= nil then
+    return cached or nil
+  end
+  local root = Git.get_root(dir)
+  root_cache[key] = root or false
+  return root
+end
+
+--- Drop memoized roots (test helper; also useful after a worktree is added or removed)
+function M.clear_cache()
+  root_cache = {}
+end
+
 --- Resolve the store path for a working directory
 --- @param cwd? string
 --- @return string
 function M.get_path(cwd)
-  local root = Git.get_root(cwd) or cwd or vim.fn.getcwd()
+  local root = git_root_cached(cwd) or cwd or vim.fn.getcwd()
   return root .. "/.vibing/pending-resume.json"
+end
+
+--- Resolve the store that owns a given chat file.
+---
+--- Per-chat reads and writes must anchor to the chat file itself, not to Neovim's current
+--- directory: a `:cd` (or a chat whose `working_dir` is a worktree) between parking a resume and
+--- firing it would otherwise resolve to a different project's store, and the pending entry would
+--- silently vanish. Enumeration (`load`/`clear`) still uses the current project, since "which
+--- chats am I resuming" is inherently scoped to the project Neovim was opened in.
+--- @param chat_file_path string
+--- @return string
+function M.get_path_for_chat(chat_file_path)
+  return M.get_path(vim.fn.fnamemodify(chat_file_path, ":h"))
 end
 
 --- Read the whole store
@@ -74,13 +111,23 @@ function M.save(entries, cwd)
   return true
 end
 
+--- The directory a per-chat operation should resolve its store from.
+--- Defaults to the chat file's own location rather than Neovim's cwd — see get_path_for_chat.
+--- @param chat_file_path string
+--- @param cwd string|nil Explicit override (tests, callers that already know the root)
+--- @return string
+local function chat_scope(chat_file_path, cwd)
+  return cwd or vim.fn.fnamemodify(chat_file_path, ":h")
+end
+
 --- Record (or refresh) the pending resume for a chat
 --- @param entry Vibing.PendingResume
 --- @param cwd? string
 function M.put(entry, cwd)
-  local entries = M.load(cwd)
+  local scope = chat_scope(entry.chat_file_path, cwd)
+  local entries = M.load(scope)
   entries[entry.chat_file_path] = entry
-  M.save(entries, cwd)
+  M.save(entries, scope)
 end
 
 --- Read one entry
@@ -88,19 +135,20 @@ end
 --- @param cwd? string
 --- @return Vibing.PendingResume|nil
 function M.get(chat_file_path, cwd)
-  return M.load(cwd)[chat_file_path]
+  return M.load(chat_scope(chat_file_path, cwd))[chat_file_path]
 end
 
 --- Drop one entry
 --- @param chat_file_path string
 --- @param cwd? string
 function M.remove(chat_file_path, cwd)
-  local entries = M.load(cwd)
+  local scope = chat_scope(chat_file_path, cwd)
+  local entries = M.load(scope)
   if entries[chat_file_path] == nil then
     return
   end
   entries[chat_file_path] = nil
-  M.save(entries, cwd)
+  M.save(entries, scope)
 end
 
 --- Drop every entry

--- a/lua/vibing/infrastructure/storage/pending_resume.lua
+++ b/lua/vibing/infrastructure/storage/pending_resume.lua
@@ -1,0 +1,109 @@
+--- Persistence for chats waiting on a usage-limit reset
+---
+--- A five-hour limit resets hours away and a weekly limit days away, so an in-memory timer is not
+--- enough: Neovim will often be restarted in between. State lives in
+--- `<project root>/.vibing/pending-resume.json` (gitignored like the rest of `.vibing/`) and is
+--- reloaded on startup so a pending resume survives a restart.
+---
+--- @module vibing.infrastructure.storage.pending_resume
+
+local Git = require("vibing.core.utils.git")
+
+local M = {}
+
+--- @class Vibing.PendingResume
+--- @field chat_file_path string Absolute path of the chat file to resume
+--- @field resets_at number|nil Unix seconds when the limit lifts
+--- @field limit_type string|nil e.g. "five_hour"
+--- @field retry_count number How many auto-resumes have already been spent on this limit hit
+--- @field recorded_at number Unix seconds when the limit was first observed
+
+--- Resolve the store path for a working directory
+--- @param cwd? string
+--- @return string
+function M.get_path(cwd)
+  local root = Git.get_root(cwd) or cwd or vim.fn.getcwd()
+  return root .. "/.vibing/pending-resume.json"
+end
+
+--- Read the whole store
+--- A missing or corrupt file yields an empty table: a resume that cannot be read is a resume that
+--- silently does not happen, which is the safe direction for something that spends tokens.
+--- @param cwd? string
+--- @return table<string, Vibing.PendingResume>
+function M.load(cwd)
+  local path = M.get_path(cwd)
+  if vim.fn.filereadable(path) == 0 then
+    return {}
+  end
+
+  local ok, lines = pcall(vim.fn.readfile, path)
+  if not ok or not lines or #lines == 0 then
+    return {}
+  end
+
+  local decoded_ok, decoded = pcall(vim.json.decode, table.concat(lines, "\n"))
+  if not decoded_ok or type(decoded) ~= "table" then
+    vim.notify("[vibing] Ignoring unreadable pending-resume.json", vim.log.levels.WARN)
+    return {}
+  end
+
+  return decoded
+end
+
+--- Overwrite the whole store
+--- @param entries table<string, Vibing.PendingResume>
+--- @param cwd? string
+--- @return boolean success
+function M.save(entries, cwd)
+  local path = M.get_path(cwd)
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+
+  -- vim.json.encode turns an empty Lua table into "[]" (an array), which decodes back as a list
+  -- and would break every keyed lookup on the next load. Store an explicit empty object instead.
+  local json = next(entries) == nil and "{}" or vim.json.encode(entries)
+
+  local ok, err = pcall(vim.fn.writefile, { json }, path)
+  if not ok then
+    vim.notify("[vibing] Failed to write pending-resume.json: " .. tostring(err), vim.log.levels.WARN)
+    return false
+  end
+  return true
+end
+
+--- Record (or refresh) the pending resume for a chat
+--- @param entry Vibing.PendingResume
+--- @param cwd? string
+function M.put(entry, cwd)
+  local entries = M.load(cwd)
+  entries[entry.chat_file_path] = entry
+  M.save(entries, cwd)
+end
+
+--- Read one entry
+--- @param chat_file_path string
+--- @param cwd? string
+--- @return Vibing.PendingResume|nil
+function M.get(chat_file_path, cwd)
+  return M.load(cwd)[chat_file_path]
+end
+
+--- Drop one entry
+--- @param chat_file_path string
+--- @param cwd? string
+function M.remove(chat_file_path, cwd)
+  local entries = M.load(cwd)
+  if entries[chat_file_path] == nil then
+    return
+  end
+  entries[chat_file_path] = nil
+  M.save(entries, cwd)
+end
+
+--- Drop every entry
+--- @param cwd? string
+function M.clear(cwd)
+  M.save({}, cwd)
+end
+
+return M

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -65,6 +65,17 @@ function M.setup(opts)
   local hook_cleanup = require("vibing.infrastructure.adapter.modules.hook_cleanup")
   hook_cleanup.cleanup_stale_dirs()
 
+  -- 使用量リミット待ちのチャットのタイマーを張り直す。
+  -- 5時間/週次リミットのリセットはNeovimの再起動を跨ぐことが多いため、
+  -- .vibing/pending-resume.json から復元する。VimEnter後に遅延させて起動を妨げない。
+  if M.config.agent and M.config.agent.auto_resume_on_limit and M.config.agent.auto_resume_on_limit.enabled then
+    vim.schedule(function()
+      pcall(function()
+        require("vibing.application.chat.auto_resume").restore()
+      end)
+    end)
+  end
+
   -- 終了時にクリーンアップ
   local augroup = vim.api.nvim_create_augroup("VibingCleanup", { clear = true })
   vim.api.nvim_create_autocmd("VimLeavePre", {
@@ -219,6 +230,66 @@ function M._register_commands()
       M.adapter:cancel()
     end
   end, { desc = "Cancel current Vibing request" })
+
+  vim.api.nvim_create_user_command("VibingPendingResumes", function()
+    local AutoResume = require("vibing.application.chat.auto_resume")
+    local entries = AutoResume.list()
+    if #entries == 0 then
+      notify.info("No chats are waiting on a usage limit reset")
+      return
+    end
+    local now = os.time()
+    local lines = {}
+    for _, entry in ipairs(entries) do
+      local when = entry.resets_at
+          and string.format(
+            "%s (in %s)",
+            os.date("%Y-%m-%d %H:%M:%S", entry.resets_at),
+            AutoResume.format_duration(math.max(entry.resets_at - now, 0))
+          )
+        or "reset time unknown"
+      table.insert(
+        lines,
+        string.format(
+          "%s - %s [%s, retries used: %d]",
+          vim.fn.fnamemodify(entry.chat_file_path, ":t"),
+          when,
+          entry.limit_type or "unknown limit",
+          entry.retry_count or 0
+        )
+      )
+    end
+    notify.info("Pending resumes:\n" .. table.concat(lines, "\n"))
+  end, { desc = "List chats waiting on a usage limit reset" })
+
+  vim.api.nvim_create_user_command("VibingCancelResume", function(opts)
+    local AutoResume = require("vibing.application.chat.auto_resume")
+
+    if opts.args == "all" then
+      notify.info(string.format("Cancelled %d pending resume(s)", AutoResume.cancel(nil)))
+      return
+    end
+
+    local view = require("vibing.presentation.chat.view")
+    local chat_buffer = view.get_current()
+    if not chat_buffer then
+      notify.warn("Not in a chat buffer. Use ':VibingCancelResume all' to cancel every pending resume.")
+      return
+    end
+
+    local path = vim.api.nvim_buf_get_name(chat_buffer:get_buffer())
+    if AutoResume.cancel(path) > 0 then
+      notify.info("Cancelled pending resume for this chat")
+    else
+      notify.info("This chat has no pending resume")
+    end
+  end, {
+    nargs = "?",
+    complete = function()
+      return { "all" }
+    end,
+    desc = "Cancel pending auto-resume for this chat (or 'all')",
+  })
 
   vim.api.nvim_create_user_command("VibingMoteDir", function(opts)
     local view = require("vibing.presentation.chat.view")

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -265,6 +265,11 @@ function M._register_commands()
   vim.api.nvim_create_user_command("VibingCancelResume", function(opts)
     local AutoResume = require("vibing.application.chat.auto_resume")
 
+    if opts.args ~= "" and opts.args ~= "all" then
+      notify.warn("Usage: :VibingCancelResume [all]")
+      return
+    end
+
     if opts.args == "all" then
       notify.info(string.format("Cancelled %d pending resume(s)", AutoResume.cancel(nil)))
       return

--- a/tests/lua/application/chat/auto_resume_spec.lua
+++ b/tests/lua/application/chat/auto_resume_spec.lua
@@ -59,6 +59,122 @@ describe("auto_resume", function()
     end)
   end)
 
+  describe("compute_delay", function()
+    local AutoResume = require("vibing.application.chat.auto_resume")
+    local OPTS = { fallback_delay_sec = 300, grace_sec = 10 }
+
+    it("waits until the reset plus the grace period", function()
+      local resets_at = os.time() + 3600
+      local delay = AutoResume._compute_delay({ resets_at = resets_at }, OPTS)
+
+      -- Timing-tolerant: os.time() may tick between the fixture and the call.
+      assert.is_true(delay >= 3605 and delay <= 3610)
+    end)
+
+    it("falls back to fallback_delay_sec when no reset time was reported", function()
+      assert.equals(300, AutoResume._compute_delay({}, OPTS))
+    end)
+
+    it("clamps an already-elapsed reset to a short delay rather than firing instantly", function()
+      -- Neovim was closed across the whole window; let startup settle before a request goes out.
+      local delay = AutoResume._compute_delay({ resets_at = os.time() - 10000 }, OPTS)
+
+      assert.equals(3, delay)
+    end)
+
+    it("refuses an implausible reset more than 8 days out", function()
+      local delay, reason = AutoResume._compute_delay({ resets_at = os.time() + 30 * 86400 }, OPTS)
+
+      -- A misread payload (wrong unit or field) must not arm a timer for weeks.
+      assert.is_nil(delay)
+      assert.truthy(reason:match("days away"))
+    end)
+
+    it("accepts a reset just inside the 8-day ceiling", function()
+      local delay = AutoResume._compute_delay({ resets_at = os.time() + 7 * 86400 }, OPTS)
+
+      assert.is_not_nil(delay)
+    end)
+  end)
+
+  describe("on_rate_limited", function()
+    local AutoResume = require("vibing.application.chat.auto_resume")
+    local Config = require("vibing.config")
+    local original_get
+    local chat_path
+
+    ---@param auto_resume_opts table
+    local function stub_config(auto_resume_opts)
+      Config.get = function()
+        return { agent = { auto_resume_on_limit = auto_resume_opts } }
+      end
+    end
+
+    before_each(function()
+      original_get = Config.get
+      -- Per-chat store operations resolve from the chat file's own directory, so a chat path
+      -- inside tmp_root keeps this test off the real repository.
+      chat_path = tmp_root .. "/chat.md"
+    end)
+
+    after_each(function()
+      Config.get = original_get
+    end)
+
+    it("does not park a chat while the feature is disabled", function()
+      stub_config({ enabled = false })
+
+      AutoResume.on_rate_limited(chat_path, { rejected = true, resets_at = os.time() + 60, source = "test" })
+
+      assert.is_nil(PendingResume.get(chat_path))
+    end)
+
+    it("parks a chat in the waiting state on the first limit hit", function()
+      stub_config({ enabled = true, max_retries = 1 })
+      local resets_at = os.time() + 3600
+
+      AutoResume.on_rate_limited(chat_path, {
+        rejected = true,
+        resets_at = resets_at,
+        limit_type = "five_hour",
+        source = "test",
+      })
+
+      local entry = PendingResume.get(chat_path)
+      assert.is_not_nil(entry)
+      assert.equals("waiting", entry.state)
+      assert.equals(0, entry.retry_count)
+      assert.equals(resets_at, entry.resets_at)
+
+      AutoResume.cancel(chat_path)
+    end)
+
+    it("gives up instead of re-parking once the retry budget is spent", function()
+      stub_config({ enabled = true, max_retries = 1 })
+      PendingResume.put({
+        chat_file_path = chat_path,
+        resets_at = os.time() + 60,
+        retry_count = 1,
+        recorded_at = os.time(),
+        state = "in_flight",
+      })
+
+      AutoResume.on_rate_limited(chat_path, { rejected = true, resets_at = os.time() + 3600, source = "test" })
+
+      -- The entry is dropped, not refreshed: a second auto-resume would exceed max_retries.
+      assert.is_nil(PendingResume.get(chat_path))
+    end)
+
+    it("ignores a chat with no file path", function()
+      stub_config({ enabled = true, max_retries = 1 })
+
+      assert.has_no.errors(function()
+        AutoResume.on_rate_limited(nil, { rejected = true, source = "test" })
+        AutoResume.on_rate_limited("", { rejected = true, source = "test" })
+      end)
+    end)
+  end)
+
   describe("format_duration", function()
     local AutoResume = require("vibing.application.chat.auto_resume")
 

--- a/tests/lua/application/chat/auto_resume_spec.lua
+++ b/tests/lua/application/chat/auto_resume_spec.lua
@@ -1,0 +1,116 @@
+describe("auto_resume", function()
+  local PendingResume = require("vibing.infrastructure.storage.pending_resume")
+
+  local tmp_root
+
+  before_each(function()
+    tmp_root = vim.fn.tempname()
+    vim.fn.mkdir(tmp_root, "p")
+  end)
+
+  after_each(function()
+    if tmp_root then
+      vim.fn.delete(tmp_root, "rf")
+    end
+  end)
+
+  describe("restore eligibility", function()
+    -- restore() arms libuv timers, so rather than wait on wall-clock these tests assert the
+    -- predicate restore() filters on: only "waiting" entries are eligible to be re-armed.
+    ---@param entry table
+    ---@return boolean
+    local function is_restorable(entry)
+      return entry.chat_file_path ~= nil and (entry.state or "waiting") == "waiting"
+    end
+
+    it("re-arms a chat still waiting on its reset", function()
+      PendingResume.put({
+        chat_file_path = "/a.md",
+        resets_at = 1778193600,
+        retry_count = 0,
+        recorded_at = 1,
+        state = "waiting",
+      }, tmp_root)
+
+      assert.is_true(is_restorable(PendingResume.get("/a.md", tmp_root)))
+    end)
+
+    it("does not re-send a resume that was already in flight when Neovim died (regression)", function()
+      -- fire() marks the entry in_flight before sending. Without this guard a restart would
+      -- schedule it again and spend a second request outside the retry budget.
+      PendingResume.put({
+        chat_file_path = "/b.md",
+        resets_at = 1778193600,
+        retry_count = 1,
+        recorded_at = 1,
+        state = "in_flight",
+      }, tmp_root)
+
+      local entry = PendingResume.get("/b.md", tmp_root)
+      assert.is_false(is_restorable(entry))
+      -- The entry survives so its retry_count still counts against max_retries.
+      assert.equals(1, entry.retry_count)
+    end)
+
+    it("treats a missing state as waiting", function()
+      PendingResume.put({ chat_file_path = "/c.md", retry_count = 0, recorded_at = 1 }, tmp_root)
+
+      assert.is_true(is_restorable(PendingResume.get("/c.md", tmp_root)))
+    end)
+  end)
+
+  describe("format_duration", function()
+    local AutoResume = require("vibing.application.chat.auto_resume")
+
+    it("formats seconds, minutes and hours", function()
+      assert.equals("45s", AutoResume.format_duration(45))
+      assert.equals("5m", AutoResume.format_duration(300))
+      assert.equals("4h58m", AutoResume.format_duration(17880))
+    end)
+  end)
+
+  describe("list", function()
+    local AutoResume = require("vibing.application.chat.auto_resume")
+    local original_load
+
+    -- Stub the store rather than write real files: list() resolves its path through
+    -- Git.get_root(nil), which runs git in the *process* cwd — i.e. this repository — so a
+    -- filesystem-backed test here would scribble on the developer's own .vibing/.
+    before_each(function()
+      original_load = PendingResume.load
+    end)
+
+    after_each(function()
+      PendingResume.load = original_load
+    end)
+
+    it("returns pending entries ordered by reset time, soonest first", function()
+      PendingResume.load = function()
+        return {
+          ["/late.md"] = { chat_file_path = "/late.md", resets_at = 2000 },
+          ["/soon.md"] = { chat_file_path = "/soon.md", resets_at = 1000 },
+        }
+      end
+
+      local entries = AutoResume.list()
+
+      assert.equals(2, #entries)
+      assert.equals("/soon.md", entries[1].chat_file_path)
+      assert.equals("/late.md", entries[2].chat_file_path)
+    end)
+
+    it("sorts entries with no reset time last", function()
+      PendingResume.load = function()
+        return {
+          ["/unknown.md"] = { chat_file_path = "/unknown.md" },
+          ["/known.md"] = { chat_file_path = "/known.md", resets_at = 1000 },
+        }
+      end
+
+      local entries = AutoResume.list()
+
+      assert.equals("/known.md", entries[1].chat_file_path)
+      assert.equals("/unknown.md", entries[2].chat_file_path)
+    end)
+  end)
+end)

--- a/tests/lua/core/utils/rate_limit_spec.lua
+++ b/tests/lua/core/utils/rate_limit_spec.lua
@@ -1,0 +1,124 @@
+describe("rate_limit", function()
+  local RateLimit = require("vibing.core.utils.rate_limit")
+
+  describe("from_event", function()
+    it("extracts reset time, type and rejection from a rejected event", function()
+      local info = RateLimit.from_event({
+        type = "rate_limit_event",
+        rate_limit_info = {
+          status = "rejected",
+          resetsAt = 1778193600,
+          rateLimitType = "five_hour",
+        },
+      })
+
+      assert.is_true(info.rejected)
+      assert.equals(1778193600, info.resets_at)
+      assert.equals("five_hour", info.limit_type)
+      assert.equals("stream_event", info.source)
+    end)
+
+    it("treats a non-rejected status as informational", function()
+      local info = RateLimit.from_event({
+        rate_limit_info = { status = "allowed", resetsAt = 1778193600 },
+      })
+
+      assert.is_false(info.rejected)
+      -- Reset time is still surfaced so a later rejection can reuse it.
+      assert.equals(1778193600, info.resets_at)
+    end)
+
+    it("accepts snake_case field spellings", function()
+      local info = RateLimit.from_event({
+        rate_limit_info = { status = "blocked", resets_at = 1778193600, rate_limit_type = "weekly" },
+      })
+
+      assert.is_true(info.rejected)
+      assert.equals(1778193600, info.resets_at)
+      assert.equals("weekly", info.limit_type)
+    end)
+
+    it("normalizes a millisecond timestamp to seconds", function()
+      local info = RateLimit.from_event({
+        rate_limit_info = { status = "rejected", resetsAt = 1778193600000 },
+      })
+
+      assert.equals(1778193600, info.resets_at)
+    end)
+
+    it("rejects when only overageStatus reports the rejection", function()
+      local info = RateLimit.from_event({
+        rate_limit_info = { status = "allowed", overageStatus = "rejected" },
+      })
+
+      assert.is_true(info.rejected)
+    end)
+
+    it("survives an unrecognized payload instead of erroring", function()
+      local info = RateLimit.from_event({ type = "rate_limit_event" })
+
+      assert.is_not_nil(info)
+      assert.is_false(info.rejected)
+      assert.is_nil(info.resets_at)
+    end)
+
+    it("returns nil for a non-table payload", function()
+      assert.is_nil(RateLimit.from_event(nil))
+      assert.is_nil(RateLimit.from_event("rate_limit_event"))
+    end)
+  end)
+
+  describe("from_hook", function()
+    it("accepts a rate_limit error type", function()
+      local info = RateLimit.from_hook({ hook_event_name = "StopFailure", error_type = "rate_limit" })
+
+      assert.is_true(info.rejected)
+      assert.equals("hook", info.source)
+    end)
+
+    it("ignores other API error types", function()
+      assert.is_nil(RateLimit.from_hook({ error_type = "overloaded" }))
+      assert.is_nil(RateLimit.from_hook({ error_type = "billing_error" }))
+      assert.is_nil(RateLimit.from_hook({}))
+    end)
+  end)
+
+  describe("from_error_text", function()
+    it("detects limit wording case-insensitively", function()
+      assert.is_not_nil(RateLimit.from_error_text("Claude AI usage limit reached"))
+      assert.is_not_nil(RateLimit.from_error_text("429 Too Many Requests"))
+    end)
+
+    it("ignores unrelated errors", function()
+      assert.is_nil(RateLimit.from_error_text("ENOENT: no such file"))
+      assert.is_nil(RateLimit.from_error_text(""))
+      assert.is_nil(RateLimit.from_error_text(nil))
+    end)
+  end)
+
+  describe("merge", function()
+    it("keeps the reset time from the stream event when the hook has none", function()
+      local merged = RateLimit.merge(
+        RateLimit.from_event({ rate_limit_info = { status = "rejected", resetsAt = 1778193600 } }),
+        RateLimit.from_hook({ error_type = "rate_limit" })
+      )
+
+      assert.is_true(merged.rejected)
+      assert.equals(1778193600, merged.resets_at)
+    end)
+
+    it("promotes rejection when only one channel saw it", function()
+      local merged = RateLimit.merge(
+        RateLimit.from_event({ rate_limit_info = { status = "allowed", resetsAt = 1778193600 } }),
+        RateLimit.from_hook({ error_type = "rate_limit" })
+      )
+
+      assert.is_true(merged.rejected)
+      assert.equals(1778193600, merged.resets_at)
+    end)
+
+    it("returns nil when nothing was detected", function()
+      assert.is_nil(RateLimit.merge(nil, nil, nil))
+    end)
+  end)
+end)

--- a/tests/lua/core/utils/rate_limit_spec.lua
+++ b/tests/lua/core/utils/rate_limit_spec.lua
@@ -120,5 +120,33 @@ describe("rate_limit", function()
     it("returns nil when nothing was detected", function()
       assert.is_nil(RateLimit.merge(nil, nil, nil))
     end)
+
+    -- Regression: merge iterated with ipairs, which stops at the first nil hole. Production
+    -- always passes one argument per channel, so a nil in any position silently discarded every
+    -- later channel — including a hook-only detection, the whole point of the StopFailure hook.
+    it("detects a hook-only limit when the leading channel is nil (regression)", function()
+      local merged = RateLimit.merge(nil, RateLimit.from_hook({ error_type = "rate_limit" }), nil)
+
+      assert.is_not_nil(merged)
+      assert.is_true(merged.rejected)
+    end)
+
+    it("still reaches the error-text fallback past a nil middle channel (regression)", function()
+      local merged = RateLimit.merge(
+        RateLimit.from_event({ rate_limit_info = { status = "allowed", resetsAt = 1778193600 } }),
+        nil,
+        RateLimit.from_error_text("Claude AI usage limit reached")
+      )
+
+      assert.is_true(merged.rejected)
+      assert.equals(1778193600, merged.resets_at)
+    end)
+
+    it("detects a limit reported only by the last channel (regression)", function()
+      local merged = RateLimit.merge(nil, nil, RateLimit.from_error_text("429 Too Many Requests"))
+
+      assert.is_not_nil(merged)
+      assert.is_true(merged.rejected)
+    end)
   end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/cli_event_processor_rate_limit_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_event_processor_rate_limit_spec.lua
@@ -1,0 +1,55 @@
+describe("cli_event_processor rate_limit_event", function()
+  local processor = require("vibing.infrastructure.adapter.modules.cli_event_processor")
+
+  ---Feed a decoded event to the processor as it would arrive on stdout.
+  ---@param context table
+  ---@param rate_limit_info table
+  local function feed(context, rate_limit_info)
+    processor.processLine(vim.json.encode({ type = "rate_limit_event", rate_limit_info = rate_limit_info }), context)
+  end
+
+  it("records a rejection with its reset time", function()
+    local context = {}
+    feed(context, { status = "rejected", resetsAt = 1778193600, rateLimitType = "five_hour" })
+
+    assert.is_true(context.rateLimitInfo.rejected)
+    assert.equals(1778193600, context.rateLimitInfo.resets_at)
+  end)
+
+  it("keeps an earlier reset time when the rejection omits it (regression)", function()
+    local context = {}
+    -- Informational event carrying the reset timestamp...
+    feed(context, { status = "allowed", resetsAt = 1778193600, rateLimitType = "five_hour" })
+    -- ...followed by the rejection that ends the turn, without one.
+    feed(context, { status = "rejected" })
+
+    assert.is_true(context.rateLimitInfo.rejected)
+    -- Losing this would silently downgrade the resume to fallback_delay_sec.
+    assert.equals(1778193600, context.rateLimitInfo.resets_at)
+    assert.equals("five_hour", context.rateLimitInfo.limit_type)
+  end)
+
+  it("prefers a newer reset time over an older one", function()
+    local context = {}
+    feed(context, { status = "allowed", resetsAt = 1778193600 })
+    feed(context, { status = "rejected", resetsAt = 1778200000 })
+
+    assert.equals(1778200000, context.rateLimitInfo.resets_at)
+  end)
+
+  it("does not let a trailing warning clear an earlier rejection", function()
+    local context = {}
+    feed(context, { status = "rejected", resetsAt = 1778193600 })
+    feed(context, { status = "allowed" })
+
+    assert.is_true(context.rateLimitInfo.rejected)
+    assert.equals(1778193600, context.rateLimitInfo.resets_at)
+  end)
+
+  it("leaves the context untouched for unrelated events", function()
+    local context = {}
+    processor.processLine(vim.json.encode({ type = "result", subtype = "success" }), context)
+
+    assert.is_nil(context.rateLimitInfo)
+  end)
+end)

--- a/tests/lua/infrastructure/hooks/settings_generator_spec.lua
+++ b/tests/lua/infrastructure/hooks/settings_generator_spec.lua
@@ -1,0 +1,65 @@
+describe("settings_generator", function()
+  local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+
+  it("points both hooks at scripts bundled with the plugin", function()
+    local pre_tool_use = SettingsGenerator.get_hook_script_path()
+    local stop_failure = SettingsGenerator.get_stop_failure_script_path()
+
+    assert.truthy(pre_tool_use:match("/bin/hooks/pre%-tool%-use%.sh$"))
+    assert.truthy(stop_failure:match("/bin/hooks/stop%-failure%.sh$"))
+    -- Resolved from the plugin's own location, so the path survives an install-dir change.
+    assert.equals(1, vim.fn.filereadable(pre_tool_use))
+    assert.equals(1, vim.fn.filereadable(stop_failure))
+    assert.equals(1, vim.fn.executable(pre_tool_use))
+    assert.equals(1, vim.fn.executable(stop_failure))
+  end)
+
+  it("registers a PreToolUse hook matching every tool", function()
+    local settings = SettingsGenerator.generate()
+    local entry = settings.hooks.PreToolUse[1]
+
+    assert.equals(".*", entry.matcher)
+    assert.equals("command", entry.hooks[1].type)
+    assert.equals(SettingsGenerator.get_hook_script_path(), entry.hooks[1].command)
+  end)
+
+  it("registers a StopFailure hook scoped to rate_limit errors", function()
+    local settings = SettingsGenerator.generate()
+    local entry = settings.hooks.StopFailure[1]
+
+    -- Only rate_limit carries a reset time worth waiting for; other API errors (overloaded,
+    -- billing_error, ...) would park a chat that can never be resumed on a schedule.
+    assert.equals("rate_limit", entry.matcher)
+    assert.equals(SettingsGenerator.get_stop_failure_script_path(), entry.hooks[1].command)
+  end)
+
+  it("writes an absolute settings path under the given cwd", function()
+    local tmp = vim.fn.tempname()
+    vim.fn.mkdir(tmp, "p")
+
+    local path = SettingsGenerator.ensure(tmp)
+
+    assert.equals(tmp .. "/.vibing/hook-settings.json", path)
+    assert.equals(1, vim.fn.filereadable(path))
+
+    local decoded = vim.json.decode(table.concat(vim.fn.readfile(path), "\n"))
+    assert.is_not_nil(decoded.hooks.PreToolUse)
+    assert.is_not_nil(decoded.hooks.StopFailure)
+
+    vim.fn.delete(tmp, "rf")
+  end)
+
+  it("regenerates the settings file on every call", function()
+    local tmp = vim.fn.tempname()
+    vim.fn.mkdir(tmp, "p")
+
+    local path = SettingsGenerator.ensure(tmp)
+    vim.fn.writefile({ "{}" }, path)
+    SettingsGenerator.ensure(tmp)
+
+    local decoded = vim.json.decode(table.concat(vim.fn.readfile(path), "\n"))
+    assert.is_not_nil(decoded.hooks)
+
+    vim.fn.delete(tmp, "rf")
+  end)
+end)

--- a/tests/lua/infrastructure/rpc/handlers/rate_limit_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/rate_limit_spec.lua
@@ -60,6 +60,19 @@ describe("rpc.handlers.rate_limit", function()
       assert.is_not_nil(handler.take_failure("chat-b"))
     end)
 
+    it("drops a failure with no handle_id instead of attributing it to a chat (regression)", function()
+      local handler = fresh_handler()
+      write_payload("req-unkeyed", { error_type = "rate_limit" })
+
+      local res = handler.stop_failure({ request_id = "req-unkeyed", handle_id = "" })
+      assert.equals("ignored", res.status)
+
+      -- Neither concurrent chat may inherit it: doing so would auto-resume a healthy chat.
+      assert.is_nil(handler.take_failure("chat-a"))
+      assert.is_nil(handler.take_failure("chat-b"))
+      assert.is_nil(handler.take_failure(nil))
+    end)
+
     it("ignores non-rate-limit API errors", function()
       local handler = fresh_handler()
       write_payload("req-overloaded", { error_type = "overloaded" })

--- a/tests/lua/infrastructure/rpc/handlers/rate_limit_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/rate_limit_spec.lua
@@ -1,0 +1,80 @@
+describe("rpc.handlers.rate_limit", function()
+  ---@return table
+  local function fresh_handler()
+    package.loaded["vibing.infrastructure.rpc.handlers.rate_limit"] = nil
+    return require("vibing.infrastructure.rpc.handlers.rate_limit")
+  end
+
+  it("returns nil when nothing was recorded", function()
+    local handler = fresh_handler()
+    assert.is_nil(handler.take_failure("handle-1"))
+  end)
+
+  it("rejects a request without request_id", function()
+    local handler = fresh_handler()
+    local res = handler.stop_failure({})
+    assert.equals("error", res.status)
+  end)
+
+  it("ignores a payload file that does not exist", function()
+    local handler = fresh_handler()
+    local res = handler.stop_failure({ request_id = "does-not-exist", handle_id = "h" })
+    assert.equals("ignored", res.status)
+  end)
+
+  describe("with a payload file on disk", function()
+    local rpc_server = require("vibing.infrastructure.rpc.server")
+    local comm_dir
+
+    ---Write a hook payload where the handler expects to find it.
+    ---@param request_id string
+    ---@param payload table
+    local function write_payload(request_id, payload)
+      comm_dir = "/tmp/vibing-hook-" .. tostring(rpc_server.get_port() or 0)
+      vim.fn.mkdir(comm_dir, "p")
+      vim.fn.writefile({ vim.json.encode(payload) }, comm_dir .. "/" .. request_id .. ".fail")
+    end
+
+    it("records a rate_limit failure and hands it to the matching handle", function()
+      local handler = fresh_handler()
+      write_payload("req-rl", { hook_event_name = "StopFailure", error_type = "rate_limit" })
+
+      local res = handler.stop_failure({ request_id = "req-rl", handle_id = "handle-a" })
+      assert.equals("ok", res.status)
+
+      local info = handler.take_failure("handle-a")
+      assert.is_not_nil(info)
+      assert.is_true(info.rejected)
+      -- Consumed, not merely peeked: a stale failure must not leak into the next turn.
+      assert.is_nil(handler.take_failure("handle-a"))
+    end)
+
+    it("does not hand one chat's failure to another concurrent chat", function()
+      local handler = fresh_handler()
+      write_payload("req-a", { error_type = "rate_limit" })
+      write_payload("req-b", { error_type = "rate_limit" })
+      handler.stop_failure({ request_id = "req-a", handle_id = "chat-a" })
+      handler.stop_failure({ request_id = "req-b", handle_id = "chat-b" })
+
+      assert.is_not_nil(handler.take_failure("chat-a"))
+      assert.is_not_nil(handler.take_failure("chat-b"))
+    end)
+
+    it("ignores non-rate-limit API errors", function()
+      local handler = fresh_handler()
+      write_payload("req-overloaded", { error_type = "overloaded" })
+
+      local res = handler.stop_failure({ request_id = "req-overloaded", handle_id = "handle-b" })
+      assert.equals("ignored", res.status)
+      assert.is_nil(handler.take_failure("handle-b"))
+    end)
+
+    it("deletes the payload file after reading it", function()
+      local handler = fresh_handler()
+      write_payload("req-cleanup", { error_type = "rate_limit" })
+      handler.stop_failure({ request_id = "req-cleanup", handle_id = "handle-c" })
+
+      assert.equals(0, vim.fn.filereadable(comm_dir .. "/req-cleanup.fail"))
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/storage/pending_resume_spec.lua
+++ b/tests/lua/infrastructure/storage/pending_resume_spec.lua
@@ -1,0 +1,74 @@
+describe("pending_resume", function()
+  local PendingResume = require("vibing.infrastructure.storage.pending_resume")
+
+  local tmp_root
+
+  before_each(function()
+    tmp_root = vim.fn.tempname()
+    vim.fn.mkdir(tmp_root, "p")
+  end)
+
+  after_each(function()
+    if tmp_root then
+      vim.fn.delete(tmp_root, "rf")
+    end
+  end)
+
+  it("returns an empty table when no store exists", function()
+    assert.same({}, PendingResume.load(tmp_root))
+  end)
+
+  it("round-trips an entry", function()
+    PendingResume.put({
+      chat_file_path = "/proj/.vibing/chat/a.md",
+      resets_at = 1778193600,
+      limit_type = "five_hour",
+      retry_count = 0,
+      recorded_at = 1778180000,
+    }, tmp_root)
+
+    local entry = PendingResume.get("/proj/.vibing/chat/a.md", tmp_root)
+    assert.is_not_nil(entry)
+    assert.equals(1778193600, entry.resets_at)
+    assert.equals("five_hour", entry.limit_type)
+    assert.equals(0, entry.retry_count)
+  end)
+
+  it("keeps entries for other chats when one is removed", function()
+    PendingResume.put({ chat_file_path = "/a.md", retry_count = 0, recorded_at = 1 }, tmp_root)
+    PendingResume.put({ chat_file_path = "/b.md", retry_count = 0, recorded_at = 1 }, tmp_root)
+
+    PendingResume.remove("/a.md", tmp_root)
+
+    assert.is_nil(PendingResume.get("/a.md", tmp_root))
+    assert.is_not_nil(PendingResume.get("/b.md", tmp_root))
+  end)
+
+  it("stays a keyed object after the last entry is removed (regression)", function()
+    -- An empty Lua table encodes as "[]", which would decode back as a list and break every
+    -- keyed lookup on the next load.
+    PendingResume.put({ chat_file_path = "/only.md", retry_count = 0, recorded_at = 1 }, tmp_root)
+    PendingResume.remove("/only.md", tmp_root)
+
+    assert.same({}, PendingResume.load(tmp_root))
+    PendingResume.put({ chat_file_path = "/again.md", retry_count = 0, recorded_at = 1 }, tmp_root)
+    assert.is_not_nil(PendingResume.get("/again.md", tmp_root))
+  end)
+
+  it("ignores a corrupt store instead of erroring", function()
+    local path = PendingResume.get_path(tmp_root)
+    vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+    vim.fn.writefile({ "{ this is not json" }, path)
+
+    assert.same({}, PendingResume.load(tmp_root))
+  end)
+
+  it("clears every entry", function()
+    PendingResume.put({ chat_file_path = "/a.md", retry_count = 0, recorded_at = 1 }, tmp_root)
+    PendingResume.put({ chat_file_path = "/b.md", retry_count = 0, recorded_at = 1 }, tmp_root)
+
+    PendingResume.clear(tmp_root)
+
+    assert.same({}, PendingResume.load(tmp_root))
+  end)
+end)

--- a/tests/lua/infrastructure/storage/pending_resume_spec.lua
+++ b/tests/lua/infrastructure/storage/pending_resume_spec.lua
@@ -63,6 +63,29 @@ describe("pending_resume", function()
     assert.same({}, PendingResume.load(tmp_root))
   end)
 
+  it("anchors a per-chat write to the chat's own project, not Neovim's cwd (regression)", function()
+    -- A :cd (or a worktree chat) between parking a resume and firing it used to resolve to a
+    -- different project's store, silently losing the pending entry.
+    local chat_path = tmp_root .. "/.vibing/chat/a.md"
+    vim.fn.mkdir(vim.fn.fnamemodify(chat_path, ":h"), "p")
+
+    PendingResume.put({ chat_file_path = chat_path, retry_count = 0, recorded_at = 1 })
+
+    -- Readable back without being told where to look, and stored under the chat's own tree.
+    assert.is_not_nil(PendingResume.get(chat_path))
+    assert.equals(1, vim.fn.filereadable(PendingResume.get_path_for_chat(chat_path)))
+  end)
+
+  it("removes a per-chat entry from the chat's own store", function()
+    local chat_path = tmp_root .. "/.vibing/chat/b.md"
+    vim.fn.mkdir(vim.fn.fnamemodify(chat_path, ":h"), "p")
+    PendingResume.put({ chat_file_path = chat_path, retry_count = 0, recorded_at = 1 })
+
+    PendingResume.remove(chat_path)
+
+    assert.is_nil(PendingResume.get(chat_path))
+  end)
+
   it("clears every entry", function()
     PendingResume.put({ chat_file_path = "/a.md", retry_count = 0, recorded_at = 1 }, tmp_root)
     PendingResume.put({ chat_file_path = "/b.md", retry_count = 0, recorded_at = 1 }, tmp_root)


### PR DESCRIPTION
When a turn is rejected because the plan's usage limit is exhausted, park the
chat and send a single continuation message once the limit lifts.

Detection merges three independent signals in core/utils/rate_limit.lua:

- `rate_limit_event` on the CLI's stream-json stdout. This was previously
  parsed and discarded by a no-op handler, and it is the only channel that
  carries `resetsAt` — without it there is nothing to schedule against.
- A new `StopFailure` hook filtered to `error_type = rate_limit`, which
  confirms the turn actually died but carries no timestamp. It is distributed
  the same way the PreToolUse hook already is: bundled at
  bin/hooks/stop-failure.sh and registered in the regenerated
  .vibing/hook-settings.json, so users need no setup. The hook has no decision
  power (Claude Code ignores its output and exit code), so it is
  fire-and-forget and never blocks the turn.
- The run's error text, as a fallback if either payload shape changes.

None of these payload shapes is officially documented, so every field is
optional and both camelCase and snake_case spellings are accepted; a schema
change degrades the feature rather than breaking the stream.

Pending resumes persist to .vibing/pending-resume.json and are re-armed on
setup(), since a five-hour reset usually outlives the Neovim session.

Opt-in via agent.auto_resume_on_limit.enabled (default false) because it
spends tokens unattended. Bounded by max_retries (default 1) per limit hit,
never overwrites an unsent `## User` message, and rejects reset timestamps
more than 8 days out as misread. Inspect and cancel with
:VibingPendingResumes and :VibingCancelResume.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Br7zg5ZNwZr6EgvdRC6gzC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automatic chat resumption after usage-limit interruptions.
  * Pending resumes persist across restarts with retry limits, safeguards, and configurable delays.
  * Added `:VibingPendingResumes` to view queued resumes.
  * Added `:VibingCancelResume [all]` to cancel one or all queued resumes.
  * Added configuration options for enabling auto-resume, prompts, retries, delays, and reset-time grace periods.

* **Bug Fixes**
  * Improved detection and handling of usage-limit signals across supported error sources.

* **Tests**
  * Added coverage for usage-limit detection, persistence, hook handling, and resume management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->