### PR TITLE
feat: apply .vibing/system-prompt.md to every request

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -458,6 +458,10 @@ Notes:
 - Utility calls (title generation, summarize, daily summary) do not receive it.
 - The file is read from the project root Neovim was started in, and is not committed
   (`.vibing/` is git-ignored) — it is per-checkout, not shared with collaborators.
+- A chat with a `working_dir` (a worktree under `.vibing/worktrees/<branch>/`) uses that
+  directory's `.vibing/system-prompt.md` when it exists and has content, and otherwise falls back
+  to the project root's file — so a worktree can override the project prompt without having to
+  copy it.
 
 ## Daily Summary
 

--- a/lua/vibing/core/utils/project_system_prompt.lua
+++ b/lua/vibing/core/utils/project_system_prompt.lua
@@ -27,6 +27,24 @@ function M.ensure(project_root)
   end
 end
 
+--- Cut `s` down to at most `max_bytes` without splitting a UTF-8 character:
+--- walk back off any continuation bytes (`0b10xxxxxx`) left at the boundary.
+--- @param s string
+--- @param max_bytes number
+--- @return string
+local function cut_at_utf8_boundary(s, max_bytes)
+  local cut = max_bytes
+  while cut > 0 do
+    local next_byte = s:byte(cut + 1)
+    -- nil (nothing dropped), ASCII, or a lead byte all mean `cut` is a boundary
+    if not next_byte or next_byte < 0x80 or next_byte >= 0xC0 then
+      break
+    end
+    cut = cut - 1
+  end
+  return s:sub(1, cut)
+end
+
 --- Read the project-local system prompt.
 --- Returns nil when the file is missing, unreadable, empty, or whitespace-only,
 --- so callers can skip it without special-casing. Content over MAX_BYTES is
@@ -51,7 +69,7 @@ function M.read(project_root)
   end
 
   if #content > MAX_BYTES then
-    content = content:sub(1, MAX_BYTES)
+    content = cut_at_utf8_boundary(content, MAX_BYTES)
     require("vibing.core.utils.notify").warn(
       string.format(".vibing/system-prompt.md exceeds %d bytes - truncated", MAX_BYTES),
       "Config"
@@ -59,6 +77,26 @@ function M.read(project_root)
   end
 
   return content
+end
+
+--- Read the prompt that applies to a request running in `cwd`.
+---
+--- A chat with a `working_dir` (a worktree under `.vibing/worktrees/<branch>/`) runs
+--- the CLI there, so its own `.vibing/system-prompt.md` wins when it has content.
+--- Worktrees are separate checkouts and `.vibing/` is git-ignored, so that file
+--- usually doesn't exist there — fall back to the root Neovim was started in, which
+--- is where `ensure()` creates the file and where users actually edit it.
+--- @param cwd string|nil working directory of the request (`opts.cwd`)
+--- @return string|nil content
+function M.read_for_cwd(cwd)
+  local nvim_root = vim.fn.getcwd()
+  if cwd and cwd ~= "" and cwd ~= nvim_root then
+    local from_cwd = M.read(cwd)
+    if from_cwd then
+      return from_cwd
+    end
+  end
+  return M.read(nvim_root)
 end
 
 return M

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -244,7 +244,9 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     -- request, so an edit takes effect from the next message onward; that edit is also
     -- the only thing that invalidates the cached system prefix (see #469 note above).
     -- An unedited file keeps the block byte-for-byte identical across turns.
-    local project_prompt = require("vibing.core.utils.project_system_prompt").read(vim.fn.getcwd())
+    -- Resolved against `opts.cwd` (the chat's `working_dir`, e.g. a worktree) first,
+    -- like every other cwd-sensitive part of the request, then the Neovim root.
+    local project_prompt = require("vibing.core.utils.project_system_prompt").read_for_cwd(opts.cwd)
     if project_prompt then
       table.insert(system_prompt_lines, project_prompt)
     end

--- a/tests/lua/core/utils/project_system_prompt_spec.lua
+++ b/tests/lua/core/utils/project_system_prompt_spec.lua
@@ -1,0 +1,117 @@
+local project_system_prompt = require("vibing.core.utils.project_system_prompt")
+
+describe("project_system_prompt", function()
+  local project_root
+  local original_notify
+
+  local function write_prompt(root, content)
+    vim.fn.mkdir(root .. "/.vibing", "p")
+    vim.fn.writefile(vim.split(content, "\n", { plain = true }), root .. "/.vibing/system-prompt.md")
+  end
+
+  before_each(function()
+    project_root = vim.fn.tempname()
+    vim.fn.mkdir(project_root, "p")
+    original_notify = vim.notify
+    vim.notify = function() end
+  end)
+
+  after_each(function()
+    vim.notify = original_notify
+    vim.fn.delete(project_root, "rf")
+  end)
+
+  describe("read", function()
+    it("returns nil when the file is missing", function()
+      assert.is_nil(project_system_prompt.read(project_root))
+    end)
+
+    it("returns nil for an empty or whitespace-only file", function()
+      write_prompt(project_root, "")
+      assert.is_nil(project_system_prompt.read(project_root))
+
+      write_prompt(project_root, "  \n\t\n")
+      assert.is_nil(project_system_prompt.read(project_root))
+    end)
+
+    it("returns the trimmed contents", function()
+      write_prompt(project_root, "Prefer pnpm.\nNever edit generated/.")
+      assert.equals("Prefer pnpm.\nNever edit generated/.", project_system_prompt.read(project_root))
+    end)
+
+    it("truncates oversized content without splitting a multibyte character", function()
+      -- 3-byte characters don't line up with the 8 KiB limit, so a naive byte cut
+      -- would leave a half-written character at the boundary.
+      local content = string.rep("あ", 4000)
+      write_prompt(project_root, content)
+
+      local result = project_system_prompt.read(project_root)
+      assert.is_not_nil(result)
+      assert.is_true(#result <= 8 * 1024)
+      -- Every byte survives as valid UTF-8: the string is a whole number of characters
+      assert.equals(0, #result % 3)
+      assert.equals(#result / 3, vim.fn.strchars(result))
+    end)
+
+    it("truncates ASCII content exactly at the limit", function()
+      write_prompt(project_root, string.rep("a", 9000))
+      assert.equals(8 * 1024, #project_system_prompt.read(project_root))
+    end)
+  end)
+
+  describe("read_for_cwd", function()
+    local worktree_root
+    local original_getcwd
+
+    before_each(function()
+      worktree_root = project_root .. "/.vibing/worktrees/feature-x"
+      vim.fn.mkdir(worktree_root, "p")
+      original_getcwd = vim.fn.getcwd
+      vim.fn.getcwd = function()
+        return project_root
+      end
+    end)
+
+    after_each(function()
+      vim.fn.getcwd = original_getcwd
+    end)
+
+    it("prefers the request cwd's file", function()
+      write_prompt(project_root, "Root rule.")
+      write_prompt(worktree_root, "Worktree rule.")
+      assert.equals("Worktree rule.", project_system_prompt.read_for_cwd(worktree_root))
+    end)
+
+    it("falls back to the Neovim root when the cwd has no usable file", function()
+      write_prompt(project_root, "Root rule.")
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(worktree_root))
+
+      write_prompt(worktree_root, "   ")
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(worktree_root))
+    end)
+
+    it("uses the Neovim root when no cwd is given", function()
+      write_prompt(project_root, "Root rule.")
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(nil))
+      assert.equals("Root rule.", project_system_prompt.read_for_cwd(""))
+    end)
+
+    it("returns nil when neither location has a file", function()
+      assert.is_nil(project_system_prompt.read_for_cwd(worktree_root))
+    end)
+  end)
+
+  describe("ensure", function()
+    it("creates an empty file that read() treats as unset", function()
+      project_system_prompt.ensure(project_root)
+      assert.equals(1, vim.fn.filereadable(project_system_prompt.path(project_root)))
+      assert.is_nil(project_system_prompt.read(project_root))
+    end)
+
+    it("does not overwrite existing content", function()
+      write_prompt(project_root, "Existing rule.")
+      project_system_prompt.ensure(project_root)
+      assert.equals("Existing rule.", project_system_prompt.read(project_root))
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -192,6 +192,50 @@ describe("cli_command_builder", function()
 
       assert.is_nil(prompt_text:find("always run the linter", 1, true))
     end)
+
+    describe("with a worktree working_dir (opts.cwd)", function()
+      local worktree_root
+
+      local function write_worktree_prompt(lines)
+        vim.fn.mkdir(worktree_root .. "/.vibing", "p")
+        vim.fn.writefile(lines, worktree_root .. "/.vibing/system-prompt.md")
+      end
+
+      before_each(function()
+        worktree_root = project_root .. "/.vibing/worktrees/feature-x"
+        vim.fn.mkdir(worktree_root, "p")
+      end)
+
+      it("prefers the worktree's own file over the project root's", function()
+        write_project_prompt({ "Root rule." })
+        write_worktree_prompt({ "Worktree rule." })
+
+        local cmd = cli_command_builder.build("hello", { cwd = worktree_root }, nil, {}, nil)
+        local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+        assert.is_true(prompt_text:find("Worktree rule.", 1, true) ~= nil)
+        assert.is_nil(prompt_text:find("Root rule.", 1, true))
+      end)
+
+      it("falls back to the project root when the worktree has no file", function()
+        write_project_prompt({ "Root rule." })
+
+        local cmd = cli_command_builder.build("hello", { cwd = worktree_root }, nil, {}, nil)
+        local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+        assert.is_true(prompt_text:find("Root rule.", 1, true) ~= nil)
+      end)
+
+      it("falls back to the project root when the worktree file is empty", function()
+        write_project_prompt({ "Root rule." })
+        write_worktree_prompt({ "" })
+
+        local cmd = cli_command_builder.build("hello", { cwd = worktree_root }, nil, {}, nil)
+        local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+
+        assert.is_true(prompt_text:find("Root rule.", 1, true) ~= nil)
+      end)
+    end)
   end)
 
   describe("--allowedTools", function()


### PR DESCRIPTION
`ensure_system_prompt()` created an empty `.vibing/system-prompt.md` on chat
creation, but nothing ever read it back — editing the file had no effect at
all. Read it in `cli_command_builder` and append it to the CLI's
`--append-system-prompt`.

Reflection rule: the file is read fresh on every request, so an edit applies
from the next message. That edit is also the only thing that changes the
system prefix, so the prompt cache stays intact while the file is untouched
(see #469).

Empty, whitespace-only, or missing files add nothing; content over 8 KiB is
truncated with a warning; lightweight utility calls (title/summary) skip it.

Closes #486

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for project-local instructions through `.vibing/system-prompt.md`.
  * Automatically applies nonblank prompt content to chat requests based on the active project or worktree.
  * Creates the prompt file when needed and supports safe size limits with UTF-8-aware truncation.
  * Excludes project prompts from lightweight requests.

* **Documentation**
  * Added setup, behavior, storage, resolution, and usage details to the configuration guide.

* **Tests**
  * Added coverage for prompt creation, lookup, updates, fallback behavior, limits, and exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->