### PR TITLE
fix: wire chat.auto_context and drop two unread setup() options

### DIFF
--- a/bin/types.ts
+++ b/bin/types.ts
@@ -83,7 +83,6 @@ export interface AgentConfig {
   mode: string | null;
   model: string | null;
   permissionMode: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto';
-  prioritizeVibingLsp: boolean;
   mcpEnabled: boolean;
   language: string | null;
   rpcPort: number | null;

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -73,7 +73,6 @@ Default configuration: >lua
         },
         auto_context = true,
         save_location_type = "project",  -- "project" | "user" | "custom"
-        context_position = "append",  -- "prepend" | "append"
       },
       agent = {
         default_mode = "code",  -- "code" | "plan" | "explore"
@@ -99,7 +98,6 @@ chat.window.width       Chat window width (0.0-1.0 or absolute)
 chat.window.border      Window border style
 chat.auto_context       Automatically add open buffers to context
 chat.save_location_type Where to save chat files
-chat.context_position   Where to place context in prompt
 agent.default_mode      Default execution mode
 agent.default_model     Default AI model to use
 permissions.allow       Tools AI can use

--- a/lua/vibing/application/context/manager.lua
+++ b/lua/vibing/application/context/manager.lua
@@ -124,7 +124,13 @@ end
 ---表示用フォーマット
 ---@return string
 function M.format_for_display()
-  local contexts = M.get_all(true)
+  local config = require("vibing.config")
+  local auto_context = config.options and config.options.chat and config.options.chat.auto_context
+  if auto_context == nil then
+    auto_context = true
+  end
+
+  local contexts = M.get_all(auto_context)
   if #contexts == 0 then
     return "No context"
   end

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -79,7 +79,6 @@
 ---Claudeのモード（code/plan/explore）とモデル（sonnet/opus/haiku/fable）を指定
 ---@field default_mode "code"|"plan"|"explore" デフォルトモード（"code": コード生成、"plan": 計画、"explore": 探索）
 ---@field default_model "sonnet"|"opus"|"haiku"|"fable" デフォルトモデル（"sonnet": バランス、"opus": 高性能、"haiku": 高速、"fable": Claude Fable）
----@field prioritize_vibing_lsp boolean vibing-nvim LSPツールを優先（true: Serena等の汎用LSPより優先、false: システムプロンプトを挿入しない、デフォルト: true）
 ---@field utility_model "sonnet"|"opus"|"haiku"|"fable" タイトル生成・要約等の軽量ユーティリティ呼び出し専用モデル（デフォルト: "haiku"）
 ---@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）
 
@@ -102,7 +101,6 @@
 ---@field auto_context boolean 自動コンテキスト有効化（trueで開いているバッファを自動的にコンテキストに含める）
 ---@field save_location_type "project"|"user"|"custom" 保存先タイプ（"project": プロジェクト内、"user": ユーザーディレクトリ、"custom": カスタムパス）
 ---@field save_dir string カスタム保存先ディレクトリ（save_location_type="custom"時に使用）
----@field context_position "prepend"|"append" コンテキスト挿入位置（"prepend": プロンプト前、"append": プロンプト後）
 
 ---@class Vibing.WindowConfig
 ---チャットウィンドウ表示設定
@@ -224,7 +222,6 @@ M.defaults = {
   agent = {
     default_mode = "code",
     default_model = "sonnet",
-    prioritize_vibing_lsp = true,
     utility_model = "haiku",
     setting_sources = { "user", "project", "local" },
     -- 使用量リミットで応答が弾かれたとき、リセット時刻を待って自動で継続リクエストを送る。
@@ -252,7 +249,6 @@ M.defaults = {
     auto_context = true,
     save_location_type = "project",
     save_dir = vim.fn.stdpath("data") .. "/vibing/chats",
-    context_position = "append",
   },
   ui = {
     wrap = "on",

--- a/tests/lua/application/context/manager_spec.lua
+++ b/tests/lua/application/context/manager_spec.lua
@@ -1,0 +1,51 @@
+describe("context manager", function()
+  local Manager = require("vibing.application.context.manager")
+  local Collector = require("vibing.infrastructure.context.collector")
+  local config = require("vibing.config")
+
+  local original_collect_buffers
+  local original_options
+
+  before_each(function()
+    original_collect_buffers = Collector.collect_buffers
+    original_options = config.options
+    Collector.collect_buffers = function()
+      return { "@file:auto.lua" }
+    end
+    Manager.manual_contexts = { "@file:manual.lua" }
+  end)
+
+  after_each(function()
+    Collector.collect_buffers = original_collect_buffers
+    config.options = original_options
+    Manager.manual_contexts = {}
+  end)
+
+  describe("format_for_display", function()
+    it("includes auto-collected buffers when chat.auto_context is true", function()
+      config.options = { chat = { auto_context = true } }
+
+      local display = Manager.format_for_display()
+
+      assert.is_truthy(display:find("manual.lua", 1, true))
+      assert.is_truthy(display:find("auto.lua", 1, true))
+    end)
+
+    it("omits auto-collected buffers when chat.auto_context is false", function()
+      config.options = { chat = { auto_context = false } }
+
+      local display = Manager.format_for_display()
+
+      assert.is_truthy(display:find("manual.lua", 1, true))
+      assert.is_nil(display:find("auto.lua", 1, true))
+    end)
+
+    it("falls back to auto context when setup() has not run", function()
+      config.options = nil
+
+      local display = Manager.format_for_display()
+
+      assert.is_truthy(display:find("auto.lua", 1, true))
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #500

## 概要

`config.lua` の defaults・型注釈に存在してユーザーが設定できるのに、実行時コードのどこからも読まれていなかったオプション3件を処理しました。issue 本文の提案どおり、`chat.auto_context` は実装、残り2件は削除しています。

## 変更内容

### 1. `chat.auto_context` — 配線して実装

`Context.get_all(auto_context)` の唯一の呼び出し箇所 `manager.lua` の `format_for_display()` がハードコードで `true` を渡していたため、`auto_context = false` にしても自動コンテキストを無効化できませんでした。config の値を渡すよう修正しています。

`setup()` 未実行（`config.options == nil`）の場合は従来どおり `true` にフォールバックします。

### 2. `agent.prioritize_vibing_lsp` — 削除

- `lua/vibing/config.lua`（型注釈 + デフォルト値）
- `bin/types.ts` の `prioritizeVibingLsp`（Lua 側から値が渡ることもない未使用フィールド）

### 3. `chat.context_position` — 削除

- `lua/vibing/config.lua`（型注釈 + デフォルト値）
- `doc/vibing.txt` の設定例と説明行

## テスト

`tests/lua/application/context/manager_spec.lua` を新規追加（3ケース: auto_context=true / false / setup()未実行時のフォールバック）。

```
Success: 3   Failed: 0   Errors: 0
```

- `find lua -name '*.lua' -exec luac -p {} \;` → OK
- `tsc --noEmit` → OK
- `tests/lua` 全体 → RPC server spec の1件のみ失敗しますが、`all ports (64546-64595) are in use` によるもので #513（並列実行時の flaky）そのものです。単体実行では origin/main の状態でも同 spec は 15/15 pass します。

## 補足（本 PR のスコープ外・要判断）

修正中に気づいた点として、**コンテキスト機構が実際のリクエストに一切載っていません**。`Context.get_all()` の呼び出し元は `format_for_display()` だけで、それはチャットバッファ先頭の `Context:` 表示行にしか使われていません。`send_message.lua` は adapter opts に `context` を設定しておらず、`cli_command_builder.build_context_prefix()` / `codex_command_builder` の該当処理はチャットフローからは到達しない状態です。

つまり `:VibingContext` で追加したファイルは表示されるだけで、プロンプトには入っていません。本 PR は #500 のスコープ（config の配線）に留めていますが、別 issue を立てる価値があると思います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)