### PR TITLE
docs: add pending-resume commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ buffers — save, search, and edit them like any other file.
 | `:VibingContext [path]`               | Add context: oil.nvim entry, visual selection (range), path argument, or current buffer when no args |
 | `:VibingClearContext`                 | Clear all context                                                                                    |
 | `:VibingCancel`                       | Cancel current request                                                                               |
+| `:VibingPendingResumes`               | List chats waiting on a usage limit reset                                                            |
+| `:VibingCancelResume [all]`           | Cancel the pending auto-resume for this chat (or every one with `all`)                               |
 | `:VibingReloadCommands`               | Reload custom slash commands and completion candidates                                               |
 | `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                          |
 | `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                      |


### PR DESCRIPTION
## Summary
- Add `:VibingPendingResumes` and `:VibingCancelResume [all]` to the README command table — they were already documented in `.claude/rules/commands-reference.md` but missing from README.md.

## Test plan
- [x] `npm run format:check` passes (ran as part of pre-commit hook)