### PR TITLE
docs: sync CLAUDE.md and .claude/rules with the CLI-direct architecture

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,45 +2,92 @@
 
 ## Communication Flow
 
+There is **no Node.js wrapper process**. vibing.nvim spawns the `claude` CLI directly with
+`vim.system()` and parses its streaming JSON output:
+
 ```text
-Neovim (Lua) → vim.system() → Node.js wrapper → Claude Agent SDK
-                    ↑
-            JSON Lines protocol
+Neovim (Lua) ──vim.system()──> claude -p --output-format stream-json
+     ▲                                    │
+     │  stream-json lines (stdout)        │
+     └────────────────────────────────────┘
+     ▲
+     │  hook callbacks (PreToolUse / StopFailure) over TCP
+     └── bin/hooks/*.sh ──> RPC server (lua/vibing/infrastructure/rpc/)
 ```
 
-The Node.js wrapper (`bin/agent-wrapper.mjs`) outputs streaming responses as JSON Lines:
+The command is assembled in `cli_command_builder.lua`; the base flags are
+`-p --output-format stream-json --verbose --include-partial-messages`, plus `--model`,
+`--resume <session_id>` (`--fork-session` for forks), `--append-system-prompt`,
+`--setting-sources`, permission flags, and `--settings .vibing/hook-settings.json`.
 
-- `{"type": "session", "session_id": "..."}` - Session identifier for resumption
-- `{"type": "chunk", "text": "..."}` - Streamed text content
-- `{"type": "tool_use", "tool": "Edit", "file_path": "..."}` - File modification event
-- `{"type": "done"}` - Completion signal
-- `{"type": "error", "message": "..."}` - Error messages
+`cli_event_processor.lua` consumes the CLI's stream-json lines — `content_block_start`,
+`content_block_delta` (`text_delta` / `input_json_delta`), `tool_use`, `tool_result`, `error`,
+and `rate_limit_event` — and turns them into chunk/tool-display callbacks.
+
+Everything that needs to call _back into_ Neovim mid-turn (permission decisions, approval UI,
+`AskUserQuestion`, rate-limit reporting) goes through the RPC server rather than the stream.
+`.vibing/hook-settings.json` (generated per cwd by `hooks/settings_generator.lua`) registers
+`bin/hooks/pre-tool-use.sh` and `bin/hooks/stop-failure.sh`.
+
+The PreToolUse hook is synchronous and blocks the tool call: it writes the hook payload to
+`/tmp/vibing-hook-<port>/<request_id>.req`, sends a one-line JSON-RPC notification to the RPC port
+with `nc`, then polls for `<request_id>.res` (up to 120s). It **fails closed** — if `nc` cannot
+connect, or the response never arrives, the hook exits 2 and the tool is denied. `VIBING_HANDLE_ID`
+is passed through so concurrent chats don't cross-wire each other's approval UI (see
+`active_stream_registry.lua`). Note that the `/tmp` comm directory is keyed only by port, which is
+machine-wide shared state.
+
+**Backends:** `claude_cli.lua` (default) and `codex_cli.lua` both implement the adapter
+interface; `init.lua` picks one from `config.adapter`, and `send_message.lua` can switch per
+request for `codex` agent types.
 
 ## Module Structure
 
+The tree is layered (`domain` / `application` / `infrastructure` / `presentation`), not the flat
+`actions/` + `ui/` layout used before v4.
+
 **Core:**
 
-- `lua/vibing/init.lua` - Entry point, command registration
-- `lua/vibing/config.lua` - Configuration with type annotations
+- `lua/vibing/init.lua` - Entry point, command registration, adapter selection
+- `lua/vibing/config.lua` - Configuration defaults with type annotations
+- `lua/vibing/core/constants/` - `tools.lua` (VALID_TOOLS), `modes.lua`, `worktree.lua`
+- `lua/vibing/core/utils/` - timestamp, language, git, mote, rate_limit, request_diff, ...
 
-**Adapter:**
+**Adapter (`lua/vibing/infrastructure/adapter/`):**
 
-- `adapters/base.lua` - Abstract adapter interface
-- `adapters/agent_sdk.lua` - Claude Agent SDK adapter (only supported backend)
+- `base.lua` - Abstract adapter interface
+- `claude_cli.lua` / `codex_cli.lua` - Backend adapters (spawn + stream lifecycle)
+- `modules/cli_command_builder.lua` - Claude CLI argv construction (flags, system prompt)
+- `modules/cli_event_processor.lua` - stream-json → chunk/tool events
+- `modules/codex_command_builder.lua` / `modules/codex_event_processor.lua` - Codex equivalents
+- `modules/session_manager.lua`, `modules/active_stream_registry.lua` - Session/handle tracking
 
-**UI:**
+**Chat (presentation + application):**
 
-- `ui/chat_buffer.lua` - Chat window with Markdown rendering, session persistence, diff viewer
-- `ui/permission_builder.lua` - Interactive permission configuration UI
+- `presentation/chat/buffer.lua`, `view.lua`, `controller.lua` - Chat buffer and window
+- `presentation/chat/modules/` - renderer, streaming_handler, frontmatter_handler, file_manager,
+  approval_parser, keymap_handler, ...
+- `application/chat/send_message.lua` - Request orchestration (opts, callbacks, diffs)
+- `application/chat/use_cases/fork.lua` - Chat fork
+- `application/chat/auto_resume.lua` - Usage-limit auto-resume scheduler
+
+**RPC / hooks:**
+
+- `infrastructure/rpc/server.lua` - Async TCP server queried by hooks and the MCP server
+- `infrastructure/rpc/handlers/permission.lua` - PreToolUse decisions, approval UI,
+  `ask_user_question`
+- `infrastructure/rpc/handlers/rate_limit.lua` - StopFailure receiver
+- `infrastructure/hooks/settings_generator.lua` - Writes `.vibing/hook-settings.json`
 
 **Context System:**
 
-- `context/init.lua` - Context manager (manual + auto from open buffers)
-- `context/collector.lua` - Collects `@file:path` formatted contexts
+- `application/context/manager.lua` - Context manager (manual + auto from open buffers)
+- `infrastructure/context/collector.lua` - Collects `@file:path` formatted contexts
 
-**Actions:**
+**UI:**
 
-- `actions/chat.lua` - Chat session orchestration with concurrent session support
+- `ui/permission_builder.lua` - Interactive permission configuration UI
+- `ui/patch_viewer/`, `ui/command_picker.lua`, `ui/chat_deletion_picker.lua`
 
 ## Key Entry Points
 
@@ -48,20 +95,25 @@ Quick reference for commonly edited files:
 
 ```text
 Lua Plugin:
-- lua/vibing/init.lua          - Plugin initialization and commands
-- lua/vibing/config.lua        - Configuration schema and defaults
-- lua/vibing/adapters/agent_sdk.lua - Agent SDK adapter implementation
-- lua/vibing/ui/chat_buffer.lua     - Chat window implementation
-- lua/vibing/actions/chat.lua       - Chat session orchestration
+- lua/vibing/init.lua                    - Plugin initialization and commands
+- lua/vibing/config.lua                  - Configuration schema and defaults
+- lua/vibing/infrastructure/adapter/claude_cli.lua                 - Claude CLI adapter
+- lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua - CLI argv / system prompt
+- lua/vibing/presentation/chat/buffer.lua                          - Chat buffer implementation
+- lua/vibing/application/chat/send_message.lua                     - Request orchestration
 
-Node.js Backend:
-- bin/agent-wrapper.ts         - Agent SDK wrapper entry point
+Node.js side (no agent wrapper — only these):
+- bin/hooks/pre-tool-use.sh    - PreToolUse hook → RPC
+- bin/hooks/stop-failure.sh    - StopFailure hook → RPC
+- bin/list-commands.ts         - Slash command/skill enumeration for completion
 - mcp-server/src/index.ts      - MCP server entry point
-- mcp-server/src/tools/        - MCP tool implementations (buffer, lsp, window)
+- mcp-server/src/tools/        - MCP tool implementations (buffer, lsp, window, chat)
 
 Tests:
-- tests/*_spec.lua             - Lua tests (plenary.nvim)
+- tests/lua/**/*_spec.lua      - Lua tests (plenary.nvim)
+- tests/*_spec.lua             - Older top-level Lua specs
 - tests/*.test.mjs             - Node.js tests
+- tests/e2e/*.spec.lua         - E2E tests against a spawned Neovim instance
 ```
 
 ## Session Persistence
@@ -71,11 +123,11 @@ Chat files are saved as Markdown with YAML frontmatter:
 ```yaml
 ---
 vibing.nvim: true
-session_id: <sdk-session-id>
+session_id: <cli-session-id>
 created_at: 2024-01-01T12:00:00
-working_dir: .vibing/workspace/0001-feature-branch/worktree # Optional: relative path from git root for working directory
+working_dir: .vibing/worktrees/fix-auth-session # Optional: relative path from git root for working directory
 model: sonnet # sonnet, opus, haiku, or fable (from config.agent.default_model)
-permissions_mode: acceptEdits # default, acceptEdits, bypassPermissions, plan, or dontAsk
+permission_mode: acceptEdits # default, acceptEdits, bypassPermissions, plan, dontAsk, or auto
 permissions_allow:
   - Read
   - Edit
@@ -95,10 +147,13 @@ via `/model` slash command. Configured permissions are recorded in frontmatter f
 transparency and auditability. The optional `language` field ensures consistent AI response language
 across sessions.
 
+Note the singular `permission_mode`: that is the key `send_message.lua` actually reads. Completion
+also offers `permissions_mode`, but nothing reads it — don't rely on the plural form.
+
 **Working directory persistence:** The `working_dir` field stores the working directory as a relative
-path from git root (e.g., `.vibing/workspace/<id>/worktree`). When a chat is reopened, the agent
+path from git root (e.g., `.vibing/worktrees/<branch>`). When a chat is reopened, the agent
 and mote commands are executed in this directory. This ensures consistent file operations across
-sessions, even when using workspace or custom directories.
+sessions, even when using a worktree or a custom directory.
 
 ## Concurrent Execution Support
 
@@ -127,24 +182,25 @@ See `docs/adr/002-concurrent-execution-support.md` for architectural details.
 ```text
 Source Chat (session-abc)
   │
-  ├─ User sends messages... SDK uses session-abc
+  ├─ User sends messages... CLI resumes session-abc
   │
   └─ :VibingChatFork right
        │
        Fork Chat (session_id: session-abc, forked_from: source.md)
          │
-         ├─ First message → SDK: query({ resume: session-abc, forkSession: true })
-         │                  → SDK returns new session-def
+         ├─ First message → CLI: claude -p --resume session-abc --fork-session
+         │                  → CLI returns new session-def
          │                  → frontmatter updated: session_id: session-def
          │                  → forked_from cleared
          │
-         └─ Subsequent messages → SDK uses session-def independently
+         └─ Subsequent messages → CLI resumes session-def independently
 ```
 
 **Key Design Decisions:**
 
 - Fork inherits the source's `session_id` directly in frontmatter (no separate side-channel)
-- The `forked_from` frontmatter field indicates a pending fork; `--fork-session` boolean flag is sent to the SDK
+- The `forked_from` frontmatter field indicates a pending fork; `opts._is_fork` makes the command
+  builder emit `--fork-session` right after `--resume`
 - After the first response, `forked_from` is cleared and `session_id` is updated to the new value
 - This avoids `BufReadPost`/`attach_to_buffer` lifecycle issues where in-memory state would be lost
 - `ForkedChatScanner` automatically updates `forked_from` links when source files are renamed
@@ -153,12 +209,12 @@ Source Chat (session-abc)
 
 - `lua/vibing/application/chat/use_cases/fork.lua` - Fork use case
 - `lua/vibing/infrastructure/link/forked_chat_scanner.lua` - Link synchronization scanner
-- `bin/agent-wrapper.ts` - `--fork-session` flag handling
+- `lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua` - `--fork-session` flag
 
 ## Key Patterns
 
-**Adapter Pattern:** All AI backends implement the `Adapter` interface with `execute()`, `stream()`,
-`cancel()`, and feature detection via `supports()`.
+**Adapter Pattern:** All AI backends (`claude_cli`, `codex_cli`) implement the `Adapter` interface
+with `execute()`, `stream()`, `cancel()`, and feature detection via `supports()`.
 
 **Context Format:** Files are referenced as `@file:relative/path.lua` or `@file:path:L10-L25` for
 selections.

--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -36,8 +36,8 @@ Implemented in `lua/vibing/utils/timestamp.lua`: `create_header(role, timestamp)
 
 ## AskUserQuestion Support
 
-Claude's `AskUserQuestion` tool renders as plain markdown in the chat buffer instead of a native
-prompt, so the user can answer with ordinary Vim editing:
+Multiple-choice questions render as plain markdown in the chat buffer instead of a native prompt,
+so the user can answer with ordinary Vim editing:
 
 ```markdown
 Which database should we use?
@@ -51,8 +51,15 @@ Please answer the question and press `<CR>` to send.
 
 Single-select questions render as a numbered list (`1. 2. 3.`); multi-select questions render as a
 bullet list (`- - -`). The user deletes unwanted options with standard Vim commands (`dd`, etc.)
-and sends the remainder with `<CR>`; Claude receives the edited list as a normal user message — no
-special Promise/state handling is required.
+and sends the remainder with `<CR>`.
 
-**Implementation:** the Agent Wrapper sends an `insert_choices` event and denies the tool; the
-choices are inserted as plain markdown (numbered for `multiSelect: false`, bulleted for `true`).
+**Implementation:** the primary path is vibing.nvim's own MCP tool
+`mcp__vibing-nvim__nvim_ask_user_question` (`mcp-server/src/tools/chat.ts`), which the CLI's
+system prompt instructs the model to use instead of the native tool. Its handler calls
+`M.ask_user_question()` in `infrastructure/rpc/handlers/permission.lua`, which cancels the
+in-flight turn and renders the choice list via `on_insert_choices`. Because the turn is killed,
+the tool's return value never reaches the model — the user's answer arrives as the next `--resume`d
+turn's user message, so no Promise/state handling is required.
+
+Native `AskUserQuestion` is unavailable in headless `claude -p` mode and is opaque to vibing.nvim,
+so the PreToolUse hook intercepts and denies it, rendering the same UI as a fallback.

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -1,7 +1,8 @@
 # MCP Integration (Model Context Protocol)
 
 vibing.nvim provides MCP server integration so Claude Code can interact with a running Neovim
-instance without deadlocks: an async RPC server (`lua/vibing/rpc_server.lua`, `vim.loop` TCP,
+instance without deadlocks: an async RPC server (`lua/vibing/infrastructure/rpc/server.lua`,
+`vim.loop` TCP,
 `vim.schedule()` for safe API calls) is queried by the Node MCP server (`mcp-server/`) acting as a
 TCP client, so both buffer reads and writes are possible. Installation is handled by `build.sh`
 (installs the `vibing-nvim` Claude Code plugin, user scope) — see `mcp-server/README.md` and
@@ -9,8 +10,8 @@ TCP client, so both buffer reads and writes are possible. Installation is handle
 
 ## User MCP Servers, Slash Commands, Skills, and Subagents
 
-vibing.nvim's Agent SDK wrapper (`bin/agent-wrapper.mjs`) loads user and project settings via
-`settingSources: ['user', 'project']`, so your existing `~/.claude.json` MCP servers,
+vibing.nvim invokes the `claude` CLI with `--setting-sources user,project,local` (configurable via
+`config.agent.setting_sources`), so your existing `~/.claude.json` MCP servers,
 `.claude/commands/` project slash commands, `.claude/skills/`, and global settings/subagents are
 all available inside vibing.nvim sessions automatically — no extra configuration needed.
 
@@ -25,6 +26,9 @@ Prefix with `mcp__vibing-nvim__`:
   `nvim_list_tabpages`, `nvim_set_window_size`, `nvim_focus_window`, `nvim_win_set_buf`,
   `nvim_win_open_file`
 - **Commands**: `nvim_execute`
+- **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
+  `features.md`), `nvim_chat_send_message`
+- **Instances**: `nvim_list_instances`
 - **LSP**: `nvim_lsp_definition`, `nvim_lsp_references`, `nvim_lsp_hover`, `nvim_diagnostics`,
   `nvim_lsp_document_symbols`, `nvim_lsp_type_definition`, `nvim_lsp_call_hierarchy_incoming`,
   `nvim_lsp_call_hierarchy_outgoing`

--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -71,7 +71,8 @@ alternative to hand-editing config or frontmatter.
 ## Tool Approval UI
 
 When permission mode is `default`, or a tool is in the `ask` list, vibing.nvim shows an approval
-prompt directly in the chat buffer instead of using the Agent SDK's console prompt:
+prompt directly in the chat buffer instead of the CLI's own console prompt (which is unreachable
+in headless `claude -p` mode):
 
 ```markdown
 ⚠️ Tool approval required
@@ -93,7 +94,8 @@ one with `<CR>`. `allow_once`/`deny_once` apply to this call only; `allow_for_se
 
 **Implementation notes:**
 
-- The RPC hook fires in `permission.lua` when Claude requests a tool in the `ask` list;
+- The PreToolUse hook (`bin/hooks/pre-tool-use.sh`) posts to the RPC server, which dispatches to
+  `infrastructure/rpc/handlers/permission.lua`. When the requested tool is in the `ask` list,
   `cancel_and_deny()` immediately cancels the Claude process and sends a deny response to the
   hook.
 - `on_approval_required` must be called from the vim main thread (inside `vim.schedule`) — the

--- a/.claude/rules/self-development.md
+++ b/.claude/rules/self-development.md
@@ -1,7 +1,7 @@
 # Developing vibing.nvim with vibing.nvim
 
-When you (Claude Agent SDK) are working on vibing.nvim itself, follow these guidelines to
-leverage vibing.nvim's built-in workflows.
+When you are working on vibing.nvim itself, follow these guidelines to leverage vibing.nvim's
+built-in workflows.
 
 ## Preferred Workflows
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-vibing.nvim is a Neovim plugin that integrates Claude AI through the Agent SDK.
-It provides chat within Neovim.
+vibing.nvim is a Neovim plugin that provides a Claude chat inside Neovim by spawning the `claude`
+CLI directly (`claude -p --output-format stream-json`) and parsing its stream. There is no
+Node.js agent wrapper process; the Node side is only the MCP server, two hook scripts, and a
+slash-command lister. A Codex CLI backend is also supported. See
+`.claude/rules/architecture.md`.
 
 ## Commands
 
@@ -13,14 +16,11 @@ It provides chat within Neovim.
 # Install dependencies
 npm install
 
-# Build TypeScript to JavaScript (production mode)
+# Build the Node.js side (MCP server + bin/list-commands.ts) into dist/
 npm run build
 
 # Build with watch mode (for development)
 npm run build:watch
-
-# Test Agent SDK wrapper directly
-node dist/bin/agent-wrapper.js --prompt "Say hello" --cwd $(pwd)
 
 # Run Lua tests (requires Neovim with plenary.nvim)
 npm run test:lua
@@ -101,7 +101,7 @@ Detailed documentation is organized in `.claude/rules/`:
 | `permissions.md`        | Permission system, granular rules, Tool Approval UI                             |
 | `self-development.md`   | Guidelines for developing vibing.nvim with vibing.nvim                          |
 | `self-testing.md`       | E2E testing procedures, 3-try auto-fix rule, test helper reference              |
-| `features.md`           | Message timestamps, AskUserQuestion support                                     |
+| `features.md`           | Auto-resume on usage limit, message timestamps, AskUserQuestion support         |
 | `configuration.md`      | Full configuration examples, window positions, daily summary                    |
 | `commands-reference.md` | User commands, slash commands                                                   |
 | `web-workflow.md`       | Claude Code on the Web git push requirements                                    |


### PR DESCRIPTION
Closes #484

## 概要

`CLAUDE.md` と `.claude/rules/*.md` は毎セッション自動ロードされるため、stale な記述はコンテキストの浪費であると同時に、エージェントを実在しないアーキテクチャへ誤誘導します。実装の実体（`claude` CLI 直接実行 + MCP + hook）に合わせて全面更新しました。

記述はすべて実コードで裏取りしています（ファイル存在確認 + 該当箇所の読み込み）。

## 変更内容

### `.claude/rules/architecture.md`

**Communication Flow** — 「Node.js wrapper → Agent SDK / JSON Lines」を全面書き換え:

- `vim.system()` で `claude -p --output-format stream-json --verbose --include-partial-messages` を直接 spawn（`cli_command_builder.lua`）
- ストリームは `cli_event_processor.lua` が `content_block_start` / `content_block_delta`(`text_delta`, `input_json_delta`) / `tool_use` / `tool_result` / `error` / `rate_limit_event` を処理
- **hook の往復を実装どおりに記述**: PreToolUse は同期ブロッキングで、`/tmp/vibing-hook-<port>/<request_id>.req` にペイロードを書き、`nc` で RPC ポートに1行 JSON-RPC 通知、`.res` を最大120秒ポーリング。接続失敗・タイムアウトは **fail closed（deny）**。`VIBING_HANDLE_ID` で並行チャットの取り違えを防止
- Codex アダプタ（`codex_cli.lua` ほか）の存在を明記

**Module Structure / Key Entry Points** — v4 以前のフラットな `adapters/` `actions/` `ui/chat_buffer.lua` 前提を、現行の `domain` / `application` / `infrastructure` / `presentation` 構成に置き換え。Node.js 側は「agent wrapper は無く、hook 2本 + list-commands + MCP サーバーだけ」と明示。

**Session Persistence** — frontmatter 例の修正:

- `permissions_mode` → `permission_mode`（`send_message.lua` が実際に読むのは単数形。補完は複数形も出すが読み手がいない旨を注記）
- `working_dir` の例を `.vibing/workspace/0001-.../worktree` → `.vibing/worktrees/<branch>`
- `<sdk-session-id>` → `<cli-session-id>`

**Chat Fork** — `query({ resume, forkSession })` → `claude -p --resume <id> --fork-session`、実装ポインタを `bin/agent-wrapper.ts` から `cli_command_builder.lua` へ。

### `.claude/rules/features.md`

AskUserQuestion を現行方式に修正。主経路は `mcp__vibing-nvim__nvim_ask_user_question`（`mcp-server/src/tools/chat.ts` → `permission.lua` の `M.ask_user_question()`）で、ターンを kill して選択肢を描画するため戻り値はモデルに届かず、ユーザーの回答は次の `--resume` ターンで渡ります。ネイティブ `AskUserQuestion` は headless `claude -p` では使えず不透明なため、PreToolUse hook で intercept + deny するフォールバック、という位置づけを明記。

### `.claude/rules/mcp-integration.md`

- `settingSources: ['user','project']`（agent-wrapper 前提）→ `--setting-sources user,project,local`（`config.agent.setting_sources` で変更可）
- RPC サーバーのパスを `lua/vibing/rpc_server.lua` → `lua/vibing/infrastructure/rpc/server.lua`
- ツール一覧に漏れていた `nvim_ask_user_question` / `nvim_chat_send_message` / `nvim_list_instances` を追加

### `.claude/rules/permissions.md`

「Agent SDK のコンソールプロンプトの代わり」→ headless `claude -p` ではそもそもコンソールプロンプトに到達できない旨に修正。hook の入口（`bin/hooks/pre-tool-use.sh` → RPC → `permission.lua`）を明記。

### `.claude/rules/self-development.md`

冒頭の "When you (Claude Agent SDK) are working on..." から SDK 前提の呼称を削除。

### `CLAUDE.md`

- Project Overview を「Agent SDK 経由」→ CLI 直接実行 + Node 側の役割の実態に修正
- Commands から `node dist/bin/agent-wrapper.js --prompt ...`（存在しないファイル）を削除、`npm run build` の説明を実際のビルド対象に修正
- Documentation Structure の `features.md` 行に Auto-Resume を追記

## PR 間の分担

- **`## Development Mode` セクション（CLAUDE.md）は本 PR では触れていません。** `node.dev_mode` 実装の撤去と同時に削除する必要があり、#501 / PR #519 が担当します（issue #501 本文でもそう指定されています）。両 PR は CLAUDE.md の別 hunk なのでコンフリクトはしません。マージ順はどちらでも構いません。
- `tests/agent-wrapper.test.mjs` と `package.json` の description に残る agent-wrapper の残骸は #505 の担当なので触れていません。
- `docs/adr/*` は当時の意思決定の記録なので更新対象外です。

## 補足

CLAUDE.md の Commands は `npm` のままにしています（このリポジトリの `package.json` scripts に合わせた記述のため）。パッケージマネージャの方針変更は別途判断してください。

## 検証

- 記述したパス・関数の実在をすべて確認（`rpc/server.lua`, `settings_generator.lua`, `presentation/chat/buffer.lua`, `auto_resume.lua`, `constants/worktree.lua`, `bin/hooks/*.sh`, `mcp-server/src/tools/chat.ts`, `cli_event_processor.lua` の `rate_limit_event` ほか）
- MCP ツール一覧は `mcp-server/src/tools/*.ts` の登録名から突き合わせ
- prettier / markdownlint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)