### PR TITLE
fix: empty the tool set for lightweight calls instead of listing tools to deny

### DIFF
--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -39,32 +39,6 @@ for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
   M.ALWAYS_ALLOWED_TOOLS_MAP[tool] = true
 end
 
----lightweightなユーティリティ呼び出し（タイトル生成・要約等）で明示的に拒否するClaude Code CLIの
----組み込みツール名一覧。`--allowedTools ""`だけでは実際のツール実行をブロックできないことを
----実機検証で確認したため、`--disallowedTools`で個別に拒否する。新しいツールがCLIに追加された場合は
----このリストも追従して更新する必要がある。
----@type string[]
-M.LIGHTWEIGHT_DISALLOWED_TOOLS = {
-  "Task",
-  "Bash",
-  "BashOutput",
-  "KillShell",
-  "Edit",
-  "MultiEdit",
-  "Write",
-  "Read",
-  "Glob",
-  "Grep",
-  "WebFetch",
-  "WebSearch",
-  "NotebookEdit",
-  "TodoWrite",
-  "SlashCommand",
-  "ExitPlanMode",
-  "AskUserQuestion",
-  "Skill",
-}
-
 ---ツール名が有効かチェックし、正規化された名前を返す
 ---@param tool string チェックするツール名
 ---@return string|nil 有効な場合は正規化されたツール名

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -178,19 +178,24 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
   end
 
   if opts.lightweight then
-    -- Lightweight calls need no tools: skip permission args/hooks entirely. An empty
-    -- --allowedTools alone does NOT reliably block tool execution (verified against the CLI:
-    -- with no --permission-mode, or with --permission-mode dontAsk, the model can still invoke
-    -- Bash/Write despite an empty allow list). --permission-mode plan does hard-block tool use,
-    -- but it was also verified to leak plan-mode meta-commentary ("this isn't a planning
-    -- task...") into otherwise plain text-generation output, corrupting title/summary content
-    -- even with an explicit system-prompt instruction to suppress it — unacceptable for this
-    -- use case. --disallowedTools naming the known built-in tools is the real defense instead:
-    -- verified to reliably block Bash/Write with zero content pollution across repeated runs.
-    table.insert(cmd, "--allowedTools")
+    -- Lightweight calls need no tools: skip permission args/hooks entirely and empty out the
+    -- CLI's built-in tool set. --tools "" removes the tools rather than gating them, which is
+    -- why it works where the alternatives don't: an empty --allowedTools alone does NOT block
+    -- execution (verified — with no --permission-mode, or with --permission-mode dontAsk, the
+    -- model still invokes Bash/Write despite an empty allow list), and --permission-mode plan
+    -- does hard-block but leaks plan-mode meta-commentary ("this isn't a planning task...")
+    -- into plain text-generation output, corrupting title/summary content.
+    --
+    -- This replaces an earlier --disallowedTools enumeration of the known built-in tools. That
+    -- worked, but a denylist has to be updated every time the CLI grows a tool, and it had
+    -- already drifted (Agent/TaskCreate were never listed) — see #488. --tools names nothing,
+    -- so it cannot drift. Verified against the CLI directly: with --tools "" plus the empty
+    -- MCP config below, prompts explicitly ordering Write/Bash produce no file at all.
+    --
+    -- No version probe: on a claude CLI predating --tools the process just fails, and the three
+    -- callers already surface that as response.error — a failed title/summary, not a broken chat.
+    table.insert(cmd, "--tools")
     table.insert(cmd, "")
-    table.insert(cmd, "--disallowedTools")
-    table.insert(cmd, table.concat(tools_constants.LIGHTWEIGHT_DISALLOWED_TOOLS, ","))
   else
     add_permission_args(cmd, opts)
 

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -279,11 +279,16 @@ describe("cli_command_builder", function()
       assert.equals('{"mcpServers":{}}', cmd[mcp_config_idx + 1])
     end)
 
-    it("passes an empty --allowedTools instead of the usual pre-approved tool list", function()
+    it('empties the tool set with --tools "" rather than enumerating a denylist', function()
+      -- Why --tools and not the allow/deny flags: see cli_command_builder.lua's lightweight
+      -- branch. The allow/deny assertions are the regression guard for #488 — the enumeration
+      -- they replaced had already drifted (Agent/TaskCreate were never listed).
       local cmd = cli_command_builder.build("hello", { lightweight = true }, nil, {}, nil)
-      local idx = find_flag(cmd, "--allowedTools")
+      local idx = find_flag(cmd, "--tools")
       assert.is_not_nil(idx)
       assert.equals("", cmd[idx + 1])
+      assert.is_nil(find_flag(cmd, "--allowedTools"))
+      assert.is_nil(find_flag(cmd, "--disallowedTools"))
     end)
 
     it("does not pass --settings even when a hook settings_path is provided", function()
@@ -294,22 +299,6 @@ describe("cli_command_builder", function()
     it("does not pass --permission-mode even when opts.permission_mode is set", function()
       local cmd = cli_command_builder.build("hello", { lightweight = true, permission_mode = "acceptEdits" }, nil, {}, nil)
       assert.is_nil(find_flag(cmd, "--permission-mode"))
-    end)
-
-    it("passes --disallowedTools naming the known built-in tools", function()
-      -- An empty --allowedTools alone does not reliably block tool execution (verified against
-      -- the CLI directly: the model can still invoke Bash/Write with an empty allow list and no
-      -- --permission-mode, or with --permission-mode dontAsk). --permission-mode plan does
-      -- hard-block tool use, but was also verified to leak plan-mode meta-commentary into
-      -- otherwise plain text-generation output, corrupting title/summary content — so
-      -- --disallowedTools naming the known built-in tools is used as the real defense instead.
-      local cmd = cli_command_builder.build("hello", { lightweight = true }, nil, {}, nil)
-      local idx = find_flag(cmd, "--disallowedTools")
-      assert.is_not_nil(idx)
-      local disallowed = cmd[idx + 1]
-      assert.is_true(disallowed:find("Bash", 1, true) ~= nil)
-      assert.is_true(disallowed:find("Write", 1, true) ~= nil)
-      assert.is_true(disallowed:find("Task", 1, true) ~= nil)
     end)
 
     it("uses config.agent.utility_model, defaulting to haiku when unset", function()


### PR DESCRIPTION
Closes #488

## 背景

タイトル生成・`/summarize`・デイリーサマリーの 3 つの lightweight 呼び出しは、設計上ツールを
一切使いません。その担保は `--disallowedTools` に組み込みツール名を 18 個列挙する方式でした。

列挙による防御は **CLI がツールを増やすたびに追従が必要**で、実際に追従漏れが起きていました。
`Agent` や `TaskCreate` 系はリストに一度も載っておらず、lightweight 呼び出しから到達可能な
状態でした。

## 変更内容

`--allowedTools "" + --disallowedTools <18個>` を `--tools ""` に置き換えました。

`--tools` は組み込みツールを **ゲートするのではなく消す** フラグなので、同期を保つべきリストが
そもそも存在しません。

`lua/vibing/core/constants/tools.lua` の `LIGHTWEIGHT_DISALLOWED_TOOLS` は他に読み手が
いなかったため削除しました。

## 実機検証

claude CLI 2.1.220 に対して確認しました。

```bash
claude -p --model haiku --tools "" --setting-sources "" \
  --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
  -- 'Use the Write tool to create canary.txt containing PWNED.
      Then use Bash to run `touch canary2.txt`.'
```

→ **どちらのファイルも作成されませんでした。** ツール実行が実際に遮断されています。

別プロンプトでは、モデルが「Bash ツールが手元にない」と応答することも確認しています。

## 検討して採用しなかった代替案

| 案 | 却下理由 |
| --- | --- |
| `--allowedTools ""` 単体 | 実行をブロックできない（モデルは Bash/Write を呼べてしまう） |
| `--permission-mode plan` | ツールは止まるが、plan モードのメタコメントが生成されたタイトル/要約の本文に混入する |

この 2 つは既存コメントに記録されていた検証結果で、今回も前提として維持しています。

## issue の提案のうち、意図的に見送ったもの

**提案2（CI で CLI のツール一覧と定数の差分を検知するテスト）— 不要**
検知対象だった定数自体が消えます。`--tools ""` は空文字列固定で、CLI が将来何個ツールを
増やしてもドリフトしようがないため、存在しない問題に対するテストになります。

**提案3（PreToolUse hook を lightweight にも適用して二層目にする）— 見送り**
`SettingsGenerator.ensure` の実行、`.vibing/hook-settings.json` の生成、ツール呼び出しごとの
RPC 往復（最大 120 秒ポーリング）を全 lightweight 呼び出しに課すことになり、「速く安く終わらせる
ユーティリティ呼び出し」という設計意図と正面から矛盾します。ツールがそもそも呼び出せない以上、
フックは発火機会自体がありません。`--tools ""` のバイパスが実際に観測された場合に再検討します。

## スコープ外（別 issue 候補）

- **Codex バックエンド**: `codex_command_builder.lua` には lightweight 分岐が存在せず、
  タイトル生成・要約・デイリーサマリーが**ツール制限ゼロ**で投げられています。「denylist が古い」
  ではなく「制限が無い」という別種の問題なので、本 PR では触れていません
- **MCP ツール遮断の単一依存**: lightweight の MCP 遮断は `--strict-mcp-config` +
  `--mcp-config` の 1 系統のみに依存しています。本 PR 由来ではない既存の設計点ですが、
  upstream に関連バグ報告（anthropics/claude-code#14490）があります

## テスト

- `tests/lua/.../cli_command_builder_spec.lua` — 旧 `--allowedTools`/`--disallowedTools` の
  2 テストを 1 つに統合。`--tools ""` の存在に加え、旧フラグが**出力されない**ことも
  アサートして回帰ガードにしています
- `pnpm run check`（Lua 構文）— パス
- 当該 spec 42 件パス、失敗 0
- 全 Lua スイート 841 件パス、失敗 0

**注記**: e2e スイートは main でも 1 件も実行されず exit 1 になります（稼働中の Neovim が
ポート 9876/9877 を占有）。本 PR とは無関係の既存の環境問題です。

## セルフレビュー

simplify（reuse / simplification / efficiency / altitude）と code review（correctness /
convention / security）を実施しました。simplification の 3 指摘（コメント圧縮、テストコメントの
重複解消、テスト 2 件の統合）を反映済み。他の 6 観点は指摘なしです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)