### PR TITLE
refactor: simplify ui.tool_markers to a flat tool -> string table

### DIFF
--- a/bin/types.ts
+++ b/bin/types.ts
@@ -1,55 +1,28 @@
 /**
- * Type definitions for vibing.nvim agent wrapper
+ * Shared type definitions for the Node.js side of vibing.nvim
  */
 
 /**
- * Tool-specific marker configuration with pattern matching support.
- * Allows different markers based on tool input (e.g., different markers for npm vs git commands in Bash).
- *
- * @example
- * ```typescript
- * const bashMarker: ToolMarkerDefinition = {
- *   default: '⏺',
- *   patterns: {
- *     '^npm': '📦',
- *     '^git': '🌿',
- *   }
- * };
- * ```
- */
-export interface ToolMarkerDefinition {
-  /** Default marker when no pattern matches */
-  default?: string;
-  /** Regex pattern to marker mapping. Patterns are tested against tool input. */
-  patterns?: Record<string, string>;
-}
-
-/**
- * Configuration for tool execution markers displayed in chat output.
- * Supports both simple string markers and pattern-based ToolMarkerDefinition objects.
+ * Markers displayed in chat output when a tool runs: a flat "tool name -> marker" table.
+ * Marker resolution only ever sees the tool name, so a marker cannot vary with a tool's
+ * arguments.
  *
  * @example
  * ```typescript
  * const markers: ToolMarkersConfig = {
  *   Task: '▶',
- *   TaskComplete: '✓',
  *   default: '⏺',
- *   Bash: {
- *     default: '⏺',
- *     patterns: { '^npm': '📦' }
- *   }
+ *   Bash: '💻',
  * };
  * ```
  */
 export interface ToolMarkersConfig {
-  /** Marker for Task tool start */
+  /** Marker for the Task tool */
   Task?: string;
-  /** Marker for Task tool completion */
-  TaskComplete?: string;
-  /** Default marker for tools without specific configuration */
+  /** Marker for tools without a specific entry */
   default?: string;
-  /** Tool-specific markers (string for simple marker, ToolMarkerDefinition for pattern matching) */
-  [toolName: string]: string | ToolMarkerDefinition | undefined;
+  /** Tool-specific markers */
+  [toolName: string]: string | undefined;
 }
 
 /**

--- a/bin/types.ts
+++ b/bin/types.ts
@@ -3,9 +3,8 @@
  */
 
 /**
- * Markers displayed in chat output when a tool runs: a flat "tool name -> marker" table.
- * Marker resolution only ever sees the tool name, so a marker cannot vary with a tool's
- * arguments.
+ * Markers displayed in chat output when a tool runs: a flat "tool name -> marker" table, with
+ * `default` used for tools that have no entry of their own.
  *
  * @example
  * ```typescript
@@ -17,11 +16,6 @@
  * ```
  */
 export interface ToolMarkersConfig {
-  /** Marker for the Task tool */
-  Task?: string;
-  /** Marker for tools without a specific entry */
-  default?: string;
-  /** Tool-specific markers */
   [toolName: string]: string | undefined;
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,8 +246,10 @@ ui = {
 }
 ```
 
-A `tool_markers` entry may also be a table with a `default` key (e.g.
-`Bash = { default = "💻" }`); only the `default` key is used.
+Every `tool_markers` entry is a plain string. Markers are resolved from the tool name alone, so
+they cannot vary with a tool's arguments (there is no way to give `Bash` one marker for `npm` and
+another for `git`). The legacy `Bash = { default = "💻" }` table form is still accepted — it is
+flattened to the `default` string with a warning — but should be replaced with `Bash = "💻"`.
 
 ## Keymaps
 

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -17,18 +17,14 @@
 ---@field colors string[] グラデーション色の配列（2色指定: {開始色, 終了色}、例: {"#cc3300", "#fffe00"}）
 ---@field interval number アニメーション更新間隔（ミリ秒、デフォルト: 100）
 
----@class Vibing.ToolMarkerDefinition
----ツール固有のマーカー定義（パターンマッチング対応）
----@field default? string ツールのデフォルトマーカー
----@field patterns? table<string, string> 正規表現パターン→マーカーのマッピング（例: Bash用に {["^npm"] = "📦", ["^git"] = "🌿"}）
-
 ---@class Vibing.ToolMarkersConfig
 ---ツールマーカー設定
 ---チャット出力でツール実行時に表示する視覚的マーカーをカスタマイズ
----@field Task? string Taskツール開始マーカー（デフォルト: "▶"）
----@field TaskComplete? string Taskツール完了マーカー（デフォルト: "✓"）
----@field default? string その他のツール用デフォルトマーカー（デフォルト: "⏺"）
----@field [string]? string|Vibing.ToolMarkerDefinition ツール名をキーとした個別マーカー（文字列またはToolMarkerDefinition）
+---ツール名 → マーカー文字列のフラットな対応表。マーカーの解決にはツール名しか渡らないため、
+---コマンド内容による出し分け（Bashの`^npm`だけ別マーカー等）は行えない
+---@field Task? string Taskツールのマーカー（デフォルト: "▶"）
+---@field default? string 個別指定のないツール用マーカー（デフォルト: "⏺"）
+---@field [string]? string ツール名をキーとしたマーカー文字列
 
 ---@class Vibing.UiConfig
 ---UI設定
@@ -140,56 +136,33 @@ local language_utils = require("vibing.core.utils.language")
 
 local M = {}
 
----Validate a single pattern entry in tool_markers
+---Flatten the legacy `{ default = "x", patterns = {...} }` marker form to a plain string.
+---`patterns` was documented but never implemented — marker resolution only ever receives a tool
+---name, never the command string — so it is dropped with an explicit warning rather than being
+---silently ignored the way it used to be. See issue #502.
 ---@param key string Tool name for error messages
----@param pattern string Pattern key
----@param marker any Marker value to validate
----@return boolean is_valid
-local function validate_pattern_entry(key, pattern, marker)
-  if type(marker) ~= "string" or marker == "" then
-    notify.warn(string.format(
-      "Invalid ui.tool_markers.%s.patterns['%s']: marker must be a non-empty string",
-      key, pattern
-    ))
-    return false
-  end
-  return true
-end
-
----Validate a ToolMarkerDefinition table
----@param key string Tool name for error messages
----@param marker table ToolMarkerDefinition to validate
----@return table|nil Validated marker or nil if invalid
-local function validate_marker_definition(key, marker)
-  if marker.default and type(marker.default) ~= "string" then
-    notify.warn(string.format("Invalid ui.tool_markers.%s.default: must be a string", key))
-    marker.default = nil
+---@param marker table Legacy marker definition
+---@return string|nil
+local function flatten_legacy_marker(key, marker)
+  if marker.patterns ~= nil then
+    notify.warn(
+      string.format("ui.tool_markers.%s.patterns is not supported and has no effect - remove it", key)
+    )
   end
 
-  if marker.patterns then
-    if type(marker.patterns) ~= "table" then
-      notify.warn(string.format("Invalid ui.tool_markers.%s.patterns: must be a table", key))
-      marker.patterns = nil
-    else
-      for pattern, pattern_marker in pairs(marker.patterns) do
-        if not validate_pattern_entry(key, pattern, pattern_marker) then
-          marker.patterns[pattern] = nil
-        end
-      end
-    end
+  if type(marker.default) == "string" and marker.default ~= "" then
+    notify.warn(
+      string.format('ui.tool_markers.%s: use the marker string directly instead of { default = ... }', key)
+    )
+    return marker.default
   end
 
-  local has_default = marker.default ~= nil
-  local has_patterns = marker.patterns and next(marker.patterns) ~= nil
-  if not has_default and not has_patterns then
-    notify.warn(string.format("ui.tool_markers.%s has no valid default or patterns - removing", key))
-    return nil
-  end
-
-  return marker
+  notify.warn(string.format("Invalid ui.tool_markers.%s: expected a non-empty string - removing", key))
+  return nil
 end
 
 ---Validate tool_markers configuration
+---Markers are a flat "tool name -> marker string" table.
 ---@param markers table Tool markers config to validate
 ---@return table Validated markers config
 local function validate_tool_markers(markers)
@@ -203,12 +176,11 @@ local function validate_tool_markers(markers)
         validated[key] = marker
       end
     elseif type(marker) == "table" then
-      validated[key] = validate_marker_definition(key, marker)
+      validated[key] = flatten_legacy_marker(key, marker)
     else
-      notify.warn(string.format(
-        "Invalid ui.tool_markers.%s: must be a string or table, got %s",
-        key, type(marker)
-      ))
+      notify.warn(
+        string.format("Invalid ui.tool_markers.%s: must be a string, got %s", key, type(marker))
+      )
     end
   end
 
@@ -259,7 +231,6 @@ M.defaults = {
     tool_result_display = "compact",
     tool_markers = {
       Task = "▶",
-      TaskComplete = "✓",
       default = "⏺",
     },
   },

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -154,11 +154,12 @@ local function validate_tool_markers(markers)
       -- Legacy `{ default = "x", patterns = {...} }`. `patterns` was documented but never
       -- implemented — resolution only ever receives a tool name, never the command string — so
       -- the whole form is dropped loudly rather than silently ignored. See issue #502.
+      -- Name `patterns` only when the user actually wrote it: mentioning a feature they never
+      -- used reads like a warning about something else.
+      local detail = marker.patterns ~= nil and "; patterns never had any effect and is dropped"
+        or ""
       notify.warn(
-        string.format(
-          "ui.tool_markers.%s: give the marker string directly; { default = ..., patterns = ... } is no longer supported",
-          key
-        )
+        string.format("ui.tool_markers.%s: give the marker string directly%s", key, detail)
       )
       if type(marker.default) == "string" and marker.default ~= "" then
         validated[key] = marker.default

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -136,31 +136,6 @@ local language_utils = require("vibing.core.utils.language")
 
 local M = {}
 
----Flatten the legacy `{ default = "x", patterns = {...} }` marker form to a plain string.
----`patterns` was documented but never implemented — marker resolution only ever receives a tool
----name, never the command string — so it is dropped with an explicit warning rather than being
----silently ignored the way it used to be. See issue #502.
----@param key string Tool name for error messages
----@param marker table Legacy marker definition
----@return string|nil
-local function flatten_legacy_marker(key, marker)
-  if marker.patterns ~= nil then
-    notify.warn(
-      string.format("ui.tool_markers.%s.patterns is not supported and has no effect - remove it", key)
-    )
-  end
-
-  if type(marker.default) == "string" and marker.default ~= "" then
-    notify.warn(
-      string.format('ui.tool_markers.%s: use the marker string directly instead of { default = ... }', key)
-    )
-    return marker.default
-  end
-
-  notify.warn(string.format("Invalid ui.tool_markers.%s: expected a non-empty string - removing", key))
-  return nil
-end
-
 ---Validate tool_markers configuration
 ---Markers are a flat "tool name -> marker string" table.
 ---@param markers table Tool markers config to validate
@@ -176,7 +151,18 @@ local function validate_tool_markers(markers)
         validated[key] = marker
       end
     elseif type(marker) == "table" then
-      validated[key] = flatten_legacy_marker(key, marker)
+      -- Legacy `{ default = "x", patterns = {...} }`. `patterns` was documented but never
+      -- implemented — resolution only ever receives a tool name, never the command string — so
+      -- the whole form is dropped loudly rather than silently ignored. See issue #502.
+      notify.warn(
+        string.format(
+          "ui.tool_markers.%s: give the marker string directly; { default = ..., patterns = ... } is no longer supported",
+          key
+        )
+      )
+      if type(marker.default) == "string" and marker.default ~= "" then
+        validated[key] = marker.default
+      end
     else
       notify.warn(
         string.format("Invalid ui.tool_markers.%s: must be a string, got %s", key, type(marker))

--- a/lua/vibing/infrastructure/adapter/modules/tool_display.lua
+++ b/lua/vibing/infrastructure/adapter/modules/tool_display.lua
@@ -18,19 +18,18 @@ function M.get_markers_config()
 end
 
 --- Resolve tool marker from config
+--- Markers are a flat "tool name -> marker string" table; config.lua normalises anything else
+--- away before it gets here.
 --- @param tool_name string
---- @param markers table|nil
+--- @param markers table<string, string>|nil
 --- @return string
 function M.resolve_marker(tool_name, markers)
   if not markers then
     return DEFAULT_MARKER
   end
-  local marker_config = markers[tool_name]
-  if type(marker_config) == "string" then
-    return marker_config
-  end
-  if type(marker_config) == "table" and marker_config.default then
-    return marker_config.default
+  local marker = markers[tool_name]
+  if type(marker) == "string" then
+    return marker
   end
   return markers.default or DEFAULT_MARKER
 end

--- a/lua/vibing/infrastructure/adapter/modules/tool_display.lua
+++ b/lua/vibing/infrastructure/adapter/modules/tool_display.lua
@@ -18,20 +18,14 @@ function M.get_markers_config()
 end
 
 --- Resolve tool marker from config
---- Markers are a flat "tool name -> marker string" table; config.lua normalises anything else
---- away before it gets here.
 --- @param tool_name string
---- @param markers table<string, string>|nil
+--- @param markers table<string, string>|nil Flat table; config.lua normalises anything else away
 --- @return string
 function M.resolve_marker(tool_name, markers)
   if not markers then
     return DEFAULT_MARKER
   end
-  local marker = markers[tool_name]
-  if type(marker) == "string" then
-    return marker
-  end
-  return markers.default or DEFAULT_MARKER
+  return markers[tool_name] or markers.default or DEFAULT_MARKER
 end
 
 --- Get tool result display mode from vibing.config

--- a/tests/lua/infrastructure/adapter/modules/tool_display_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/tool_display_spec.lua
@@ -1,0 +1,62 @@
+-- Tests for vibing.infrastructure.adapter.modules.tool_display
+
+local tool_display = require("vibing.infrastructure.adapter.modules.tool_display")
+
+describe("tool_display.resolve_marker", function()
+  it("returns the marker configured for the tool", function()
+    assert.equals("▶", tool_display.resolve_marker("Task", { Task = "▶", default = "⏺" }))
+  end)
+
+  it("falls back to the configured default for an unlisted tool", function()
+    assert.equals("⏺", tool_display.resolve_marker("Read", { Task = "▶", default = "⏺" }))
+  end)
+
+  it("falls back to the built-in default when no markers are configured", function()
+    assert.equals("⏺", tool_display.resolve_marker("Read", nil))
+    assert.equals("⏺", tool_display.resolve_marker("Read", {}))
+  end)
+end)
+
+describe("config validation of ui.tool_markers", function()
+  local config = require("vibing.config")
+
+  local function markers_after_setup(tool_markers)
+    config.setup({ ui = { tool_markers = tool_markers } })
+    return config.get().ui.tool_markers
+  end
+
+  after_each(function()
+    config.setup({})
+  end)
+
+  it("keeps plain string markers", function()
+    local markers = markers_after_setup({ Bash = "💻", default = "⏺" })
+    assert.equals("💻", markers.Bash)
+    assert.equals("⏺", markers.default)
+  end)
+
+  it("drops an empty string marker so the default applies", function()
+    assert.is_nil(markers_after_setup({ Bash = "" }).Bash)
+  end)
+
+  it("drops a marker that is not a string", function()
+    assert.is_nil(markers_after_setup({ Bash = 42 }).Bash)
+  end)
+
+  it("flattens the legacy { default = ... } form to a string", function()
+    assert.equals("💻", markers_after_setup({ Bash = { default = "💻" } }).Bash)
+  end)
+
+  it("drops the never-implemented patterns key instead of pretending it works", function()
+    local markers = markers_after_setup({
+      Bash = { default = "💻", patterns = { ["^npm"] = "📦" } },
+    })
+    assert.equals("💻", markers.Bash)
+    -- Resolution only ever sees the tool name, so a pattern marker could never win.
+    assert.equals("💻", tool_display.resolve_marker("Bash", markers))
+  end)
+
+  it("drops a legacy table with no usable default", function()
+    assert.is_nil(markers_after_setup({ Bash = { patterns = { ["^npm"] = "📦" } } }).Bash)
+  end)
+end)


### PR DESCRIPTION
Closes #502

issue の推奨どおり **(b) 撤去して簡素化**を採用。パターンマッチングの需要が明確でない一方、実装するには「コマンド文字列を `resolve_marker` まで配線」「`patterns` を配列形式に変更」が必要で、コストが見合わないため。

## 変更内容

### 1. `patterns` と `ToolMarkerDefinition` を撤去

`resolve_marker(tool_name, markers)` にはツール名しか渡らず、コマンド文字列はそもそもスコープに存在しない。`patterns` は一度も参照されていなかった。**動きようのない設定のために約70行の検証コードが保守されていた**状態を解消。

### 2. `TaskComplete` デフォルトを削除

`config.lua` にデフォルト値だけがあり、`"TaskComplete"` というキーで `resolve_marker` が呼ばれる箇所はゼロだった。

### 3. 旧形式は警告付きで平坦化（黙って壊さない）

既存ユーザーの `Bash = { default = "💻" }` は文字列 `"💻"` に平坦化し、非推奨の警告を出す。`patterns` キーがあれば「効果がない」と明示的に警告する（**これまでは黙って無視**されていて、動いていないことに気づけなかった）。

### 4. `resolve_marker` から table 分岐を削除

config 層で正規化済みなので、解決側は文字列だけを見ればよくなった。

## 動作確認

`tool_markers` にはテストが1件も無かったので新規追加した。

```
$ 新規 tests/lua/infrastructure/adapter/modules/tool_display_spec.lua   9 pass
   - マーカー解決（個別 / default / 未設定時の組み込みデフォルト）
   - 空文字・非文字列の除去
   - 旧 { default = ... } の平坦化
   - patterns 付き設定を渡しても結局 default が使われること（＝パターンは勝ちようがない）

$ PlenaryBustedDirectory tests/lua    全て pass
$ tests/config_spec.lua               7 pass
$ find lua -name '*.lua' -exec luac -p {} \;   # 構文エラーなし
$ pnpm run format:check                         # pass
```

## 補足

`docs/configuration.md` の「table with a `default` key も使える」という記述を、「マーカーはツール名からのみ解決されるので引数によって出し分けはできない／旧 table 形式は警告付きで受理するが文字列に書き換えるべき」に更新した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)