### PR TITLE
docs: rewrite :help vibing against the current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ buffers — save, search, and edit them like any other file.
 
 ## 🚀 Usage
 
+Also available offline as `:help vibing-commands`, which carries per-command
+help tags.
+
 ### User Commands
 
 | Command                               | Description                                                                                          |

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -1,14 +1,14 @@
 # API Reference
 
-このドキュメントは vibing.nvim の全 API の詳細なリファレンスです。
+vibing.nvim が公開している API のリファレンス。設定項目そのものは
+[docs/configuration.md](../docs/configuration.md) を参照。
 
 ## 目次
 
 - [Core API](#core-api)
 - [Adapter API](#adapter-api)
-- [Context API](#context-api)
-- [Chat Buffer API](#chat-buffer-api)
-- [Output Buffer API](#output-buffer-api)
+- [Internal Modules](#internal-modules)
+- [Types](#types)
 
 ## Core API
 
@@ -70,7 +70,7 @@ end
 
 ```lua
 local config = require("vibing").get_config()
-print(config.adapter)  -- "agent_sdk"
+print(config.adapter)  -- "claude"
 ```
 
 ## Adapter API
@@ -186,18 +186,18 @@ end
 
 ### Adapter Types
 
-#### Agent SDK Adapter
+#### Claude CLI Adapter
 
-Claude Agent SDK を使用するアダプター（推奨）。
+`claude` CLI を直接 spawn するアダプター（デフォルト）。
+`claude -p --output-format stream-json` の出力をパースする。
 
 **Configuration:**
 
 ```lua
 {
-  adapter = "agent_sdk",
+  adapter = "claude",
   agent = {
-    mode = "command",  -- または "agentic"
-    model = "claude-sonnet-4-5",
+    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
   },
 }
 ```
@@ -208,20 +208,23 @@ Claude Agent SDK を使用するアダプター（推奨）。
 - ✅ Tools
 - ✅ Model selection
 - ✅ Context
-- ✅ Session management
+- ✅ Session management（`--resume <session_id>`）
 
-#### Claude CLI Adapter
+**Implementation:** `lua/vibing/infrastructure/adapter/claude_cli.lua`
 
-公式 `claude` CLI を使用するアダプター。
+#### Codex CLI Adapter
+
+OpenAI の `codex` CLI（`codex exec --json`）を使用するアダプター。
 
 **Configuration:**
 
 ```lua
 {
-  adapter = "claude",
-  cli_path = "claude",  -- CLI のパス
+  adapter = "codex",
 }
 ```
+
+チャットごとに切り替える場合は frontmatter の `agent: codex` を使う。
 
 **Features:**
 
@@ -229,183 +232,22 @@ Claude Agent SDK を使用するアダプター（推奨）。
 - ✅ Tools
 - ✅ Model selection
 - ✅ Context
-- ❌ Session management
-
-#### Claude ACP Adapter
-
-JSON-RPC プロトコルでclaude-code-acpと通信するアダプター。
-
-**Configuration:**
-
-```lua
-{
-  adapter = "claude_acp",
-}
-```
-
-**Features:**
-
-- ✅ Streaming
-- ✅ Tools
-- ❌ Model selection
-- ✅ Context
 - ✅ Session management
 
-## Context API
+**Implementation:** `lua/vibing/infrastructure/adapter/codex_cli.lua`
 
-### `Context.add(path?)`
+## Internal Modules
 
-手動でコンテキストを追加します。
+`vibing.setup()` / `vibing.get_adapter()` / `vibing.get_config()` と、上のアダプター
+インターフェース以外は内部実装であり、予告なく変わる。
 
-**Parameters:**
+以前このドキュメントには Context API (`require("vibing.context")`)、Chat Buffer API、
+Output Buffer API の節があったが、いずれも v4 のレイヤー分割で移動・削除されており、
+記載どおりのモジュールはもう存在しない（`vibing.context` と Output Buffer は現存せず、
+チャットバッファは `vibing.presentation.chat.buffer` に移り、メソッド構成も変わっている）。
+誤った API を載せ続けるより外すほうが害が小さいため、節ごと削除した。
 
-- `path` (`string?`): ファイルパス（省略時は現在のバッファ）
-
-**Example:**
-
-```lua
-local Context = require("vibing.context")
-Context.add("lua/vibing/init.lua")
-Context.add()  -- 現在のバッファを追加
-```
-
-### `Context.clear()`
-
-全てのコンテキストをクリアします。
-
-**Example:**
-
-```lua
-require("vibing.context").clear()
-```
-
-### `Context.get_all(auto_context)`
-
-全コンテキストを取得します（自動 + 手動）。
-
-**Parameters:**
-
-- `auto_context` (`boolean`): 自動コンテキストを含めるか
-
-**Returns:**
-
-- `string[]`: コンテキスト配列（@file:path形式）
-
-### `Context.get_selection()`
-
-ビジュアル選択範囲のコンテキストを取得します。
-
-**Returns:**
-
-- `string?`: コンテキスト（@file:path:L10-L25形式）
-
-## Chat Buffer API
-
-### `ChatBuffer:new(config)`
-
-チャットバッファインスタンスを生成します。
-
-**Parameters:**
-
-- `config` (`Vibing.ChatConfig`): チャット設定
-
-**Returns:**
-
-- `Vibing.ChatBuffer`: 新しいチャットバッファインスタンス
-
-### `ChatBuffer:open()`
-
-チャットウィンドウを開きます。
-
-### `ChatBuffer:close()`
-
-チャットウィンドウを閉じます。
-
-### `ChatBuffer:is_open()`
-
-チャットウィンドウが開いているかチェックします。
-
-**Returns:**
-
-- `boolean`: 開いている場合true
-
-### `ChatBuffer:append_chunk(chunk)`
-
-ストリーミングチャンクを追加します。
-
-**Parameters:**
-
-- `chunk` (`string`): 追加するテキスト
-
-### `ChatBuffer:start_spinner()`
-
-処理中スピナーを開始します。
-
-### `ChatBuffer:stop_spinner()`
-
-処理中スピナーを停止します。
-
-### `ChatBuffer:save()`
-
-チャットをファイルに保存します。
-
-**Returns:**
-
-- `string?`: 保存したファイルパス（失敗時はnil）
-
-## Output Buffer API
-
-### `OutputBuffer:new(title)`
-
-出力バッファインスタンスを生成します。
-
-**Parameters:**
-
-- `title` (`string`): バッファタイトル
-
-**Returns:**
-
-- `Vibing.OutputBuffer`: 新しい出力バッファインスタンス
-
-### `OutputBuffer:open()`
-
-出力ウィンドウを開きます。
-
-### `OutputBuffer:close()`
-
-出力ウィンドウを閉じます。
-
-### `OutputBuffer:is_open()`
-
-出力ウィンドウが開いているかチェックします。
-
-**Returns:**
-
-- `boolean`: 開いている場合true
-
-### `OutputBuffer:set_content(lines)`
-
-バッファの内容を設定します。
-
-**Parameters:**
-
-- `lines` (`string[]`): 設定する行の配列
-
-### `OutputBuffer:append_chunk(chunk)`
-
-ストリーミングチャンクを追加します。
-
-**Parameters:**
-
-- `chunk` (`string`): 追加するテキスト
-
-### `OutputBuffer:show_error(error_message)`
-
-エラーメッセージを表示します。
-
-**Parameters:**
-
-- `error_message` (`string`): エラーメッセージ
+現在のモジュール構成は `.claude/rules/architecture.md` の "Module Structure" を参照。
 
 ## Types
 
@@ -446,6 +288,6 @@ require("vibing.context").clear()
 
 ## See Also
 
-- [Getting Started Tutorial](tutorials/getting-started.md)
-- [Configuration Examples](examples/configurations.md)
-- [Architecture Overview](architecture/overview.md)
+- [Configuration Reference](../docs/configuration.md)
+- [`:help vibing`](./vibing.txt)
+- [Architecture](../.claude/rules/architecture.md)

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -241,32 +241,15 @@ OpenAI の `codex` CLI（`codex exec --json`）を使用するアダプター。
 `vibing.setup()` / `vibing.get_adapter()` / `vibing.get_config()` と、上のアダプター
 インターフェース以外は内部実装であり、予告なく変わる。
 
-以前このドキュメントには Context API (`require("vibing.context")`)、Chat Buffer API、
-Output Buffer API の節があったが、いずれも v4 のレイヤー分割で移動・削除されており、
-記載どおりのモジュールはもう存在しない（`vibing.context` と Output Buffer は現存せず、
-チャットバッファは `vibing.presentation.chat.buffer` に移り、メソッド構成も変わっている）。
-誤った API を載せ続けるより外すほうが害が小さいため、節ごと削除した。
-
 現在のモジュール構成は `.claude/rules/architecture.md` の "Module Structure" を参照。
 
 ## Types
 
 ### `Vibing.Config`
 
-```lua
----@class Vibing.Config
----@field adapter "claude"|"codex" バックエンドアダプター選択
----@field agent Vibing.AgentConfig エージェント設定（モード、モデル）
----@field chat Vibing.ChatConfig チャット設定
----@field ui Vibing.UiConfig UI設定
----@field keymaps Vibing.KeymapConfig キーマップ設定
----@field diff Vibing.DiffConfig diff表示設定
----@field permissions Vibing.PermissionsConfig 権限設定
----@field node Vibing.NodeConfig Node.js実行ファイル設定
----@field mcp Vibing.McpConfig MCP統合設定
----@field language string|Vibing.LanguageConfig? AI応答のデフォルト言語
----@field daily_summary Vibing.DailySummaryConfig? Daily Summary機能設定
-```
+`setup()` が受け取る設定オブジェクト。フィールド一覧と型注釈は
+`lua/vibing/config.lua` の `---@class Vibing.Config`、各項目の意味と既定値は
+`docs/configuration.md` にある。ここに写すと設定が増えるたびに古くなるので置かない。
 
 ### `Vibing.AdapterOpts`
 

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -278,6 +278,10 @@ Output Buffer API の節があったが、いずれも v4 のレイヤー分割�
 ---@field context string[] コンテキストファイル（@file:path形式）
 ```
 
+これはアダプターインターフェースが要求する最小の形。実行時には
+`send_message` が権限・セッション・cwd などの内部フィールドも載せて渡す
+（`lua/vibing/core/types.lua` の同名クラスが全項目）。
+
 ### `Vibing.Response`
 
 ```lua

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -1,4 +1,4 @@
-*vibing.txt*  Claude AI integration for Neovim
+*vibing.txt*  Claude chat inside Neovim, driven by the Claude/Codex CLI
 
 ==============================================================================
 CONTENTS                                                     *vibing-contents*
@@ -8,33 +8,49 @@ CONTENTS                                                     *vibing-contents*
     3. Installation ............................ |vibing-installation|
     4. Configuration ........................... |vibing-configuration|
     5. Commands ................................ |vibing-commands|
-    6. Chat Commands ........................... |vibing-chat-commands|
+    6. Slash Commands .......................... |vibing-slash-commands|
     7. Mappings ................................ |vibing-mappings|
-    8. API ..................................... |vibing-api|
-    9. Adapters ................................ |vibing-adapters|
-   10. Troubleshooting ......................... |vibing-troubleshooting|
-   11. License ................................. |vibing-license|
+    8. Chat File Format ........................ |vibing-chat-file|
+    9. Backends ................................ |vibing-backends|
+   10. API ..................................... |vibing-api|
+   11. Troubleshooting ......................... |vibing-troubleshooting|
+   12. License ................................. |vibing-license|
+
+This help is deliberately short. The authoritative, always-current references
+are kept in the repository:
+
+    Every setup() option ...... docs/configuration.md
+    Commands & keybindings .... README.md, "Usage"
+    Architecture .............. .claude/rules/architecture.md
 
 ==============================================================================
 1. INTRODUCTION                                          *vibing-introduction*
 
-vibing.nvim is a Neovim plugin that integrates Claude AI through the Agent
-SDK, providing an intelligent chat interface directly within your
-editor.
+vibing.nvim runs a Claude conversation inside a Neovim buffer. It spawns the
+`claude` CLI directly (`claude -p --output-format stream-json`) and parses its
+stream; there is no wrapper daemon. A Codex CLI backend is also supported.
 
 Features:~
-  • Interactive chat window with Claude AI
-  • Session persistence with context management
-  • Configurable permissions and execution modes
-  • Remote Neovim control via socket
+  • Chat in an ordinary Markdown buffer — edit, yank and search as usual
+  • Chats persist to disk with YAML frontmatter, and resume by session id
+  • Per-chat model, language and tool permissions
+  • Tool approval and multiple-choice questions rendered in the buffer
+  • An MCP server that lets the CLI read and drive the running Neovim
+  • Per-request diffs, viewable with `gd` on a file path in the chat
 
 ==============================================================================
 2. REQUIREMENTS                                          *vibing-requirements*
 
-• Neovim >= 0.8.0
-• Node.js >= 16.0.0
-• npm or yarn
-• Claude API access (via Agent SDK)
+• Neovim >= 0.10 (uses |vim.system()|)
+• Node.js >= 18 (for the MCP server)
+• At least one CLI backend on your PATH:
+    - Claude CLI: npm install -g @anthropic-ai/claude-code
+    - Codex CLI:  npm install -g @openai/codex
+
+Optional:~
+• oil.nvim — |:VibingContext| with no argument picks up the file under the
+  cursor in an oil buffer
+• plenary.nvim — required only to run the test suite
 
 ==============================================================================
 3. INSTALLATION                                          *vibing-installation*
@@ -42,256 +58,301 @@ Features:~
 Using lazy.nvim: >lua
     {
       "shabaraba/vibing.nvim",
-      build = "npm install",
+      dependencies = {
+        "stevearc/oil.nvim",  -- optional
+      },
+      build = "./build.sh",
       config = function()
         require("vibing").setup()
       end,
     }
 <
-
 Using packer.nvim: >lua
     use {
       "shabaraba/vibing.nvim",
-      run = "npm install",
+      run = "./build.sh",
       config = function()
         require("vibing").setup()
       end,
     }
 <
-
+`build.sh` builds the MCP server and, when the `claude` CLI is on your PATH,
+registers vibing.nvim as a Claude Code plugin (user scope). That plugin ships
+the `vibing-nvim` MCP server, the bundled skills and the `nvim-navigator`
+subagent. To install it by hand instead: >
+    /plugin marketplace add shabaraba/vibing.nvim
+    /plugin install vibing-nvim@vibing-nvim
+<
 ==============================================================================
 4. CONFIGURATION                                        *vibing-configuration*
 
-Default configuration: >lua
+`require("vibing").setup()` works with no arguments. The options people
+actually tend to change: >lua
     require("vibing").setup({
-      adapter = "agent_sdk",  -- "agent_sdk" | "claude" | "claude_acp"
+      adapter = "claude",               -- "claude" | "codex"
       chat = {
         window = {
-          position = "right",  -- "right" | "left" | "float"
+          -- "current" | "right" | "left" | "top" | "bottom" | "back"
+          -- | "float"
+          position = "current",
+          -- ratio below 1, absolute columns at 1 and above
           width = 0.4,
-          border = "rounded",
         },
-        auto_context = true,
         save_location_type = "project",  -- "project" | "user" | "custom"
       },
       agent = {
-        default_mode = "code",  -- "code" | "plan" | "explore"
-        default_model = "sonnet",  -- "sonnet" | "opus" | "haiku"
+        -- "sonnet" | "opus" | "haiku" | "fable"
+        default_model = "sonnet",
       },
       permissions = {
-        allow = { "Read", "Edit", "Write", "Glob", "Grep" },
+        -- "default" | "acceptEdits" | "plan" | "auto" | "dontAsk"
+        -- | "bypassPermissions"
+        mode = "acceptEdits",
+        allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill" },
         deny = { "Bash" },
       },
-      keymaps = {
-        send = "<CR>",
-        cancel = "<C-c>",
-        add_context = "<C-a>",
-      },
+      -- "ja", or { default = "ja", chat = "ja" }
+      language = nil,
     })
 <
+The permissions above are only a starting point for new chat files. What
+gets enforced at runtime is the permission block in each chat file's own
+frontmatter — see |vibing-chat-file|.
 
-Configuration options:~
-
-adapter                 Which backend to use for Claude AI
-chat.window.position    Where to open chat window
-chat.window.width       Chat window width (0.0-1.0 or absolute)
-chat.window.border      Window border style
-chat.auto_context       Automatically add open buffers to context
-chat.save_location_type Where to save chat files
-agent.default_mode      Default execution mode
-agent.default_model     Default AI model to use
-permissions.allow       Tools AI can use
-permissions.deny        Tools AI cannot use
-keymaps.send           Key to send message in chat
-keymaps.cancel         Key to cancel current request
-keymaps.add_context    Key to add file to context
+For the full list — window details, UI and tool markers, diff backends,
+granular permission rules, MCP, Node.js executable, auto-resume on usage
+limit, daily summary — read docs/configuration.md. It is generated against
+lua/vibing/config.lua and is the only complete reference; this section is not
+kept in sync field by field.
 
 ==============================================================================
 5. COMMANDS                                                  *vibing-commands*
 
-                                                              *:VibingChat*
-:VibingChat
-    Open the chat window.
+                                                                *:VibingChat*
+:VibingChat [{position}|{file}]
+    Create a new chat. {position} is one of `current` (replace the current
+    window), `right`, `left`, `top`, `bottom` (splits sized by
+    `chat.window.width`/`height`) or `back` (buffer only, no window).
+    Passing a path opens that saved chat file instead of creating one.
 
-                                                           *:VibingContext*
-:VibingContext [path]
-    Add file to context. If no path provided, adds current buffer.
+                                                          *:VibingToggleChat*
+:VibingToggleChat
+    Toggle the chat window without ending the conversation.
 
-                                                      *:VibingClearContext*
+                                                            *:VibingChatFork*
+:VibingChatFork [{position}]
+    Branch a new chat off the current one. The fork inherits the source
+    session and diverges from its first message onward.
+
+                                                       *:VibingSlashCommands*
+:VibingSlashCommands
+    Open the slash-command picker for the current chat.
+
+                                                        *:VibingSetFileTitle*
+:VibingSetFileTitle
+    Generate a title from the conversation and rename the chat file.
+
+                                                           *:VibingSummarize*
+:VibingSummarize
+    Summarise the conversation so far and insert it into the buffer.
+
+                                                         *:VibingDeleteChats*
+:VibingDeleteChats [--unrenamed]
+    Pick chat files to delete. With `--unrenamed`, delete every chat that
+    still has its generated filename.
+
+                                                           *:VibingCleanMote*
+:VibingCleanMote
+    Drop mote objects belonging to chat files, keeping the chats themselves.
+
+                                                             *:VibingContext*
+:[range]VibingContext [{path}]
+    Add a file to the context. With no argument, uses the current buffer — or
+    the file under the cursor in an oil.nvim buffer. Accepts a range to add
+    only the selected lines.
+
+                                                        *:VibingClearContext*
 :VibingClearContext
-    Clear all context files.
+    Clear every context entry.
 
-                                                            *:VibingCancel*
+                                                              *:VibingCancel*
 :VibingCancel
-    Cancel the current AI request.
+    Cancel the request in flight.
+
+                                                       *:VibingPendingResumes*
+:VibingPendingResumes
+    List chats parked until a usage limit resets.
+
+                                                        *:VibingCancelResume*
+:VibingCancelResume [all]
+    Cancel this chat's pending auto-resume, or every one with `all`.
+
+                                                              *:VibingMoteDir*
+:VibingMoteDir [{dir}]
+    Add a directory to this chat's mote tracking list (defaults to the
+    current working directory).
+
+                                                      *:VibingReloadCommands*
+:VibingReloadCommands
+    Reload custom slash commands and completion candidates.
+
+                                                *:VibingCopyUnsentUserHeader*
+:VibingCopyUnsentUserHeader
+    Copy `## User <!-- unsent -->` to the clipboard.
+
+                                                        *:VibingDailySummary*
+:VibingDailySummary [{YYYY-MM-DD}]
+    Summarise this project's chat files for a day (default: today).
+
+                                                     *:VibingDailySummaryAll*
+:VibingDailySummaryAll [{YYYY-MM-DD}]
+    Same, across every chat file rather than just this project's.
 
 ==============================================================================
-6. CHAT COMMANDS                                        *vibing-chat-commands*
+6. SLASH COMMANDS                                      *vibing-slash-commands*
 
-These commands are available within the chat buffer:
+Type these on their own line in a chat buffer and send with `<CR>`:
 
-/context <file>         Add file to context
-/clear                  Clear context
-/save                   Save current chat
-/summarize              Summarize conversation
-/mode <mode>            Set execution mode (auto/plan/code)
-/model <model>          Set AI model (opus/sonnet/haiku)
+/context <file>         Add a file to the context
+/clear                  Clear the context
+/save                   Save the current chat
+/summarize              Summarise the conversation
+/model <model>          Set the model (sonnet|opus|haiku|fable)
+/help                   List the available slash commands
+/permissions, /perm     Interactive permission builder
+/allow [tool]           Add to the allow list, or show it
+/deny [tool]            Add to the deny list, or show it
+/ask [tool]             Require approval for a tool, or show the list
+/permission [mode]      Set the permission mode
+/new-session            Forget the session and start fresh
+
+`/allow`, `/deny` and `/ask` accept granular patterns such as `Bash(git:*)`,
+`Read(src/**/*.ts)` and `WebFetch(github.com)`; prefix a tool with `-` to
+remove it (e.g. `/allow -Bash`).
+
+Worktree workflows (list, create, attach, run, finish) are not slash commands.
+Ask for them in plain language — they are backed by the bundled
+`vibing-worktree-*` Claude Code skills.
 
 ==============================================================================
 7. MAPPINGS                                                  *vibing-mappings*
 
-Default keymaps in chat buffer:~
+In a chat buffer:~
 
-<CR>        Send message
-<C-c>       Cancel current request
-<C-a>       Add current file to context
+    <CR>        Send the message (normal mode)
+    <C-c>       Cancel the current request
+    <C-a>       Add a file to the context
+    gd          Show the diff for the file path under the cursor
+    gf          Open the file path under the cursor
+    gx          Open the URL on the current line in a browser
+    q           Close the chat window
 
-You can customize these in setup(): >lua
+Everything except `q` is configurable: >lua
     require("vibing").setup({
       keymaps = {
-        send = "<C-CR>",
-        cancel = "<Esc>",
-        add_context = "<C-f>",
+        send = "<CR>",
+        cancel = "<C-c>",
+        add_context = "<C-a>",
+        open_diff = "gd",
+        open_file = "gf",
+        open_url = "gx",
       },
     })
 <
+==============================================================================
+8. CHAT FILE FORMAT                                         *vibing-chat-file*
+
+Chats are Markdown files (by default `.vibing/chat/chat-<timestamp>-....md`)
+with YAML frontmatter: >
+    ---
+    vibing.nvim: true
+    session_id: <cli-session-id>
+    created_at: 2026-01-01T12:00:00
+    working_dir: .vibing/worktrees/fix-auth   # optional, relative to git root
+    agent: claude
+    model: sonnet
+    permission_mode: acceptEdits
+    permissions_allow:
+      - Read
+      - Edit
+    permissions_deny:
+      - Bash
+    language: ja                              # optional
+    ---
+<
+Note the singular `permission_mode`; the permissions lists are plural. Reopen
+a chat with |:VibingChat| {file} or plain |:edit| — the session resumes from
+`session_id`, and `working_dir` decides where the CLI runs.
 
 ==============================================================================
-8. API                                                              *vibing-api*
+9. BACKENDS                                                  *vibing-backends*
 
-For detailed API documentation, see: doc/api-reference.md
+Set globally with `adapter`, or per chat with the `agent` frontmatter field.
 
-Core functions:~
+claude                                                        *vibing-claude*
+    Default. Runs `claude -p --output-format stream-json --verbose
+    --include-partial-messages`, plus flags for the model, session resume,
+    system prompt, setting sources and permissions.
+    Requires: the `claude` CLI.
+
+codex                                                          *vibing-codex*
+    Runs the Codex CLI (`codex exec --json`).
+    Requires: the `codex` CLI.
+
+Both implement the same adapter interface (`execute`, `stream`, `cancel`,
+`supports`), so chat behaviour is the same either way; only the flags and the
+stream format differ.
+
+==============================================================================
+10. API                                                           *vibing-api*
 
 require("vibing").setup({opts})                              *vibing.setup()*
-    Initialize the plugin
-    Parameters:~
-        {opts} Configuration table (optional)
+    Initialise the plugin, register the commands and validate the config.
+    {opts} is optional.
 
 require("vibing").get_adapter()                        *vibing.get_adapter()*
-    Get current adapter instance
-    Returns:~
-        Adapter instance or nil
+    The adapter instance currently selected by `config.adapter`, or nil
+    before setup().
 
 require("vibing").get_config()                          *vibing.get_config()*
-    Get current configuration
-    Returns:~
-        Configuration table
+    The merged, validated configuration table.
+
+Everything under `lua/vibing/` beyond these three functions is internal and
+may change without notice.
 
 ==============================================================================
-9. ADAPTERS                                                    *vibing-adapters*
+11. TROUBLESHOOTING                                   *vibing-troubleshooting*
 
-agent_sdk                                                      *vibing-agent_sdk*
-    Claude Agent SDK adapter (recommended)
-    Features:~
-        • Streaming responses
-        • Tool usage support
-        • Model selection
-        • Context management
-        • Session persistence
-
-    Requirements:~
-        • Node.js >= 18
-        • npm install (run automatically)
-
-    Configuration:~
->lua
-        require("vibing").setup({
-          adapter = "agent_sdk",
-          agent = {
-            mode = "command",
-            model = "claude-sonnet-4-5",
-          },
-        })
-<
-
-claude                                                              *vibing-claude*
-    Official Claude CLI adapter
-    Features:~
-        • Streaming responses
-        • Tool usage support
-        • Model selection
-        • Context management
-
-    Requirements:~
-        • Claude Code CLI installed
-
-    Configuration:~
->lua
-        require("vibing").setup({
-          adapter = "claude",
-          cli_path = "claude",
-        })
-<
-
-claude_acp                                                        *vibing-claude_acp*
-    Claude ACP (Agent Communication Protocol) adapter
-    Features:~
-        • Streaming responses
-        • Tool usage support
-        • Context management
-        • Session persistence
-
-    Requirements:~
-        • claude-code-acp installed
-
-    Configuration:~
->lua
-        require("vibing").setup({
-          adapter = "claude_acp",
-        })
-<
-
-==============================================================================
-10. TROUBLESHOOTING                                      *vibing-troubleshooting*
-
-Chat not responding:~
-    1. Check Claude CLI installation: >
+Nothing comes back when you send a message:~
+    1. Check the backend runs at all: >
         $ claude --version
-<
-    2. Verify API key is configured
-    3. Check network connection
-    4. View error messages: >
+<    2. Check it is authenticated (run `claude` once in a terminal).
+    3. Read the errors: >
         :messages
 <
+Every tool call is denied:~
+    The PreToolUse hook fails closed on purpose: if it cannot reach Neovim's
+    RPC server, the tool is denied rather than silently allowed. Check that
+    `mcp.enabled` is true and that `.vibing/hook-settings.json` exists in the
+    directory the CLI runs in.
 
-Adapter not found error:~
-    Error: Adapter 'agent_sdk' not found
+MCP tools cannot find the right Neovim:~
+    Several Neovim instances each get their own RPC port. Pass the port shown
+    in the chat's system prompt on every `mcp__vibing-nvim__*` call rather
+    than guessing.
 
-    Solution:~
-        • Ensure Node.js is installed (>= 18)
-        • Run npm install in plugin directory
-        • Try different adapter: >lua
-            require("vibing").setup({ adapter = "claude" })
-<
+A chat resumes into the wrong directory:~
+    The `working_dir` field in the chat's frontmatter wins over Neovim's
+    current directory. Edit or remove it.
 
-Performance issues:~
-    • Disable auto_context if not needed
-    • Close unused buffers to reduce context
-    • Use smaller context when possible
-    • Consider using "command" mode instead of "agentic"
-
-Session persistence not working:~
-    • Check save location configuration
-    • Ensure directory exists and is writable
-    • Verify frontmatter format in chat file
-
-Enable debug logging:~
->lua
-    vim.g.vibing_debug = true
-<
-
-Report issues:~
+Reporting a bug:~
     https://github.com/shabaraba/vibing.nvim/issues
 
-Include in bug reports:~
-    • Neovim version (`:version`)
-    • Plugin configuration
-    • Error messages (`:messages`)
-    • Steps to reproduce
+    Please include the Neovim version (|:version|), your `setup()` call, the
+    output of |:messages|, and the steps to reproduce.
 
 ==============================================================================
-11. LICENSE                                                    *vibing-license*
+12. LICENSE                                                   *vibing-license*
 
 MIT License
 

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -20,7 +20,7 @@ This help is deliberately short. The authoritative, always-current references
 are kept in the repository:
 
     Every setup() option ...... docs/configuration.md
-    Commands & keybindings .... README.md, "Usage"
+    Commands & keybindings .... README.md, "🚀 Usage"
     Architecture .............. .claude/rules/architecture.md
 
 ==============================================================================

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -345,6 +345,12 @@ A chat resumes into the wrong directory:~
     The `working_dir` field in the chat's frontmatter wins over Neovim's
     current directory. Edit or remove it.
 
+Seeing what the CLI actually sent:~
+    Set |g:vibing_debug_stream| to log the spawned command, its PID and the
+    stream events it produces via |vim.notify()|: >lua
+    vim.g.vibing_debug_stream = true
+<    (The old `vim.g.vibing_debug` flag was never read by anything.)
+
 Reporting a bug:~
     https://github.com/shabaraba/vibing.nvim/issues
 

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -20,8 +20,10 @@ This help is deliberately short. The authoritative, always-current references
 are kept in the repository:
 
     Every setup() option ...... docs/configuration.md
-    Commands & keybindings .... README.md, "🚀 Usage"
     Architecture .............. .claude/rules/architecture.md
+
+Commands, slash commands and keybindings are documented here (sections 5-7);
+they carry the |:VibingChat|-style tags, so this file is their reference.
 
 ==============================================================================
 1. INTRODUCTION                                          *vibing-introduction*
@@ -108,7 +110,7 @@ actually tend to change: >lua
         -- "default" | "acceptEdits" | "plan" | "auto" | "dontAsk"
         -- | "bypassPermissions"
         mode = "acceptEdits",
-        allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill" },
+        -- omit allow/deny to keep the shipped defaults
         deny = { "Bash" },
       },
       -- "ja", or { default = "ja", chat = "ja" }
@@ -270,12 +272,15 @@ with YAML frontmatter: >
     created_at: 2026-01-01T12:00:00
     working_dir: .vibing/worktrees/fix-auth   # optional, relative to git root
     agent: claude
+    mode: code                                # code | plan | explore
     model: sonnet
     permission_mode: acceptEdits
     permissions_allow:
       - Read
       - Edit
     permissions_deny:
+      - Bash
+    permissions_ask:
       - Bash
     language: ja                              # optional
     ---
@@ -349,8 +354,7 @@ Seeing what the CLI actually sent:~
     Set |g:vibing_debug_stream| to log the spawned command, its PID and the
     stream events it produces via |vim.notify()|: >lua
     vim.g.vibing_debug_stream = true
-<    (The old `vim.g.vibing_debug` flag was never read by anything.)
-
+<
 Reporting a bug:~
     https://github.com/shabaraba/vibing.nvim/issues
 


### PR DESCRIPTION
Closes #507

## 背景

`doc/vibing.txt` は Agent SDK 前提のまま止まっており、`:help vibing` を読んだ人には**数バージョン前の存在しないプラグイン**が説明されていた。

## 現状の乖離（修正前）

- COMMANDS に4コマンドしかない（実装は18コマンド登録）
- ADAPTERS が `agent_sdk` / `claude` / `claude_acp` の3つ（現存するのは `claude` / `codex`）
- CONFIGURATION が `adapter = "agent_sdk"`、`position` に `current`/`top`/`bottom`/`back` が無い、`permission_mode` の記載なし
- CHAT COMMANDS に存在しない `/mode`、`/permission` 系・`/new-session` が欠落
- MAPPINGS に `gd` / `gf` / `gx` / `q` が無い
- REQUIREMENTS が Neovim 0.8 / Node 16 / 「Claude API access (via Agent SDK)」

## 方針

issue の指示どおり「詳細は `docs/configuration.md` へ誘導し、ヘルプ側は簡潔に保つ（二重管理を作らない）」。冒頭に一次情報源への誘導を置き、設定は「よく変える項目」だけに絞った。**この help が壊れた原因が全設定を写経していたこと**なので、そこは繰り返さない。

## 変更内容（doc/vibing.txt）

- 全18コマンドを、実際の引数・range・補完まで含めて記載
- スラッシュコマンド13種、キーバインド7種、frontmatter 形式
- バックエンドを claude / codex に。要件を Neovim 0.10+ / Node 18+ / いずれかの CLI に
- インストールを `build.sh` + Claude Code プラグイン登録の現行手順に
- TROUBLESHOOTING をこの設計で実際に起きる失敗（fail-closed な hook、インスタンスごとの RPC ポート、cwd より優先される `working_dir`）に書き換え

## 変更内容（doc/api-reference.md）

issue の「併せて `doc/api-reference.md` の鮮度も確認」の分。確認したところ**存在しないモジュールを説明している節**があった:

- `Context API` — `require("vibing.context")` は存在しない
- `Output Buffer API` — モジュールごと存在しない
- `Chat Buffer API` — バッファ自体は `presentation/chat/buffer.lua` に移動、`start_spinner` / `stop_spinner` / `save` は存在しない

誤った API を載せ続けるより外すほうが害が小さいので節ごと削除し、「これらは内部実装、構成は architecture.md 参照」に置き換えた。併せてアダプター節を claude/codex に更新し、リンク切れの See Also（`tutorials/getting-started.md` 等、いずれも存在しないパス）を修正。

## 動作確認

```
$ nvim --headless -c "helptags doc" -c qa
  → エラーなし、37タグ生成（コマンド18 + セクション + API 3、意図しないタグなし）
     ※ 途中 `*template*` という不要タグが生成されていたのを検出して修正済み
$ 全行78カラム以内であることを確認
$ markdownlint doc/api-reference.md   # pass
$ pnpm run format:check                # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)