### PR TITLE
feat: ship deny rules for destructive Bash commands

### DIFF
--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -58,12 +58,16 @@ require("vibing").setup({
 Fields: `tools` (target tools), `paths` (glob, for Read/Write/Edit), `commands`/`patterns` (Bash),
 `domains` (WebFetch/WebSearch), `action` (`allow`/`deny`), `message` (optional, for deny rules).
 
-**Evaluation order:** deny rules are checked first — before the permission mode and the tool-level
-lists, so they hold under `mode = "auto"` and for always-allowed tools (`bypassPermissions` is the
-one deliberate way past them) → allow rules after the tool-level lists → default deny if nothing
-matches ("No matching allow rule"). Paths are normalized to absolute, symlink-resolved paths
-before matching (prevents traversal attacks); glob patterns support `*` (single directory) and
-`**` (recursive). `patterns` are **Lua patterns, not regex**.
+**Evaluation order:** deny rules are checked first — before the permission mode, the tool-level
+lists and the session-level allow list — so they hold under `mode = "auto"`, for always-allowed
+tools, and after an `allow_for_session` approval (which records only the bare tool name, so it
+would otherwise whitelist every later Bash command). `bypassPermissions` is the one deliberate way
+past them. Allow rules are evaluated after the tool-level lists, and anything unmatched is denied
+("No matching allow rule").
+
+Paths are normalized to absolute, symlink-resolved paths before matching (prevents traversal
+attacks); glob patterns support `*` (single directory) and `**` (recursive). `patterns` are **Lua
+patterns, not regex**.
 
 **Default deny rules:** `permissions.default_deny_rules` (default `true`) prepends bundled deny
 rules for destructive Bash commands — `rm -rf /` or `$HOME`, `sudo`/`doas`, raw device writes

--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -43,7 +43,8 @@ require("vibing").setup({
         message = "Cannot modify sensitive files",
       },
       { tools = { "Bash" }, commands = { "npm", "yarn" }, action = "allow" },
-      { tools = { "Bash" }, patterns = { "^rm -rf", "^sudo", "^dd if=" }, action = "deny" },
+      -- Lua patterns, NOT regex: "-" is a quantifier, so escape it as "%-"
+      { tools = { "Bash" }, patterns = { "^rm%s+%-rf", "^sudo%f[%W]" }, action = "deny" },
       {
         tools = { "WebFetch", "WebSearch" },
         domains = { "github.com", "*.npmjs.com", "docs.rs" },
@@ -57,10 +58,19 @@ require("vibing").setup({
 Fields: `tools` (target tools), `paths` (glob, for Read/Write/Edit), `commands`/`patterns` (Bash),
 `domains` (WebFetch/WebSearch), `action` (`allow`/`deny`), `message` (optional, for deny rules).
 
-**Evaluation order:** deny rules are checked first (any match blocks immediately) → allow rules
-second → default deny if nothing matches ("No matching allow rule"). Paths are normalized to
-absolute, symlink-resolved paths before matching (prevents traversal attacks); glob patterns
-support `*` (single directory) and `**` (recursive).
+**Evaluation order:** deny rules are checked first — before the permission mode and the tool-level
+lists, so they hold under `mode = "auto"` and for always-allowed tools (`bypassPermissions` is the
+one deliberate way past them) → allow rules after the tool-level lists → default deny if nothing
+matches ("No matching allow rule"). Paths are normalized to absolute, symlink-resolved paths
+before matching (prevents traversal attacks); glob patterns support `*` (single directory) and
+`**` (recursive). `patterns` are **Lua patterns, not regex**.
+
+**Default deny rules:** `permissions.default_deny_rules` (default `true`) prepends bundled deny
+rules for destructive Bash commands — `rm -rf /` or `$HOME`, `sudo`/`doas`, raw device writes
+(`dd`/`mkfs`), `chmod -R 777`, and force-pushing main/master. They are defined in
+`lua/vibing/core/constants/destructive_commands.lua`; see `docs/configuration.md` → "Default Deny
+Rules" for the list and its known gaps. The approval UI is the last line of defence, not the
+primary one — the deterministic boundary comes first.
 
 ## Interactive Permission Builder
 

--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -58,23 +58,17 @@ require("vibing").setup({
 Fields: `tools` (target tools), `paths` (glob, for Read/Write/Edit), `commands`/`patterns` (Bash),
 `domains` (WebFetch/WebSearch), `action` (`allow`/`deny`), `message` (optional, for deny rules).
 
-**Evaluation order:** deny rules are checked first — before the permission mode, the tool-level
-lists and the session-level allow list — so they hold under `mode = "auto"`, for always-allowed
-tools, and after an `allow_for_session` approval (which records only the bare tool name, so it
-would otherwise whitelist every later Bash command). `bypassPermissions` is the one deliberate way
-past them. Allow rules are evaluated after the tool-level lists, and anything unmatched is denied
-("No matching allow rule").
-
-Paths are normalized to absolute, symlink-resolved paths before matching (prevents traversal
-attacks); glob patterns support `*` (single directory) and `**` (recursive). `patterns` are **Lua
-patterns, not regex**.
+**Evaluation order (the part worth knowing before editing `can_use_tool.lua`):** deny rules are
+checked before the permission mode, the tool-level lists _and_ the session-level allow list. That
+last one is the non-obvious constraint — `allow_for_session` records only the bare tool name, so
+evaluating it first would let one approved `Bash` call whitelist every later one. Allow rules run
+after the tool-level lists. Full field/matching table and the rest of the ordering:
+`docs/configuration.md` → "Granular Permission Rules". `patterns` are **Lua patterns, not regex**.
 
 **Default deny rules:** `permissions.default_deny_rules` (default `true`) prepends bundled deny
-rules for destructive Bash commands — `rm -rf /` or `$HOME`, `sudo`/`doas`, raw device writes
-(`dd`/`mkfs`), `chmod -R 777`, and force-pushing main/master. They are defined in
-`lua/vibing/core/constants/destructive_commands.lua`; see `docs/configuration.md` → "Default Deny
-Rules" for the list and its known gaps. The approval UI is the last line of defence, not the
-primary one — the deterministic boundary comes first.
+rules for destructive Bash commands, defined in
+`lua/vibing/core/constants/destructive_commands.lua`. The blocked list and its known gaps live in
+`docs/configuration.md` → "Default Deny Rules".
 
 ## Interactive Permission Builder
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,7 +408,7 @@ over as one command. The full list lives in
 Known gaps — these are a safety net, not a sandbox:
 
 - Split short flags (`rm -r -f /`) and obfuscation (`$(echo rm) -rf /`) are not matched. Combined
-  short flags (`-rf`) and GNU longform (`--recursive`) are.
+  short flags (`-rf`), GNU longform (`--recursive`) and quoted targets (`rm -rf "$HOME"`) are.
 - Matching is case-sensitive; every command covered here is a lowercase Unix command name.
 - A bare `git push --force` is allowed, because a pattern cannot know which branch it lands on.
   Naming the branch is caught in either flag order (`--force origin main` and `origin main

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,8 +400,9 @@ permissions = {
 | World-writable trees                 | `chmod -R 777 .`                                              |
 | Force-pushing main/master            | `git push --force origin main` (`--force-with-lease` is fine) |
 
-They match after shell separators too, so `cd /tmp && sudo rm -rf /` is caught, not just a command
-at the start of the line. The full list lives in
+They match after shell separators **and after newlines**, so both `cd /tmp && sudo rm -rf /` and a
+`sudo` on the second line of a multi-line script are caught — the Bash tool hands a whole script
+over as one command. The full list lives in
 `lua/vibing/core/constants/destructive_commands.lua`.
 
 Known gaps — these are a safety net, not a sandbox:
@@ -410,6 +411,8 @@ Known gaps — these are a safety net, not a sandbox:
   short flags (`-rf`) and GNU longform (`--recursive`) are.
 - Matching is case-sensitive; every command covered here is a lowercase Unix command name.
 - A bare `git push --force` is allowed, because a pattern cannot know which branch it lands on.
+  Naming the branch is caught in either flag order (`--force origin main` and `origin main
+--force`), and a branch that merely starts with main/master (`main-v2`) is not.
 - `permissions.deny`/`allow` cannot switch off an individual bundled rule; use
   `default_deny_rules = false` and re-add the ones you want to `rules`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -374,10 +374,45 @@ Field reference:
 
 Evaluation notes:
 
-- Rules are evaluated **after** the tool-level `allow`/`ask` lists.
-- Any matching `deny` rule blocks immediately and beats every `allow` rule.
+- `deny` rules run **before** the permission mode and the tool-level lists, so a denied call stays
+  denied even under `mode = "auto"` and for always-allowed tools. `mode = "bypassPermissions"` is
+  the one deliberate way past them.
+- `allow` rules are evaluated **after** the tool-level `allow`/`ask` lists.
 - A rule whose condition doesn't apply to the tool's input (e.g. `paths` on a `Bash` call)
   is skipped.
+
+## Default Deny Rules
+
+vibing.nvim ships deny rules for a small set of destructive Bash commands, enabled by default:
+
+```lua
+permissions = {
+  default_deny_rules = true,  -- set to false to ship nothing and rely on your own rules
+}
+```
+
+| Blocked                              | Examples                                                      |
+| ------------------------------------ | ------------------------------------------------------------- |
+| Recursive deletion of `/` or `$HOME` | `rm -rf /`, `rm -rf /*`, `rm -rf ~`, `rm -rf $HOME`           |
+| Privilege escalation                 | `sudo ...`, `doas ...`                                        |
+| Raw device writes                    | `dd if=... of=/dev/sda`, `mkfs.ext4 /dev/sda1`                |
+| World-writable trees                 | `chmod -R 777 .`                                              |
+| Force-pushing main/master            | `git push --force origin main` (`--force-with-lease` is fine) |
+
+They match after shell separators too, so `cd /tmp && sudo rm -rf /` is caught, not just a command
+at the start of the line. The full list lives in
+`lua/vibing/core/constants/destructive_commands.lua`.
+
+Known gaps — these are a safety net, not a sandbox:
+
+- Split flags (`rm -r -f /`) and obfuscation (`$(echo rm) -rf /`) are not matched.
+- A bare `git push --force` is allowed, because a pattern cannot know which branch it lands on.
+- `permissions.deny`/`allow` cannot switch off an individual bundled rule; use
+  `default_deny_rules = false` and re-add the ones you want to `rules`.
+
+The point is that the boundary is drawn in the environment rather than in an approval prompt:
+prompts are approved reflexively most of the time, so they are a last line of defence, not the
+primary one.
 
 ## MCP
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -374,9 +374,10 @@ Field reference:
 
 Evaluation notes:
 
-- `deny` rules run **before** the permission mode and the tool-level lists, so a denied call stays
-  denied even under `mode = "auto"` and for always-allowed tools. `mode = "bypassPermissions"` is
-  the one deliberate way past them.
+- `deny` rules run **before** the permission mode, the tool-level lists, and any session-level
+  grant, so a denied call stays denied under `mode = "auto"`, for always-allowed tools, and after
+  an "allow for this session" approval. `mode = "bypassPermissions"` is the one deliberate way
+  past them.
 - `allow` rules are evaluated **after** the tool-level `allow`/`ask` lists.
 - A rule whose condition doesn't apply to the tool's input (e.g. `paths` on a `Bash` call)
   is skipped.
@@ -405,7 +406,9 @@ at the start of the line. The full list lives in
 
 Known gaps — these are a safety net, not a sandbox:
 
-- Split flags (`rm -r -f /`) and obfuscation (`$(echo rm) -rf /`) are not matched.
+- Split short flags (`rm -r -f /`) and obfuscation (`$(echo rm) -rf /`) are not matched. Combined
+  short flags (`-rf`) and GNU longform (`--recursive`) are.
+- Matching is case-sensitive; every command covered here is a lowercase Unix command name.
 - A bare `git push --force` is allowed, because a pattern cannot know which branch it lands on.
 - `permissions.deny`/`allow` cannot switch off an individual bundled rule; use
   `default_deny_rules = false` and re-add the ones you want to `rules`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -396,8 +396,8 @@ permissions = {
 | ------------------------------------ | ------------------------------------------------------------- |
 | Recursive deletion of `/` or `$HOME` | `rm -rf /`, `rm -rf /*`, `rm -rf ~`, `rm -rf $HOME`           |
 | Privilege escalation                 | `sudo ...`, `doas ...`                                        |
-| Raw device writes                    | `dd if=... of=/dev/sda`, `mkfs.ext4 /dev/sda1`                |
-| World-writable trees                 | `chmod -R 777 .`                                              |
+| Raw device writes                    | `dd ... of=/dev/sda`, `mkfs.ext4 /dev/sda1`                   |
+| World-writable trees                 | `chmod -R 777 .`, `chmod 777 -R .`                            |
 | Force-pushing main/master            | `git push --force origin main` (`--force-with-lease` is fine) |
 
 They match after shell separators **and after newlines**, so both `cd /tmp && sudo rm -rf /` and a
@@ -409,6 +409,12 @@ Known gaps — these are a safety net, not a sandbox:
 
 - Split short flags (`rm -r -f /`) and obfuscation (`$(echo rm) -rf /`) are not matched. Combined
   short flags (`-rf`), GNU longform (`--recursive`) and quoted targets (`rm -rf "$HOME"`) are.
+- Flag order does not matter. GNU `getopt_long` permutes options, so `rm / -rf` and
+  `chmod 777 -R .` run exactly as their flag-first spellings do and are matched the same way.
+- `dd` is judged by its write target only: `dd ... of=/dev/...` is blocked, an ordinary
+  file-to-file copy such as `dd if=backup.img of=backup2.img` is not.
+- Matching never reaches across a newline to assemble a hit from two different lines, but it
+  cannot tell a real command from the same text quoted inside an `echo` on its own line.
 - Matching is case-sensitive; every command covered here is a lowercase Unix command name.
 - A bare `git push --force` is allowed, because a pattern cannot know which branch it lands on.
   Naming the branch is caught in either flag order (`--force origin main` and `origin main

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -59,7 +59,7 @@
 ---@field tools string[] 対象ツール名のリスト（例: {"Read", "Write"}）
 ---@field paths string[]? ファイルパスのglobパターンリスト（例: {"src/**", "tests/**"}）
 ---@field commands string[]? Bashコマンド名のリスト（例: {"npm", "yarn"}）
----@field patterns string[]? Bashコマンドパターン（正規表現）のリスト（例: {"^rm -rf", "^sudo"}）
+---@field patterns string[]? Bashコマンドパターン（**Lua pattern**であって正規表現ではない）のリスト（例: {"^rm%s+%-rf", "^sudo%f[%W]"}）。`-`は量指定子なのでリテラルは`%-`とエスケープすること
 ---@field domains string[]? 許可/拒否するドメインリスト（例: {"github.com", "*.example.com"}）
 ---@field action "allow"|"deny" ルールのアクション（"allow": 許可、"deny": 拒否）
 ---@field message string? 拒否時のメッセージ（actionが"deny"の場合に表示）
@@ -73,6 +73,7 @@
 ---@field deny string[] 拒否するツールリスト（例: {"Bash"}、危険なツールを明示的に禁止）
 ---@field ask string[] 確認が必要なツールリスト（例: {"Bash"}、使用前に承認を要求）
 ---@field rules Vibing.PermissionRule[]? 粒度の細かい権限制御ルール（オプション）
+---@field default_deny_rules boolean? 破壊的Bashコマンド（`rm -rf /`、`sudo`、`dd`、`chmod -R 777`、main/masterへのforce push等）の同梱denyルールを有効にするか（デフォルト: true）。`core/constants/destructive_commands.lua`を参照
 
 ---@class Vibing.AgentConfig
 ---Agent SDK設定
@@ -284,6 +285,7 @@ M.defaults = {
     deny = { "Bash" },
     ask = {},
     rules = {},
+    default_deny_rules = true,
   },
   node = {
     executable = "auto",

--- a/lua/vibing/core/constants/destructive_commands.lua
+++ b/lua/vibing/core/constants/destructive_commands.lua
@@ -16,14 +16,23 @@
 ---扱うのはいずれも小文字固定のUnixコマンド名なので、これは意図的な割り切り。
 local M = {}
 
----コマンド位置（行頭、または`;` `&&` `||` `|` の直後）に現れる`command`にマッチするパターン群
+---コマンド位置（先頭、または`;` `&&` `||` `|` 改行の直後）に現れる`command`にマッチするパターン群。
+---Bashツールは複数行スクリプトを1つの`command`として渡してくるので、改行も区切りとして扱わないと
+---2行目以降のコマンドが素通りする。
 ---@param command string Lua pattern（コマンド名部分）
 ---@return string[]
 local function at_command_position(command)
   return {
     "^%s*" .. command,
-    "[;&|]%s*" .. command,
+    "[;&|\n]%s*" .. command,
   }
+end
+
+---トークンの終端（空白 or 文字列末尾）。`%f[%s]`だけだと末尾のトークンを取りこぼす。
+---@param token string Lua pattern
+---@return string[]
+local function token_end(token)
+  return { token .. "%f[%s]", token .. "$" }
 end
 
 ---複数のパターン配列を連結する
@@ -61,6 +70,35 @@ local function rm_patterns(targets)
   return patterns
 end
 
+---main/masterへのforce pushを表すパターン群を展開する。
+---`git push`はフラグの位置を問わないので、`--force origin main`と`origin main --force`の
+---両方の並び順を生成する必要がある（Lua patternに選択がないため）。
+---ブランチ名は空白/末尾で区切られたトークンとしてのみ一致させる。`%f[%W]`だけだと`-`も境界に
+---なってしまい、`main-v2`のような別ブランチを誤検知する。
+---@return string[]
+local function git_force_push_patterns()
+  local PREFIX = "git%s+push%s+"
+  local SEGMENT = "[^;&|\n]*"
+  -- 長形式と短縮クラスタ（`-f`, `-uf` ...）。`--force-with-lease`はいずれにも一致しない。
+  local FORCE_FLAGS = { "%-%-force", "%-%a*f%a*" }
+  local BRANCHES = { "main", "master" }
+
+  local patterns = {}
+  for _, flag in ipairs(FORCE_FLAGS) do
+    for _, branch in ipairs(BRANCHES) do
+      for _, branch_token in ipairs(token_end("%s" .. branch)) do
+        -- フラグが先: git push --force origin main
+        table.insert(patterns, PREFIX .. SEGMENT .. flag .. "%f[%s]" .. SEGMENT .. branch_token)
+      end
+      for _, flag_token in ipairs(token_end(flag)) do
+        -- ブランチが先: git push origin main --force
+        table.insert(patterns, PREFIX .. SEGMENT .. "%s" .. branch .. "%f[%s]" .. SEGMENT .. flag_token)
+      end
+    end
+  end
+  return patterns
+end
+
 ---@type PermissionRule[]
 M.DEFAULT_DENY_RULES = {
   {
@@ -89,8 +127,9 @@ M.DEFAULT_DENY_RULES = {
   {
     tools = { "Bash" },
     patterns = concat(
-      -- dd writing to a raw device, and filesystem creation
-      { "dd%s+[^;&|]*of=/dev/" },
+      -- dd writing to a raw device, and filesystem creation.
+      -- `dd` is anchored at command position so "add"/"odd" cannot trip the rule.
+      at_command_position("dd%f[%W][^;&|]*of=/dev/"),
       at_command_position("dd%s+if="),
       at_command_position("mkfs%f[%W]"),
       at_command_position("mkfs%.")
@@ -112,14 +151,9 @@ M.DEFAULT_DENY_RULES = {
   {
     -- Only force-pushes that name main/master are matched: a Lua pattern cannot know which branch
     -- a bare `git push --force` would land on. `--force-with-lease` is deliberately allowed —
-    -- `%f[%s]` requires whitespace right after "force".
+    -- the flag must be followed by whitespace or end there, and "force-with-lease" is neither.
     tools = { "Bash" },
-    patterns = {
-      "git%s+push%s+[^;&|]*%-%-force%f[%s][^;&|]*%f[%w]main%f[%W]",
-      "git%s+push%s+[^;&|]*%-%-force%f[%s][^;&|]*%f[%w]master%f[%W]",
-      "git%s+push%s+[^;&|]*%-%a*f%a*%f[%s][^;&|]*%f[%w]main%f[%W]",
-      "git%s+push%s+[^;&|]*%-%a*f%a*%f[%s][^;&|]*%f[%w]master%f[%W]",
-    },
+    patterns = git_force_push_patterns(),
     action = "deny",
     message = "Force-pushing main/master is blocked by vibing.nvim's default deny rules. "
       .. "Use --force-with-lease on a feature branch, or set permissions.default_deny_rules = false.",

--- a/lua/vibing/core/constants/destructive_commands.lua
+++ b/lua/vibing/core/constants/destructive_commands.lua
@@ -1,0 +1,107 @@
+---@class Vibing.Core.DestructiveCommandsConstants
+---Bashコマンドのうち、デフォルトで拒否する破壊的操作のルール定義。
+---
+---承認プロンプトは主防御にならない（ユーザーは大半を素通り承認する）ため、環境層に決定論的な
+---境界を先に引く。これらは`permissions.rules`の先頭に差し込まれ、deny優先で評価される。
+---`permissions.default_deny_rules = false`で無効化できる。
+---
+---**パターンはLua patternであって正規表現ではない**。`-`は量指定子、`$`は行末アンカーなので、
+---リテラルとして書きたい文字は`%`でエスケープすること（`^rm -rf /`は "rm" + 空白0個以上 + "rf /"
+---と解釈され、実際の`rm -rf /`にマッチしない）。
+---
+---意図的に`^`で先頭固定していない。`cd /tmp && sudo rm -rf /`のように、パイプや`&&`の後ろに
+---現れる破壊的コマンドも捕まえるため。
+local M = {}
+
+---コマンド位置（行頭、または`;` `&&` `||` `|` の直後）に現れる`command`にマッチするパターン群
+---@param command string Lua pattern（コマンド名部分）
+---@return string[]
+local function at_command_position(command)
+  return {
+    "^%s*" .. command,
+    "[;&|]%s*" .. command,
+  }
+end
+
+---複数のパターン配列を連結する
+---@param ... string[]
+---@return string[]
+local function concat(...)
+  local result = {}
+  for _, list in ipairs({ ... }) do
+    for _, pattern in ipairs(list) do
+      table.insert(result, pattern)
+    end
+  end
+  return result
+end
+
+---`rm`の再帰削除フラグ（`-rf` / `-fr` / `-Rf` ...）
+local RM_RECURSIVE = "rm%s+%-%a*[rR]%a*%s+"
+
+---@type PermissionRule[]
+M.DEFAULT_DENY_RULES = {
+  {
+    tools = { "Bash" },
+    patterns = {
+      -- rm -rf / , rm -rf /* , rm -rf / --no-preserve-root
+      RM_RECURSIVE .. "/%s*$",
+      RM_RECURSIVE .. "/%s",
+      RM_RECURSIVE .. "/%*",
+      -- rm -rf ~ , rm -rf ~/ , rm -rf $HOME
+      RM_RECURSIVE .. "~",
+      RM_RECURSIVE .. "%$HOME",
+      RM_RECURSIVE .. "%${HOME}",
+    },
+    action = "deny",
+    message = "Recursive deletion of / or the home directory is blocked by vibing.nvim's default "
+      .. "deny rules. Delete a specific path instead, or set permissions.default_deny_rules = false.",
+  },
+  {
+    tools = { "Bash" },
+    patterns = concat(at_command_position("sudo%f[%W]"), at_command_position("doas%f[%W]")),
+    action = "deny",
+    message = "Running commands as root is blocked by vibing.nvim's default deny rules. "
+      .. "Run it yourself in a terminal, or set permissions.default_deny_rules = false.",
+  },
+  {
+    tools = { "Bash" },
+    patterns = concat(
+      -- dd writing to a raw device, and filesystem creation
+      { "dd%s+[^;&|]*of=/dev/" },
+      at_command_position("dd%s+if="),
+      at_command_position("mkfs%f[%W]"),
+      at_command_position("mkfs%.")
+    ),
+    action = "deny",
+    message = "Writing raw devices or creating filesystems is blocked by vibing.nvim's default "
+      .. "deny rules. Set permissions.default_deny_rules = false if you really need this.",
+  },
+  {
+    tools = { "Bash" },
+    patterns = {
+      "chmod%s+[^;&|]*%-%a*[rR]%a*%s+0?777",
+      "chmod%s+[^;&|]*%-%-recursive%s+0?777",
+    },
+    action = "deny",
+    message = "Recursively making a tree world-writable is blocked by vibing.nvim's default deny "
+      .. "rules. Set a narrower mode, or set permissions.default_deny_rules = false.",
+  },
+  {
+    -- Only force-pushes that name main/master are matched: a Lua pattern cannot know which branch
+    -- a bare `git push --force` would land on. `--force-with-lease` is deliberately allowed —
+    -- `%f[%s]` requires whitespace right after "force".
+    tools = { "Bash" },
+    patterns = {
+      "git%s+push%s+[^;&|]*%-%-force%f[%s][^;&|]*%f[%w]main%f[%W]",
+      "git%s+push%s+[^;&|]*%-%-force%f[%s][^;&|]*%f[%w]master%f[%W]",
+      "git%s+push%s+[^;&|]*%-%a*f%a*%f[%s][^;&|]*%f[%w]main%f[%W]",
+      "git%s+push%s+[^;&|]*%-%a*f%a*%f[%s][^;&|]*%f[%w]master%f[%W]",
+    },
+    action = "deny",
+    message = "Force-pushing main/master is blocked by vibing.nvim's default deny rules. "
+      .. "Use --force-with-lease on a feature branch, or set permissions.default_deny_rules = false.",
+  },
+}
+
+return M

--- a/lua/vibing/core/constants/destructive_commands.lua
+++ b/lua/vibing/core/constants/destructive_commands.lua
@@ -28,6 +28,10 @@ local function at_command_position(command)
   }
 end
 
+---引数を囲むクォート（任意）。`rm -rf "$HOME"`のようにクォートするのはshellcheckも勧める
+---普通の書き方で、難読化ではない。
+local QUOTE = "[\"']?"
+
 ---トークンの終端（空白 or 文字列末尾）。`%f[%s]`だけだと末尾のトークンを取りこぼす。
 ---@param token string Lua pattern
 ---@return string[]
@@ -52,9 +56,11 @@ end
 ---それぞれ別パターンとして持つ。Lua patternに選択（`|`）がないため、ターゲットごとに両方を展開する。
 ---`[%-%a%s]*`はフラグらしい文字しか含まないので、`rm --recursive ./dist/`のターゲット部分を
 ---巻き込んでしまうことがない（`.`や`/`がクラスに入っていない）。
+---`%f[%w]`で単語境界を要求する。コマンド位置への固定ではないのは、`find . | xargs rm -rf /`の
+---ような形も捕まえたいため。境界だけ見れば`xterm -rf /`の誤検知は防げる。
 local RM_RECURSIVE_FLAGS = {
-  "rm%s+%-%a*[rR]%a*%s+",
-  "rm%s+[%-%a%s]*%-%-recursive[%-%a%s]*%s",
+  "%f[%w]rm%s+%-%a*[rR]%a*%s+",
+  "%f[%w]rm%s+[%-%a%s]*%-%-recursive[%-%a%s]*%s",
 }
 
 ---再帰削除フラグ × 危険なターゲットの組み合わせを展開する
@@ -77,7 +83,10 @@ end
 ---なってしまい、`main-v2`のような別ブランチを誤検知する。
 ---@return string[]
 local function git_force_push_patterns()
-  local PREFIX = "git%s+push%s+"
+  -- `git -C /path push ...` や `git --no-pager push ...` のように、gitとpushの間にグローバル
+  -- オプションが挟まる形も拾う。クラスにクォートを含めないので、`git commit -m "push ..."` の
+  -- ようなメッセージ中の push は跨げない。
+  local PREFIX = "git%s+[%-%w%./_%s]*push%s+"
   local SEGMENT = "[^;&|\n]*"
   -- 長形式と短縮クラスタ（`-f`, `-uf` ...）。`--force-with-lease`はいずれにも一致しない。
   local FORCE_FLAGS = { "%-%-force", "%-%a*f%a*" }
@@ -86,13 +95,16 @@ local function git_force_push_patterns()
   local patterns = {}
   for _, flag in ipairs(FORCE_FLAGS) do
     for _, branch in ipairs(BRANCHES) do
-      for _, branch_token in ipairs(token_end("%s" .. branch)) do
+      for _, branch_token in ipairs(token_end("%s" .. QUOTE .. branch .. QUOTE)) do
         -- フラグが先: git push --force origin main
         table.insert(patterns, PREFIX .. SEGMENT .. flag .. "%f[%s]" .. SEGMENT .. branch_token)
       end
       for _, flag_token in ipairs(token_end(flag)) do
         -- ブランチが先: git push origin main --force
-        table.insert(patterns, PREFIX .. SEGMENT .. "%s" .. branch .. "%f[%s]" .. SEGMENT .. flag_token)
+        table.insert(
+          patterns,
+          PREFIX .. SEGMENT .. "%s" .. QUOTE .. branch .. QUOTE .. "%f[%s]" .. SEGMENT .. flag_token
+        )
       end
     end
   end
@@ -104,14 +116,14 @@ M.DEFAULT_DENY_RULES = {
   {
     tools = { "Bash" },
     patterns = rm_patterns({
-      -- / , /* , / --no-preserve-root
-      "/%s*$",
-      "/%s",
-      "/%*",
-      -- ~ , ~/ , $HOME , ${HOME}
-      "~",
-      "%$HOME",
-      "%${HOME}",
+      -- / , "/" , / --no-preserve-root , /*
+      QUOTE .. "/" .. QUOTE .. "%s*$",
+      QUOTE .. "/" .. QUOTE .. "%s",
+      QUOTE .. "/%*",
+      -- ~ , ~/ , $HOME , ${HOME} , and the quoted forms of each
+      QUOTE .. "~",
+      QUOTE .. "%$HOME",
+      QUOTE .. "%${HOME}",
     }),
     action = "deny",
     message = "Recursive deletion of / or the home directory is blocked by vibing.nvim's default "

--- a/lua/vibing/core/constants/destructive_commands.lua
+++ b/lua/vibing/core/constants/destructive_commands.lua
@@ -16,16 +16,18 @@
 ---扱うのはいずれも小文字固定のUnixコマンド名なので、これは意図的な割り切り。
 local M = {}
 
----コマンド位置（先頭、または`;` `&&` `||` `|` 改行の直後）に現れる`command`にマッチするパターン群。
+---コマンド位置（先頭、または`;` `&&` `||` `|` 改行の直後）に現れるコマンドにマッチするパターン群。
 ---Bashツールは複数行スクリプトを1つの`command`として渡してくるので、改行も区切りとして扱わないと
 ---2行目以降のコマンドが素通りする。
----@param command string Lua pattern（コマンド名部分）
+---@param ... string Lua pattern（コマンド名部分）
 ---@return string[]
-local function at_command_position(command)
-  return {
-    "^%s*" .. command,
-    "[;&|\n]%s*" .. command,
-  }
+local function at_command_position(...)
+  local patterns = {}
+  for _, command in ipairs({ ... }) do
+    table.insert(patterns, "^%s*" .. command)
+    table.insert(patterns, "[;&|\n]%s*" .. command)
+  end
+  return patterns
 end
 
 ---引数を囲むクォート（任意）。`rm -rf "$HOME"`のようにクォートするのはshellcheckも勧める
@@ -39,38 +41,40 @@ local function token_end(token)
   return { token .. "%f[%s]", token .. "$" }
 end
 
----複数のパターン配列を連結する
----@param ... string[]
+---再帰フラグを`prefix`と`suffix`で挟んだパターンに展開する。短縮クラスタ（`-rf` / `-fr` /
+---`-R` ...）とGNUのlongform（`--recursive`）は別々に書くしかない（Lua patternに選択がない）。
+---longformの前後の`[%-%a%s]*`は`rm -f --recursive /`のように他のフラグと並ぶ形のための穴埋めで、
+---フラグらしい文字しか含まないのでターゲットの`.`や`/`を巻き込まない。
+---@param prefix string フラグの手前（コマンド名まで）
+---@param suffix string フラグの後ろ（ターゲット）
 ---@return string[]
-local function concat(...)
-  local result = {}
-  for _, list in ipairs({ ... }) do
-    for _, pattern in ipairs(list) do
-      table.insert(result, pattern)
-    end
-  end
-  return result
+local function recursive_variants(prefix, suffix)
+  return {
+    prefix .. "%-%a*[rR]%a*%s+" .. suffix,
+    prefix .. "[%-%a%s]*%-%-recursive[%-%a%s]*%s" .. suffix,
+  }
 end
 
----`rm`の再帰削除フラグ。短縮形（`-rf` / `-fr` / `-Rf` ...）とGNUのlongform（`--recursive`）を
----それぞれ別パターンとして持つ。Lua patternに選択（`|`）がないため、ターゲットごとに両方を展開する。
----`[%-%a%s]*`はフラグらしい文字しか含まないので、`rm --recursive ./dist/`のターゲット部分を
----巻き込んでしまうことがない（`.`や`/`がクラスに入っていない）。
----`%f[%w]`で単語境界を要求する。コマンド位置への固定ではないのは、`find . | xargs rm -rf /`の
+---`rm`による再帰削除のうち、/ とホームディレクトリを狙うものを展開する。
+---`%f[%w]`で単語境界を要求するだけでコマンド位置には固定しない。`find . | xargs rm -rf /`の
 ---ような形も捕まえたいため。境界だけ見れば`xterm -rf /`の誤検知は防げる。
-local RM_RECURSIVE_FLAGS = {
-  "%f[%w]rm%s+%-%a*[rR]%a*%s+",
-  "%f[%w]rm%s+[%-%a%s]*%-%-recursive[%-%a%s]*%s",
-}
-
----再帰削除フラグ × 危険なターゲットの組み合わせを展開する
----@param targets string[] Lua pattern（フラグの直後に続く部分）
 ---@return string[]
-local function rm_patterns(targets)
+local function rm_deny_patterns()
+  local TARGETS = {
+    -- / , "/" , / --no-preserve-root , /*
+    QUOTE .. "/" .. QUOTE .. "%s*$",
+    QUOTE .. "/" .. QUOTE .. "%s",
+    QUOTE .. "/%*",
+    -- ~ , ~/ , $HOME , ${HOME} , and the quoted forms of each
+    QUOTE .. "~",
+    QUOTE .. "%$HOME",
+    QUOTE .. "%${HOME}",
+  }
+
   local patterns = {}
-  for _, flags in ipairs(RM_RECURSIVE_FLAGS) do
-    for _, target in ipairs(targets) do
-      table.insert(patterns, flags .. target)
+  for _, target in ipairs(TARGETS) do
+    for _, pattern in ipairs(recursive_variants("%f[%w]rm%s+", target)) do
+      table.insert(patterns, pattern)
     end
   end
   return patterns
@@ -95,80 +99,79 @@ local function git_force_push_patterns()
   local patterns = {}
   for _, flag in ipairs(FORCE_FLAGS) do
     for _, branch in ipairs(BRANCHES) do
-      for _, branch_token in ipairs(token_end("%s" .. QUOTE .. branch .. QUOTE)) do
+      local branch_token = "%s" .. QUOTE .. branch .. QUOTE
+      for _, terminated in ipairs(token_end(branch_token)) do
         -- フラグが先: git push --force origin main
-        table.insert(patterns, PREFIX .. SEGMENT .. flag .. "%f[%s]" .. SEGMENT .. branch_token)
+        table.insert(patterns, PREFIX .. SEGMENT .. flag .. "%f[%s]" .. SEGMENT .. terminated)
       end
-      for _, flag_token in ipairs(token_end(flag)) do
+      for _, terminated in ipairs(token_end(flag)) do
         -- ブランチが先: git push origin main --force
-        table.insert(
-          patterns,
-          PREFIX .. SEGMENT .. "%s" .. QUOTE .. branch .. QUOTE .. "%f[%s]" .. SEGMENT .. flag_token
-        )
+        table.insert(patterns, PREFIX .. SEGMENT .. branch_token .. "%f[%s]" .. SEGMENT .. terminated)
       end
     end
   end
   return patterns
 end
 
+---全ルール共通の逃げ道。文面を1か所に集約して、ルールごとの言い回しのブレをなくす。
+local ESCAPE_HATCH = "Set permissions.default_deny_rules = false to turn these defaults off."
+
+---@param reason string そのルール固有の説明
+---@return string
+local function deny_message(reason)
+  return reason .. " " .. ESCAPE_HATCH
+end
+
 ---@type PermissionRule[]
 M.DEFAULT_DENY_RULES = {
   {
     tools = { "Bash" },
-    patterns = rm_patterns({
-      -- / , "/" , / --no-preserve-root , /*
-      QUOTE .. "/" .. QUOTE .. "%s*$",
-      QUOTE .. "/" .. QUOTE .. "%s",
-      QUOTE .. "/%*",
-      -- ~ , ~/ , $HOME , ${HOME} , and the quoted forms of each
-      QUOTE .. "~",
-      QUOTE .. "%$HOME",
-      QUOTE .. "%${HOME}",
-    }),
+    patterns = rm_deny_patterns(),
     action = "deny",
-    message = "Recursive deletion of / or the home directory is blocked by vibing.nvim's default "
-      .. "deny rules. Delete a specific path instead, or set permissions.default_deny_rules = false.",
-  },
-  {
-    tools = { "Bash" },
-    patterns = concat(at_command_position("sudo%f[%W]"), at_command_position("doas%f[%W]")),
-    action = "deny",
-    message = "Running commands as root is blocked by vibing.nvim's default deny rules. "
-      .. "Run it yourself in a terminal, or set permissions.default_deny_rules = false.",
-  },
-  {
-    tools = { "Bash" },
-    patterns = concat(
-      -- dd writing to a raw device, and filesystem creation.
-      -- `dd` is anchored at command position so "add"/"odd" cannot trip the rule.
-      at_command_position("dd%f[%W][^;&|]*of=/dev/"),
-      at_command_position("dd%s+if="),
-      at_command_position("mkfs%f[%W]"),
-      at_command_position("mkfs%.")
+    message = deny_message(
+      "Recursive deletion of / or the home directory is blocked by vibing.nvim's default deny "
+        .. "rules. Delete a specific path instead."
     ),
-    action = "deny",
-    message = "Writing raw devices or creating filesystems is blocked by vibing.nvim's default "
-      .. "deny rules. Set permissions.default_deny_rules = false if you really need this.",
   },
   {
     tools = { "Bash" },
-    patterns = {
-      "chmod%s+[^;&|]*%-%a*[rR]%a*%s+0?777",
-      "chmod%s+[^;&|]*%-%-recursive%s+0?777",
-    },
+    patterns = at_command_position("sudo%f[%W]", "doas%f[%W]"),
     action = "deny",
-    message = "Recursively making a tree world-writable is blocked by vibing.nvim's default deny "
-      .. "rules. Set a narrower mode, or set permissions.default_deny_rules = false.",
+    message = deny_message(
+      "Running commands as root is blocked by vibing.nvim's default deny rules. Run it yourself "
+        .. "in a terminal."
+    ),
+  },
+  {
+    tools = { "Bash" },
+    -- dd writing to a raw device, and filesystem creation.
+    -- `dd` is anchored at command position so "add"/"odd" cannot trip the rule.
+    patterns = at_command_position("dd%f[%W][^;&|]*of=/dev/", "dd%s+if=", "mkfs%f[%W]", "mkfs%."),
+    action = "deny",
+    message = deny_message(
+      "Writing raw devices or creating filesystems is blocked by vibing.nvim's default deny rules."
+    ),
+  },
+  {
+    tools = { "Bash" },
+    patterns = recursive_variants("chmod%s+[^;&|]*", "0?777"),
+    action = "deny",
+    message = deny_message(
+      "Recursively making a tree world-writable is blocked by vibing.nvim's default deny rules. "
+        .. "Set a narrower mode."
+    ),
   },
   {
     -- Only force-pushes that name main/master are matched: a Lua pattern cannot know which branch
-    -- a bare `git push --force` would land on. `--force-with-lease` is deliberately allowed —
+    -- a bare `git push --force` would land on. `--force-with-lease` is deliberately allowed --
     -- the flag must be followed by whitespace or end there, and "force-with-lease" is neither.
     tools = { "Bash" },
     patterns = git_force_push_patterns(),
     action = "deny",
-    message = "Force-pushing main/master is blocked by vibing.nvim's default deny rules. "
-      .. "Use --force-with-lease on a feature branch, or set permissions.default_deny_rules = false.",
+    message = deny_message(
+      "Force-pushing main/master is blocked by vibing.nvim's default deny rules. Use "
+        .. "--force-with-lease on a feature branch."
+    ),
   },
 }
 

--- a/lua/vibing/core/constants/destructive_commands.lua
+++ b/lua/vibing/core/constants/destructive_commands.lua
@@ -11,6 +11,9 @@
 ---
 ---意図的に`^`で先頭固定していない。`cd /tmp && sudo rm -rf /`のように、パイプや`&&`の後ろに
 ---現れる破壊的コマンドも捕まえるため。
+---
+---マッチは大文字小文字を区別する（`rule_checker`が`command`をそのまま`:match`する）。ここで
+---扱うのはいずれも小文字固定のUnixコマンド名なので、これは意図的な割り切り。
 local M = {}
 
 ---コマンド位置（行頭、または`;` `&&` `||` `|` の直後）に現れる`command`にマッチするパターン群
@@ -36,23 +39,42 @@ local function concat(...)
   return result
 end
 
----`rm`の再帰削除フラグ（`-rf` / `-fr` / `-Rf` ...）
-local RM_RECURSIVE = "rm%s+%-%a*[rR]%a*%s+"
+---`rm`の再帰削除フラグ。短縮形（`-rf` / `-fr` / `-Rf` ...）とGNUのlongform（`--recursive`）を
+---それぞれ別パターンとして持つ。Lua patternに選択（`|`）がないため、ターゲットごとに両方を展開する。
+---`[%-%a%s]*`はフラグらしい文字しか含まないので、`rm --recursive ./dist/`のターゲット部分を
+---巻き込んでしまうことがない（`.`や`/`がクラスに入っていない）。
+local RM_RECURSIVE_FLAGS = {
+  "rm%s+%-%a*[rR]%a*%s+",
+  "rm%s+[%-%a%s]*%-%-recursive[%-%a%s]*%s",
+}
+
+---再帰削除フラグ × 危険なターゲットの組み合わせを展開する
+---@param targets string[] Lua pattern（フラグの直後に続く部分）
+---@return string[]
+local function rm_patterns(targets)
+  local patterns = {}
+  for _, flags in ipairs(RM_RECURSIVE_FLAGS) do
+    for _, target in ipairs(targets) do
+      table.insert(patterns, flags .. target)
+    end
+  end
+  return patterns
+end
 
 ---@type PermissionRule[]
 M.DEFAULT_DENY_RULES = {
   {
     tools = { "Bash" },
-    patterns = {
-      -- rm -rf / , rm -rf /* , rm -rf / --no-preserve-root
-      RM_RECURSIVE .. "/%s*$",
-      RM_RECURSIVE .. "/%s",
-      RM_RECURSIVE .. "/%*",
-      -- rm -rf ~ , rm -rf ~/ , rm -rf $HOME
-      RM_RECURSIVE .. "~",
-      RM_RECURSIVE .. "%$HOME",
-      RM_RECURSIVE .. "%${HOME}",
-    },
+    patterns = rm_patterns({
+      -- / , /* , / --no-preserve-root
+      "/%s*$",
+      "/%s",
+      "/%*",
+      -- ~ , ~/ , $HOME , ${HOME}
+      "~",
+      "%$HOME",
+      "%${HOME}",
+    }),
     action = "deny",
     message = "Recursive deletion of / or the home directory is blocked by vibing.nvim's default "
       .. "deny rules. Delete a specific path instead, or set permissions.default_deny_rules = false.",

--- a/lua/vibing/core/constants/destructive_commands.lua
+++ b/lua/vibing/core/constants/destructive_commands.lua
@@ -41,18 +41,43 @@ local function token_end(token)
   return { token .. "%f[%s]", token .. "$" }
 end
 
----再帰フラグを`prefix`と`suffix`で挟んだパターンに展開する。短縮クラスタ（`-rf` / `-fr` /
----`-R` ...）とGNUのlongform（`--recursive`）は別々に書くしかない（Lua patternに選択がない）。
----longformの前後の`[%-%a%s]*`は`rm -f --recursive /`のように他のフラグと並ぶ形のための穴埋めで、
----フラグらしい文字しか含まないのでターゲットの`.`や`/`を巻き込まない。
----@param prefix string フラグの手前（コマンド名まで）
----@param suffix string フラグの後ろ（ターゲット）
+---同一コマンド内の他の引数。`SEGMENT`と同じく改行は跨がない。Bashツールは複数行スクリプトを
+---1つの`command`として渡してくるので、跨げるようにすると別の行の文字列で誤検知する。
+local ARGS = "[^;&|\n]*"
+
+---フラグの並びだけを飛ばすための穴埋め。フラグらしい文字しか含まないのでターゲットの`.`や`/`を
+---巻き込まず、`%s`ではなく空白とタブに限ることで行も跨がない。
+local FLAG_FILLER = "[%-%a \t]*"
+
+---再帰フラグ。Lua patternに選択（`|`）がないので、短縮クラスタとGNUのlongformを別々に持つ。
+---短縮側の`%f[%-]`は「連続するダッシュの途中から」始まるのを禁じる。これが無いと`--force`や
+---`--verbose`が`-`+`...r...`として短縮クラスタに化け、`rm --force ~/notes`のような非再帰の
+---操作まで拾ってしまう。
+local RECURSIVE_FLAGS = {
+  "%f[%-]%-%a*[rR]%a*",
+  "%-%-recursive",
+}
+
+---再帰フラグとターゲットが「どちらが先でも」マッチするパターンを展開する。
+---GNUのgetopt_longはオプションを並べ替えるので、`rm / -rf`は`rm -rf /`と、`chmod 777 -R .`は
+---`chmod -R 777 .`と等価に動く。git pushで両方向を生成しているのと同じ理由。
+---@param prefix string コマンド名と直後の空白まで
+---@param target string ターゲット部分
+---@param endings string[] ターゲット直後に要求する終端（トークン境界）
 ---@return string[]
-local function recursive_variants(prefix, suffix)
-  return {
-    prefix .. "%-%a*[rR]%a*%s+" .. suffix,
-    prefix .. "[%-%a%s]*%-%-recursive[%-%a%s]*%s" .. suffix,
-  }
+local function either_order(prefix, target, endings)
+  local patterns = {}
+  for _, ending in ipairs(endings) do
+    for _, flag in ipairs(RECURSIVE_FLAGS) do
+      -- フラグが先: rm -rf /
+      table.insert(patterns, prefix .. FLAG_FILLER .. flag .. FLAG_FILLER .. "%s" .. target .. ending)
+      -- ターゲットが先: rm / -rf
+      for _, terminated in ipairs(token_end(flag)) do
+        table.insert(patterns, prefix .. target .. ending .. FLAG_FILLER .. terminated)
+      end
+    end
+  end
+  return patterns
 end
 
 ---`rm`による再帰削除のうち、/ とホームディレクトリを狙うものを展開する。
@@ -60,20 +85,19 @@ end
 ---ような形も捕まえたいため。境界だけ見れば`xterm -rf /`の誤検知は防げる。
 ---@return string[]
 local function rm_deny_patterns()
+  -- `/`だけは完全なトークンとして一致させる（そうしないと`rm -rf /home/x`まで巻き込む）。
+  -- 残りは前方一致でよい: `~/foo`や`$HOME/bar`も同じ危険度として扱う。
   local TARGETS = {
-    -- / , "/" , / --no-preserve-root , /*
-    QUOTE .. "/" .. QUOTE .. "%s*$",
-    QUOTE .. "/" .. QUOTE .. "%s",
-    QUOTE .. "/%*",
-    -- ~ , ~/ , $HOME , ${HOME} , and the quoted forms of each
-    QUOTE .. "~",
-    QUOTE .. "%$HOME",
-    QUOTE .. "%${HOME}",
+    { QUOTE .. "/" .. QUOTE, token_end("") },
+    { QUOTE .. "/%*", { "" } },
+    { QUOTE .. "~", { "" } },
+    { QUOTE .. "%$HOME", { "" } },
+    { QUOTE .. "%${HOME}", { "" } },
   }
 
   local patterns = {}
   for _, target in ipairs(TARGETS) do
-    for _, pattern in ipairs(recursive_variants("%f[%w]rm%s+", target)) do
+    for _, pattern in ipairs(either_order("%f[%w]rm%s+", target[1], target[2])) do
       table.insert(patterns, pattern)
     end
   end
@@ -146,7 +170,11 @@ M.DEFAULT_DENY_RULES = {
     tools = { "Bash" },
     -- dd writing to a raw device, and filesystem creation.
     -- `dd` is anchored at command position so "add"/"odd" cannot trip the rule.
-    patterns = at_command_position("dd%f[%W][^;&|]*of=/dev/", "dd%s+if=", "mkfs%f[%W]", "mkfs%."),
+    -- 危険なのは書き込み先で、読み込み元ではない。`dd%s+if=`という広い形も持っていたが、
+    -- `dd if=backup.img of=backup2.img`のような無害なファイルコピーまで拒否してしまう上、
+    -- 実際に塞ぎたいケースは`of=/dev/`側だけで足りる。
+    -- `mkfs%f[%W]`のfrontierは`.`の直前でも成立するので、`mkfs.ext4`もこれ1本で足りる。
+    patterns = at_command_position("dd%f[%W]" .. ARGS .. "of=/dev/", "mkfs%f[%W]"),
     action = "deny",
     message = deny_message(
       "Writing raw devices or creating filesystems is blocked by vibing.nvim's default deny rules."
@@ -154,7 +182,7 @@ M.DEFAULT_DENY_RULES = {
   },
   {
     tools = { "Bash" },
-    patterns = recursive_variants("chmod%s+[^;&|]*", "0?777"),
+    patterns = either_order("chmod%s+", "0?777", { "%f[%W]" }),
     action = "deny",
     message = deny_message(
       "Recursively making a tree world-writable is blocked by vibing.nvim's default deny rules. "

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -3,17 +3,18 @@
 ---
 --- Permission evaluation order (highest to lowest priority):
 --- 1. Session-level deny list (immediate block)
---- 2. Session-level allow list (auto-approve)
---- 3. Internal tools (always allowed, e.g. ToolSearch, Agent)
---- 3.5. bypassPermissions mode (bypasses deny list too)
+--- 2. Internal tools (always allowed, e.g. ToolSearch, Agent)
+--- 3. bypassPermissions mode (bypasses deny list too)
 --- 4. Deny list (deny takes precedence over allow)
---- 4.5. Deny rules (path/command/pattern/domain based) — before any mode shortcut, so the bundled
----      destructive-command rules hold under `auto` mode and for always-allowed tools
---- 5. Always-allowed tools (bypass allow list; deny/ask still respected)
---- 6. Permission modes (auto, acceptEdits, default; dontAsk changes ask→deny below)
---- 7. Allow list (with pattern matching support)
---- 8. Ask list (granular patterns override broader allow list permissions)
---- 9. Granular allow rules (path/command/pattern/domain based)
+--- 4.5. Deny rules (path/command/pattern/domain based) — before any mode shortcut or session
+---      grant, so the bundled destructive-command rules hold under `auto` mode, for
+---      always-allowed tools, and after an "allow_for_session" approval
+--- 5. Session-level allow list (auto-approve)
+--- 6. Always-allowed tools (bypass allow list; deny/ask still respected)
+--- 7. Permission modes (auto, acceptEdits, default; dontAsk changes ask→deny below)
+--- 8. Allow list (with pattern matching support)
+--- 9. Ask list (granular patterns override broader allow list permissions)
+--- 10. Granular allow rules (path/command/pattern/domain based)
 ---
 --- @module vibing.infrastructure.permissions.can_use_tool
 
@@ -194,20 +195,14 @@ function M.can_use_tool(tool_name, input, config)
       return session_deny_result
     end
 
-    -- 2. Session-level allow list
-    local session_allow_result = check_session_list(tool_name, input, config.session_allowed_tools, "allow")
-    if session_allow_result then
-      return session_allow_result
-    end
-
-    -- 3. Always allow Claude Code internal tools
+    -- 2. Always allow Claude Code internal tools
     if INTERNAL_TOOLS[tool_name] then
       return allow(input)
     end
 
     local mode = config.permission_mode
 
-    -- 3.5. bypassPermissions: truly bypass all operations including deny list
+    -- 3. bypassPermissions: truly bypass all operations including deny list
     if mode == "bypassPermissions" then
       return allow(input)
     end
@@ -221,10 +216,10 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
-    -- 4.5. Deny rules, before any mode shortcut can allow the call. The rules' documented
-    -- semantics are "deny is checked first", and the bundled destructive-command rules are only
-    -- a real boundary if `auto` mode and always-allowed tools cannot walk past them.
-    -- bypassPermissions (handled above) remains the one deliberate way out.
+    -- 4.5. Deny rules, before any mode shortcut or session grant can allow the call. The rules'
+    -- documented semantics are "deny is checked first", and the bundled destructive-command rules
+    -- are only a real boundary if `auto` mode, always-allowed tools and a session grant cannot
+    -- walk past them. bypassPermissions (handled above) remains the one deliberate way out.
     if config.permission_rules and #config.permission_rules > 0 then
       for _, rule in ipairs(config.permission_rules) do
         if rule.action == "deny" and rule_checker.check_rule(rule, tool_name, input) == "deny" then
@@ -233,7 +228,16 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
-    -- 5. Always-allowed tools: bypass allow list, but respect deny (checked above) and ask
+    -- 5. Session-level allow list. Deliberately after the deny checks: "allow_for_session" on a
+    -- Bash approval records the bare tool name, so it matches every later Bash call regardless of
+    -- its command. Approving `npm install` for the session must not thereby approve
+    -- `sudo rm -rf /`.
+    local session_allow_result = check_session_list(tool_name, input, config.session_allowed_tools, "allow")
+    if session_allow_result then
+      return session_allow_result
+    end
+
+    -- 6. Always-allowed tools: bypass allow list, but respect deny (checked above) and ask
     if tools_constants.ALWAYS_ALLOWED_TOOLS_MAP[tool_name] then
       for _, pattern in ipairs(config.asked_tools) do
         if matchers.matches_permission(tool_name, input, pattern) then
@@ -246,7 +250,7 @@ function M.can_use_tool(tool_name, input, config)
       return allow(input)
     end
 
-    -- 6. Permission modes
+    -- 7. Permission modes
     if mode == "auto" then
       return allow(input)
     end
@@ -266,7 +270,7 @@ function M.can_use_tool(tool_name, input, config)
       return deny("vibing.nvim MCP integration is disabled. Enable it in config: mcp.enabled = true")
     end
 
-    -- 7. Check allow list (with pattern support)
+    -- 8. Check allow list (with pattern support)
     if #config.allowed_tools > 0 then
       local is_allowed = false
       for _, pattern in ipairs(config.allowed_tools) do
@@ -283,7 +287,7 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
-    -- 8. Check ask list (AFTER allow list - granular patterns override broader permissions)
+    -- 9. Check ask list (AFTER allow list - granular patterns override broader permissions)
     for _, pattern in ipairs(config.asked_tools) do
       if matchers.matches_permission(tool_name, input, pattern) then
         if mode == "dontAsk" then
@@ -293,7 +297,7 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
-    -- 9. Check granular allow rules (deny rules already ran at step 4.5)
+    -- 10. Check granular allow rules (deny rules already ran at step 4.5)
     if config.permission_rules and #config.permission_rules > 0 then
       for _, rule in ipairs(config.permission_rules) do
         if rule.action ~= "deny" and rule_checker.check_rule(rule, tool_name, input) == "allow" then

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -7,11 +7,13 @@
 --- 3. Internal tools (always allowed, e.g. ToolSearch, Agent)
 --- 3.5. bypassPermissions mode (bypasses deny list too)
 --- 4. Deny list (deny takes precedence over allow)
+--- 4.5. Deny rules (path/command/pattern/domain based) — before any mode shortcut, so the bundled
+---      destructive-command rules hold under `auto` mode and for always-allowed tools
 --- 5. Always-allowed tools (bypass allow list; deny/ask still respected)
 --- 6. Permission modes (auto, acceptEdits, default; dontAsk changes ask→deny below)
 --- 7. Allow list (with pattern matching support)
 --- 8. Ask list (granular patterns override broader allow list permissions)
---- 9. Granular permission rules (path/command/pattern/domain based)
+--- 9. Granular allow rules (path/command/pattern/domain based)
 ---
 --- @module vibing.infrastructure.permissions.can_use_tool
 
@@ -219,6 +221,18 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
+    -- 4.5. Deny rules, before any mode shortcut can allow the call. The rules' documented
+    -- semantics are "deny is checked first", and the bundled destructive-command rules are only
+    -- a real boundary if `auto` mode and always-allowed tools cannot walk past them.
+    -- bypassPermissions (handled above) remains the one deliberate way out.
+    if config.permission_rules and #config.permission_rules > 0 then
+      for _, rule in ipairs(config.permission_rules) do
+        if rule.action == "deny" and rule_checker.check_rule(rule, tool_name, input) == "deny" then
+          return deny(rule.message or string.format("Tool %s is denied by permission rule", tool_name))
+        end
+      end
+    end
+
     -- 5. Always-allowed tools: bypass allow list, but respect deny (checked above) and ask
     if tools_constants.ALWAYS_ALLOWED_TOOLS_MAP[tool_name] then
       for _, pattern in ipairs(config.asked_tools) do
@@ -279,19 +293,12 @@ function M.can_use_tool(tool_name, input, config)
       end
     end
 
-    -- 9. Check granular permission rules
+    -- 9. Check granular allow rules (deny rules already ran at step 4.5)
     if config.permission_rules and #config.permission_rules > 0 then
-      local has_matching_allow = false
       for _, rule in ipairs(config.permission_rules) do
-        local rule_result = rule_checker.check_rule(rule, tool_name, input)
-        if rule_result == "deny" then
-          return deny(rule.message or string.format("Tool %s is denied by permission rule", tool_name))
-        elseif rule_result == "allow" then
-          has_matching_allow = true
+        if rule.action ~= "deny" and rule_checker.check_rule(rule, tool_name, input) == "allow" then
+          return allow(input)
         end
-      end
-      if has_matching_allow then
-        return allow(input)
       end
     end
 

--- a/lua/vibing/infrastructure/permissions/rule_checker.lua
+++ b/lua/vibing/infrastructure/permissions/rule_checker.lua
@@ -10,7 +10,7 @@ local M = {}
 --- @field tools string[] Tools this rule applies to
 --- @field paths? string[] Glob patterns for file paths
 --- @field commands? string[] Allowed/denied command names
---- @field patterns? string[] Regex patterns for command matching
+--- @field patterns? string[] Lua patterns (not regex) for command matching; escape `-` as `%-`
 --- @field domains? string[] Domain patterns for web requests
 --- @field action "allow"|"deny"
 --- @field message? string Custom error message

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -67,7 +67,7 @@ end
 --- can_use_tool checks every deny rule before any allow rule.
 --- @param perms table config.permissions
 --- @return PermissionRule[]
-local function resolve_permission_rules(perms)
+function M._resolve_permission_rules(perms)
   local user_rules = perms.rules or {}
 
   if perms.default_deny_rules == false then
@@ -94,7 +94,7 @@ local function build_permission_config(handle_id)
     asked_tools = o.permissions_ask or perms.ask or {},
     session_allowed_tools = session_state.allowed,
     session_denied_tools = session_state.denied,
-    permission_rules = resolve_permission_rules(perms),
+    permission_rules = M._resolve_permission_rules(perms),
     permission_mode = o.permission_mode or perms.mode or "default",
     mcp_enabled = config.mcp and config.mcp.enabled or false,
   }

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -62,6 +62,24 @@ local function get_active_opts(handle_id)
   return nil
 end
 
+--- Combine the bundled destructive-command deny rules with the user's own rules.
+--- The defaults go first so they read as the baseline, though order does not decide the outcome:
+--- can_use_tool checks every deny rule before any allow rule.
+--- @param perms table config.permissions
+--- @return PermissionRule[]
+local function resolve_permission_rules(perms)
+  local user_rules = perms.rules or {}
+
+  if perms.default_deny_rules == false then
+    return user_rules
+  end
+
+  local destructive = require("vibing.core.constants.destructive_commands")
+  local rules = vim.list_slice(destructive.DEFAULT_DENY_RULES)
+  vim.list_extend(rules, user_rules)
+  return rules
+end
+
 --- Build permission config from frontmatter opts (priority) or global config
 --- @param handle_id string|nil
 --- @return PermissionConfig
@@ -76,7 +94,7 @@ local function build_permission_config(handle_id)
     asked_tools = o.permissions_ask or perms.ask or {},
     session_allowed_tools = session_state.allowed,
     session_denied_tools = session_state.denied,
-    permission_rules = perms.rules or {},
+    permission_rules = resolve_permission_rules(perms),
     permission_mode = o.permission_mode or perms.mode or "default",
     mcp_enabled = config.mcp and config.mcp.enabled or false,
   }

--- a/tests/lua/core/constants/destructive_commands_spec.lua
+++ b/tests/lua/core/constants/destructive_commands_spec.lua
@@ -43,12 +43,26 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("echo prep\nrm -rf /"))
     end)
 
+    it("blocks the quoted forms, which are the shellcheck-recommended way to write them", function()
+      assert.is_true(is_denied('rm -rf "$HOME"'))
+      assert.is_true(is_denied("rm -rf '$HOME'"))
+      assert.is_true(is_denied('rm -rf "/"'))
+      assert.is_true(is_denied('rm -rf "~"'))
+    end)
+
     it("leaves ordinary deletions alone", function()
       assert.is_false(is_denied("rm -rf node_modules"))
       assert.is_false(is_denied("rm --recursive ./dist/"))
       assert.is_false(is_denied("rm -rf ./dist"))
       assert.is_false(is_denied("rm file.txt"))
       assert.is_false(is_denied("rm -rf /tmp/vibing-test"))
+      assert.is_false(is_denied('rm -rf "./dist"'))
+      -- A word merely ending in "rm" is not the rm command.
+      assert.is_false(is_denied("xterm -rf /"))
+    end)
+
+    it("still catches rm reached through a pipe, which is why it is not command-anchored", function()
+      assert.is_true(is_denied("find . -name '*.log' | xargs rm -rf /"))
     end)
   end)
 
@@ -120,6 +134,17 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("git push origin master -f"))
     end)
 
+    it("blocks a quoted branch name", function()
+      assert.is_true(is_denied('git push --force origin "main"'))
+      assert.is_true(is_denied("git push origin 'master' --force"))
+    end)
+
+    it("blocks it when a global git option sits before push", function()
+      -- `git -C <dir> push` is ordinary usage from a script or another directory.
+      assert.is_true(is_denied("git -C /path/to/repo push --force origin main"))
+      assert.is_true(is_denied("git --no-pager push -f origin master"))
+    end)
+
     it("allows --force-with-lease, and force-pushing other branches", function()
       assert.is_false(is_denied("git push --force-with-lease origin main"))
       assert.is_false(is_denied("git push --force origin my-feature"))
@@ -130,6 +155,10 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_false(is_denied("git push --force origin main-v2"))
       assert.is_false(is_denied("git push --force origin master-old"))
       assert.is_false(is_denied("git push origin mainline --force"))
+    end)
+
+    it("does not read a commit message as a push", function()
+      assert.is_false(is_denied('git commit -m "push --force to main"'))
     end)
   end)
 end)
@@ -198,5 +227,46 @@ describe("can_use_tool with the bundled deny rules", function()
     local result = can_use_tool.can_use_tool("Bash", { command = "sudo apt install tree" }, perm_config({}))
     assert.equals("deny", result.behavior)
     assert.is_truthy(result.message:find("default deny rules", 1, true))
+  end)
+end)
+
+describe("permission handler rule composition", function()
+  -- The real merge point: config.permissions.rules + the bundled defaults. The tests above pass
+  -- DEFAULT_DENY_RULES to can_use_tool directly, which skips this step entirely.
+  local perm_handler = require("vibing.infrastructure.rpc.handlers.permission")
+
+  local user_rule = {
+    tools = { "Bash" },
+    patterns = { "^my%-own%-command" },
+    action = "deny",
+    message = "user rule",
+  }
+
+  it("puts the bundled rules in front of the user's own", function()
+    local rules = perm_handler._resolve_permission_rules({ rules = { user_rule } })
+
+    assert.equals(#destructive.DEFAULT_DENY_RULES + 1, #rules)
+    assert.same(destructive.DEFAULT_DENY_RULES[1], rules[1])
+    assert.same(user_rule, rules[#rules])
+  end)
+
+  it("ships the bundled rules when the user configured none", function()
+    local rules = perm_handler._resolve_permission_rules({})
+    assert.equals(#destructive.DEFAULT_DENY_RULES, #rules)
+  end)
+
+  it("keeps only the user's rules when default_deny_rules is off", function()
+    local rules = perm_handler._resolve_permission_rules({
+      rules = { user_rule },
+      default_deny_rules = false,
+    })
+
+    assert.same({ user_rule }, rules)
+  end)
+
+  it("does not mutate the shared DEFAULT_DENY_RULES table", function()
+    local before = #destructive.DEFAULT_DENY_RULES
+    perm_handler._resolve_permission_rules({ rules = { user_rule } })
+    assert.equals(before, #destructive.DEFAULT_DENY_RULES)
   end)
 end)

--- a/tests/lua/core/constants/destructive_commands_spec.lua
+++ b/tests/lua/core/constants/destructive_commands_spec.lua
@@ -33,6 +33,20 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("rm --recursive ~"))
     end)
 
+    it("blocks the target-first flag order GNU getopt permutes", function()
+      -- `rm / -rf` is what `rm -rf /` actually runs: getopt_long reorders options.
+      assert.is_true(is_denied("rm / -rf"))
+      assert.is_true(is_denied("rm ~ -rf"))
+      assert.is_true(is_denied("rm '/' -rf"))
+      assert.is_true(is_denied("rm $HOME --recursive"))
+    end)
+
+    it("does not mistake a long flag for a short recursive cluster", function()
+      -- "--force" contains "-...r...", so a naive short-cluster pattern matches it and would
+      -- block this non-recursive deletion.
+      assert.is_false(is_denied("rm --force ~/notes.txt"))
+    end)
+
     it("blocks it after a shell separator, not just at the start of the line", function()
       assert.is_true(is_denied("cd /tmp && rm -rf /"))
       assert.is_true(is_denied("echo hi; rm -rf ~"))
@@ -59,6 +73,9 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_false(is_denied('rm -rf "./dist"'))
       -- A word merely ending in "rm" is not the rm command.
       assert.is_false(is_denied("xterm -rf /"))
+      -- Target-first order must not widen the target: these are not / or $HOME.
+      assert.is_false(is_denied("rm /tmp/x -rf"))
+      assert.is_false(is_denied("rm ./release -rf"))
     end)
 
     it("still catches rm reached through a pipe, which is why it is not command-anchored", function()
@@ -104,6 +121,16 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       -- "add" contains "dd"; the rule is anchored at command position so this is not a match.
       assert.is_false(is_denied("echo add of=/dev/null"))
     end)
+
+    it("only cares about the write target, not the read source", function()
+      -- The danger is of=/dev/, so an ordinary file-to-file copy must stay allowed.
+      assert.is_false(is_denied("dd if=backup.img bs=1M"))
+      assert.is_false(is_denied("dd if=backup.img of=backup2.img"))
+    end)
+
+    it("does not reach across a newline to find of=/dev/", function()
+      assert.is_false(is_denied('dd if=backup.img bs=1M\necho "restore skipped; of=/dev/sda1"'))
+    end)
   end)
 
   describe("chmod", function()
@@ -111,6 +138,22 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("chmod -R 777 ."))
       assert.is_true(is_denied("chmod -R 0777 /var/www"))
       assert.is_true(is_denied("chmod --recursive 777 ."))
+    end)
+
+    it("blocks the mode-first flag order GNU getopt permutes", function()
+      -- `chmod 777 -R .` is what `chmod -R 777 .` actually runs.
+      assert.is_true(is_denied("chmod 777 -R ."))
+      assert.is_true(is_denied("chmod 0777 --recursive /var/www"))
+      assert.is_true(is_denied("chmod -v -R 777 dist"))
+    end)
+
+    it("does not mistake a long flag for a short recursive cluster", function()
+      -- "--verbose" contains "-...r...", so a naive short-cluster pattern matches it.
+      assert.is_false(is_denied("chmod --verbose 777 file.txt"))
+    end)
+
+    it("does not reach across a newline to find the flag", function()
+      assert.is_false(is_denied("chmod 644 f.txt\necho '-R 0777'"))
     end)
 
     it("allows narrower modes and non-recursive changes", function()

--- a/tests/lua/core/constants/destructive_commands_spec.lua
+++ b/tests/lua/core/constants/destructive_commands_spec.lua
@@ -28,6 +28,11 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("rm -rf ${HOME}"))
     end)
 
+    it("blocks the GNU longform flag too", function()
+      assert.is_true(is_denied("rm --recursive --force /"))
+      assert.is_true(is_denied("rm --recursive ~"))
+    end)
+
     it("blocks it after a shell separator, not just at the start of the line", function()
       assert.is_true(is_denied("cd /tmp && rm -rf /"))
       assert.is_true(is_denied("echo hi; rm -rf ~"))
@@ -35,6 +40,7 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
 
     it("leaves ordinary deletions alone", function()
       assert.is_false(is_denied("rm -rf node_modules"))
+      assert.is_false(is_denied("rm --recursive ./dist/"))
       assert.is_false(is_denied("rm -rf ./dist"))
       assert.is_false(is_denied("rm file.txt"))
       assert.is_false(is_denied("rm -rf /tmp/vibing-test"))
@@ -128,6 +134,19 @@ describe("can_use_tool with the bundled deny rules", function()
     assert.equals("deny", result.behavior)
 
     local harmless = can_use_tool.can_use_tool("Bash", { command = "ls" }, perm_config({ permission_mode = "auto" }))
+    assert.equals("allow", harmless.behavior)
+  end)
+
+  it("still denies after the user approved some other Bash command for the session", function()
+    -- The approval UI records the bare tool name, so "allow_for_session" on `npm install`
+    -- matches every later Bash call. It must not thereby approve a destructive one.
+    local config = perm_config({ session_allowed_tools = { "Bash" } })
+
+    local result = can_use_tool.can_use_tool("Bash", { command = "sudo rm -rf /" }, config)
+    assert.equals("deny", result.behavior)
+
+    -- The session grant still does its job for everything else.
+    local harmless = can_use_tool.can_use_tool("Bash", { command = "npm install" }, config)
     assert.equals("allow", harmless.behavior)
   end)
 

--- a/tests/lua/core/constants/destructive_commands_spec.lua
+++ b/tests/lua/core/constants/destructive_commands_spec.lua
@@ -1,0 +1,154 @@
+-- Tests for the bundled destructive-command deny rules
+
+local destructive = require("vibing.core.constants.destructive_commands")
+local rule_checker = require("vibing.infrastructure.permissions.rule_checker")
+
+---Run a Bash command through every bundled deny rule.
+---@param command string
+---@return boolean denied
+local function is_denied(command)
+  for _, rule in ipairs(destructive.DEFAULT_DENY_RULES) do
+    if rule_checker.check_rule(rule, "Bash", { command = command }) == "deny" then
+      return true
+    end
+  end
+  return false
+end
+
+describe("destructive_commands.DEFAULT_DENY_RULES", function()
+  describe("rm", function()
+    it("blocks recursive deletion of the root and the home directory", function()
+      assert.is_true(is_denied("rm -rf /"))
+      assert.is_true(is_denied("rm -rf /*"))
+      assert.is_true(is_denied("rm -rf / --no-preserve-root"))
+      assert.is_true(is_denied("rm -fr /"))
+      assert.is_true(is_denied("rm -rf ~"))
+      assert.is_true(is_denied("rm -rf ~/Documents"))
+      assert.is_true(is_denied("rm -rf $HOME"))
+      assert.is_true(is_denied("rm -rf ${HOME}"))
+    end)
+
+    it("blocks it after a shell separator, not just at the start of the line", function()
+      assert.is_true(is_denied("cd /tmp && rm -rf /"))
+      assert.is_true(is_denied("echo hi; rm -rf ~"))
+    end)
+
+    it("leaves ordinary deletions alone", function()
+      assert.is_false(is_denied("rm -rf node_modules"))
+      assert.is_false(is_denied("rm -rf ./dist"))
+      assert.is_false(is_denied("rm file.txt"))
+      assert.is_false(is_denied("rm -rf /tmp/vibing-test"))
+    end)
+  end)
+
+  describe("privilege escalation", function()
+    it("blocks sudo and doas in command position", function()
+      assert.is_true(is_denied("sudo rm file"))
+      assert.is_true(is_denied("  sudo -i"))
+      assert.is_true(is_denied("make && sudo make install"))
+      assert.is_true(is_denied("doas pkg_add tree"))
+    end)
+
+    it("does not trip on the word appearing inside an argument", function()
+      assert.is_false(is_denied("grep sudo /etc/group"))
+      assert.is_false(is_denied("echo 'no sudo here'"))
+      assert.is_false(is_denied("ls sudoers.d"))
+    end)
+  end)
+
+  describe("raw device writes", function()
+    it("blocks dd and mkfs", function()
+      assert.is_true(is_denied("dd if=/dev/zero of=/dev/disk2"))
+      assert.is_true(is_denied("dd if=image.iso of=/dev/sda bs=4M"))
+      assert.is_true(is_denied("mkfs.ext4 /dev/sda1"))
+      assert.is_true(is_denied("mkfs -t ext4 /dev/sda1"))
+    end)
+
+    it("leaves unrelated commands alone", function()
+      assert.is_false(is_denied("ls /dev/null"))
+      assert.is_false(is_denied("cat file > /dev/null"))
+    end)
+  end)
+
+  describe("chmod", function()
+    it("blocks recursive 777", function()
+      assert.is_true(is_denied("chmod -R 777 ."))
+      assert.is_true(is_denied("chmod -R 0777 /var/www"))
+      assert.is_true(is_denied("chmod --recursive 777 ."))
+    end)
+
+    it("allows narrower modes and non-recursive changes", function()
+      assert.is_false(is_denied("chmod 777 one-file"))
+      assert.is_false(is_denied("chmod -R 755 ."))
+      assert.is_false(is_denied("chmod +x script.sh"))
+    end)
+  end)
+
+  describe("git push", function()
+    it("blocks force-pushing main/master", function()
+      assert.is_true(is_denied("git push --force origin main"))
+      assert.is_true(is_denied("git push --force origin master"))
+      assert.is_true(is_denied("git push -f origin main"))
+    end)
+
+    it("allows --force-with-lease, and force-pushing other branches", function()
+      assert.is_false(is_denied("git push --force-with-lease origin main"))
+      assert.is_false(is_denied("git push --force origin my-feature"))
+      assert.is_false(is_denied("git push origin main"))
+    end)
+  end)
+end)
+
+describe("can_use_tool with the bundled deny rules", function()
+  local can_use_tool = require("vibing.infrastructure.permissions.can_use_tool")
+
+  ---@param overrides table
+  ---@return table
+  local function perm_config(overrides)
+    return vim.tbl_extend("force", {
+      allowed_tools = { "Bash" },
+      denied_tools = {},
+      asked_tools = {},
+      session_allowed_tools = {},
+      session_denied_tools = {},
+      permission_rules = destructive.DEFAULT_DENY_RULES,
+      permission_mode = "default",
+      mcp_enabled = false,
+    }, overrides or {})
+  end
+
+  it("denies a destructive command that the allow list would otherwise permit", function()
+    local result = can_use_tool.can_use_tool("Bash", { command = "sudo rm -rf /" }, perm_config({}))
+    assert.equals("deny", result.behavior)
+  end)
+
+  it("still denies under auto mode, which allows everything else outright", function()
+    local result =
+      can_use_tool.can_use_tool("Bash", { command = "sudo rm -rf /" }, perm_config({ permission_mode = "auto" }))
+    assert.equals("deny", result.behavior)
+
+    local harmless = can_use_tool.can_use_tool("Bash", { command = "ls" }, perm_config({ permission_mode = "auto" }))
+    assert.equals("allow", harmless.behavior)
+  end)
+
+  it("still lets bypassPermissions through, as the documented escape hatch", function()
+    local result = can_use_tool.can_use_tool(
+      "Bash",
+      { command = "sudo rm -rf /" },
+      perm_config({ permission_mode = "bypassPermissions" })
+    )
+    assert.equals("allow", result.behavior)
+  end)
+
+  it("does not deny anything once the rules are removed", function()
+    local result =
+      can_use_tool.can_use_tool("Bash", { command = "sudo apt install tree" }, perm_config({ permission_rules = {} }))
+    assert.equals("allow", result.behavior)
+  end)
+
+  it("surfaces the rule's own message so the model knows why", function()
+    local result = can_use_tool.can_use_tool("Bash", { command = "sudo apt install tree" }, perm_config({}))
+    assert.equals("deny", result.behavior)
+    assert.is_truthy(result.message:find("default deny rules", 1, true))
+  end)
+end)

--- a/tests/lua/core/constants/destructive_commands_spec.lua
+++ b/tests/lua/core/constants/destructive_commands_spec.lua
@@ -38,6 +38,11 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("echo hi; rm -rf ~"))
     end)
 
+    it("blocks it on a later line of a multi-line script", function()
+      -- The Bash tool passes a whole script as one command string.
+      assert.is_true(is_denied("echo prep\nrm -rf /"))
+    end)
+
     it("leaves ordinary deletions alone", function()
       assert.is_false(is_denied("rm -rf node_modules"))
       assert.is_false(is_denied("rm --recursive ./dist/"))
@@ -55,6 +60,11 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("doas pkg_add tree"))
     end)
 
+    it("blocks it on a later line of a multi-line script", function()
+      assert.is_true(is_denied("echo prep\nsudo rm -rf /important-data"))
+      assert.is_true(is_denied("cd /tmp\ndoas pkg_add tree"))
+    end)
+
     it("does not trip on the word appearing inside an argument", function()
       assert.is_false(is_denied("grep sudo /etc/group"))
       assert.is_false(is_denied("echo 'no sudo here'"))
@@ -70,9 +80,15 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("mkfs -t ext4 /dev/sda1"))
     end)
 
+    it("blocks them on a later line of a multi-line script", function()
+      assert.is_true(is_denied("echo prep\nmkfs.ext4 /dev/sda1"))
+    end)
+
     it("leaves unrelated commands alone", function()
       assert.is_false(is_denied("ls /dev/null"))
       assert.is_false(is_denied("cat file > /dev/null"))
+      -- "add" contains "dd"; the rule is anchored at command position so this is not a match.
+      assert.is_false(is_denied("echo add of=/dev/null"))
     end)
   end)
 
@@ -95,12 +111,25 @@ describe("destructive_commands.DEFAULT_DENY_RULES", function()
       assert.is_true(is_denied("git push --force origin main"))
       assert.is_true(is_denied("git push --force origin master"))
       assert.is_true(is_denied("git push -f origin main"))
+      assert.is_true(is_denied("git push -uf origin master"))
+    end)
+
+    it("blocks it regardless of where the flag sits", function()
+      -- git push does not care about flag order, so neither can the rule.
+      assert.is_true(is_denied("git push origin main --force"))
+      assert.is_true(is_denied("git push origin master -f"))
     end)
 
     it("allows --force-with-lease, and force-pushing other branches", function()
       assert.is_false(is_denied("git push --force-with-lease origin main"))
       assert.is_false(is_denied("git push --force origin my-feature"))
       assert.is_false(is_denied("git push origin main"))
+    end)
+
+    it("does not mistake a branch that merely starts with main/master", function()
+      assert.is_false(is_denied("git push --force origin main-v2"))
+      assert.is_false(is_denied("git push --force origin master-old"))
+      assert.is_false(is_denied("git push origin mainline --force"))
     end)
   end)
 end)


### PR DESCRIPTION
Closes #491

## 背景

承認プロンプトは主防御にならない（ユーザーが大半を素通り承認する）。vibing.nvim には決定論的な仕組み（PreToolUse hook、fail-closed、granular rules）が既に揃っているのに、**デフォルトでは1つも配線されておらず**、防御はユーザーが自分でルールを書くか承認 UI 頼みだった。

## 変更内容

### 1. `core/constants/destructive_commands.lua`（新規）

| 拒否対象 | 例 |
| --- | --- |
| `/` や `$HOME` の再帰削除 | `rm -rf /`, `rm -rf /*`, `rm -rf ~`, `rm -rf $HOME` |
| 権限昇格 | `sudo ...`, `doas ...` |
| raw デバイス書き込み | `dd if=... of=/dev/sda`, `mkfs.ext4 /dev/sda1` |
| world-writable 化 | `chmod -R 777 .` |
| main/master への force push | `git push --force origin main`（`--force-with-lease` は許可） |

意図的に `^` で先頭固定していないので、`cd /tmp && sudo rm -rf /` のように `&&` や `;` の後ろに現れるものも捕まえる。各ルールに `message` を付けて拒否理由をモデルに返す。

### 2. escape hatch

`permissions.default_deny_rules`（デフォルト `true`）。評価時にユーザーの `rules` の前に差し込む方式なので、`config.permissions.rules` はユーザーが書いたまま round-trip する。

### 3. deny ルールの評価位置を 4.5 に前倒し（重要）

**元の実装では deny ルールがステップ9にあり、`mode = "auto"` とalways-allowed tools がその手前で `allow` を返して素通りしていた。** モードで飛び越せる deny は「境界」にならないので、tool-level deny list の直後（4.5）に移した。

- `permissions.md` が元から謳っている「deny rules are checked first」というセマンティクスに実装を合わせた形でもある
- `bypassPermissions` は従来どおり素通り（ドキュメント化された唯一の抜け道）
- 既存の allow ルールはステップ9のまま

### 4. Lua pattern の罠を修正

`.claude/rules/permissions.md` の例 `{ "^rm -rf", "^sudo", "^dd if=" }` は **Lua pattern として動かない**。`-` は量指定子なので `^rm -rf /` は「`rm` + 空白0個以上 + `rf /`」と解釈され、実際の `rm -rf /` にマッチしない（検証済み）。issue が言及していた「#484 の『正規表現』記載問題と同種の罠」がまさにこれ。例を `"^rm%s+%-rf"` に修正し、Lua pattern である旨を型注釈にも明記した。

## 動作確認

```
$ 新規 tests/lua/core/constants/destructive_commands_spec.lua   16 pass
   - 各カテゴリの拒否ケース
   - 誤爆しないこと: rm -rf node_modules / chmod -R 755 / grep sudo /etc/group /
     echo 'no sudo here' / git push --force-with-lease / git push --force origin my-feature
   - auto モードでも拒否されること、bypassPermissions では通ること
   - default_deny_rules を外せば通ること

$ tests/lua/infrastructure/permissions/can_use_tool_spec.lua  27 pass
$ tests/security_spec.lua 38 pass / tests/permission_rules_spec.lua 3 pass
$ tests/session_permissions_spec.lua 19 pass / tests/permission_builder_spec.lua 24 pass
$ find lua -name '*.lua' -exec luac -p {} \;   # 構文エラーなし
$ markdownlint / prettier --check                # pass
```

## 既知の限界（docs にも記載）

サンドボックスではなく安全網。分割フラグ（`rm -r -f /`）、難読化（`$(echo rm) -rf /`）、ブランチ名を書かない `git push --force` は捕まえられない。また個別ルールだけを無効化する手段はなく、`default_deny_rules = false` にして必要な分を `rules` に書き戻す形になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enabled-by-default safeguards blocking potentially destructive Bash commands, including dangerous deletion, privilege escalation, device writes, unsafe permission changes, and force-pushing protected branches.
  - Added an option to disable the bundled safeguards when needed.

- **Bug Fixes**
  - Deny rules now take precedence over session approvals, automatic permission modes, and allow rules. Only explicit permission bypass can override them.
  - Improved command matching across quoting, multiline scripts, separators, and varied syntax.

- **Documentation**
  - Clarified permission evaluation order, Lua pattern syntax, default protections, customization, and known matching limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->