### PR TITLE
fix(codex): stop registering a chat_bufnr Codex can never use

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -48,7 +48,8 @@ so a concurrent instance's in-flight `.req`/`.res` files are never deleted.
 
 **Backends:** `claude_cli.lua` (default) and `codex_cli.lua` both implement the adapter
 interface; `init.lua` picks one from `config.adapter`, and `send_message.lua` can switch per
-request for `codex` agent types.
+request for `codex` agent types. Implementing the interface is not the same as feature parity —
+`AskUserQuestion` is Claude-only, for reasons `features.md` records.
 
 ## Module Structure
 

--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -63,3 +63,20 @@ turn's user message, so no Promise/state handling is required.
 
 Native `AskUserQuestion` is unavailable in headless `claude -p` mode and is opaque to vibing.nvim,
 so the PreToolUse hook intercepts and denies it, rendering the same UI as a fallback.
+
+**Codex backend: not available.** Codex sessions cannot reach this UI, so `codex_cli.lua`
+deliberately omits `chat_bufnr` when registering with `ActiveStreamRegistry`. Two things block it,
+and neither is fixable from this side:
+
+- Codex takes no system prompt (context and language are prepended to the user prompt instead), so
+  there is no place to hand the model the `chat_bufnr` the tool needs.
+- Registering the MCP server per run via `-c mcp_servers.*` would not help. Headless `codex exec`
+  auto-cancels MCP tool calls at the approval prompt — stdin is closed, so EOF reads as a denial —
+  unless it runs with `--dangerously-bypass-approvals-and-sandbox`, which vibing.nvim only passes
+  in `bypassPermissions` mode. See [openai/codex#24135][codex-24135].
+
+What still works on Codex is the ordinary tool-approval flow (the `ask` permission list): it routes
+on `handle_id`, not `chat_bufnr`. Only the question-list UI is missing. Revisit if the upstream
+issue is resolved.
+
+[codex-24135]: https://github.com/openai/codex/issues/24135

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -136,9 +136,15 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   -- chats don't cross-wire each other's approval UI (see ActiveStreamRegistry).
   env.VIBING_HANDLE_ID = handle_id
 
+  -- No chat_bufnr here, unlike claude_cli: it only exists to route nvim_ask_user_question back to
+  -- the right chat buffer, and Codex has no way to call that tool. Codex takes no system prompt,
+  -- so there is nowhere to tell the model the value, and registering the MCP server via
+  -- `-c mcp_servers.*` does not help either — headless `codex exec` auto-cancels MCP tool calls
+  -- on the approval prompt unless run with --dangerously-bypass-approvals-and-sandbox
+  -- (openai/codex#24135), which vibing.nvim only passes in bypassPermissions mode. Registering a
+  -- value nothing can consume would just look like a working route. See #532.
   ActiveStreamRegistry.register({
     handle_id = handle_id,
-    chat_bufnr = opts.chat_bufnr,
     adapter = self,
     on_insert_choices = opts.on_insert_choices,
     on_approval_required = opts.on_approval_required,


### PR DESCRIPTION
Closes #532

## 調査結果: issue の選択肢 3 を採ります

issue は 3 択でした。

1. Codex に MCP サーバーを登録する経路があるか調査する
2. あるなら `chat_bufnr` / `rpc_port` をモデルへ伝える
3. どちらも見込みがないなら登録を外してドキュメントに明記する

調査の結果 **1 は「経路はあるが使えない」** という答えになったので、3 を採りました。

## なぜ 2 が成立しないのか

**理由 A: Codex には system prompt がない**

`codex_command_builder.lua` はコンテキストも言語指定もすべて `full_prompt`（ユーザープロンプト）へ
前置する方式で、`--append-system-prompt` に相当するフラグを使っていません。モデルに `chat_bufnr` を
伝える定位置がありません。

**理由 B: MCP を登録しても、ヘッドレス実行ではツール呼び出しが通らない**

Codex は `[mcp_servers.<name>]` 形式で MCP に対応しており、`codex_settings_generator.lua` が既に
`-c 'hooks.pre_tool_use=[...]'` で実行毎の設定注入を実現しているので、同じ `-c` で
`mcp_servers.*` を注入する道は**あります**。

しかし上流に未解決の問題があります — [openai/codex#24135][codex-24135]。

> 非対話モードでは stdin が閉じているため、承認プロンプトが EOF を「拒否」と解釈し、MCP ツール
> 呼び出しが自動キャンセルされる。`approval_policy = "never"` も
> `mcp_servers.*.approval_policy = "never"` も効かない。

唯一の回避策は `--dangerously-bypass-approvals-and-sandbox` ですが、`codex_command_builder.lua` が
このフラグを付けるのは `permission_mode == "bypassPermissions"` のときだけです。つまり
`default` / `acceptEdits` / `plan` / `dontAsk` / `auto` の**通常運用ではほぼ確実に固まります**。

実装しても「質問しようとしたら固まる」という失敗モードになるため、見送りました。

## 変更内容

`codex_cli.lua` の `ActiveStreamRegistry.register()` から `chat_bufnr` を外し、理由をコメントに残し
ました。読み手のいない値が登録されていると、動く経路があるように見えてしまいます。

`.claude/rules/features.md` の AskUserQuestion セクションに Codex の制約と上流 issue へのリンクを
追記し、`.claude/rules/architecture.md` の Backends の一文に「インターフェースの実装 ≠ 機能パリティ」
を明記しました。次に見た人が同じ調査を繰り返さずに済みます。

## Codex でも動くもの

通常のツール承認フロー（`ask` 権限リスト）は **`handle_id` でルーティングされる**ため引き続き動作
します。使えないのは質問リスト UI だけです。

## 検証

- `pnpm run check`（Lua 構文）パス
- `ActiveStreamRegistry` の型定義は `@field chat_bufnr? number` で任意、`get_by_chat_bufnr` も
  nil を許容するため、外しても壊れません
- `cli_command_builder_spec.lua` 43 件パス（Claude 側に影響がないことの確認）
- `pnpm run lint:md` — 変更した 2 ファイルにエラーなし

## 注記

この環境に `codex` バイナリがインストールされていないため、Codex CLI の実挙動は検証できていません。
ただし本 PR は**機能を追加せず、消費されない値の登録を外すだけ**なので、Codex 側の挙動に依存しません。
上流 issue が解消されたら選択肢 2 を再検討する、という形で issue にトリガー条件を残します。

[codex-24135]: https://github.com/openai/codex/issues/24135

🤖 Generated with [Claude Code](https://claude.com/claude-code)