### PR TITLE
feat: let the agent point at code instead of describing where it is

### DIFF
--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -26,7 +26,7 @@ Prefix with `mcp__vibing-nvim__`:
   `nvim_list_tabpages`, `nvim_set_window_size`, `nvim_focus_window`, `nvim_win_set_buf`,
   `nvim_win_open_file`
 - **Commands**: `nvim_execute`
-- **Highlighting**: `nvim_highlight_range`, `nvim_clear_highlight` (see "Showing code" below)
+- **Highlighting**: `nvim_highlight_range`, `nvim_clear_highlight` (see "Showing Code" below)
 - **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
   `features.md`), `nvim_chat_send_message`
 - **Instances**: `nvim_list_instances`
@@ -40,7 +40,7 @@ chat window may not be active when a request is sent). Always call `nvim_list_wi
 match the target by `buffer_name`/`is_current`, and use the returned `winnr` — don't assume
 `winnr: 0` is the right window.
 
-## Showing code
+## Showing Code
 
 When the user asks to see code, open it rather than describing where it is: `nvim_list_windows` →
 pick a window that isn't the chat → `nvim_win_open_file` → `nvim_set_cursor` → `nvim_highlight_range`.

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -26,6 +26,7 @@ Prefix with `mcp__vibing-nvim__`:
   `nvim_list_tabpages`, `nvim_set_window_size`, `nvim_focus_window`, `nvim_win_set_buf`,
   `nvim_win_open_file`
 - **Commands**: `nvim_execute`
+- **Highlighting**: `nvim_highlight_range`, `nvim_clear_highlight` (see "Showing code" below)
 - **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
   `features.md`), `nvim_chat_send_message`
 - **Instances**: `nvim_list_instances`
@@ -38,6 +39,20 @@ Prefix with `mcp__vibing-nvim__`:
 chat window may not be active when a request is sent). Always call `nvim_list_windows()` first,
 match the target by `buffer_name`/`is_current`, and use the returned `winnr` — don't assume
 `winnr: 0` is the right window.
+
+## Showing code
+
+When the user asks to see code, open it rather than describing where it is: `nvim_list_windows` →
+pick a window that isn't the chat → `nvim_win_open_file` → `nvim_set_cursor` → `nvim_highlight_range`.
+The CLI's system prompt tells the model to do this, so the tools exist to make that instruction
+actionable.
+
+`nvim_highlight_range` puts an extmark range in the `vibing_highlight` namespace using the
+`VibingHighlight` group, which is `default link`ed to `Visual` so `hi VibingHighlight ...` in a
+user's config overrides it. It clears itself after `duration_ms` (default 3000; `0` keeps it), and
+a second call to the same buffer replaces the first rather than stacking. Out-of-range lines are
+clamped to the buffer rather than rejected — search results go stale by a line or two, and pointing
+at roughly the right place beats refusing to point.
 
 ## Background LSP Analysis
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -230,8 +230,9 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         .. "mcp__vibing-nvim__nvim_list_windows to find a window that is not the chat, open the file "
         .. "there with mcp__vibing-nvim__nvim_win_open_file, move to the line with "
         .. "mcp__vibing-nvim__nvim_set_cursor, and point at the range with "
-        .. "mcp__vibing-nvim__nvim_highlight_range. Then explain the point in the chat. Skip this "
-        .. "when the user only wants a path or a name."
+        .. "mcp__vibing-nvim__nvim_highlight_range. Then explain the point in the chat. If the chat "
+        .. "is the only window, make one with mcp__vibing-nvim__nvim_execute and a split command. "
+        .. "Skip all of this when the user only wants a path or a name."
     )
 
     if rpc_port then

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -224,6 +224,15 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         .. 'this turn\'s "Current vibing.nvim chat buffer number" (given elsewhere in this system '
         .. "prompt) as the chat_bufnr argument."
     )
+    table.insert(
+      system_prompt_lines,
+      "When the user asks to see code, show it rather than describing where it lives: call "
+        .. "mcp__vibing-nvim__nvim_list_windows to find a window that is not the chat, open the file "
+        .. "there with mcp__vibing-nvim__nvim_win_open_file, move to the line with "
+        .. "mcp__vibing-nvim__nvim_set_cursor, and point at the range with "
+        .. "mcp__vibing-nvim__nvim_highlight_range. Then explain the point in the chat. Skip this "
+        .. "when the user only wants a path or a name."
+    )
 
     if rpc_port then
       table.insert(

--- a/lua/vibing/infrastructure/rpc/handlers/highlight.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/highlight.lua
@@ -19,15 +19,24 @@ local function ensure_highlight_group()
 end
 
 --- @param bufnr number
-local function clear(bufnr)
-  local timer = clear_timers[bufnr]
-  if timer then
-    timer:stop()
-    clear_timers[bufnr] = nil
-  end
+local function clear_marks(bufnr)
   if vim.api.nvim_buf_is_valid(bufnr) then
     vim.api.nvim_buf_clear_namespace(bufnr, NAMESPACE, 0, -1)
   end
+end
+
+--- Cancel a pending auto-clear and drop the marks. Only for the early paths — the timer's own
+--- callback must not come through here, because vim.defer_fn closes the handle after the callback
+--- returns and closing it again from inside errors.
+--- @param bufnr number
+local function clear(bufnr)
+  local timer = clear_timers[bufnr]
+  clear_timers[bufnr] = nil
+  if timer and not timer:is_closing() then
+    timer:stop()
+    timer:close()
+  end
+  clear_marks(bufnr)
 end
 
 --- @param bufnr any
@@ -69,8 +78,10 @@ function M.highlight_range(params)
   start_line = math.max(1, math.min(start_line, line_count))
   end_line = math.max(start_line, math.min(end_line, line_count))
 
+  -- A negative duration would otherwise fall through the `> 0` check below and read as "keep
+  -- forever", which is what 0 means. Treat it as unset rather than as a second way to say 0.
   local duration_ms = params.duration_ms
-  if type(duration_ms) ~= "number" then
+  if type(duration_ms) ~= "number" or duration_ms < 0 then
     duration_ms = DEFAULT_DURATION_MS
   end
 
@@ -86,7 +97,8 @@ function M.highlight_range(params)
 
   if duration_ms > 0 then
     clear_timers[bufnr] = vim.defer_fn(function()
-      clear(bufnr)
+      clear_timers[bufnr] = nil
+      clear_marks(bufnr)
     end, duration_ms)
   end
 

--- a/lua/vibing/infrastructure/rpc/handlers/highlight.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/highlight.lua
@@ -1,0 +1,119 @@
+--- Temporary range highlighting, so the agent can point at code instead of describing where it is.
+--- @module vibing.infrastructure.rpc.handlers.highlight
+
+local M = {}
+
+local NAMESPACE = vim.api.nvim_create_namespace("vibing_highlight")
+
+--- Pending auto-clear timers, keyed by buffer. A second call to the same buffer has to stop the
+--- first one, or the earlier timer fires mid-way through the new highlight and clears it early.
+--- @type table<number, uv.uv_timer_t>
+local clear_timers = {}
+
+local DEFAULT_DURATION_MS = 3000
+
+--- `default = true` so `hi VibingHighlight ...` in a user's config wins. Visual is the closest
+--- built-in in meaning: "this is the bit being pointed at".
+local function ensure_highlight_group()
+  vim.api.nvim_set_hl(0, "VibingHighlight", { link = "Visual", default = true })
+end
+
+--- @param bufnr number
+local function clear(bufnr)
+  local timer = clear_timers[bufnr]
+  if timer then
+    timer:stop()
+    clear_timers[bufnr] = nil
+  end
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    vim.api.nvim_buf_clear_namespace(bufnr, NAMESPACE, 0, -1)
+  end
+end
+
+--- @param bufnr any
+--- @return number
+local function resolve_bufnr(bufnr)
+  if type(bufnr) ~= "number" then
+    error("Missing bufnr parameter")
+  end
+  if bufnr == 0 then
+    return vim.api.nvim_get_current_buf()
+  end
+  return bufnr
+end
+
+--- Highlight a line range, then take it away again.
+--- @param params table
+---   - bufnr (number): target buffer, 0 for current (required)
+---   - start_line (number): 1-indexed first line (required)
+---   - end_line (number): 1-indexed last line, inclusive (defaults to start_line)
+---   - duration_ms (number): clear after this many ms; 0 keeps it until the next call
+--- @return table
+function M.highlight_range(params)
+  params = params or {}
+
+  local start_line = params.start_line
+  if type(start_line) ~= "number" then
+    error("Missing start_line parameter")
+  end
+
+  local bufnr = resolve_bufnr(params.bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    error("Invalid buffer: " .. tostring(bufnr))
+  end
+
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  local end_line = params.end_line or start_line
+  -- Clamp rather than error: the agent is working from search results that may be a few lines
+  -- stale, and pointing at roughly the right place beats refusing to point at all.
+  start_line = math.max(1, math.min(start_line, line_count))
+  end_line = math.max(start_line, math.min(end_line, line_count))
+
+  local duration_ms = params.duration_ms
+  if type(duration_ms) ~= "number" then
+    duration_ms = DEFAULT_DURATION_MS
+  end
+
+  ensure_highlight_group()
+  clear(bufnr)
+
+  local last = vim.api.nvim_buf_get_lines(bufnr, end_line - 1, end_line, false)[1] or ""
+  vim.api.nvim_buf_set_extmark(bufnr, NAMESPACE, start_line - 1, 0, {
+    end_row = end_line - 1,
+    end_col = #last,
+    hl_group = "VibingHighlight",
+  })
+
+  if duration_ms > 0 then
+    clear_timers[bufnr] = vim.defer_fn(function()
+      clear(bufnr)
+    end, duration_ms)
+  end
+
+  return {
+    success = true,
+    bufnr = bufnr,
+    start_line = start_line,
+    end_line = end_line,
+    duration_ms = duration_ms,
+  }
+end
+
+--- Drop the highlight before its timer runs out.
+---
+--- This is what makes `duration_ms = 0` usable: without it, a highlight asked to stay could only
+--- be taken away by highlighting something else.
+--- @param params table - bufnr (number): target buffer, 0 for current (required)
+--- @return table
+function M.clear_highlight(params)
+  params = params or {}
+  local bufnr = resolve_bufnr(params.bufnr)
+
+  clear(bufnr)
+  return { success = true, bufnr = bufnr }
+end
+
+--- @private Exposed for tests.
+M._namespace = NAMESPACE
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -6,6 +6,7 @@ local cursor = require("vibing.infrastructure.rpc.handlers.cursor")
 local window = require("vibing.infrastructure.rpc.handlers.window")
 local lsp = require("vibing.infrastructure.rpc.handlers.lsp")
 local execute = require("vibing.infrastructure.rpc.handlers.execute")
+local highlight = require("vibing.infrastructure.rpc.handlers.highlight")
 local message = require("vibing.infrastructure.rpc.handlers.message")
 local permission = require("vibing.infrastructure.rpc.handlers.permission")
 local rate_limit = require("vibing.infrastructure.rpc.handlers.rate_limit")
@@ -41,6 +42,9 @@ M.lsp_call_hierarchy_incoming = lsp.lsp_call_hierarchy_incoming
 M.lsp_call_hierarchy_outgoing = lsp.lsp_call_hierarchy_outgoing
 
 M.execute = execute.execute
+
+M.highlight_range = highlight.highlight_range
+M.clear_highlight = highlight.clear_highlight
 
 M.send_message = message.send_message
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -202,6 +202,38 @@ The MCP server exposes the following tools to Claude:
 - **nvim_execute** - Execute Neovim command
   - `command` (required): Neovim command string (e.g., "write", "edit foo.txt")
 
+### Highlighting
+
+- **nvim_highlight_range** - Temporarily highlight a line range so the user can see which code you
+  mean. Pair with `nvim_win_open_file` and `nvim_set_cursor` to open and jump there first
+  - `bufnr` (required): Buffer number (0 for current)
+  - `start_line` (required): First line to highlight (1-indexed)
+  - `end_line` (optional): Last line, inclusive (defaults to `start_line`)
+  - `duration_ms` (optional): Auto-clear delay, default 3000. `0` keeps it until the next
+    highlight or `nvim_clear_highlight`
+  - Uses the `VibingHighlight` group, `default link`ed to `Visual` and overridable with
+    `hi VibingHighlight ...`
+
+- **nvim_clear_highlight** - Remove the highlight before it times out
+  - `bufnr` (required): Buffer number (0 for current)
+
+### Chat
+
+- **nvim_chat_send_message** - Send a message to a chat buffer and start an AI request
+  - `bufnr` (required): Chat buffer number
+  - `message` (required): Message text
+  - `sender` (optional): Sender label, defaults to "User"
+
+- **nvim_ask_user_question** - Render a multiple-choice question in the chat buffer. This cancels
+  the in-flight turn; the user's answer arrives as the next turn's message
+  - `chat_bufnr` (required): Chat buffer number
+  - `questions` (required): Array of `{ question, options, multiSelect? }`
+
+### Instances
+
+- **nvim_list_instances** - List running Neovim instances with a vibing.nvim RPC server
+  - Returns: `{ instances: [{ pid, port, cwd, started_at }] }`
+
 ### LSP Operations
 
 - **nvim_lsp_definition** - Get definition location(s) of symbol

--- a/mcp-server/src/handlers/highlight.ts
+++ b/mcp-server/src/handlers/highlight.ts
@@ -1,0 +1,52 @@
+import { callNeovim } from '../rpc.js';
+
+/**
+ * Highlight a line range in a buffer for a short while.
+ *
+ * @param args - `bufnr` and `start_line` are required; `end_line` defaults to `start_line` and
+ *   `duration_ms` defaults to 3000 on the Neovim side.
+ * @returns A content block describing what was highlighted.
+ * @throws Error when `bufnr` or `start_line` is missing.
+ */
+export async function handleHighlightRange(args: any) {
+  if (!args || args.bufnr === undefined) {
+    throw new Error('Missing required parameter: bufnr');
+  }
+  if (args.start_line === undefined) {
+    throw new Error('Missing required parameter: start_line');
+  }
+
+  const result = await callNeovim(
+    'highlight_range',
+    {
+      bufnr: args.bufnr,
+      start_line: args.start_line,
+      end_line: args.end_line,
+      duration_ms: args.duration_ms,
+    },
+    args.rpc_port
+  );
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+  };
+}
+
+/**
+ * Remove the highlight from a buffer before its timer runs out.
+ *
+ * @param args - `bufnr` is required.
+ * @returns A content block confirming the clear.
+ * @throws Error when `bufnr` is missing.
+ */
+export async function handleClearHighlight(args: any) {
+  if (!args || args.bufnr === undefined) {
+    throw new Error('Missing required parameter: bufnr');
+  }
+
+  const result = await callNeovim('clear_highlight', { bufnr: args.bufnr }, args.rpc_port);
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/mcp-server/src/handlers/index.ts
+++ b/mcp-server/src/handlers/index.ts
@@ -5,6 +5,7 @@ import * as window from './window.js';
 import * as lsp from './lsp.js';
 import * as instances from './instances.js';
 import * as chat from './chat.js';
+import * as highlight from './highlight.js';
 
 export const handlers: Record<string, (args: any) => Promise<any>> = {
   // Buffer operations
@@ -48,4 +49,8 @@ export const handlers: Record<string, (args: any) => Promise<any>> = {
   // Chat operations
   nvim_chat_send_message: chat.handleChatSendMessage,
   nvim_ask_user_question: chat.handleAskUserQuestion,
+
+  // Highlighting
+  nvim_highlight_range: highlight.handleHighlightRange,
+  nvim_clear_highlight: highlight.handleClearHighlight,
 };

--- a/mcp-server/src/tools/highlight.ts
+++ b/mcp-server/src/tools/highlight.ts
@@ -1,0 +1,48 @@
+import { withRpcPort, requireRpcPort } from './common.js';
+
+export const highlightTools = [
+  {
+    name: 'nvim_highlight_range',
+    description:
+      'Temporarily highlight a line range so the user can see which code you mean. Pair with ' +
+      'nvim_win_open_file and nvim_set_cursor to open the file and jump there first.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: withRpcPort({
+        bufnr: {
+          type: 'number' as const,
+          description: 'Buffer number (0 for current buffer)',
+        },
+        start_line: {
+          type: 'number' as const,
+          description: 'First line to highlight (1-indexed)',
+        },
+        end_line: {
+          type: 'number' as const,
+          description: 'Last line to highlight, inclusive (1-indexed, defaults to start_line)',
+        },
+        duration_ms: {
+          type: 'number' as const,
+          description:
+            'Clear the highlight after this many milliseconds (default 3000). Pass 0 to leave it ' +
+            'until the next highlight or nvim_clear_highlight.',
+        },
+      }),
+      required: requireRpcPort(['bufnr', 'start_line']),
+    },
+  },
+  {
+    name: 'nvim_clear_highlight',
+    description: 'Remove the nvim_highlight_range highlight from a buffer before it times out',
+    inputSchema: {
+      type: 'object' as const,
+      properties: withRpcPort({
+        bufnr: {
+          type: 'number' as const,
+          description: 'Buffer number (0 for current buffer)',
+        },
+      }),
+      required: requireRpcPort(['bufnr']),
+    },
+  },
+];

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -5,6 +5,7 @@ import { lspTools } from './lsp.js';
 import { executeTools } from './execute.js';
 import { instanceTools } from './instances.js';
 import { chatTools } from './chat.js';
+import { highlightTools } from './highlight.js';
 
 export const allTools = [
   ...bufferTools,
@@ -14,4 +15,5 @@ export const allTools = [
   ...executeTools,
   ...instanceTools,
   ...chatTools,
+  ...highlightTools,
 ];

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -35,6 +35,14 @@ describe("cli_command_builder", function()
       assert.is_true(prompt_text:find(".vibing/worktrees/", 1, true) ~= nil)
     end)
 
+    it("tells the model to open, jump and highlight rather than describe where code is", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+      assert.is_true(prompt_text:find("nvim_highlight_range", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("nvim_win_open_file", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("nvim_set_cursor", 1, true) ~= nil)
+    end)
+
     it("combines the language instruction and worktree instruction into a single flag", function()
       local config = { language = "ja" }
       local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
@@ -350,6 +358,7 @@ describe("cli_command_builder", function()
       assert.is_nil(prompt_text:find("nvim_ask_user_question", 1, true))
       assert.is_nil(prompt_text:find("Your rpc_port for this turn is", 1, true))
       assert.is_nil(prompt_text:find("Current vibing.nvim chat buffer number:", 1, true))
+      assert.is_nil(prompt_text:find("nvim_highlight_range", 1, true))
     end)
 
     it("still applies the language instruction to the system prompt", function()

--- a/tests/lua/infrastructure/rpc/handlers/highlight_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/highlight_spec.lua
@@ -1,0 +1,139 @@
+---@diagnostic disable: undefined-field
+local highlight = require("vibing.infrastructure.rpc.handlers.highlight")
+
+local function make_buffer(line_count)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  local lines = {}
+  for i = 1, line_count do
+    lines[i] = "line " .. i
+  end
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  return bufnr
+end
+
+local function marks(bufnr)
+  return vim.api.nvim_buf_get_extmarks(bufnr, highlight._namespace, 0, -1, { details = true })
+end
+
+describe("rpc handlers highlight", function()
+  local bufnr
+
+  before_each(function()
+    bufnr = make_buffer(10)
+  end)
+
+  after_each(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end)
+
+  describe("highlight_range", function()
+    it("marks the requested range with VibingHighlight", function()
+      highlight.highlight_range({ bufnr = bufnr, start_line = 3, end_line = 5 })
+
+      local found = marks(bufnr)
+      assert.equals(1, #found)
+      assert.equals(2, found[1][2]) -- 0-indexed start row for line 3
+      assert.equals(4, found[1][4].end_row)
+      assert.equals("VibingHighlight", found[1][4].hl_group)
+    end)
+
+    it("highlights a single line when end_line is omitted", function()
+      highlight.highlight_range({ bufnr = bufnr, start_line = 7 })
+
+      local found = marks(bufnr)
+      assert.equals(6, found[1][2])
+      assert.equals(6, found[1][4].end_row)
+    end)
+
+    it("replaces the previous highlight instead of stacking a second one", function()
+      highlight.highlight_range({ bufnr = bufnr, start_line = 1, end_line = 2 })
+      highlight.highlight_range({ bufnr = bufnr, start_line = 8, end_line = 9 })
+
+      local found = marks(bufnr)
+      assert.equals(1, #found)
+      assert.equals(7, found[1][2])
+    end)
+
+    it("clamps a range that runs past the end of the buffer", function()
+      -- Search results go stale by a line or two; pointing at roughly the right place beats
+      -- refusing to point.
+      local result = highlight.highlight_range({ bufnr = bufnr, start_line = 9, end_line = 999 })
+
+      assert.equals(9, result.start_line)
+      assert.equals(10, result.end_line)
+      assert.equals(9, marks(bufnr)[1][4].end_row)
+    end)
+
+    it("keeps the highlight when duration_ms is 0", function()
+      local result = highlight.highlight_range({ bufnr = bufnr, start_line = 1, duration_ms = 0 })
+
+      assert.equals(0, result.duration_ms)
+      assert.equals(1, #marks(bufnr))
+    end)
+
+    it("clears the highlight once duration_ms has elapsed", function()
+      highlight.highlight_range({ bufnr = bufnr, start_line = 1, duration_ms = 20 })
+      assert.equals(1, #marks(bufnr))
+
+      vim.wait(300, function()
+        return #marks(bufnr) == 0
+      end)
+
+      assert.equals(0, #marks(bufnr))
+    end)
+
+    it("does not let an earlier timer clear a later highlight", function()
+      -- The bug this guards: without cancelling the first timer, the 20ms one fires while the
+      -- second highlight is still meant to be showing.
+      highlight.highlight_range({ bufnr = bufnr, start_line = 1, duration_ms = 20 })
+      highlight.highlight_range({ bufnr = bufnr, start_line = 5, duration_ms = 0 })
+
+      vim.wait(100)
+
+      assert.equals(1, #marks(bufnr))
+      assert.equals(4, marks(bufnr)[1][2])
+    end)
+
+    it("errors instead of guessing when start_line is missing", function()
+      assert.has_error(function()
+        highlight.highlight_range({ bufnr = bufnr })
+      end)
+    end)
+
+    it("errors instead of guessing when bufnr is missing", function()
+      assert.has_error(function()
+        highlight.highlight_range({ start_line = 1 })
+      end)
+    end)
+
+    it("errors on a buffer that does not exist", function()
+      assert.has_error(function()
+        highlight.highlight_range({ bufnr = 999999, start_line = 1 })
+      end)
+    end)
+  end)
+
+  describe("clear_highlight", function()
+    it("removes a highlight that has not timed out yet", function()
+      highlight.highlight_range({ bufnr = bufnr, start_line = 2, duration_ms = 0 })
+      highlight.clear_highlight({ bufnr = bufnr })
+
+      assert.equals(0, #marks(bufnr))
+    end)
+
+    it("is a no-op on a buffer with no highlight", function()
+      assert.equals(true, highlight.clear_highlight({ bufnr = bufnr }).success)
+    end)
+  end)
+
+  describe("VibingHighlight group", function()
+    it("is defined as a default link so a user's own hi command wins", function()
+      highlight.highlight_range({ bufnr = bufnr, start_line = 1 })
+
+      local hl = vim.api.nvim_get_hl(0, { name = "VibingHighlight" })
+      assert.equals("Visual", hl.link)
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #495

## 背景

「このコードどこ?」と聞かれたとき、vibing.nvim はパスと行番号をテキストで返すだけで、開いて
スクロールするのはユーザーの仕事でした。エディタを操作できるアシスタントとしては不自然です。
隣に座ったペアプロ相手なら画面を指差します。

## 変更内容

### 1. MCP ツール `nvim_highlight_range`

指定バッファの行範囲に extmark で一時ハイライトを当て、一定時間後に自動で消します。

| パラメータ | 説明 |
| --- | --- |
| `bufnr`（必須） | 対象バッファ（0 で現在のバッファ） |
| `start_line`（必須） | 開始行（1-indexed） |
| `end_line` | 終了行・inclusive（省略時は `start_line`） |
| `duration_ms` | 自動クリアまでの時間（既定 3000）。`0` で保持 |

### 2. MCP ツール `nvim_clear_highlight`

`duration_ms: 0` を実際に使えるようにするためのものです。これがないと「保持」と指定した
ハイライトは、別の場所をハイライトする以外に消す手段がありません。

### 3. システムプロンプトへの行動指針

「ウィンドウを列挙 → チャット以外を選ぶ → ファイルを開く → カーソル移動 → ハイライト → 説明」
という手順を指示します。チャットしかウィンドウがない場合は split を作ることも含みます。
パスや名前だけを求められたときはスキップするよう明記しています（lightweight 呼び出しには
入りません）。

## 設計上の判断

**`VibingHighlight` は `Visual` への `default link`** なので、`hi VibingHighlight ...` で
上書きできます。呼び出しごとに再宣言しているのは、`:colorscheme` で消えるためです。1 回だけの
定義にして `ColorScheme` autocmd で復活させる案より、毎回 `nvim_set_hl` を呼ぶ方が部品が
少なくて済みます。

**連続呼び出しは置き換え、かつ前のタイマーをキャンセル**します。このキャンセルがないと、
先のタイマーが後のハイライトの表示中に発火して早期に消してしまいます。この挙動には専用の
テストがあります。

**範囲外の行はエラーではなくクランプ**します。モデルは 1〜2 行ずれうる検索結果を元に動くので、
だいたい正しい位置を指す方が、指すのを拒否するより有用です。

**タイマーのクローズ経路を分けています。** 早期キャンセル（`clear`）では
`timer:stop()` + `timer:close()` を呼びますが、タイマー自身のコールバックからは呼べません
（`vim.defer_fn` がコールバック終了後にハンドルを閉じるため、二重クローズでエラーになる）。
そのため `clear()`（キャンセル用）と `clear_marks()`（コールバック用）に分割しています。

**負の `duration_ms` は未指定扱い**にしました。そのままだと `> 0` の判定をすり抜けて `0`
（＝保持）と同じ意味になってしまい、`-1` を渡した呼び出し元の意図とは考えにくいためです。

## スコープ外とした指示

issue は `mcp-server/src/registry/tool-registry.ts` へのエントリ追加も指示していますが、
**追加していません**。

このモジュールは本体から一切参照されておらず（`index.ts` は `tools/index.ts` の `allTools` と
`handlers/index.ts` の `handlers` だけを使う）、参照元は自身のテストのみです。中身は
`handler: async () => ({ content: '', lines: 0 })` のようなダミー実装が約 12 個で、
`nvim_win_open_file` / `nvim_ask_user_question` / LSP call hierarchy 系など既存の多くの
ツールを欠いています。13 個目の陳腐化したエントリを足しても負債が増えるだけです。

**#492（MCP ツール表面積の棚卸し）で削除を検討すべき候補**として記録します。

## テスト

`tests/lua/infrastructure/rpc/handlers/highlight_spec.lua`（新規 13 件）— 範囲指定、単一行、
置き換え、クランプ、`duration_ms: 0`、自動クリア、**古いタイマーが新しいハイライトを消さないこと**、
エラー経路 3 種、`clear_highlight` 2 種、`default link` の確認。

`cli_command_builder_spec.lua` に 1 件追加（指針が入ること）、既存の lightweight テストに
`nvim_highlight_range` が入らないことのアサーションを追加。

- 全 Lua スイート 792 件パス、失敗 0
- MCP 側 62 件パス、`tsc --noEmit` クリーン
- `pnpm run check` パス

## セルフレビュー

simplify（reuse / simplification / efficiency+altitude）と code review（correctness /
convention / robustness）を実施しました。

反映した指摘:
- タイマーコールバックが `clear()` を再実装していた重複の解消（simplification）
- `bufnr` 正規化の重複を `resolve_bufnr` に集約（simplification）
- 早期キャンセル時の `timer:close()` 漏れ。リポジトリ規約との不一致（correctness）
- 負の `duration_ms` の意味の曖昧さ（robustness）
- チャットしかウィンドウがない場合の指針欠落（robustness）
- 見出しの Title Case（convention）
- あわせて `mcp-server/README.md` のツール一覧を実態に合わせて更新（本ブランチ以前から 3 ツール
  分が欠落していました）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP tools to temporarily highlight code ranges in Neovim and clear highlights.
  * Supports single-line or multi-line ranges, automatic line clamping, configurable highlight duration, and persistent highlights until cleared.
  * Improved code-display guidance so relevant requests can open files, position the cursor, and highlight code in the editor.
* **Documentation**
  * Added usage guidance and reference documentation for highlighting, chat interactions, and running Neovim instances.
* **Tests**
  * Added coverage for highlighting, clearing, timers, validation, range handling, and code-display instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->