### PR TITLE
refactor: read the default allow list from tools.lua instead of restating it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,13 @@ All `.md` files in `.claude/rules/` are automatically loaded into Claude Code's 
 
 ## Key Constants
 
-- **有効ツール名リスト (`VALID_TOOLS`)**: `lua/vibing/core/constants/tools.lua`
-  - 権限バリデーション（未知ツール名の警告）に使用
-  - 新しいツールを追加する場合はここと `lua/vibing/config.lua` の `M.defaults.permissions.allow` の両方に追加する
+`lua/vibing/core/constants/tools.lua` がツール名の唯一の定義元。`lua/vibing/config.lua` は値を
+再列挙せずここを参照する。
+
+- **`VALID_TOOLS`**: 権限設定に書けるツール名の一覧。権限バリデーション（未知ツール名の警告）に使う
+- **`DEFAULT_ALLOWED_TOOLS`**: `permissions.allow` の既定値。`VALID_TOOLS` からの差集合としては
+  導出しない（理由は同ファイルのコメント参照）
+- **`ALWAYS_ALLOWED_TOOLS`**: `allow` の内容に関わらず（`ask` / `deny` に無い限り）常に許可される
+  下限。`DEFAULT_ALLOWED_TOOLS` から外しても、こちらに残っていれば許可されたままになる
+- 新しいツールを追加するとき: 既定で許可するなら `VALID_TOOLS` と `DEFAULT_ALLOWED_TOOLS` の
+  両方に、Bash のように既定では許可しないなら `VALID_TOOLS` にのみ足す

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -133,7 +133,7 @@
 ---@field file_finder_strategy? Vibing.FileFinderStrategy ファイル検索戦略（"auto": 最適なツールを自動選択、"fd": fd使用、"find": find使用、"locate": locate/plocate使用、"ripgrep": rg使用）
 
 local notify = require("vibing.core.utils.notify")
-local tools_const = require("vibing.constants.tools")
+local tools_const = require("vibing.core.constants.tools")
 local language_utils = require("vibing.core.utils.language")
 
 local M = {}
@@ -241,7 +241,7 @@ M.defaults = {
   },
   permissions = {
     mode = "acceptEdits",
-    allow = { "Read", "Edit", "Write", "Glob", "Grep", "Skill", "StructuredOutput" },
+    allow = vim.deepcopy(tools_const.DEFAULT_ALLOWED_TOOLS),
     deny = { "Bash" },
     ask = {},
     rules = {},

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -39,6 +39,23 @@ for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
   M.ALWAYS_ALLOWED_TOOLS_MAP[tool] = true
 end
 
+---`permissions.allow`の既定値。`config.lua`はこのリストを参照するだけで、値を再列挙しない。
+---VALID_TOOLSからの差集合としては導出しない。導出にするとVALID_TOOLSへツールを足した人が
+---「既定で許可してよいか」を判断しないまま自動的に許可され得るため、あえて列挙にしてその判断を
+---1行の追加として残す。ここに無いのはBash（任意コマンド実行）とWebSearch/WebFetch（外部通信）。
+---`ALWAYS_ALLOWED_TOOLS`とは別物で、あちらは`allow`の内容に関わらず効く下限。ここから外しても
+---あちらに残っていれば許可されたままになる。
+---@type string[]
+M.DEFAULT_ALLOWED_TOOLS = {
+  "Read",
+  "Edit",
+  "Write",
+  "Glob",
+  "Grep",
+  "Skill",
+  "StructuredOutput",
+}
+
 ---ツール名が有効かチェックし、正規化された名前を返す
 ---@param tool string チェックするツール名
 ---@return string|nil 有効な場合は正規化されたツール名

--- a/tests/tools_spec.lua
+++ b/tests/tools_spec.lua
@@ -75,4 +75,38 @@ describe("vibing.constants.tools", function()
       assert.is_nil(tools.validate_tool("Bash()"))
     end)
   end)
+
+  describe("DEFAULT_ALLOWED_TOOLS", function()
+    it("only names tools that VALID_TOOLS knows about", function()
+      -- The drift guard: DEFAULT_ALLOWED_TOOLS is written out by hand rather than derived, so a
+      -- typo or a rename in VALID_TOOLS would otherwise silently drop a tool from the default
+      -- allow list.
+      for _, tool in ipairs(tools.DEFAULT_ALLOWED_TOOLS) do
+        assert.is_true(tools.VALID_TOOLS_MAP[tool] ~= nil, tool .. " is not in VALID_TOOLS")
+      end
+    end)
+
+    it("leaves out the tools that must not be allowed by default", function()
+      for _, tool in ipairs({ "Bash", "WebSearch", "WebFetch" }) do
+        assert.is_false(vim.tbl_contains(tools.DEFAULT_ALLOWED_TOOLS, tool), tool .. " is allowed by default")
+      end
+    end)
+
+    it("is the value config.defaults.permissions.allow uses", function()
+      -- The point of #493: config.lua must not re-list these names, it must read them from here.
+      local config = require("vibing.config")
+      assert.same(tools.DEFAULT_ALLOWED_TOOLS, config.defaults.permissions.allow)
+    end)
+
+    it("survives a caller mutating config.defaults.permissions.allow", function()
+      local config = require("vibing.config")
+      local before = vim.deepcopy(tools.DEFAULT_ALLOWED_TOOLS)
+
+      table.insert(config.defaults.permissions.allow, "Bash")
+      local unchanged = vim.deepcopy(tools.DEFAULT_ALLOWED_TOOLS)
+      table.remove(config.defaults.permissions.allow)
+
+      assert.same(before, unchanged)
+    end)
+  end)
 end)


### PR DESCRIPTION
Closes #493

## 背景

CLAUDE.md の Key Constants にこう書かれていました。

> 新しいツールを追加する場合はここ（`tools.lua` の `VALID_TOOLS`）と `lua/vibing/config.lua` の
> `M.defaults.permissions.allow` の**両方に追加する**

典型的な二重管理で、しかも検知手段がありません。片方だけ更新すると次のどちらかが静かに起きます。

- `VALID_TOOLS` だけ → 既定で許可されない
- `allow` だけ → 未知ツール名の警告が出ない

## 変更内容

`tools.lua` に `DEFAULT_ALLOWED_TOOLS` を定義し、`config.lua` はそれを参照するだけにしました。
ツール名を書く場所が 1 ファイルになります。

ついでに `config.lua` の require を非推奨リダイレクト `vibing.constants.tools` から
`vibing.core.constants.tools` へ直しています。

## 設計判断: なぜ差集合で導出しないのか

`DEFAULT_ALLOWED_TOOLS = VALID_TOOLS - { Bash, WebSearch, WebFetch }` と導出すれば、名前を書く場所は
完全に 1 箇所になります。**採用しませんでした。**

導出にすると、`VALID_TOOLS` にツールを足した人が「既定で許可してよいか」を判断しないまま
自動的に許可されます。これは #488 で lightweight の denylist を廃止した理由と**同じ構造の失敗**です
（列挙の更新漏れが安全でない方向に作用する）。

明示的に列挙しておけば、その判断が必ず diff の 1 行として現れます。列挙の代償である「片方だけ
更新される」リスクは、下記のテストで機械的に潰しました。

## テスト

`tests/tools_spec.lua` に `describe("DEFAULT_ALLOWED_TOOLS")` を追加（4 件）。

| テスト | 目的 |
| --- | --- |
| only names tools that VALID_TOOLS knows about | ドリフトガード本体。手書きリストのタイポ・リネーム漏れを検知 |
| leaves out the tools that must not be allowed by default | `Bash` / `WebSearch` / `WebFetch` が既定許可に入らないことの回帰防止 |
| is the value config.defaults.permissions.allow uses | 本 PR の本質。`config.lua` が値を再列挙していないことの担保 |
| survives a caller mutating config.defaults.permissions.allow | `vim.deepcopy` により定数が汚染されないことを、参照比較ではなく挙動で検証 |

- 該当 spec 13 件パス、失敗 0
- 全 Lua スイート 63 spec 実行、失敗 0
- `pnpm run check`（Lua 構文）パス

**注記**: e2e スイートは main でも 1 件も実行されず exit 1 になります（稼働中の Neovim が
ポート 9876/9877 を占有）。本 PR とは無関係の既存の環境問題です。

## ドキュメント

CLAUDE.md の Key Constants を書き換え、`VALID_TOOLS` / `DEFAULT_ALLOWED_TOOLS` /
`ALWAYS_ALLOWED_TOOLS` の 3 つの役割分担と、新ツール追加時の判断（既定で許可するか否か）を
明記しました。

## スコープ外

`ui/permission_builder.lua` と `application/chat/handlers/{allow,deny,ask}.lua` は今も非推奨
リダイレクト経由で require していますが、リダイレクトは同一テーブルを返すだけで実害がなく、
本 PR の焦点をぼかすため触っていません。別 PR での機械的置換が妥当です。

## セルフレビュー

simplify（reuse / simplification / efficiency / altitude）と code review（correctness /
convention / security）を実施しました。

反映した指摘:
- コメントの圧縮（simplification）
- `ALWAYS_ALLOWED_TOOLS` との役割分担をコメントと CLAUDE.md に追記（altitude）
- 「参照が別オブジェクトである」ことを見るテストを、実際に mutate してみる挙動テストに置換（simplification）

残り 4 観点は指摘なしでした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how available tools and default permissions are managed.
  * Added guidance for adding tools with or without default access.

* **Configuration**
  * Default tool permissions now consistently include Read, Edit, Write, Glob, Grep, Skill, and StructuredOutput.
  * Bash, WebSearch, and WebFetch are no longer enabled by default.

* **Tests**
  * Added coverage to verify valid tools, default permissions, and configuration isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->