### PR TITLE
feat: show review points next to the code instead of only in the chat

### DIFF
--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -14,6 +14,7 @@
 | `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                   |
 | `:VibingClearContext`                 | Clear all context                                                                                   |
 | `:VibingCancel`                       | Cancel current request                                                                              |
+| `:VibingClearAnnotations`             | Remove inline review annotations from every buffer                                                  |
 | `:VibingPendingResumes`               | List chats waiting on a usage limit reset                                                           |
 | `:VibingCancelResume [all]`           | Cancel the pending auto-resume for this chat (or every one with `all`)                              |
 | `:VibingReloadCommands`               | Reload custom slash commands                                                                        |

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -27,6 +27,7 @@ Prefix with `mcp__vibing-nvim__`:
   `nvim_win_open_file`
 - **Commands**: `nvim_execute`
 - **Highlighting**: `nvim_highlight_range`, `nvim_clear_highlight` (see "Showing Code" below)
+- **Annotations**: `nvim_annotate`, `nvim_clear_annotations` (see "Inline Review Notes" below)
 - **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
   `features.md`), `nvim_chat_send_message`
 - **Instances**: `nvim_list_instances`
@@ -53,6 +54,21 @@ user's config overrides it. It clears itself after `duration_ms` (default 3000; 
 a second call to the same buffer replaces the first rather than stacking. Out-of-range lines are
 clamped to the buffer rather than rejected — search results go stale by a line or two, and pointing
 at roughly the right place beats refusing to point.
+
+## Inline Review Notes
+
+`nvim_annotate` puts a review point under the line it is about, as extmark `virt_lines` in the
+`vibing_annotations` namespace. The file is never written and `modified` never gets set. Severity
+picks between `VibingAnnotationInfo` / `Warn` / `Error`, each `default link`ed to the matching
+`DiagnosticVirtualText*` group so a user's own `hi` command overrides it. Every annotation line is
+prefixed with `┃ ` so a note can't be misread as code.
+
+Annotations are **not persisted** — unloading the buffer takes them with it. That is the intended
+lifetime: a review is read once and dismissed. Editing near an annotation moves it the way
+extmarks normally move; no attempt is made to re-anchor it.
+
+`nvim_clear_annotations` clears one buffer, or every buffer when `bufnr` is omitted.
+`:VibingClearAnnotations` is the same thing from the user's side.
 
 ## Background LSP Analysis
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -245,6 +245,13 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         .. "is the only window, make one with mcp__vibing-nvim__nvim_execute and a split command. "
         .. "Skip all of this when the user only wants a path or a name."
     )
+    table.insert(
+      system_prompt_lines,
+      "When reviewing code, put each point next to the code it is about: load the file with "
+        .. "mcp__vibing-nvim__nvim_load_buffer and call mcp__vibing-nvim__nvim_annotate for every "
+        .. "finding, choosing severity info, warn or error. Keep the chat to the overall verdict "
+        .. "and the count, and mention that :VibingClearAnnotations removes the notes."
+    )
 
     if rpc_port then
       table.insert(

--- a/lua/vibing/infrastructure/rpc/handlers/annotations.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/annotations.lua
@@ -1,0 +1,122 @@
+--- Inline review notes, shown next to the code they are about instead of only in the chat.
+---
+--- Annotations are extmark virt_lines: the file is never touched and `modified` never gets set.
+--- They are deliberately not persisted — a review is read once and then dismissed, so unloading
+--- the buffer taking them with it is the intended lifetime, not a gap.
+--- @module vibing.infrastructure.rpc.handlers.annotations
+
+local M = {}
+
+local resolve_bufnr = require("vibing.infrastructure.rpc.handlers.bufnr").resolve
+
+local NAMESPACE = vim.api.nvim_create_namespace("vibing_annotations")
+
+--- Marker down the left of every annotation line, so a note can't be mistaken for real code.
+local MARKER = "┃ "
+
+--- @type table<string, string>
+local SEVERITY_GROUPS = {
+  info = "VibingAnnotationInfo",
+  warn = "VibingAnnotationWarn",
+  error = "VibingAnnotationError",
+}
+
+--- `default = true` so a user's own `hi VibingAnnotationWarn ...` wins. Linked to the diagnostic
+--- virtual-text groups because that is what a reader already reads as "a note about this line".
+local function ensure_highlight_groups()
+  vim.api.nvim_set_hl(0, "VibingAnnotationInfo", { link = "DiagnosticVirtualTextInfo", default = true })
+  vim.api.nvim_set_hl(0, "VibingAnnotationWarn", { link = "DiagnosticVirtualTextWarn", default = true })
+  vim.api.nvim_set_hl(0, "VibingAnnotationError", { link = "DiagnosticVirtualTextError", default = true })
+end
+
+--- Attach a note to a line.
+--- @param params table
+---   - bufnr (number): target buffer, 0 for current (required)
+---   - line (number): 1-indexed line to annotate (required)
+---   - text (string): note body; newlines become separate virtual lines (required)
+---   - severity (string): "info" | "warn" | "error" (defaults to "info")
+--- @return table
+function M.annotate(params)
+  params = params or {}
+
+  local bufnr = resolve_bufnr(params.bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    error("Invalid buffer: " .. tostring(bufnr))
+  end
+
+  local line = params.line
+  if type(line) ~= "number" then
+    error("Missing line parameter")
+  end
+
+  local text = params.text
+  if type(text) ~= "string" or text == "" then
+    error("Missing text parameter")
+  end
+
+  local severity = params.severity
+  local hl_group = SEVERITY_GROUPS[severity]
+  if not hl_group then
+    severity = "info"
+    hl_group = SEVERITY_GROUPS.info
+  end
+
+  -- Same reasoning as highlight_range: the model works from search results that go stale by a
+  -- line or two, so land the note near the right place rather than refusing to place it.
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  line = math.max(1, math.min(line, line_count))
+
+  ensure_highlight_groups()
+
+  local virt_lines = {}
+  for _, chunk in ipairs(vim.split(text, "\n", { plain = true })) do
+    table.insert(virt_lines, { { MARKER .. chunk, hl_group } })
+  end
+
+  local id = vim.api.nvim_buf_set_extmark(bufnr, NAMESPACE, line - 1, 0, {
+    virt_lines = virt_lines,
+  })
+
+  return {
+    success = true,
+    bufnr = bufnr,
+    line = line,
+    severity = severity,
+    extmark_id = id,
+  }
+end
+
+--- Drop annotations.
+--- @param params table - bufnr (number): target buffer; omit to clear every buffer
+--- @return table
+function M.clear_annotations(params)
+  params = params or {}
+
+  local cleared = {}
+  local targets
+  if params.bufnr == nil then
+    targets = vim.api.nvim_list_bufs()
+  else
+    targets = { resolve_bufnr(params.bufnr) }
+  end
+
+  for _, bufnr in ipairs(targets) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      -- Only report buffers that actually had something: cleared_buffers is part of the tool's
+      -- return value, so listing untouched buffers would mislead the caller. limit = 1 because
+      -- this only needs to know whether any mark exists, not fetch them all.
+      local existing = vim.api.nvim_buf_get_extmarks(bufnr, NAMESPACE, 0, -1, { limit = 1 })
+      if #existing > 0 then
+        vim.api.nvim_buf_clear_namespace(bufnr, NAMESPACE, 0, -1)
+        table.insert(cleared, bufnr)
+      end
+    end
+  end
+
+  return { success = true, cleared_buffers = cleared }
+end
+
+--- @private Exposed for tests.
+M._namespace = NAMESPACE
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/bufnr.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/bufnr.lua
@@ -1,0 +1,22 @@
+--- Shared buffer-argument handling for RPC handlers.
+--- @module vibing.infrastructure.rpc.handlers.bufnr
+
+local M = {}
+
+--- Turn an incoming bufnr argument into a real buffer number.
+---
+--- Errors rather than defaulting when the caller gave nothing: the tools that use this change what
+--- the user sees, so guessing a buffer is worse than refusing.
+--- @param bufnr any
+--- @return number
+function M.resolve(bufnr)
+  if type(bufnr) ~= "number" then
+    error("Missing bufnr parameter")
+  end
+  if bufnr == 0 then
+    return vim.api.nvim_get_current_buf()
+  end
+  return bufnr
+end
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/highlight.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/highlight.lua
@@ -3,6 +3,8 @@
 
 local M = {}
 
+local resolve_bufnr = require("vibing.infrastructure.rpc.handlers.bufnr").resolve
+
 local NAMESPACE = vim.api.nvim_create_namespace("vibing_highlight")
 
 --- Pending auto-clear timers, keyed by buffer. A second call to the same buffer has to stop the
@@ -37,18 +39,6 @@ local function clear(bufnr)
     timer:close()
   end
   clear_marks(bufnr)
-end
-
---- @param bufnr any
---- @return number
-local function resolve_bufnr(bufnr)
-  if type(bufnr) ~= "number" then
-    error("Missing bufnr parameter")
-  end
-  if bufnr == 0 then
-    return vim.api.nvim_get_current_buf()
-  end
-  return bufnr
 end
 
 --- Highlight a line range, then take it away again.

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -7,6 +7,7 @@ local window = require("vibing.infrastructure.rpc.handlers.window")
 local lsp = require("vibing.infrastructure.rpc.handlers.lsp")
 local execute = require("vibing.infrastructure.rpc.handlers.execute")
 local highlight = require("vibing.infrastructure.rpc.handlers.highlight")
+local annotations = require("vibing.infrastructure.rpc.handlers.annotations")
 local message = require("vibing.infrastructure.rpc.handlers.message")
 local permission = require("vibing.infrastructure.rpc.handlers.permission")
 local rate_limit = require("vibing.infrastructure.rpc.handlers.rate_limit")
@@ -45,6 +46,9 @@ M.execute = execute.execute
 
 M.highlight_range = highlight.highlight_range
 M.clear_highlight = highlight.clear_highlight
+
+M.annotate = annotations.annotate
+M.clear_annotations = annotations.clear_annotations
 
 M.send_message = message.send_message
 

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -226,6 +226,22 @@ function M._register_commands()
     end
   end, { desc = "Cancel current Vibing request" })
 
+  vim.api.nvim_create_user_command("VibingClearAnnotations", function()
+    -- Reaches into the RPC handler rather than a presentation controller, unlike the commands
+    -- around it. There is no presentation state to own here: annotations live entirely in an
+    -- extmark namespace, and this command and the MCP tool both want the same one function. A
+    -- controller would be a pass-through with nothing in it. Give annotations real UI state and
+    -- this should grow one like the rest.
+    local annotations = require("vibing.infrastructure.rpc.handlers.annotations")
+    local result = annotations.clear_annotations({})
+    local count = #result.cleared_buffers
+    if count == 0 then
+      notify.info("No annotations to clear")
+    else
+      notify.info(string.format("Cleared annotations in %d buffer(s)", count))
+    end
+  end, { desc = "Clear vibing.nvim inline review annotations from all buffers" })
+
   vim.api.nvim_create_user_command("VibingPendingResumes", function()
     local AutoResume = require("vibing.application.chat.auto_resume")
     local entries = AutoResume.list()

--- a/mcp-server/src/handlers/annotations.ts
+++ b/mcp-server/src/handlers/annotations.ts
@@ -1,0 +1,49 @@
+import { callNeovim } from '../rpc.js';
+
+/**
+ * Attach an inline review note to a line.
+ *
+ * @param args - `bufnr`, `line` and `text` are required; `severity` defaults to "info".
+ * @returns A content block with the created extmark id.
+ * @throws Error when `bufnr`, `line` or `text` is missing.
+ */
+export async function handleAnnotate(args: any) {
+  if (!args || args.bufnr === undefined) {
+    throw new Error('Missing required parameter: bufnr');
+  }
+  if (args.line === undefined) {
+    throw new Error('Missing required parameter: line');
+  }
+  if (args.text === undefined) {
+    throw new Error('Missing required parameter: text');
+  }
+
+  const result = await callNeovim(
+    'annotate',
+    {
+      bufnr: args.bufnr,
+      line: args.line,
+      text: args.text,
+      severity: args.severity,
+    },
+    args.rpc_port
+  );
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+  };
+}
+
+/**
+ * Remove annotations from one buffer, or from all of them.
+ *
+ * @param args - `bufnr` is optional; omitting it clears every buffer.
+ * @returns A content block listing the buffers that had annotations removed.
+ */
+export async function handleClearAnnotations(args: any) {
+  const result = await callNeovim('clear_annotations', { bufnr: args?.bufnr }, args?.rpc_port);
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/mcp-server/src/handlers/index.ts
+++ b/mcp-server/src/handlers/index.ts
@@ -6,6 +6,7 @@ import * as lsp from './lsp.js';
 import * as instances from './instances.js';
 import * as chat from './chat.js';
 import * as highlight from './highlight.js';
+import * as annotations from './annotations.js';
 
 export const handlers: Record<string, (args: any) => Promise<any>> = {
   // Buffer operations
@@ -53,4 +54,8 @@ export const handlers: Record<string, (args: any) => Promise<any>> = {
   // Highlighting
   nvim_highlight_range: highlight.handleHighlightRange,
   nvim_clear_highlight: highlight.handleClearHighlight,
+
+  // Annotations
+  nvim_annotate: annotations.handleAnnotate,
+  nvim_clear_annotations: annotations.handleClearAnnotations,
 };

--- a/mcp-server/src/tools/annotations.ts
+++ b/mcp-server/src/tools/annotations.ts
@@ -1,0 +1,47 @@
+import { withRpcPort, requireRpcPort } from './common.js';
+
+export const annotationTools = [
+  {
+    name: 'nvim_annotate',
+    description:
+      'Attach a review note to a line, shown inline under it as virtual text. The file is not ' +
+      'modified.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: withRpcPort({
+        bufnr: {
+          type: 'number' as const,
+          description: 'Buffer number (0 for current buffer)',
+        },
+        line: {
+          type: 'number' as const,
+          description: 'Line to annotate (1-indexed)',
+        },
+        text: {
+          type: 'string' as const,
+          description: 'Note body. Newlines become separate annotation lines.',
+        },
+        severity: {
+          type: 'string' as const,
+          enum: ['info', 'warn', 'error'],
+          description: 'Colours the note (default "info")',
+        },
+      }),
+      required: requireRpcPort(['bufnr', 'line', 'text']),
+    },
+  },
+  {
+    name: 'nvim_clear_annotations',
+    description: 'Remove annotations from a buffer, or from every buffer when bufnr is omitted',
+    inputSchema: {
+      type: 'object' as const,
+      properties: withRpcPort({
+        bufnr: {
+          type: 'number' as const,
+          description: 'Buffer number (0 for current). Omit to clear every buffer.',
+        },
+      }),
+      required: requireRpcPort(),
+    },
+  },
+];

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -6,6 +6,7 @@ import { executeTools } from './execute.js';
 import { instanceTools } from './instances.js';
 import { chatTools } from './chat.js';
 import { highlightTools } from './highlight.js';
+import { annotationTools } from './annotations.js';
 
 export const allTools = [
   ...bufferTools,
@@ -16,4 +17,5 @@ export const allTools = [
   ...instanceTools,
   ...chatTools,
   ...highlightTools,
+  ...annotationTools,
 ];

--- a/tests/lua/infrastructure/rpc/handlers/annotations_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/annotations_spec.lua
@@ -1,0 +1,142 @@
+---@diagnostic disable: undefined-field
+local annotations = require("vibing.infrastructure.rpc.handlers.annotations")
+
+local function make_buffer(line_count)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  local lines = {}
+  for i = 1, line_count do
+    lines[i] = "line " .. i
+  end
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  return bufnr
+end
+
+local function marks(bufnr)
+  return vim.api.nvim_buf_get_extmarks(bufnr, annotations._namespace, 0, -1, { details = true })
+end
+
+describe("rpc handlers annotations", function()
+  local bufnr
+
+  before_each(function()
+    bufnr = make_buffer(10)
+  end)
+
+  after_each(function()
+    annotations.clear_annotations({})
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end)
+
+  describe("annotate", function()
+    it("puts the note under the requested line as virtual lines", function()
+      annotations.annotate({ bufnr = bufnr, line = 4, text = "this leaks a handle" })
+
+      local found = marks(bufnr)
+      assert.equals(1, #found)
+      assert.equals(3, found[1][2]) -- 0-indexed row for line 4
+      assert.equals(1, #found[1][4].virt_lines)
+      assert.equals("┃ this leaks a handle", found[1][4].virt_lines[1][1][1])
+    end)
+
+    it("never marks the buffer modified, since the file is untouched", function()
+      annotations.annotate({ bufnr = bufnr, line = 1, text = "note" })
+
+      assert.is_false(vim.bo[bufnr].modified)
+    end)
+
+    it("splits a multi-line note into one virtual line each", function()
+      annotations.annotate({ bufnr = bufnr, line = 2, text = "first\nsecond\nthird" })
+
+      local virt_lines = marks(bufnr)[1][4].virt_lines
+      assert.equals(3, #virt_lines)
+      assert.equals("┃ second", virt_lines[2][1][1])
+    end)
+
+    it("colours the note by severity", function()
+      annotations.annotate({ bufnr = bufnr, line = 1, text = "a", severity = "warn" })
+      assert.equals("VibingAnnotationWarn", marks(bufnr)[1][4].virt_lines[1][1][2])
+
+      annotations.clear_annotations({ bufnr = bufnr })
+      annotations.annotate({ bufnr = bufnr, line = 1, text = "a", severity = "error" })
+      assert.equals("VibingAnnotationError", marks(bufnr)[1][4].virt_lines[1][1][2])
+    end)
+
+    it("falls back to info for an unknown severity", function()
+      local result = annotations.annotate({ bufnr = bufnr, line = 1, text = "a", severity = "nope" })
+
+      assert.equals("info", result.severity)
+      assert.equals("VibingAnnotationInfo", marks(bufnr)[1][4].virt_lines[1][1][2])
+    end)
+
+    it("keeps several notes on the same buffer, unlike highlights", function()
+      annotations.annotate({ bufnr = bufnr, line = 1, text = "one" })
+      annotations.annotate({ bufnr = bufnr, line = 5, text = "two" })
+
+      assert.equals(2, #marks(bufnr))
+    end)
+
+    it("clamps a line past the end of the buffer", function()
+      local result = annotations.annotate({ bufnr = bufnr, line = 999, text = "a" })
+
+      assert.equals(10, result.line)
+    end)
+
+    it("returns the extmark id", function()
+      local result = annotations.annotate({ bufnr = bufnr, line = 1, text = "a" })
+
+      assert.is_number(result.extmark_id)
+    end)
+
+    it("errors when line or text is missing", function()
+      assert.has_error(function()
+        annotations.annotate({ bufnr = bufnr, text = "a" })
+      end)
+      assert.has_error(function()
+        annotations.annotate({ bufnr = bufnr, line = 1 })
+      end)
+      assert.has_error(function()
+        annotations.annotate({ bufnr = bufnr, line = 1, text = "" })
+      end)
+    end)
+  end)
+
+  describe("clear_annotations", function()
+    it("clears the named buffer", function()
+      annotations.annotate({ bufnr = bufnr, line = 1, text = "a" })
+      local result = annotations.clear_annotations({ bufnr = bufnr })
+
+      assert.equals(0, #marks(bufnr))
+      assert.same({ bufnr }, result.cleared_buffers)
+    end)
+
+    it("clears every buffer when bufnr is omitted", function()
+      local other = make_buffer(3)
+      annotations.annotate({ bufnr = bufnr, line = 1, text = "a" })
+      annotations.annotate({ bufnr = other, line = 1, text = "b" })
+
+      local result = annotations.clear_annotations({})
+
+      assert.equals(0, #marks(bufnr))
+      assert.equals(0, #marks(other))
+      assert.equals(2, #result.cleared_buffers)
+
+      vim.api.nvim_buf_delete(other, { force = true })
+    end)
+
+    it("reports no buffers when there was nothing to clear", function()
+      assert.same({}, annotations.clear_annotations({}).cleared_buffers)
+    end)
+  end)
+
+  describe("highlight groups", function()
+    it("defines the three severity groups as default links", function()
+      annotations.annotate({ bufnr = bufnr, line = 1, text = "a" })
+
+      assert.equals("DiagnosticVirtualTextInfo", vim.api.nvim_get_hl(0, { name = "VibingAnnotationInfo" }).link)
+      assert.equals("DiagnosticVirtualTextWarn", vim.api.nvim_get_hl(0, { name = "VibingAnnotationWarn" }).link)
+      assert.equals("DiagnosticVirtualTextError", vim.api.nvim_get_hl(0, { name = "VibingAnnotationError" }).link)
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #496

> **Stacked on #543**（`feat-nvim-highlight-range`）。#495 と extmark の流儀を共有するため、
> issue の「どちらかが先に入ったら流儀を合わせること」に従ってそちらを base にしています。
> #543 がマージされたら base を `main` に切り替えてください。

## 背景

コードレビューを頼むと指摘がチャットに縦に並ぶだけで、「チャットの指摘 ↔ 対象コード」を目で往復する
必要がありました。GitHub の PR レビューのように、指摘が該当行の真横に見える体験をエディタ内で実現します。

## 変更内容

### 1. `nvim_annotate`

指定行の下に virtual lines で注釈を表示します。`bufnr` / `line` / `text` が必須、`severity` は
`info` / `warn` / `error`（既定 `info`）。`text` の改行は複数の virtual line に展開されます。

**ファイルには一切触れません。** `modified` フラグも立ちません（テストで固定）。

### 2. `nvim_clear_annotations` と `:VibingClearAnnotations`

`bufnr` 指定で 1 バッファ、省略で全バッファ。ユーザー側からは `:VibingClearAnnotations`。

### 3. システムプロンプトへの行動指針

レビュー時は `nvim_load_buffer` でファイルを読み込み、各指摘を `nvim_annotate` で該当行に表示し、
チャットには総評と件数だけを書くよう指示します。

## 意図的な割り切り（ドキュメントに明記）

- **注釈は永続化されません。** バッファをアンロードすると消えます。レビューは読んだら消える一過性の
  ものとして扱う、というのが意図した寿命です
- **編集時の追従は extmark の仕様どおり**で、ズレの厳密な管理はしません

## ハイライトグループ

`VibingAnnotationInfo` / `Warn` / `Error` を、それぞれ対応する `DiagnosticVirtualText*` に
`default link` します。`hi VibingAnnotationWarn ...` で上書き可能です。注釈行の先頭には `┃ ` を
付けて、コードと視覚的に区別します。

## #495 との重複の扱い

セルフレビューで `resolve_bufnr` が `highlight.lua` とバイト単位で同一だと指摘され、共有モジュール
`handlers/bufnr.lua` に切り出しました。純粋な引数検証で機能固有の要素がゼロだったためです。

一方で**共通化しなかったもの**:

- **ハイライトグループ定義** — グループ名・リンク先・個数がすべて機能固有で、テーブル駆動の抽象に
  するとコード量が増えるだけ。「偶然似ているだけ」で共有ロジックではありません
- **クランプ処理** — highlight は範囲、annotate は 1 行。1 行の共通化に指標参照を足す価値がない
- **namespace とライフサイクル** — highlight は1バッファ1件・タイマー自動消滅、annotation は複数件・
  自動消滅なし・全バッファ一括クリア。共有しているのは「private namespace の extmark」という発想だけで、
  状態機械としては別物です

## テスト

`tests/lua/infrastructure/rpc/handlers/annotations_spec.lua`（新規 13 件、全パス）。

virtual lines の構造、**`modified` が立たないこと**、複数行の展開、severity ごとの色分け、未知 severity の
info フォールバック、同一バッファへの複数注釈の共存、行のクランプ、extmark id の返却、エラー経路 3 種、
1 バッファ / 全バッファのクリア、`default link` の確認。

全 Lua スイート 805 件パス、MCP 側 62 件パス、`tsc --noEmit` クリーン、`pnpm run check` パス。

## セルフレビュー

simplify 4 観点 + correctness を実施。反映した指摘:

- `resolve_bufnr` の重複を共有モジュールへ（reuse）
- 存在確認だけなのに全 extmark を取得していたので `{ limit = 1 }` に（simplification）
- ツール description がシステムプロンプトの理由説明を重複していたので削り、`nvim_highlight_range` と
  同じ簡潔な書き方に揃えた（altitude）
- `:VibingClearAnnotations` が他コマンドと違い presentation controller を経由しない点。中身のない
  pass-through を作るより、理由をコメントで明示する形にしました（altitude）

## 未対応（フォローアップ候補）

セルフレビューが指摘した通り、システムプロンプトの常時付与ブロックがこれで **4 つ目**になりました
（worktree 規約 / ask_user_question / show-don't-tell / review-annotate）。いずれも異なるユーザー意図で
発火するのに全ターンで無条件に送られており、機能追加のたびに線形に増えます。本 PR は既存 3 つと同じ形
なので状況を質的に悪化させてはいませんが、条件付きロード（skill 化）や 2 つのコード提示系ブロックの統合を
検討する頃合いです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)