### PR TITLE
test: stop asserting an exact size for a full-screen float

### DIFF
--- a/tests/lua/presentation/chat/modules/window_manager_spec.lua
+++ b/tests/lua/presentation/chat/modules/window_manager_spec.lua
@@ -55,9 +55,13 @@ describe("window_manager.create_window", function()
   -- These three go through "float" because nvim_open_win is the call that actually rejects an
   -- out-of-range size; :resize would silently clamp for us and hide a missing guard.
   it("clamps an oversized absolute size instead of failing nvim_open_win", function()
+    -- Without the clamp nvim_open_win rejects the size outright, so reaching these assertions at
+    -- all is most of the test. Compare with <= rather than ==: Neovim shrinks a full-height float
+    -- by the cmdline, so the exact result depends on cmdheight.
     local win = window_manager.create_window(buf, { position = "float", width = 5000, height = 5000 })
-    assert.equals(vim.o.columns, vim.api.nvim_win_get_width(win))
-    assert.equals(vim.o.lines, vim.api.nvim_win_get_height(win))
+    assert.is_not_nil(win)
+    assert.is_true(vim.api.nvim_win_get_width(win) <= vim.o.columns)
+    assert.is_true(vim.api.nvim_win_get_height(win) <= vim.o.lines)
     vim.api.nvim_win_close(win, true)
   end)
 


### PR DESCRIPTION
## 概要

#527 で追加した clamp のテストが、単体実行（`PlenaryBustedFile`）では通るのに一括実行（`PlenaryBustedDirectory`）では落ちていました。main にマージ後の全体実行で発覚したものです。

```
window_manager.create_window clamps an oversized absolute size instead of failing nvim_open_win
  Passed in: (number) 23
  Expected:  (number) 24
```

## 原因

`vim.o.lines` と完全一致で比較していましたが、画面いっぱいの float は cmdline の分だけ Neovim 側が縮めるため、結果が `cmdheight` に依存します。ハーネスによって値が変わるので、等値比較が成立しません。

## 対応

`<=` 比較に変更しました。clamp が無ければ `nvim_open_win` がサイズを拒否して例外になるので、assertion に到達すること自体がテストの主眼です。

## 検証

- `PlenaryBustedDirectory tests/lua/presentation` で green
- clamp を外すと引き続き落ちることを確認（"never resolves to a zero or negative size" が失敗）
- `PlenaryBustedDirectory tests/lua` 全体 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)