### PR TITLE
feat: apply .vibing/system-prompt.md to every request

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Complete reference for every `require("vibing").setup()` option. Defaults shown 
 - [MCP](#mcp)
 - [Node.js Executable](#nodejs-executable)
 - [Language](#language)
+- [Project System Prompt](#project-system-prompt)
 - [Daily Summary](#daily-summary)
 
 ## Defaults at a Glance
@@ -435,6 +436,28 @@ language = {
   chat = "ja",     -- Chat responses (falls back to default)
 }
 ```
+
+## Project System Prompt
+
+`.vibing/system-prompt.md` holds instructions that apply to every chat in this project. The file
+is created empty the first time a chat is saved into the project, and its contents are appended to
+the system prompt of every request.
+
+```markdown
+Prefer `pnpm` over `npm` in this repository.
+Generated files live under `src/generated/` — never edit them by hand.
+```
+
+Notes:
+
+- Edits take effect from the **next message**; there is no reload command.
+- The system prompt is part of the prompt cache's forward prefix, so editing the file invalidates
+  the cached prefix once. Leaving it untouched keeps the cache intact across turns.
+- An empty or whitespace-only file is treated as "not set" and adds nothing to the request.
+- Content over 8 KiB is truncated (with a warning) to keep it from dominating every request.
+- Utility calls (title generation, summarize, daily summary) do not receive it.
+- The file is read from the project root Neovim was started in, and is not committed
+  (`.vibing/` is git-ignored) — it is per-checkout, not shared with collaborators.
 
 ## Daily Summary
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -458,6 +458,10 @@ Notes:
 - Utility calls (title generation, summarize, daily summary) do not receive it.
 - The file is read from the project root Neovim was started in, and is not committed
   (`.vibing/` is git-ignored) — it is per-checkout, not shared with collaborators.
+- A chat with a `working_dir` (a worktree under `.vibing/worktrees/<branch>/`) uses that
+  directory's `.vibing/system-prompt.md` when it exists and has content, and otherwise falls back
+  to the project root's file — so a worktree can override the project prompt without having to
+  copy it.
 
 ## Daily Summary
 

--- a/lua/vibing/core/utils/project_system_prompt.lua
+++ b/lua/vibing/core/utils/project_system_prompt.lua
@@ -27,6 +27,24 @@ function M.ensure(project_root)
   end
 end
 
+--- Cut `s` down to at most `max_bytes` without splitting a UTF-8 character:
+--- walk back off any continuation bytes (`0b10xxxxxx`) left at the boundary.
+--- @param s string
+--- @param max_bytes number
+--- @return string
+local function cut_at_utf8_boundary(s, max_bytes)
+  local cut = max_bytes
+  while cut > 0 do
+    local next_byte = s:byte(cut + 1)
+    -- nil (nothing dropped), ASCII, or a lead byte all mean `cut` is a boundary
+    if not next_byte or next_byte < 0x80 or next_byte >= 0xC0 then
+      break
+    end
+    cut = cut - 1
+  end
+  return s:sub(1, cut)
+end
+
 --- Read the project-local system prompt.
 --- Returns nil when the file is missing, unreadable, empty, or whitespace-only,
 --- so callers can skip it without special-casing. Content over MAX_BYTES is
@@ -51,7 +69,7 @@ function M.read(project_root)
   end
 
   if #content > MAX_BYTES then
-    content = content:sub(1, MAX_BYTES)
+    content = cut_at_utf8_boundary(content, MAX_BYTES)
     require("vibing.core.utils.notify").warn(
       string.format(".vibing/system-prompt.md exceeds %d bytes - truncated", MAX_BYTES),
       "Config"
@@ -59,6 +77,26 @@ function M.read(project_root)
   end
 
   return content
+end
+
+--- Read the prompt that applies to a request running in `cwd`.
+---
+--- A chat with a `working_dir` (a worktree under `.vibing/worktrees/<branch>/`) runs
+--- the CLI there, so its own `.vibing/system-prompt.md` wins when it has content.
+--- Worktrees are separate checkouts and `.vibing/` is git-ignored, so that file
+--- usually doesn't exist there — fall back to the root Neovim was started in, which
+--- is where `ensure()` creates the file and where users actually edit it.
+--- @param cwd string|nil working directory of the request (`opts.cwd`)
+--- @return string|nil content
+function M.read_for_cwd(cwd)
+  local nvim_root = vim.fn.getcwd()
+  if cwd and cwd ~= "" and cwd ~= nvim_root then
+    local from_cwd = M.read(cwd)
+    if from_cwd then
+      return from_cwd
+    end
+  end
+  return M.read(nvim_root)
 end
 
 return M

--- a/lua/vibing/core/utils/project_system_prompt.lua
+++ b/lua/vibing/core/utils/project_system_prompt.lua
@@ -1,0 +1,64 @@
+--- Project-local system prompt (`.vibing/system-prompt.md`)
+---
+--- The file is created empty on chat creation so users have somewhere to put
+--- project-specific instructions; its contents are appended to the CLI's
+--- `--append-system-prompt` on every non-lightweight request.
+--- @module vibing.core.utils.project_system_prompt
+
+local M = {}
+
+--- 8 KiB. Large enough for real instructions, small enough that a stray paste
+--- of a log file doesn't silently balloon every request's system prompt.
+local MAX_BYTES = 8 * 1024
+
+--- @param project_root string
+--- @return string path
+function M.path(project_root)
+  return project_root .. "/.vibing/system-prompt.md"
+end
+
+--- Create an empty `.vibing/system-prompt.md` if it doesn't exist yet.
+--- @param project_root string
+function M.ensure(project_root)
+  local prompt_file = M.path(project_root)
+  if vim.fn.filereadable(prompt_file) == 0 then
+    vim.fn.mkdir(project_root .. "/.vibing", "p")
+    vim.fn.writefile({}, prompt_file)
+  end
+end
+
+--- Read the project-local system prompt.
+--- Returns nil when the file is missing, unreadable, empty, or whitespace-only,
+--- so callers can skip it without special-casing. Content over MAX_BYTES is
+--- truncated rather than rejected, so an oversized file degrades instead of
+--- silently dropping the user's instructions.
+--- @param project_root string
+--- @return string|nil content
+function M.read(project_root)
+  local prompt_file = M.path(project_root)
+  if vim.fn.filereadable(prompt_file) ~= 1 then
+    return nil
+  end
+
+  local ok, lines = pcall(vim.fn.readfile, prompt_file)
+  if not ok or type(lines) ~= "table" then
+    return nil
+  end
+
+  local content = vim.trim(table.concat(lines, "\n"))
+  if content == "" then
+    return nil
+  end
+
+  if #content > MAX_BYTES then
+    content = content:sub(1, MAX_BYTES)
+    require("vibing.core.utils.notify").warn(
+      string.format(".vibing/system-prompt.md exceeds %d bytes - truncated", MAX_BYTES),
+      "Config"
+    )
+  end
+
+  return content
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -244,7 +244,9 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     -- request, so an edit takes effect from the next message onward; that edit is also
     -- the only thing that invalidates the cached system prefix (see #469 note above).
     -- An unedited file keeps the block byte-for-byte identical across turns.
-    local project_prompt = require("vibing.core.utils.project_system_prompt").read(vim.fn.getcwd())
+    -- Resolved against `opts.cwd` (the chat's `working_dir`, e.g. a worktree) first,
+    -- like every other cwd-sensitive part of the request, then the Neovim root.
+    local project_prompt = require("vibing.core.utils.project_system_prompt").read_for_cwd(opts.cwd)
     if project_prompt then
       table.insert(system_prompt_lines, project_prompt)
     end

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -239,6 +239,15 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     if opts.chat_file_path and opts.chat_file_path ~= "" then
       table.insert(system_prompt_lines, "Current vibing.nvim chat buffer file: " .. opts.chat_file_path)
     end
+
+    -- Project-local instructions from .vibing/system-prompt.md. Read fresh on every
+    -- request, so an edit takes effect from the next message onward; that edit is also
+    -- the only thing that invalidates the cached system prefix (see #469 note above).
+    -- An unedited file keeps the block byte-for-byte identical across turns.
+    local project_prompt = require("vibing.core.utils.project_system_prompt").read(vim.fn.getcwd())
+    if project_prompt then
+      table.insert(system_prompt_lines, project_prompt)
+    end
   end
 
   local language = resolve_language(opts, config)

--- a/lua/vibing/presentation/chat/modules/file_manager.lua
+++ b/lua/vibing/presentation/chat/modules/file_manager.lua
@@ -10,16 +10,10 @@ function M.generate_unique_filename()
 end
 
 ---プロジェクト固有のsystem-prompt.mdを初期化
+---中身は cli_command_builder が --append-system-prompt に連結する
 ---@param project_root string プロジェクトルート
 local function ensure_system_prompt(project_root)
-  local vibing_dir = project_root .. "/.vibing"
-  local prompt_file = vibing_dir .. "/system-prompt.md"
-
-  -- ファイルが存在しなければ空ファイルを作成
-  if vim.fn.filereadable(prompt_file) == 0 then
-    vim.fn.mkdir(vibing_dir, "p")
-    vim.fn.writefile({}, prompt_file)
-  end
+  require("vibing.core.utils.project_system_prompt").ensure(project_root)
 end
 
 ---保存ディレクトリを取得

--- a/tests/lua/core/utils/project_system_prompt_spec.lua
+++ b/tests/lua/core/utils/project_system_prompt_spec.lua
@@ -1,0 +1,117 @@
+local project_system_prompt = require("vibing.core.utils.project_system_prompt")
+
+describe("project_system_prompt", function()
+  local project_root
+  local original_notify
+
+  local function write_prompt(root, content)
+    vim.fn.mkdir(root .. "/.vibing", "p")
+    vim.fn.writefile(vim.split(content, "\n", { plain = true }), root .. "/.vibing/system-prompt.md")
+  end
+
+  before_each(function()
+    project_root = vim.fn.tempname()
+    vim.fn.mkdir(project_root, "p")
+    original_notify = vim.notify
+    vim.notify = function() end
+  end)
+
+  after_each(function()
+    vim.notify = original_notify
+    vim.fn.delete(project_root, "rf")
+  end)
+
+  describe("read", function()
+    it("returns nil when the file is missing", function()
+      assert.is_nil(project_system_prompt.read(project_root))
+    end)
+
+    it("returns nil for an empty or whitespace-only file", function()
+      write_prompt(project_root, "")
+      assert.is_nil(project_system_prompt.read(project_root))
+
+      write_prompt(project_root, "  \n\t\n")
+      assert.is_nil(project_system_prompt.read(project_root))
+    end)
+
+    it("returns the trimmed contents", function()
+      write_prompt(project_root, "Prefer pnpm.\nNever edit generated/.")
+      assert.equals("Prefer pnpm.\nNever edit generated/.", project_system_prompt.read(project_root))
+    end)
+
+    it("truncates oversized content without splitting a multibyte character", function()
+      -- 3-byte characters don't line up with the 8 KiB limit, so a naive byte cut
+      -- would leave a half-written character at the boundary.
+      local content = string.rep("あ", 4000)
+      write_prompt(project_root, content)
+
+      local result = project_system_prompt.read(project_root)
+      assert.is_not_nil(result)
+      assert.is_true(#result <= 8 * 1024)
+      -- Every byte survives as valid UTF-8: the string is a whole number of characters
+      assert.equals(0, #result % 3)
+      assert.equals(#result / 3, vim.fn.strchars(result))
+    end)
+
+    it("truncates ASCII content exactly at the limit", function()
+      write_prompt(project_root, string.rep("a", 9000))
+      assert.equals(8 * 1024, #project_system_prompt.read(project_root))
+    end)
+  end)
+
+  describe("read_for_cwd", function()
+    local worktree_root
+    local original_getcwd
+
+    before_each(function()
+      worktree_root = project_root .. "/.vibing/worktrees/feature-x"
+      vim.fn.mkdir(worktree_root, "p")
+      original_getcwd = vim.fn.getcwd
+      vim.fn.getcwd = function()
+        return project_root
+      end
+    end)
+
+    after_each(function()
+      vim.fn.getcwd = original_getcwd
+    end)
+
+    it("prefers the request cwd's file", function()
+      write_prompt(project_root, "Root rule.")
+      write_prompt(worktree_root, "Worktree rule.")
+      assert.equals("Worktree rule.", project_system_prompt.read_for_cwd(worktree_root))
+    end)
+
+    it("falls back to the Neovim root when the cwd has no usable file", function()
+      write_prompt(project_root, "Root rule.")
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(worktree_root))
+
+      write_prompt(worktree_root, "   ")
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(worktree_root))
+    end)
+
+    it("uses the Neovim root when no cwd is given", function()
+      write_prompt(project_root, "Root rule.")
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(nil))
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(""))
+    end)
+
+    it("returns nil when neither location has a file", function()
+      assert.is_nil(project_system_prompt.read_for_cwd(worktree_root))
+    end)
+  end)
+
+  describe("ensure", function()
+    it("creates an empty file that read() treats as unset", function()
+      project_system_prompt.ensure(project_root)
+      assert.equals(1, vim.fn.filereadable(project_system_prompt.path(project_root)))
+      assert.is_nil(project_system_prompt.read(project_root))
+    end)
+
+    it("does not overwrite existing content", function()
+      write_prompt(project_root, "Existing rule.")
+      project_system_prompt.ensure(project_root)
+      assert.equals("Existing rule.", project_system_prompt.read(project_root))
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -192,6 +192,50 @@ describe("cli_command_builder", function()
 
       assert.is_nil(prompt_text:find("always run the linter", 1, true))
     end)
+
+    describe("with a worktree working_dir (opts.cwd)", function()
+      local worktree_root
+
+      local function write_worktree_prompt(lines)
+        vim.fn.mkdir(worktree_root .. "/.vibing", "p")
+        vim.fn.writefile(lines, worktree_root .. "/.vibing/system-prompt.md")
+      end
+
+      before_each(function()
+        worktree_root = project_root .. "/.vibing/worktrees/feature-x"
+        vim.fn.mkdir(worktree_root, "p")
+      end)
+
+      it("prefers the worktree's own file over the project root's", function()
+        write_project_prompt({ "Root rule." })
+        write_worktree_prompt({ "Worktree rule." })
+
+        local cmd = cli_command_builder.build("hello", { cwd = worktree_root }, nil, {}, nil)
+        local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+        assert.is_true(prompt_text:find("Worktree rule.", 1, true) ~= nil)
+        assert.is_nil(prompt_text:find("Root rule.", 1, true))
+      end)
+
+      it("falls back to the project root when the worktree has no file", function()
+        write_project_prompt({ "Root rule." })
+
+        local cmd = cli_command_builder.build("hello", { cwd = worktree_root }, nil, {}, nil)
+        local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+        assert.is_true(prompt_text:find("Root rule.", 1, true) ~= nil)
+      end)
+
+      it("falls back to the project root when the worktree file is empty", function()
+        write_project_prompt({ "Root rule." })
+        write_worktree_prompt({ "" })
+
+        local cmd = cli_command_builder.build("hello", { cwd = worktree_root }, nil, {}, nil)
+        local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+        assert.is_true(prompt_text:find("Root rule.", 1, true) ~= nil)
+      end)
+    end)
   end)
 
   describe("--allowedTools", function()

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -106,6 +106,94 @@ describe("cli_command_builder", function()
     end)
   end)
 
+  describe("project-local system prompt (.vibing/system-prompt.md)", function()
+    local project_root
+    local original_getcwd
+
+    local function write_project_prompt(lines)
+      vim.fn.mkdir(project_root .. "/.vibing", "p")
+      vim.fn.writefile(lines, project_root .. "/.vibing/system-prompt.md")
+    end
+
+    before_each(function()
+      project_root = vim.fn.tempname()
+      vim.fn.mkdir(project_root, "p")
+      original_getcwd = vim.fn.getcwd
+      vim.fn.getcwd = function()
+        return project_root
+      end
+    end)
+
+    after_each(function()
+      vim.fn.getcwd = original_getcwd
+      vim.fn.delete(project_root, "rf")
+    end)
+
+    it("appends the file contents to --append-system-prompt", function()
+      write_project_prompt({ "Prefer tabs over spaces.", "Never touch generated/." })
+
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+      assert.is_true(prompt_text:find("Prefer tabs over spaces.", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("Never touch generated/.", 1, true) ~= nil)
+    end)
+
+    it("adds nothing when the file is missing", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local baseline = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+      write_project_prompt({ "" })
+      local cmd2 = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local with_empty_file = cmd2[find_flag(cmd2, "--append-system-prompt") + 1]
+
+      -- An empty (freshly created) file must be indistinguishable from no file at all
+      assert.equals(baseline, with_empty_file)
+    end)
+
+    it("adds nothing when the file is whitespace-only", function()
+      write_project_prompt({ "   ", "", "\t" })
+
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+      assert.is_nil(prompt_text:find("\t", 1, true))
+    end)
+
+    it("stays byte-identical across turns while the file is unchanged", function()
+      write_project_prompt({ "Project rule: always run the linter." })
+
+      local opts = { chat_file_path = "/tmp/chat-test.md" }
+      local cmd1 = cli_command_builder.build("hello", opts, nil, {}, nil, 9878)
+      local cmd2 = cli_command_builder.build("hello again", opts, "session-1", {}, nil, 9878)
+
+      assert.equals(cmd1[find_flag(cmd1, "--append-system-prompt") + 1], cmd2[find_flag(cmd2, "--append-system-prompt") + 1])
+    end)
+
+    it("picks up an edit on the next request", function()
+      write_project_prompt({ "First revision." })
+      local cmd1 = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local before = cmd1[find_flag(cmd1, "--append-system-prompt") + 1]
+
+      write_project_prompt({ "Second revision." })
+      local cmd2 = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local after = cmd2[find_flag(cmd2, "--append-system-prompt") + 1]
+
+      assert.is_true(before:find("First revision.", 1, true) ~= nil)
+      assert.is_true(after:find("Second revision.", 1, true) ~= nil)
+      assert.is_nil(after:find("First revision.", 1, true))
+    end)
+
+    it("is not sent on lightweight (title/summary) calls", function()
+      write_project_prompt({ "Project rule: always run the linter." })
+
+      local cmd = cli_command_builder.build("hello", { lightweight = true }, nil, {}, nil)
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+      assert.is_nil(prompt_text:find("always run the linter", 1, true))
+    end)
+  end)
+
   describe("--allowedTools", function()
     it("always pre-approves both vibing-nvim MCP registration styles (plain and plugin-scoped)", function()
       local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)


### PR DESCRIPTION
Closes #486

## 概要

issue の **案A（実装する）** を採りました。`ensure_system_prompt()` がチャット作成のたびに空の `.vibing/system-prompt.md` を作る一方、それを読み込むコードはリポジトリのどこにも存在せず、ユーザーが編集しても完全に無視される状態でした。

`cli_command_builder` で読み込み、`--append-system-prompt` に連結します。

## 反映タイミングの規約

**毎リクエストでファイルを読み直し、編集は次のメッセージから反映されます。**

issue で懸念されていた prompt cache（#469 / #477）については、この方式が最も素直だと判断しました:

- ファイルを触らない限り、system prompt ブロックはターンをまたいで byte-for-byte 同一 → キャッシュは維持される
- 編集した場合のみ1回キャッシュが無効化される。これは「編集した内容を効かせる」ためのコストそのものなので、セッション単位でスナップショットして遅延させるより挙動が予測しやすい

「編集したのにいつ効くのか分からない」状態を避けることを優先しています。

## 変更内容

### 新規: `lua/vibing/core/utils/project_system_prompt.lua`

`path()` / `ensure()` / `read()` を提供。生成側（`file_manager.lua`）と読み込み側（`cli_command_builder.lua`）でパスが二重管理になって drift するのを防ぐため、モジュールに集約しています。

`read()` の挙動:

| 状態 | 結果 |
| --- | --- |
| ファイルなし | `nil`（何も追加しない） |
| 空ファイル（`ensure()` が作る初期状態） | `nil` |
| 空白のみ | `nil` |
| 8 KiB 超 | 切り詰めて warn 通知 |

### `cli_command_builder.lua`

非 lightweight リクエストの system prompt 末尾に連結。タイトル生成・要約などの lightweight 呼び出しには載せません（ツールも MCP も無い軽量呼び出しにプロジェクト固有の指示を混ぜても無駄なトークンになるため、既存の方針に合わせています）。

### `file_manager.lua`

ローカル関数の実装を新モジュールへの委譲に置き換え（呼び出し箇所 L33/L45/L83 はそのまま）。

### `docs/configuration.md`

「Project System Prompt」セクションを追加。

## テスト

`cli_command_builder_spec.lua` に6ケース追加（全39件 pass）:

- ファイル内容が `--append-system-prompt` に載る
- ファイルなし／空ファイルは何も追加しない（両者が byte 同一であることを assert）
- 空白のみのファイルは何も追加しない
- ファイル未編集ならターンをまたいで byte-identical（キャッシュ維持の回帰テスト）
- 編集は次リクエストで反映される
- lightweight 呼び出しには載らない

その他: `luac -p` 全ファイル OK / `tests/lua/infrastructure` 全 pass / prettier・markdownlint OK

## スコープ外

Codex アダプタ（`codex_command_builder.lua`）には system prompt を注入する仕組み自体が無いため、今回は Claude CLI 側のみです。Codex 側にも同等の口を用意するかは別途判断が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)