### PR TITLE
chore: remove the unimplemented node.dev_mode option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,47 +49,6 @@ npm run lint:md
 
 For Neovim testing, load the plugin and run `:VibingChat`.
 
-## Development Mode
-
-vibing.nvim supports two execution modes:
-
-**Production Mode (default):**
-
-- Uses compiled JavaScript from `dist/bin/agent-wrapper.js`
-- Requires `npm run build` after code changes
-- Faster startup time
-
-**Development Mode:**
-
-- Directly executes TypeScript from `bin/agent-wrapper.ts` using bun
-- No build step required - changes take effect immediately
-- Requires bun to be installed in PATH
-
-**Enable via Lazy.nvim (recommended):**
-
-```lua
-return {
-  "yourusername/vibing.nvim",
-  dev = true,  -- Automatically enables dev_mode
-  dir = "~/workspaces/nvim-plugins/vibing.nvim",
-  config = function()
-    require("vibing").setup({
-      -- node.dev_mode is automatically set to true when dev = true
-    })
-  end,
-}
-```
-
-**Manual enable:**
-
-```lua
-require("vibing").setup({
-  node = {
-    dev_mode = true,  -- Enable TypeScript direct execution with bun
-  },
-})
-```
-
 ## Documentation Structure
 
 Detailed documentation is organized in `.claude/rules/`:

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -87,7 +87,6 @@
 ---Node.js実行ファイル設定
 ---Agent SDKラッパーとMCPビルドで使用するNode.js実行ファイルのパスを指定
 ---@field executable string|"auto" Node.js実行ファイルのパス ("auto": PATHから自動検出、文字列: 明示的なパス指定)
----@field dev_mode boolean 開発モード有効化 (true: TypeScriptを直接bunで実行、false: コンパイル済みJSを使用)
 
 ---@class Vibing.McpConfig
 ---MCP統合設定
@@ -292,7 +291,6 @@ M.defaults = {
   },
   node = {
     executable = "auto",
-    dev_mode = false,
   },
   mcp = {
     enabled = true,
@@ -309,40 +307,12 @@ M.defaults = {
 ---@type Vibing.Config?
 M.options = nil
 
----Lazy.nvimのdevモードを検出
----vibing.nvimプラグインがLazy.nvimでdev=trueとして設定されているかチェック
----@return boolean Lazy.nvimのdevモードが有効な場合true
-local function is_lazy_dev_mode()
-  local ok, lazy_config = pcall(require, "lazy.core.config")
-  if ok and lazy_config.plugins then
-    local vibing_plugin = lazy_config.plugins["vibing.nvim"]
-    if vibing_plugin and vibing_plugin.dev then
-      return true
-    end
-  end
-  return false
-end
-
 ---vibing.nvimプラグインの設定を初期化
 ---ユーザー設定とデフォルト設定をマージし、ツール権限の妥当性を検証
 ---permissionsで指定されたツール名が有効かチェックし、無効な場合は警告を出力
----Lazy.nvimのdev=trueが設定されている場合、node.dev_modeを自動的にtrueに設定
 ---@param opts? Vibing.Config ユーザー設定オブジェクト（nilの場合はデフォルト設定のみ使用）
 function M.setup(opts)
-  -- Capture user config before merge to detect if dev_mode was explicitly set
-  local user_opts = opts or {}
-  local user_dev_mode = user_opts.node and user_opts.node.dev_mode
-
-  M.options = vim.tbl_deep_extend("force", {}, M.defaults, user_opts)
-
-  -- Auto-detect dev_mode from Lazy.nvim if not explicitly set by user
-  if user_dev_mode == nil then
-    local lazy_dev = is_lazy_dev_mode()
-    if lazy_dev then
-      M.options.node.dev_mode = true
-      notify.info("[vibing.nvim] Detected Lazy.nvim dev mode - enabling TypeScript direct execution")
-    end
-  end
+  M.options = vim.tbl_deep_extend("force", {}, M.defaults, opts or {})
 
   -- Auto-add "Skill" to permissions.allow if not already present and not in deny/ask lists
   if M.options.permissions and M.options.permissions.allow then

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -134,9 +134,9 @@ local function resolve_list_commands()
 
   local config = Config.get()
 
-  -- Always use compiled JS + node for list-commands regardless of dev_mode.
-  -- Running list-commands.ts via bun causes the process to hang indefinitely
-  -- due to SDK async operations not resolving under bun.
+  -- Always use compiled JS + node for list-commands: running list-commands.ts via
+  -- bun causes the process to hang indefinitely due to SDK async operations not
+  -- resolving under bun.
   local script_path = plugin_dir .. "/dist/bin/list-commands.js"
   if vim.fn.filereadable(script_path) ~= 1 then
     return nil, nil


### PR DESCRIPTION
Closes #501

## 概要

issue 本文の提案 **(b) 削除** を採りました。`node.dev_mode` は「true にすると bun で TypeScript を直接実行する」と案内されていましたが、その挙動を実装しているコードは存在せず、`M.options.node.dev_mode` の読み手はゼロでした。

dev_mode を使いそうな唯一の箇所（`skills.lua` の list-commands 呼び出し）は「bun だとプロセスがハングするので常にコンパイル済み JS を使う」と明示的にオプトアウトしており、現アーキテクチャ（claude CLI を直接 spawn）では Node 側コードの役割も小さいため、実装ではなく撤去が妥当と判断しています。

## 変更内容

- `lua/vibing/config.lua`
  - `Vibing.NodeConfig.dev_mode` の型注釈を削除
  - `M.defaults.node.dev_mode = false` を削除
  - `is_lazy_dev_mode()` と、`setup()` 内の Lazy.nvim `dev = true` 自動検出・`notify.info("... enabling TypeScript direct execution")` を削除
  - 上記に伴い `setup()` 冒頭の `user_dev_mode` キャプチャが不要になったため、マージ処理を1行に整理
- `lua/vibing/infrastructure/completion/providers/skills.lua`
  - コメントから `regardless of dev_mode` の言及を削除（理由（bun でハングする）はそのまま残しています）
- `CLAUDE.md`
  - `## Development Mode` セクションを削除

## 影響

`dev_mode` を設定していたユーザーがいても、`vim.tbl_deep_extend` は未知キーをそのまま保持するのでエラーにはなりません（従来どおり何も起きません）。Lazy の `dev = true` を使っていた場合、起動時の誤解を招く通知が出なくなります。

## スコープ外

- `docs/adr/007-bun-binary-compilation-rejected.md` に `dev_mode` への言及がありますが、ADR は当時の意思決定の記録なので書き換えていません。
- CLAUDE.md / `.claude/rules` に残る agent-wrapper 前提の記述全般は #484（別 PR）で対応します。本 PR は `dev_mode` を直接説明していた `## Development Mode` セクションのみに触れています。

## テスト

- `find lua -name '*.lua' -exec luac -p {} \;` → OK
- `tests/init_spec.lua` → 13/13 pass
- `tests/lua/core` → 6/6, 13/13 pass
- format:check → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)