### PR TITLE
fix: stop treating overageStatus as a usage-limit rejection

### DIFF
--- a/lua/vibing/core/utils/rate_limit.lua
+++ b/lua/vibing/core/utils/rate_limit.lua
@@ -85,12 +85,16 @@ function M.from_event(msg)
     info = msg
   end
 
+  -- `status` alone decides rejection. `overageStatus` sits right next to it and uses the same
+  -- vocabulary, but it answers a different question — whether extra-usage billing is available —
+  -- and is a standing account property, not this request's outcome. An account with no credits
+  -- reports `overageStatus = "rejected"` (alongside `overageDisabledReason = "out_of_credits"`)
+  -- on every event, `status = "allowed"` ones included, so reading it as a rejection marked every
+  -- successful turn as limit-blocked. It stays in `raw` for diagnostics.
   local status = pick(info, "status", "rateLimitStatus")
-  local overage_status = pick(info, "overageStatus", "overage_status")
 
   return {
-    rejected = REJECTED_STATUSES[tostring(status):lower()] == true
-      or REJECTED_STATUSES[tostring(overage_status):lower()] == true,
+    rejected = REJECTED_STATUSES[tostring(status):lower()] == true,
     resets_at = to_unix_seconds(pick(info, "resetsAt", "resets_at", "resetAt", "reset_at")),
     limit_type = pick(info, "rateLimitType", "rate_limit_type", "limitType"),
     status = status and tostring(status) or nil,

--- a/tests/lua/core/utils/rate_limit_spec.lua
+++ b/tests/lua/core/utils/rate_limit_spec.lua
@@ -46,12 +46,23 @@ describe("rate_limit", function()
       assert.equals(1778193600, info.resets_at)
     end)
 
-    it("rejects when only overageStatus reports the rejection", function()
+    -- Real payload from an account with no extra-usage credits. Every event looks like this,
+    -- including the ones for turns that completed normally.
+    it("ignores overageStatus, which reports billing availability rather than this request", function()
       local info = RateLimit.from_event({
-        rate_limit_info = { status = "allowed", overageStatus = "rejected" },
+        rate_limit_info = {
+          status = "allowed",
+          resetsAt = 1786506000,
+          rateLimitType = "five_hour",
+          overageStatus = "rejected",
+          overageDisabledReason = "out_of_credits",
+          isUsingOverage = false,
+        },
       })
 
-      assert.is_true(info.rejected)
+      assert.is_false(info.rejected)
+      assert.equals(1786506000, info.resets_at)
+      assert.equals("five_hour", info.limit_type)
     end)
 
     it("survives an unrecognized payload instead of erroring", function()


### PR DESCRIPTION
## 問題

使用量リミットに達していないのに、auto-resume が `Continue from where you left off.` を勝手に送信していました。

`rate_limit.lua` の `from_event()` は `status` と `overageStatus` の **どちらか** が `REJECTED_STATUSES` に該当すればリクエストが弾かれたとみなしていました。この2つは別々のことを答えるフィールドです。

- `status` — **そのリクエストの結果**
- `overageStatus` — **追加クレジット（従量課金）が使えるかどうか**というアカウントの常時状態

追加クレジットを持たないアカウントでは、CLI が毎回こう返します:

```json
{"type":"rate_limit_event","rate_limit_info":{
  "status":"allowed",
  "resetsAt":1786506000,
  "rateLimitType":"five_hour",
  "overageStatus":"rejected",
  "overageDisabledReason":"out_of_credits",
  "isUsingOverage":false
}}
```

`status: "allowed"`（=リクエストは通っている）にもかかわらず `overageStatus: "rejected"` なので、**すべての正常なターンがリミットで拒否されたと判定**されていました。

## 影響の連鎖

1. `claude_cli.lua` — `merged.rejected` が true になり `response._rate_limit_info` がセットされる
2. `send_message.lua` — `on_rate_limited()` に入る。`elseif` の後ろにある `on_success()`（リトライ予算のクリア）には到達しない
3. `auto_resume.lua` — `resetsAt + grace_sec` にタイマーを仕込む
4. リセット時刻にタイマーが発火し、リミットに一度も当たっていないチャットへ継続メッセージを送信

auto-resume 側は設計どおりに動いていました。毎回発火しなかったのは `fire()` が未送信のユーザー入力があれば中止するためで、**リセット境界をまたいで放置されたチャットだけ**が撃たれていました。

## 修正

rejection の判定を `status` のみに戻します。`overageStatus` は診断用に `raw` へそのまま残るので情報は失われません。

## テスト

- `tests/lua/core/utils/rate_limit_spec.lua` の "rejects when only overageStatus reports the rejection" は誤った挙動を固定していたので差し替え。新しいテストは実際に観測したペイロードをそのまま使い、**旧実装に対しては落ちること**を確認済み
- 変更したファイルの spec は 17/17 pass
- フルスイート (`test:lua`) は `tests/lua/infrastructure/rpc/` に落ちるものがありますが、**本変更前の同一ツリーでも落ちる**既知の flaky (#513) で、実行ごとに落ちるテストが入れ替わります。単独実行では pass します

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected rate-limit handling so overage information alone no longer incorrectly marks an otherwise allowed request as rejected.
  * Preserved rate-limit status, reset-time, and type reporting for affected events.

* **Tests**
  * Added coverage for requests with rejected overage status that remain allowed by the primary rate-limit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->