### PR TITLE
feat: let /perm narrow any tool that supports an argument, not just Bash

### DIFF
--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -72,9 +72,26 @@ rules for destructive Bash commands, defined in
 
 ## Interactive Permission Builder
 
-`/permissions` (or `/perm`) launches a `vim.ui.select()`-driven UI: pick a tool, choose allow/deny,
-optionally specify a Bash command pattern, and the result is written to chat frontmatter — an
-alternative to hand-editing config or frontmatter.
+`/permissions` (or `/perm`) launches a `vim.ui.select()`-driven UI: pick a tool, choose
+allow/ask/deny, optionally narrow it with an argument, and the result is written to chat
+frontmatter — an alternative to hand-editing config or frontmatter. The allow/ask/deny step shows
+what is currently set for that tool, so you can see `Bash(git:*)` is already allowed before adding
+another entry.
+
+Which argument a tool takes follows `infrastructure/permissions/matchers.lua`, since that is what
+has to parse the result back:
+
+| Tool                         | Argument       | Example                |
+| ---------------------------- | -------------- | ---------------------- |
+| `Bash`                       | command prefix | `Bash(git:*)`          |
+| `Read` / `Write` / `Edit`    | path glob      | `Read(src/**)`         |
+| `WebFetch` / `WebSearch`     | domain         | `WebFetch(github.com)` |
+| `Glob` / `Grep`              | exact pattern  | `Glob(**/*.ts)`        |
+| `Skill` / `StructuredOutput` | none           | `Skill`                |
+
+The last row is deliberate. `matchers` classifies anything else as `unknown_pattern` and never
+matches it, so letting the picker build a `Skill(x)` would produce a rule that silently never
+fires.
 
 ## Tool Approval UI
 

--- a/lua/vibing/application/chat/handlers/permissions.lua
+++ b/lua/vibing/application/chat/handlers/permissions.lua
@@ -16,12 +16,20 @@ return function(args, chat_buffer)
         return
       end
 
-      permission_builder.prompt_permission_type(tool.name, function(permission_type)
+      -- Read back the current state so the allow/ask/deny prompt can show what is already set for
+      -- this tool, instead of asking blind.
+      local current_lists = {
+        allow = chat_buffer:get_frontmatter_list("permissions_allow"),
+        ask = chat_buffer:get_frontmatter_list("permissions_ask"),
+        deny = chat_buffer:get_frontmatter_list("permissions_deny"),
+      }
+
+      permission_builder.prompt_permission_type(tool.name, current_lists, function(permission_type)
         if not permission_type then
           return
         end
 
-        permission_builder.handle_bash_pattern_selection(tool, permission_type, function(permission_string)
+        permission_builder.handle_pattern_selection(tool, permission_type, function(permission_string)
           if not permission_string then
             return
           end

--- a/lua/vibing/ui/permission_builder.lua
+++ b/lua/vibing/ui/permission_builder.lua
@@ -25,6 +25,24 @@ local TOOL_DESCRIPTIONS = {
   Grep = "Search for patterns in files",
   WebSearch = "Search the web for information",
   WebFetch = "Fetch content from URLs",
+  Skill = "Invoke a Claude Code skill",
+  StructuredOutput = "Return a schema-validated response",
+}
+
+---ツール名 → 引数の種類。`matchers.parse_tool_pattern` が解釈できる形だけを載せる。
+---ここに無いツール（Skill / StructuredOutput）にはピッカーから引数を付けさせない。
+---`matchers` は未知の形を `unknown_pattern` として黙って不一致にするので、付けられるようにすると
+---「ルールを作ったのに永久にマッチしない」という静かな不具合になる。
+---@type table<string, "bash"|"path"|"domain"|"literal">
+M.ARG_KIND = {
+  Bash = "bash",
+  Read = "path",
+  Write = "path",
+  Edit = "path",
+  WebFetch = "domain",
+  WebSearch = "domain",
+  Glob = "literal",
+  Grep = "literal",
 }
 
 ---Bashコマンドプリセット
@@ -35,6 +53,24 @@ M.bash_presets = {
   { pattern = "docker", description = "Dockerコマンド", danger = false },
   { pattern = "chmod", description = "パーミッション変更", danger = true },
   { pattern = "sudo", description = "特権実行", danger = true },
+}
+
+---パスパターンのプリセット（Read / Write / Edit）
+---`danger` が付くものは deny 向けの例。allow で選ぶと機密ファイルを開放してしまうため警告を出す。
+M.path_presets = {
+  { pattern = "src/**", description = "ソースツリー全体", danger = false },
+  { pattern = "tests/**", description = "テストツリー全体", danger = false },
+  { pattern = "docs/**", description = "ドキュメント", danger = false },
+  { pattern = ".env", description = "環境変数ファイル（deny向け）", danger = true },
+  { pattern = "*.secret", description = "シークレットファイル（deny向け）", danger = true },
+  { pattern = "*.key", description = "鍵ファイル（deny向け）", danger = true },
+}
+
+---ドメインのプリセット（WebFetch / WebSearch）
+M.domain_presets = {
+  { pattern = "github.com", description = "GitHub", danger = false },
+  { pattern = "*.npmjs.com", description = "npm レジストリ", danger = false },
+  { pattern = "docs.rs", description = "Rust ドキュメント", danger = false },
 }
 
 ---組み込みツールのリストを取得
@@ -176,16 +212,34 @@ function M._show_telescope(chat_buffer, callback)
     :find()
 end
 
----Bashプリセットピッカーを表示
----@param callback function(pattern: string)
-function M.show_bash_preset_picker(callback)
+---引数の種類ごとのプリセットとプロンプト文言
+---@param kind "bash"|"path"|"domain"|"literal"
+---@return table[] presets, string prompt_title, string skip_description
+function M._presets_for_kind(kind)
+  if kind == "bash" then
+    return M.bash_presets, "Select Bash command pattern:", "パターンなし（Bash全体）"
+  elseif kind == "path" then
+    return M.path_presets, "Select path pattern:", "パターンなし（全パス）"
+  elseif kind == "domain" then
+    return M.domain_presets, "Select domain:", "ドメイン指定なし（全ドメイン）"
+  end
+  -- literal は完全一致でしか使えないため、事前定義しても再利用性がない。custom 入力だけ出す。
+  return {}, "Enter pattern:", "パターンなし（全体）"
+end
+
+---パターンピッカーを表示
+---@param presets table[] 選択肢のプリセット
+---@param prompt_title string
+---@param skip_description string 「パターンなし」の説明文
+---@param callback function(pattern: string?)
+function M.show_pattern_picker(presets, prompt_title, skip_description, callback)
   local preset_list = vim.tbl_map(function(preset)
     return {
       pattern = preset.pattern,
       description = preset.description,
       danger = preset.danger,
     }
-  end, M.bash_presets)
+  end, presets)
 
   table.insert(preset_list, {
     pattern = "custom",
@@ -195,25 +249,26 @@ function M.show_bash_preset_picker(callback)
 
   table.insert(preset_list, {
     pattern = "skip",
-    description = "パターンなし（Bash全体）",
+    description = skip_description,
     danger = false,
   })
 
   local has_telescope, _ = pcall(require, "telescope")
 
   if has_telescope then
-    M._show_bash_telescope(preset_list, callback)
+    M._show_pattern_telescope(preset_list, prompt_title, callback)
   else
-    M._show_bash_native(preset_list, callback)
+    M._show_pattern_native(preset_list, prompt_title, callback)
   end
 end
 
----vim.ui.selectでBashプリセット選択
+---vim.ui.selectでパターン選択
 ---@param preset_list table[]
+---@param prompt_title string
 ---@param callback function(pattern: string)
-function M._show_bash_native(preset_list, callback)
+function M._show_pattern_native(preset_list, prompt_title, callback)
   vim.ui.select(preset_list, {
-    prompt = "Select Bash command pattern:",
+    prompt = prompt_title,
     format_item = function(item)
       local danger_mark = item.danger and "⚠️ " or ""
       return string.format("%s%s - %s", danger_mark, item.pattern, item.description)
@@ -233,10 +288,11 @@ function M._show_bash_native(preset_list, callback)
   end)
 end
 
----TelescopeでBashプリセット選択
+---Telescopeでパターン選択
 ---@param preset_list table[]
+---@param prompt_title string
 ---@param callback function(pattern: string)
-function M._show_bash_telescope(preset_list, callback)
+function M._show_pattern_telescope(preset_list, prompt_title, callback)
   local pickers = require("telescope.pickers")
   local finders = require("telescope.finders")
   local conf = require("telescope.config").values
@@ -262,7 +318,7 @@ function M._show_bash_telescope(preset_list, callback)
 
   pickers
     .new({}, {
-      prompt_title = "Bash Command Pattern",
+      prompt_title = prompt_title,
       finder = finders.new_table({
         results = preset_list,
         entry_maker = function(entry)
@@ -311,15 +367,47 @@ function M._prompt_custom_pattern(callback)
   end)
 end
 
----Allow/Deny選択プロンプト
----@param tool_name string ツール名
----@param callback function(permission_type: string) "allow" または "deny"
-function M.prompt_permission_type(tool_name, callback)
-  local choices = {
-    { type = "allow", description = "Allow - このツールの使用を許可" },
-    { type = "ask", description = "Ask - このツールの使用前に確認を要求" },
-    { type = "deny", description = "Deny - このツールの使用を拒否" },
+---allow/ask/deny の選択肢を、そのツールの現在の設定付きで組み立てる
+---「このツール、もう allow に入ってたっけ?」に答えられるようにするのが目的。
+---引数付きのエントリ（`Bash(git:*)`）も同じツールのものとして拾う。
+---@param tool_name string
+---@param current_lists table {allow: string[], ask: string[], deny: string[]}
+---@return table[] choices
+function M.build_permission_type_choices(tool_name, current_lists)
+  current_lists = current_lists or {}
+
+  local function summarize(list)
+    local matches = vim.tbl_filter(function(entry)
+      return entry == tool_name or vim.startswith(entry, tool_name .. "(")
+    end, list or {})
+    if #matches == 0 then
+      return "現在: なし"
+    end
+    return "現在: " .. table.concat(matches, ", ")
+  end
+
+  return {
+    {
+      type = "allow",
+      description = string.format("Allow - このツールの使用を許可 (%s)", summarize(current_lists.allow)),
+    },
+    {
+      type = "ask",
+      description = string.format("Ask - このツールの使用前に確認を要求 (%s)", summarize(current_lists.ask)),
+    },
+    {
+      type = "deny",
+      description = string.format("Deny - このツールの使用を拒否 (%s)", summarize(current_lists.deny)),
+    },
   }
+end
+
+---Allow/Ask/Deny選択プロンプト
+---@param tool_name string ツール名
+---@param current_lists table {allow: string[], ask: string[], deny: string[]}
+---@param callback function(permission_type: string) "allow" / "ask" / "deny"
+function M.prompt_permission_type(tool_name, current_lists, callback)
+  local choices = M.build_permission_type_choices(tool_name, current_lists)
 
   vim.ui.select(choices, {
     prompt = string.format("Configure permission for '%s':", tool_name),
@@ -333,32 +421,44 @@ function M.prompt_permission_type(tool_name, callback)
   end)
 end
 
----Bashパターン選択フロー
----Bashツールの場合のみパターン選択を促す
+---パターン選択フロー
+---引数を取れるツール（`ARG_KIND` に載っているもの）だけパターン選択を促す。
+---載っていないツールに引数を付けさせないのは意図的: `matchers` が解釈できない形は
+---`unknown_pattern` として黙って不一致になり、作ったルールが永久に効かなくなるため。
 ---@param tool table ツール情報
----@param permission_type string "allow" または "deny"
+---@param permission_type string "allow" / "ask" / "deny"
 ---@param callback function(permission_string: string)
-function M.handle_bash_pattern_selection(tool, permission_type, callback)
-  if not tool.is_bash then
-    local permission_string = M.build_permission_string(tool.name, nil)
-    callback(permission_string)
+function M.handle_pattern_selection(tool, permission_type, callback)
+  local kind = M.ARG_KIND[tool.name]
+  if not kind then
+    callback(M.build_permission_string(tool.name, nil))
     return
   end
 
-  M.show_bash_preset_picker(function(pattern)
-    local permission_string = M.build_permission_string(tool.name, pattern)
-    callback(permission_string)
+  local presets, prompt_title, skip_description = M._presets_for_kind(kind)
+  M.show_pattern_picker(presets, prompt_title, skip_description, function(pattern)
+    callback(M.build_permission_string(tool.name, pattern))
   end)
 end
 
 ---権限文字列を構築
+---Bashだけが `Bash(git:*)` のように `:*` を付ける。パス・ドメイン・リテラルは
+---`Read(src/**)` のように素の引数を括弧に入れる（`matchers.parse_tool_pattern` の分類に従う）。
 ---@param tool_name string ツール名
----@param pattern string? Bashコマンドパターン
+---@param pattern string? 引数パターン
 ---@return string permission_string
 function M.build_permission_string(tool_name, pattern)
-  if tool_name == "Bash" and pattern then
-    return string.format("Bash(%s:*)", pattern)
+  if not pattern or pattern == "" then
+    return tool_name
   end
+
+  local kind = M.ARG_KIND[tool_name]
+  if kind == "bash" then
+    return string.format("%s(%s:*)", tool_name, pattern)
+  elseif kind then
+    return string.format("%s(%s)", tool_name, pattern)
+  end
+
   return tool_name
 end
 

--- a/tests/permission_builder_spec.lua
+++ b/tests/permission_builder_spec.lua
@@ -22,16 +22,16 @@ describe("vibing.ui.permission_builder", function()
       assert.is_function(permission_builder._show_telescope)
     end)
 
-    it("should have show_bash_preset_picker function", function()
-      assert.is_function(permission_builder.show_bash_preset_picker)
+    it("should have show_pattern_picker function", function()
+      assert.is_function(permission_builder.show_pattern_picker)
     end)
 
-    it("should have _show_bash_native function", function()
-      assert.is_function(permission_builder._show_bash_native)
+    it("should have _show_pattern_native function", function()
+      assert.is_function(permission_builder._show_pattern_native)
     end)
 
-    it("should have _show_bash_telescope function", function()
-      assert.is_function(permission_builder._show_bash_telescope)
+    it("should have _show_pattern_telescope function", function()
+      assert.is_function(permission_builder._show_pattern_telescope)
     end)
 
     it("should have _prompt_custom_pattern function", function()
@@ -42,8 +42,8 @@ describe("vibing.ui.permission_builder", function()
       assert.is_function(permission_builder.prompt_permission_type)
     end)
 
-    it("should have handle_bash_pattern_selection function", function()
-      assert.is_function(permission_builder.handle_bash_pattern_selection)
+    it("should have handle_pattern_selection function", function()
+      assert.is_function(permission_builder.handle_pattern_selection)
     end)
 
     it("should have build_permission_string function", function()
@@ -114,6 +114,120 @@ describe("vibing.ui.permission_builder", function()
       assert.equals("Bash(npm:*)", permission_builder.build_permission_string("Bash", "npm"))
       assert.equals("Bash(docker:*)", permission_builder.build_permission_string("Bash", "docker"))
     end)
+
+    it("should build a path pattern without the Bash :* suffix", function()
+      assert.equals("Read(src/**)", permission_builder.build_permission_string("Read", "src/**"))
+      assert.equals("Write(.env)", permission_builder.build_permission_string("Write", ".env"))
+      assert.equals("Edit(tests/**)", permission_builder.build_permission_string("Edit", "tests/**"))
+    end)
+
+    it("should build a domain pattern", function()
+      assert.equals("WebFetch(github.com)", permission_builder.build_permission_string("WebFetch", "github.com"))
+      assert.equals(
+        "WebSearch(*.npmjs.com)",
+        permission_builder.build_permission_string("WebSearch", "*.npmjs.com")
+      )
+    end)
+
+    it("should build a literal pattern for Glob and Grep", function()
+      assert.equals("Glob(**/*.ts)", permission_builder.build_permission_string("Glob", "**/*.ts"))
+      assert.equals("Grep(TODO)", permission_builder.build_permission_string("Grep", "TODO"))
+    end)
+
+    it("should drop the pattern for tools matchers.lua cannot parse", function()
+      -- Skill(foo) parses as unknown_pattern and never matches, so never emit one.
+      assert.equals("Skill", permission_builder.build_permission_string("Skill", "foo"))
+      assert.equals("StructuredOutput", permission_builder.build_permission_string("StructuredOutput", "x"))
+    end)
+
+    it("should return the bare tool name for an empty pattern", function()
+      assert.equals("Bash", permission_builder.build_permission_string("Bash", ""))
+      assert.equals("Read", permission_builder.build_permission_string("Read", ""))
+    end)
+  end)
+
+  describe("ARG_KIND", function()
+    it("should map every tool that matchers.lua can parse an argument for", function()
+      local expected = {
+        Bash = "bash",
+        Read = "path",
+        Write = "path",
+        Edit = "path",
+        WebFetch = "domain",
+        WebSearch = "domain",
+        Glob = "literal",
+        Grep = "literal",
+      }
+      assert.same(expected, permission_builder.ARG_KIND)
+    end)
+  end)
+
+  describe("build_permission_type_choices", function()
+    it("should report no current setting when the lists are empty", function()
+      local choices = permission_builder.build_permission_type_choices("Bash", { allow = {}, ask = {}, deny = {} })
+
+      assert.equals(3, #choices)
+      for _, choice in ipairs(choices) do
+        assert.is_true(choice.description:find("現在: なし", 1, true) ~= nil)
+      end
+    end)
+
+    it("should show the entry that is already configured", function()
+      local choices = permission_builder.build_permission_type_choices("Read", {
+        allow = { "Read", "Write" },
+        ask = {},
+        deny = {},
+      })
+
+      assert.is_true(choices[1].description:find("現在: Read", 1, true) ~= nil)
+      assert.is_true(choices[2].description:find("現在: なし", 1, true) ~= nil)
+    end)
+
+    it("should match argument-carrying entries for the same tool", function()
+      local choices = permission_builder.build_permission_type_choices("Bash", {
+        allow = { "Bash(git:*)", "Bash(npm:*)", "Read" },
+        ask = {},
+        deny = {},
+      })
+
+      assert.is_true(choices[1].description:find("Bash(git:*), Bash(npm:*)", 1, true) ~= nil)
+      -- "Read" is a different tool and must not be counted here.
+      assert.is_nil(choices[1].description:find("Read", 1, true))
+    end)
+
+    it("should tolerate missing lists", function()
+      local choices = permission_builder.build_permission_type_choices("Bash", {})
+      assert.equals(3, #choices)
+    end)
+  end)
+
+  describe("path_presets and domain_presets", function()
+    it("should define path presets with the shared preset fields", function()
+      assert.is_true(#permission_builder.path_presets > 0)
+      for _, preset in ipairs(permission_builder.path_presets) do
+        assert.is_string(preset.pattern)
+        assert.is_string(preset.description)
+        assert.is_boolean(preset.danger)
+      end
+    end)
+
+    it("should flag the sensitive path presets as dangerous", function()
+      local danger = {}
+      for _, preset in ipairs(permission_builder.path_presets) do
+        danger[preset.pattern] = preset.danger
+      end
+      assert.is_true(danger[".env"])
+      assert.is_true(danger["*.secret"])
+      assert.is_false(danger["src/**"])
+    end)
+
+    it("should define domain presets", function()
+      local patterns = {}
+      for _, preset in ipairs(permission_builder.domain_presets) do
+        patterns[preset.pattern] = true
+      end
+      assert.is_true(patterns["github.com"])
+    end)
   end)
 
   describe("bash_presets", function()
@@ -143,19 +257,55 @@ describe("vibing.ui.permission_builder", function()
     end)
   end)
 
-  describe("handle_bash_pattern_selection", function()
-    it("should call callback with tool name for non-Bash tools", function()
+  describe("handle_pattern_selection", function()
+    it("should skip the pattern prompt for tools that cannot take an argument", function()
+      -- Skill has no ARG_KIND: matchers.lua would parse Skill(x) as unknown_pattern and never
+      -- match it, so the picker must not let one be built.
       local called_with = nil
-      local tool = {
-        name = "Read",
-        is_bash = false,
-      }
 
-      permission_builder.handle_bash_pattern_selection(tool, "allow", function(result)
+      permission_builder.handle_pattern_selection({ name = "Skill" }, "allow", function(result)
         called_with = result
       end)
 
-      assert.equals("Read", called_with)
+      assert.equals("Skill", called_with)
+    end)
+
+    it("should offer path presets for Read", function()
+      local seen_presets = nil
+      local original_show = permission_builder.show_pattern_picker
+      permission_builder.show_pattern_picker = function(presets, _title, _skip, callback)
+        seen_presets = presets
+        callback("src/**")
+      end
+
+      local result = nil
+      permission_builder.handle_pattern_selection({ name = "Read" }, "allow", function(permission_string)
+        result = permission_string
+      end)
+
+      assert.equals(permission_builder.path_presets, seen_presets)
+      assert.equals("Read(src/**)", result)
+
+      permission_builder.show_pattern_picker = original_show
+    end)
+
+    it("should offer domain presets for WebFetch", function()
+      local seen_presets = nil
+      local original_show = permission_builder.show_pattern_picker
+      permission_builder.show_pattern_picker = function(presets, _title, _skip, callback)
+        seen_presets = presets
+        callback("github.com")
+      end
+
+      local result = nil
+      permission_builder.handle_pattern_selection({ name = "WebFetch" }, "allow", function(permission_string)
+        result = permission_string
+      end)
+
+      assert.equals(permission_builder.domain_presets, seen_presets)
+      assert.equals("WebFetch(github.com)", result)
+
+      permission_builder.show_pattern_picker = original_show
     end)
 
     it("should prompt for pattern when tool is Bash", function()
@@ -165,14 +315,14 @@ describe("vibing.ui.permission_builder", function()
       }
 
       local picker_shown = false
-      local original_show = permission_builder.show_bash_preset_picker
-      permission_builder.show_bash_preset_picker = function(callback)
+      local original_show = permission_builder.show_pattern_picker
+      permission_builder.show_pattern_picker = function(_presets, _title, _skip, callback)
         picker_shown = true
         callback("git") -- Simulate user selecting "git"
       end
 
       local result = nil
-      permission_builder.handle_bash_pattern_selection(tool, "allow", function(permission_string)
+      permission_builder.handle_pattern_selection(tool, "allow", function(permission_string)
         result = permission_string
       end)
 
@@ -180,7 +330,7 @@ describe("vibing.ui.permission_builder", function()
       assert.equals("Bash(git:*)", result)
 
       -- Restore
-      permission_builder.show_bash_preset_picker = original_show
+      permission_builder.show_pattern_picker = original_show
     end)
   end)
 end)
@@ -199,6 +349,10 @@ describe("vibing.application.chat.handlers.permissions", function()
       buf = 1,
       update_frontmatter_list = function(self, key, value, action)
         return true
+      end,
+      -- The builder reads these back so the allow/ask/deny prompt can show what is already set.
+      get_frontmatter_list = function(self, key)
+        return {}
       end,
     }
 


### PR DESCRIPTION
Closes #226

## 背景

issue の要求は 2 つでした。

> コマンド名だけじゃなくて Bash(rm:*) みたいな引数も込で作れるように
> allow, ask, deny の選択もリッチにできるように

調べたところ、**必要な解釈エンジンは既に揃っていて、ピッカーだけが取り残されていました**。

`infrastructure/permissions/matchers.lua` の `parse_tool_pattern` は以前から次を解釈できます。

| 形式 | 分類 |
| --- | --- |
| `Bash(cmd:*)` / `Bash(cmd)` | コマンドマッチ |
| `Read(glob)` / `Write(glob)` / `Edit(glob)` | `file_glob` → `input.file_path` に対して照合 |
| `WebFetch(domain)` / `WebSearch(domain)` | `domain_pattern`（`*.` ワイルドカード対応） |
| `Glob(pattern)` / `Grep(pattern)` | `search_pattern`（完全一致） |

さらに `/allow` のエラーメッセージは既に `Read(src/**/*.ts)` や `WebFetch(github.com)` を利用例として
案内しています。つまりこれらは**意図された仕様として存在していた**のに、`/perm` からは作れませんでした。

## 変更内容

### 1. 引数を Bash 以外にも拡張

`M.ARG_KIND` テーブルでツールごとの引数の種類を宣言し、Bash 専用だったプリセットピッカーを
プリセットリストを受け取る形に一般化しました。

| ツール | 引数 | 生成される形 |
| --- | --- | --- |
| `Bash` | コマンド前方一致 | `Bash(git:*)` |
| `Read` / `Write` / `Edit` | パス glob | `Read(src/**)` |
| `WebFetch` / `WebSearch` | ドメイン | `WebFetch(github.com)` |
| `Glob` / `Grep` | 完全一致パターン | `Glob(**/*.ts)` |

`:*` サフィックスが付くのは Bash だけです。`Read(src/**:*)` のような無意味な形は生成されません。

パス・ドメインのプリセットを追加しました。Glob/Grep は完全一致なので事前定義の再利用性がなく、
custom 入力のみです。

### 2. Skill / StructuredOutput は意図的に対象外

`matchers` は解釈できない形を `unknown_pattern` として扱い、`matches_permission` が最後まで到達して
`false` を返します。つまり `Skill(foo)` のようなルールは**作れてしまうが永久にマッチしない**という
静かな不具合になります。

ピッカーがこれを作れないようにするのが `ARG_KIND` に載せない理由です。テストで固定しています。

### 3. allow/ask/deny の選択に現在の設定を表示

```text
Allow - このツールの使用を許可 (現在: Bash(git:*), Bash(npm:*))
Ask  - このツールの使用前に確認を要求 (現在: なし)
Deny - このツールの使用を拒否 (現在: なし)
```

「このツール、もう allow に入ってたっけ?」をピッカーを抜けずに判断できます。引数付きのエントリも
同じツールのものとして拾い、`Read` を見ているときに `Bash(...)` を数えることはありません。

選択肢の組み立ては純粋関数 `build_permission_type_choices` に切り出したので、`vim.ui.select` を
モックせずにテストできます（既存テストの流儀と揃えるため）。

### 4. ついでの修正

`TOOL_DESCRIPTIONS` に `Skill` と `StructuredOutput` が無く「No description」と表示されていたのを
埋めました。

## リネーム

Bash 専用だった名前を汎用化しました。外部から呼ばれない内部関数なので後方互換ラッパーは残していません。

| 変更前 | 変更後 |
| --- | --- |
| `show_bash_preset_picker` | `show_pattern_picker` |
| `_show_bash_native` / `_show_bash_telescope` | `_show_pattern_native` / `_show_pattern_telescope` |
| `handle_bash_pattern_selection` | `handle_pattern_selection` |

Telescope とネイティブの 2 経路はそのまま流用しているので、**重複は増えず、むしろ Bash 専用だった
1 ペアが 4 種類で共有される形に縮小**しています。

## 変更していないもの

`matchers.lua` / `can_use_tool.lua` / `cli_command_builder.lua` は**一切変更不要**です。ピッカーが
生成する文字列を既存パーサーの既知の型に合わせただけで、新しい構文は発明していません。

## テスト

`tests/permission_builder_spec.lua` を 24 件 → 39 件に拡張（全パス）。

- `build_permission_string` — パス / ドメイン / リテラルの各形式、`Skill` で引数が落ちること、空文字
- `ARG_KIND` — 8 ツールのマッピング全体を固定（うっかり Skill を足して matchers と不整合になる回帰を防ぐ）
- `build_permission_type_choices` — 未設定、設定済み、引数付きエントリの照合、リスト欠落への耐性
- `handle_pattern_selection` — Read でパスプリセット、WebFetch でドメインプリセット、Skill で即スキップ
- `path_presets` / `domain_presets` — 形状と `danger` フラグ

既存の Bash 経路（`Bash(git:*)`）のテストは無変更で通ります。

全 Lua スイート 793 件パス、`pnpm run check` パス。

## セキュリティ上の注意

パスプリセットの `.env` / `*.secret` / `*.key` は **deny 用の例**です。allow で選ぶと機密ファイルを
開放してしまうため、既存の Bash プリセットと同じ `danger` フラグを付けて ⚠️ を表示します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)