### PR TITLE
refactor: stop the shared layers from knowing which backend is running

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -46,10 +46,28 @@ The instance registry has the same treatment via `$VIBING_INSTANCES_DIR` (honour
 its owning Neovim is gone: it cross-checks `registry.list()`, which already filters to live PIDs,
 so a concurrent instance's in-flight `.req`/`.res` files are never deleted.
 
-**Backends:** `claude_cli.lua` (default) and `codex_cli.lua` both implement the adapter
-interface; `init.lua` picks one from `config.adapter`, and `send_message.lua` can switch per
-request for `codex` agent types. Implementing the interface is not the same as feature parity —
-`AskUserQuestion` is Claude-only, for reasons `features.md` records.
+**Backends:** `claude_cli.lua` (default), `codex_cli.lua` and `copilot_cli.lua` implement the
+adapter interface; `init.lua` picks one from `config.adapter`, and `send_message.lua` can switch
+per request for non-claude agent types. Implementing the interface is not the same as feature
+parity — `AskUserQuestion` is Claude-only, for reasons `features.md` records.
+
+`lua/vibing/core/constants/agents.lua` is the single definition of what a backend is — module
+path, export name, description, model candidates. `factory.lua`, `modes.lua` (`VALID_AGENTS`,
+`VALID_MODELS`), `completion/providers/frontmatter.lua` and `infrastructure/init.lua` all derive
+from it, so adding a fourth backend is a one-file change. It deliberately requires nothing, which
+is what keeps the dependency one-way.
+
+Two things stop backend identity leaking into shared code:
+
+- **Tool vocabulary.** Backends name their tools differently (codex calls an edit `apply_patch`,
+  copilot uses `bash`/`view`/`create`/`edit`/`web_search`). Each adapter owns a
+  `<backend>_tool_vocabulary.lua` and passes it to `set_active_opts` as a generic
+  `_tool_vocabulary`; `rpc/handlers/permission.lua` just calls `to_canonical` if it was given one.
+  The handler contains no backend name.
+- **`dynamic_permissions` capability.** `adapter:supports("dynamic_permissions")` is `false` for
+  copilot, because its CLI has no per-run hook flag: permissions are fixed at launch with
+  `--allow-all-tools` + `--deny-tool`, so `permission_mode`, the `ask` list and the approval UI do
+  nothing there. Declared rather than left to be discovered by reading the adapter.
 
 ## Module Structure
 
@@ -60,16 +78,18 @@ The tree is layered (`domain` / `application` / `infrastructure` / `presentation
 
 - `lua/vibing/init.lua` - Entry point, command registration, adapter selection
 - `lua/vibing/config.lua` - Configuration defaults with type annotations
-- `lua/vibing/core/constants/` - `tools.lua` (VALID_TOOLS), `modes.lua`, `worktree.lua`
+- `lua/vibing/core/constants/` - `agents.lua` (backend registry), `tools.lua` (VALID_TOOLS),
+  `modes.lua`, `worktree.lua`
 - `lua/vibing/core/utils/` - timestamp, language, git, mote, rate_limit, request_diff, ...
 
 **Adapter (`lua/vibing/infrastructure/adapter/`):**
 
 - `base.lua` - Abstract adapter interface
-- `claude_cli.lua` / `codex_cli.lua` - Backend adapters (spawn + stream lifecycle)
+- `claude_cli.lua` / `codex_cli.lua` / `copilot_cli.lua` - Backend adapters (spawn + stream lifecycle)
 - `modules/cli_command_builder.lua` - Claude CLI argv construction (flags, system prompt)
 - `modules/cli_event_processor.lua` - stream-json → chunk/tool events
 - `modules/codex_command_builder.lua` / `modules/codex_event_processor.lua` - Codex equivalents
+- `modules/<backend>_tool_vocabulary.lua` - Native tool name <-> canonical name, per backend
 - `modules/session_manager.lua`, `modules/active_stream_registry.lua` - Session/handle tracking
 
 **Chat (presentation + application):**

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -37,7 +37,7 @@ Slash commands can be used within the chat buffer for quick actions:
 | `/clear`                  | Clear context                                                                 |
 | `/save`                   | Save current chat                                                             |
 | `/summarize`              | Summarize conversation                                                        |
-| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                        |
+| `/model <model>`          | Set AI model (haiku/sonnet/opus/fable)                                        |
 | `/help`                   | Show available slash commands                                                 |
 | `/permissions` or `/perm` | Interactive Permission Builder - configure tool permissions                   |
 | `/allow [tool]`           | Add tool to allow list, or show current list if no args                       |

--- a/README.ja.md
+++ b/README.ja.md
@@ -197,7 +197,7 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 | `/clear`                  | コンテキストをクリア                                                       |
 | `/save`                   | 現在のチャットを保存                                                       |
 | `/summarize`              | 会話を要約                                                                 |
-| `/model <model>`          | AI モデルを設定(opus/sonnet/haiku/fable)                                   |
+| `/model <model>`          | AI モデルを設定(haiku/sonnet/opus/fable)                                   |
 | `/help`                   | 利用可能なスラッシュコマンドを表示                                         |
 | `/permissions` or `/perm` | 対話的 Permission Builder — ツールの allow/deny ルールを設定               |
 | `/allow [tool]`           | allow リストに追加(`-tool` で削除)。引数なしで現在のリストを表示           |

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ help tags.
 | `/clear`                  | Clear context                                                                 |
 | `/save`                   | Save current chat                                                             |
 | `/summarize`              | Summarize conversation                                                        |
-| `/model <model>`          | Set AI model (opus/sonnet/haiku/fable)                                        |
+| `/model <model>`          | Set AI model (haiku/sonnet/opus/fable)                                        |
 | `/help`                   | Show available slash commands                                                 |
 | `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules              |
 | `/allow [tool]`           | Add tool to allow list (`-tool` removes), or show current list if no args     |

--- a/lua/vibing/core/constants/agents.lua
+++ b/lua/vibing/core/constants/agents.lua
@@ -1,9 +1,5 @@
 ---@class Vibing.Core.AgentsConstants
----バックエンド（エージェント）定義の単一ソース。
----`factory.lua` / `modes.lua` / `completion/providers/frontmatter.lua` / `infrastructure/init.lua`
----はすべてここから派生する。以前はこの4箇所に同じ知識が散っていて、`VALID_AGENTS` にあって
----factory に無いエージェントが検証を通った上で黙って claude にフォールバックし得た。
----バックエンドの追加はこのファイル1箇所の変更で完結する。
+---バックエンド（エージェント）定義の単一ソース。派生先と経緯は architecture.md を参照。
 ---
 ---このモジュールは意図的に何も require しない。派生先がここを require する一方向の依存に
 ---しておくことで、循環 require が構造的に起きないようにしている。

--- a/lua/vibing/core/constants/agents.lua
+++ b/lua/vibing/core/constants/agents.lua
@@ -1,0 +1,101 @@
+---@class Vibing.Core.AgentsConstants
+---バックエンド（エージェント）定義の単一ソース。
+---`factory.lua` / `modes.lua` / `completion/providers/frontmatter.lua` / `infrastructure/init.lua`
+---はすべてここから派生する。以前はこの4箇所に同じ知識が散っていて、`VALID_AGENTS` にあって
+---factory に無いエージェントが検証を通った上で黙って claude にフォールバックし得た。
+---バックエンドの追加はこのファイル1箇所の変更で完結する。
+---
+---このモジュールは意図的に何も require しない。派生先がここを require する一方向の依存に
+---しておくことで、循環 require が構造的に起きないようにしている。
+local M = {}
+
+---@class Vibing.AgentModelCandidate
+---@field value string モデル識別子
+---@field description string 補完UIに出す説明
+
+---@class Vibing.AgentDefinition
+---@field id string エージェント識別子（frontmatter の `agent` フィールドの値）
+---@field adapter_module string アダプターの require パス
+---@field export_name string `infrastructure/init.lua` でのエクスポート名
+---@field description string frontmatter 補完の agent enum に出す説明
+---@field models Vibing.AgentModelCandidate[] 補完候補。妥当性検証ではない（自由入力を許す
+---  バックエンドもある）ので、ここに無いモデルを弾く用途には使わないこと
+
+---@type table<string, Vibing.AgentDefinition>
+M.AGENTS = {
+  claude = {
+    id = "claude",
+    adapter_module = "vibing.infrastructure.adapter.claude_cli",
+    export_name = "ClaudeCLIAdapter",
+    description = "Claude CLI (Anthropic)",
+    models = {
+      { value = "haiku", description = "Claude Haiku (fastest)" },
+      { value = "sonnet", description = "Claude Sonnet (balanced)" },
+      { value = "opus", description = "Claude Opus (most capable)" },
+      { value = "fable", description = "Claude Fable" },
+    },
+  },
+  codex = {
+    id = "codex",
+    adapter_module = "vibing.infrastructure.adapter.codex_cli",
+    export_name = "CodexCLIAdapter",
+    description = "Codex CLI (OpenAI)",
+    models = {
+      { value = "gpt-5.5", description = "GPT-5.5 (default)" },
+      { value = "gpt-5.4", description = "gpt-5.4" },
+      { value = "gpt-5.4-mini", description = "GPT-5.4-Mini" },
+      { value = "gpt-5.3-codex", description = "gpt-5.3-codex" },
+      { value = "gpt-5.2", description = "gpt-5.2" },
+    },
+  },
+  copilot = {
+    id = "copilot",
+    adapter_module = "vibing.infrastructure.adapter.copilot_cli",
+    export_name = "CopilotCLIAdapter",
+    description = "GitHub Copilot CLI",
+    -- copilot は30種類以上のモデルを持つため、代表的なものだけを候補に出す。
+    -- 実際に使えるモデルは利用者のプランに依存するので、ここは候補提示であって検証ではない。
+    models = {
+      { value = "auto", description = "Let Copilot pick the model" },
+      { value = "claude-sonnet-5", description = "Claude Sonnet 5" },
+      { value = "claude-opus-5", description = "Claude Opus 5" },
+      { value = "claude-haiku-4.5", description = "Claude Haiku 4.5 (fastest)" },
+      { value = "gpt-5.5", description = "GPT-5.5" },
+      { value = "gpt-5.4", description = "GPT-5.4" },
+      { value = "gpt-5.4-mini", description = "GPT-5.4 Mini" },
+      { value = "gpt-5.3-codex", description = "GPT-5.3 Codex" },
+      { value = "gemini-3.1-pro-preview", description = "Gemini 3.1 Pro (preview)" },
+    },
+  },
+}
+
+---列挙順。`pairs()` の順序は不定なので、ユーザーに見える一覧はすべてこれを経由する。
+---@type string[]
+M.ORDER = { "claude", "codex", "copilot" }
+
+---未知・未指定のエージェントのフォールバック先
+---@type string
+M.DEFAULT = "claude"
+
+---@return Vibing.AgentDefinition[] ORDER順の定義配列
+function M.list()
+  local out = {}
+  for _, id in ipairs(M.ORDER) do
+    table.insert(out, M.AGENTS[id])
+  end
+  return out
+end
+
+---@param id string?
+---@return boolean
+function M.is_valid(id)
+  return id ~= nil and M.AGENTS[id] ~= nil
+end
+
+---@param id string?
+---@return Vibing.AgentDefinition 未知のidならDEFAULTの定義
+function M.get(id)
+  return M.AGENTS[id] or M.AGENTS[M.DEFAULT]
+end
+
+return M

--- a/lua/vibing/core/constants/modes.lua
+++ b/lua/vibing/core/constants/modes.lua
@@ -8,7 +8,7 @@ local Agents = require("vibing.core.constants.agents")
 ---@type string[]
 M.VALID_MODELS = vim.tbl_map(function(m)
   return m.value
-end, Agents.AGENTS[Agents.DEFAULT].models)
+end, Agents.get(Agents.DEFAULT).models)
 
 ---権限モード
 ---@type string[]

--- a/lua/vibing/core/constants/modes.lua
+++ b/lua/vibing/core/constants/modes.lua
@@ -2,9 +2,13 @@
 ---モデル、権限モード、エージェントタイプの定数定義
 local M = {}
 
+local Agents = require("vibing.core.constants.agents")
+
 ---有効なモデル（claude短縮名。codex/copilot固有のモデル名は各command_builder側で自由入力を許可）
 ---@type string[]
-M.VALID_MODELS = { "sonnet", "opus", "haiku", "fable" }
+M.VALID_MODELS = vim.tbl_map(function(m)
+  return m.value
+end, Agents.AGENTS[Agents.DEFAULT].models)
 
 ---権限モード
 ---@type string[]
@@ -12,7 +16,7 @@ M.PERMISSION_MODES = { "default", "acceptEdits", "bypassPermissions", "plan", "d
 
 ---有効なエージェント（バックエンド）
 ---@type string[]
-M.VALID_AGENTS = { "claude", "codex", "copilot" }
+M.VALID_AGENTS = Agents.ORDER
 
 ---エージェントモード（`agent.default_mode` / frontmatter の `mode`）
 ---ユーザーがそのチャットの意図を記録するためのメタデータで、現状は挙動を変えない。
@@ -38,7 +42,7 @@ end
 ---@param agent string
 ---@return boolean
 function M.is_valid_agent(agent)
-  return vim.tbl_contains(M.VALID_AGENTS, agent)
+  return Agents.is_valid(agent)
 end
 
 ---エージェントモードが有効かチェック

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -24,6 +24,9 @@ local SUPPORTED_FEATURES = {
   model_selection = true,
   context = true,
   session = true,
+  -- Permission decisions are made per tool call at runtime, via the PreToolUse hook: the
+  -- ask list, session-level allow/deny and the approval UI all work.
+  dynamic_permissions = true,
 }
 
 ---@param config Vibing.Config

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -24,8 +24,6 @@ local SUPPORTED_FEATURES = {
   model_selection = true,
   context = true,
   session = true,
-  -- Permission decisions are made per tool call at runtime, via the PreToolUse hook: the
-  -- ask list, session-level allow/deny and the approval UI all work.
   dynamic_permissions = true,
 }
 

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -24,8 +24,6 @@ local SUPPORTED_FEATURES = {
   model_selection = true,
   context = true,
   session = true,
-  -- Permission decisions are made per tool call at runtime, via the PreToolUse hook: the
-  -- ask list, session-level allow/deny and the approval UI all work.
   dynamic_permissions = true,
 }
 

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -24,6 +24,9 @@ local SUPPORTED_FEATURES = {
   model_selection = true,
   context = true,
   session = true,
+  -- Permission decisions are made per tool call at runtime, via the PreToolUse hook: the
+  -- ask list, session-level allow/deny and the approval UI all work.
+  dynamic_permissions = true,
 }
 
 ---@param config Vibing.Config
@@ -151,7 +154,8 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   })
 
   local perm_handler = require("vibing.infrastructure.rpc.handlers.permission")
-  perm_handler.set_active_opts(handle_id, vim.tbl_extend("force", opts, { _is_codex = true }))
+  local ToolVocabulary = require("vibing.infrastructure.adapter.modules.codex_tool_vocabulary")
+  perm_handler.set_active_opts(handle_id, vim.tbl_extend("force", opts, { _tool_vocabulary = ToolVocabulary }))
 
   local wrapped_on_done = function(response)
     if not completed then

--- a/lua/vibing/infrastructure/adapter/copilot_cli.lua
+++ b/lua/vibing/infrastructure/adapter/copilot_cli.lua
@@ -23,6 +23,11 @@ local SUPPORTED_FEATURES = {
   model_selection = true,
   context = true,
   session = true,
+  -- Copilot CLI has no flag to inject a hook per run, so permissions are fixed at launch with
+  -- --allow-all-tools plus --deny-tool. permission_mode, the ask list, session-level allow and
+  -- the approval UI therefore do nothing here. Declared rather than left to be discovered by
+  -- reading copilot_cli.lua; #512 tracks making it real.
+  dynamic_permissions = false,
 }
 
 ---@param config Vibing.Config

--- a/lua/vibing/infrastructure/adapter/copilot_cli.lua
+++ b/lua/vibing/infrastructure/adapter/copilot_cli.lua
@@ -23,10 +23,7 @@ local SUPPORTED_FEATURES = {
   model_selection = true,
   context = true,
   session = true,
-  -- Copilot CLI has no flag to inject a hook per run, so permissions are fixed at launch with
-  -- --allow-all-tools plus --deny-tool. permission_mode, the ask list, session-level allow and
-  -- the approval UI therefore do nothing here. Declared rather than left to be discovered by
-  -- reading copilot_cli.lua; #512 tracks making it real.
+  -- False here, true for the others: see architecture.md. #512 tracks making it real.
   dynamic_permissions = false,
 }
 

--- a/lua/vibing/infrastructure/adapter/factory.lua
+++ b/lua/vibing/infrastructure/adapter/factory.lua
@@ -15,7 +15,8 @@ local function resolve_module(agent_type)
 end
 
 --- Get the adapter instance name for an agent type.
---- Derived from the module path so it cannot drift from ADAPTER_MODULES.
+--- Derived from the module path in agents.lua, so it cannot drift from what factory actually
+--- loads.
 --- @param agent_type string|nil
 --- @return string
 function M.adapter_name(agent_type)

--- a/lua/vibing/infrastructure/adapter/factory.lua
+++ b/lua/vibing/infrastructure/adapter/factory.lua
@@ -4,20 +4,14 @@
 
 local M = {}
 
-local ADAPTER_MODULES = {
-  claude = "vibing.infrastructure.adapter.claude_cli",
-  codex = "vibing.infrastructure.adapter.codex_cli",
-  copilot = "vibing.infrastructure.adapter.copilot_cli",
-}
-
-local DEFAULT_AGENT = "claude"
+local Agents = require("vibing.core.constants.agents")
 
 --- Resolve an agent type to its adapter module path
 --- Unknown or nil agent types fall back to the claude adapter
 --- @param agent_type string|nil
 --- @return string
 local function resolve_module(agent_type)
-  return ADAPTER_MODULES[agent_type] or ADAPTER_MODULES[DEFAULT_AGENT]
+  return Agents.get(agent_type).adapter_module
 end
 
 --- Get the adapter instance name for an agent type.

--- a/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
@@ -1,0 +1,22 @@
+--- Codex's tool names, translated to the canonical vocabulary the rest of vibing.nvim speaks.
+---
+--- Lives beside the adapter rather than in the permission handler so that shared infrastructure
+--- never has to know which backend it is talking to: `codex_cli.lua` hands this module to
+--- `set_active_opts` as a generic `_tool_vocabulary`, and the handler just calls whatever it was
+--- given. See #516.
+--- @module vibing.infrastructure.adapter.modules.codex_tool_vocabulary
+
+local M = {}
+
+--- @type table<string, string>
+local NATIVE_TO_CANONICAL = {
+  apply_patch = "Edit", -- Codex's file patch tool maps to Claude's Edit
+}
+
+--- @param native_tool_name string
+--- @return string|nil canonical name, or nil when there is no mapping
+function M.to_canonical(native_tool_name)
+  return NATIVE_TO_CANONICAL[native_tool_name]
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
@@ -6,6 +6,8 @@ local Modes = require("vibing.core.constants.modes")
 
 local M = {}
 
+local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
+
 --- Resolve model name from opts or config
 --- Claude short names (sonnet/opus/haiku/fable) are not valid copilot model ids,
 --- so they are dropped and copilot's own default is used instead.
@@ -52,73 +54,6 @@ local function build_context_prefix(opts)
   return table.concat(parts, "\n") .. "\n\n"
 end
 
---- Map a vibing permission entry to a copilot permission pattern
---- The bare kind name matches every invocation of that kind; empty parens ("shell()")
---- are rejected by the CLI as an invalid rule format.
---- @param entry string
---- @return string|nil
-function M.to_deny_pattern(entry)
-  local bash_pattern = entry:match("^Bash%((.+)%)$")
-  if bash_pattern then
-    return string.format("shell(%s)", bash_pattern)
-  end
-  if entry == "Bash" then
-    return "shell"
-  end
-  if entry == "Write" or entry == "Edit" then
-    return "write"
-  end
-  if entry == "WebFetch" or entry == "WebSearch" then
-    return "url"
-  end
-  return nil
-end
-
---- Entries already reported as unsupported, so a repeated request does not re-warn.
---- @type table<string, boolean>
-local warned_unmapped = {}
-
---- Reset the unsupported-deny-entry warning state. Test seam only.
-function M._reset_unmapped_warnings()
-  warned_unmapped = {}
-end
-
---- Convert a deny list into deduplicated copilot patterns, preserving input order.
---- Entries copilot has no permission pattern for are dropped, and warned about once each —
---- silently ignoring them would leave the user believing a tool is blocked when it is not.
---- @param deny string[]|nil
---- @return string[]
-function M.build_deny_patterns(deny)
-  local patterns, seen = {}, {}
-  local unmapped = {}
-
-  for _, entry in ipairs(deny or {}) do
-    local pattern = M.to_deny_pattern(entry)
-    if pattern then
-      if not seen[pattern] then
-        seen[pattern] = true
-        table.insert(patterns, pattern)
-      end
-    elseif not warned_unmapped[entry] then
-      warned_unmapped[entry] = true
-      table.insert(unmapped, entry)
-    end
-  end
-
-  if #unmapped > 0 then
-    vim.notify(
-      string.format(
-        "[vibing] copilot has no deny pattern for %s; %s will not be blocked",
-        table.concat(unmapped, ", "),
-        #unmapped == 1 and "it" or "they"
-      ),
-      vim.log.levels.WARN
-    )
-  end
-
-  return patterns
-end
-
 --- Append permission flags. copilot's non-interactive mode requires --allow-all-tools,
 --- so denies are expressed with --deny-tool rather than an allow list.
 --- @param cmd string[]
@@ -136,7 +71,7 @@ local function append_permission_flags(cmd, opts)
   end
   table.insert(cmd, "--allow-all-tools")
 
-  for _, pattern in ipairs(M.build_deny_patterns(opts.permissions_deny)) do
+  for _, pattern in ipairs(ToolVocabulary.build_deny_patterns(opts.permissions_deny)) do
     table.insert(cmd, "--deny-tool")
     table.insert(cmd, pattern)
   end

--- a/lua/vibing/infrastructure/adapter/modules/copilot_item_display.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_item_display.lua
@@ -6,23 +6,17 @@ local ToolDisplay = require("vibing.infrastructure.adapter.modules.tool_display"
 
 local M = {}
 
+local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
+
 local ARGUMENT_SUMMARY_LIMIT = 100
 
 --- copilot tool names that map onto a vibing-style display label.
 --- Names absent here are displayed verbatim; extend as more are confirmed on real runs.
-local TOOL_LABELS = {
-  bash = "Bash",
-  view = "Read",
-  create = "Write",
-  edit = "Edit",
-  web_search = "WebSearch",
-}
-
 --- Map a copilot tool name to its display label
 --- @param tool_name string
 --- @return string
 function M.resolve_label(tool_name)
-  return TOOL_LABELS[tool_name] or tool_name
+  return ToolVocabulary.to_canonical(tool_name) or tool_name
 end
 
 --- Summarize tool arguments for the header

--- a/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
@@ -1,10 +1,6 @@
---- Copilot's tool vocabulary: its own tool names and permission-rule syntax, kept next to the
---- adapter rather than spread across the display, permission and command-building code.
----
---- There used to be three separate views of the same correspondence — a native→canonical label
---- map for display, a canonical→native map for `--deny-tool`, and nothing at all for permission
---- checks — which drifted: display distinguished `edit`→Edit from `create`→Write while deny
---- collapsed both to `write`. One table per direction, in one file, is the fix (#516).
+--- Copilot.s tool vocabulary: its own tool names and permission-rule syntax, in one place instead
+--- of spread across the display, permission and command-building code, where the two directions
+--- had already drifted from each other. See architecture.md.
 --- @module vibing.infrastructure.adapter.modules.copilot_tool_vocabulary
 
 local M = {}

--- a/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
@@ -1,0 +1,96 @@
+--- Copilot's tool vocabulary: its own tool names and permission-rule syntax, kept next to the
+--- adapter rather than spread across the display, permission and command-building code.
+---
+--- There used to be three separate views of the same correspondence — a native→canonical label
+--- map for display, a canonical→native map for `--deny-tool`, and nothing at all for permission
+--- checks — which drifted: display distinguished `edit`→Edit from `create`→Write while deny
+--- collapsed both to `write`. One table per direction, in one file, is the fix (#516).
+--- @module vibing.infrastructure.adapter.modules.copilot_tool_vocabulary
+
+local M = {}
+
+--- Copilot's native tool names → the canonical vocabulary (`tools.lua`) that `ui.tool_markers`
+--- and `permissions_*` are written in.
+--- @type table<string, string>
+local NATIVE_TO_CANONICAL = {
+  bash = "Bash",
+  view = "Read",
+  create = "Write",
+  edit = "Edit",
+  web_search = "WebSearch",
+}
+
+--- @param native_tool_name string
+--- @return string|nil canonical name, or nil when there is no mapping
+function M.to_canonical(native_tool_name)
+  return NATIVE_TO_CANONICAL[native_tool_name]
+end
+
+--- Map a vibing permission entry to a copilot permission pattern
+--- The bare kind name matches every invocation of that kind; empty parens ("shell()")
+--- are rejected by the CLI as an invalid rule format.
+--- @param entry string
+--- @return string|nil
+function M.to_deny_pattern(entry)
+  local bash_pattern = entry:match("^Bash%((.+)%)$")
+  if bash_pattern then
+    return string.format("shell(%s)", bash_pattern)
+  end
+  if entry == "Bash" then
+    return "shell"
+  end
+  if entry == "Write" or entry == "Edit" then
+    return "write"
+  end
+  if entry == "WebFetch" or entry == "WebSearch" then
+    return "url"
+  end
+  return nil
+end
+
+--- Entries already reported as unsupported, so a repeated request does not re-warn.
+--- @type table<string, boolean>
+local warned_unmapped = {}
+
+--- Reset the unsupported-deny-entry warning state. Test seam only.
+function M._reset_unmapped_warnings()
+  warned_unmapped = {}
+end
+
+--- Convert a deny list into deduplicated copilot patterns, preserving input order.
+--- Entries copilot has no permission pattern for are dropped, and warned about once each —
+--- silently ignoring them would leave the user believing a tool is blocked when it is not.
+--- @param deny string[]|nil
+--- @return string[]
+function M.build_deny_patterns(deny)
+  local patterns, seen = {}, {}
+  local unmapped = {}
+
+  for _, entry in ipairs(deny or {}) do
+    local pattern = M.to_deny_pattern(entry)
+    if pattern then
+      if not seen[pattern] then
+        seen[pattern] = true
+        table.insert(patterns, pattern)
+      end
+    elseif not warned_unmapped[entry] then
+      warned_unmapped[entry] = true
+      table.insert(unmapped, entry)
+    end
+  end
+
+  if #unmapped > 0 then
+    vim.notify(
+      string.format(
+        "[vibing] copilot has no deny pattern for %s; %s will not be blocked",
+        table.concat(unmapped, ", "),
+        #unmapped == 1 and "it" or "they"
+      ),
+      vim.log.levels.WARN
+    )
+  end
+
+  return patterns
+end
+
+return M

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -3,13 +3,22 @@
 ---@module "vibing.infrastructure.completion.providers.frontmatter"
 local M = {}
 
+local Agents = require("vibing.core.constants.agents")
+
+---Agent enum and per-agent model candidates both come from the backend registry, so adding a
+---backend needs no edit here.
+local AGENT_ENUM = vim.tbl_map(function(def)
+  return { value = def.id, description = def.description }
+end, Agents.list())
+
+local MODELS_BY_AGENT = {}
+for _, def in ipairs(Agents.list()) do
+  MODELS_BY_AGENT[def.id] = def.models
+end
+
 ---Enum values for frontmatter fields
 local ENUMS = {
-  agent = {
-    { value = "claude", description = "Claude CLI (Anthropic)" },
-    { value = "codex", description = "Codex CLI (OpenAI)" },
-    { value = "copilot", description = "GitHub Copilot CLI" },
-  },
+  agent = AGENT_ENUM,
   permission_mode = {
     { value = "default", description = "Ask for confirmation before each tool use" },
     { value = "acceptEdits", description = "Auto-approve Edit/Write, ask for others" },
@@ -18,42 +27,6 @@ local ENUMS = {
     { value = "dontAsk", description = "Deny instead of prompting (pre-approved tools only)" },
     { value = "bypassPermissions", description = "Auto-approve all operations (isolated env only)" },
   },
-}
-
----Model candidates per agent backend
-local CLAUDE_MODELS = {
-  { value = "haiku", description = "Claude Haiku (fastest)" },
-  { value = "sonnet", description = "Claude Sonnet (balanced)" },
-  { value = "opus", description = "Claude Opus (most capable)" },
-  { value = "fable", description = "Claude Fable" },
-}
-
-local CODEX_MODELS = {
-  { value = "gpt-5.5", description = "GPT-5.5 (default)" },
-  { value = "gpt-5.4", description = "gpt-5.4" },
-  { value = "gpt-5.4-mini", description = "GPT-5.4-Mini" },
-  { value = "gpt-5.3-codex", description = "gpt-5.3-codex" },
-  { value = "gpt-5.2", description = "gpt-5.2" },
-}
-
----copilot は 30 種類以上のモデルを持つため、代表的なものだけを候補に出す。
----実際に利用できるモデルは利用者のプランに依存するので、ここは候補提示であって検証ではない。
-local COPILOT_MODELS = {
-  { value = "auto", description = "Let Copilot pick the model" },
-  { value = "claude-sonnet-5", description = "Claude Sonnet 5" },
-  { value = "claude-opus-5", description = "Claude Opus 5" },
-  { value = "claude-haiku-4.5", description = "Claude Haiku 4.5 (fastest)" },
-  { value = "gpt-5.5", description = "GPT-5.5" },
-  { value = "gpt-5.4", description = "GPT-5.4" },
-  { value = "gpt-5.4-mini", description = "GPT-5.4 Mini" },
-  { value = "gpt-5.3-codex", description = "GPT-5.3 Codex" },
-  { value = "gemini-3.1-pro-preview", description = "Gemini 3.1 Pro (preview)" },
-}
-
-local MODELS_BY_AGENT = {
-  claude = CLAUDE_MODELS,
-  codex = CODEX_MODELS,
-  copilot = COPILOT_MODELS,
 }
 
 ---Available tool names for permissions lists
@@ -103,7 +76,7 @@ end
 ---@param agent string? "claude" | "codex" | "copilot" (defaults to "claude")
 ---@return Vibing.CompletionItem[]
 function M.get_model_values(agent)
-  local models = MODELS_BY_AGENT[agent] or CLAUDE_MODELS
+  local models = MODELS_BY_AGENT[agent] or MODELS_BY_AGENT[Agents.DEFAULT]
   local items = {}
   for _, m in ipairs(models) do
     table.insert(items, {

--- a/lua/vibing/infrastructure/init.lua
+++ b/lua/vibing/infrastructure/init.lua
@@ -4,9 +4,9 @@ local M = {}
 
 -- Adapters
 M.BaseAdapter = require("vibing.infrastructure.adapter.base")
-M.ClaudeCLIAdapter = require("vibing.infrastructure.adapter.claude_cli")
-M.CodexCLIAdapter = require("vibing.infrastructure.adapter.codex_cli")
-M.CopilotCLIAdapter = require("vibing.infrastructure.adapter.copilot_cli")
+for _, def in ipairs(require("vibing.core.constants.agents").list()) do
+  M[def.export_name] = require(def.adapter_module)
+end
 
 -- RPC
 M.RpcServer = require("vibing.infrastructure.rpc.server")

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -19,12 +19,6 @@ local session_state = {
 --- @type table<string, table>
 local active_opts_by_handle = {}
 
---- Codex uses different tool names than Claude for equivalent operations.
---- This mapping ensures frontmatter permissions work identically across adapters.
-local CODEX_TOOL_ALIASES = {
-  apply_patch = "Edit", -- Codex's file patch tool maps to Claude's Edit
-}
-
 local APPROVAL_OPTIONS = {
   { value = "allow_once", label = "allow_once - Allow this execution only" },
   { value = "deny_once", label = "deny_once - Deny this execution only" },
@@ -193,8 +187,12 @@ function M.check_tool_permission(params)
   local tool_input = hook_input.tool_input or {}
   local active_opts = get_active_opts(handle_id)
 
-  if active_opts and active_opts._is_codex then
-    tool_name = CODEX_TOOL_ALIASES[tool_name] or tool_name
+  -- Backends name their tools differently (codex calls an edit "apply_patch"). The adapter
+  -- supplies its own translation table as a generic `_tool_vocabulary`, so this handler stays
+  -- ignorant of which backend it is serving -- adding a fourth needs no change here (#516).
+  local vocabulary = active_opts and active_opts._tool_vocabulary
+  if vocabulary and vocabulary.to_canonical then
+    tool_name = vocabulary.to_canonical(tool_name) or tool_name
   end
 
   -- Kill process first, call UI callback, then write deny response. Used by both

--- a/tests/copilot_command_builder_spec.lua
+++ b/tests/copilot_command_builder_spec.lua
@@ -40,62 +40,6 @@ describe("copilot_command_builder", function()
     vim.fn.exepath = original_exepath
   end)
 
-  describe("to_deny_pattern", function()
-    it("maps Bash to shell", function()
-      assert.are.equal("shell", Builder.to_deny_pattern("Bash"))
-    end)
-
-    it("maps Bash(npm:*) to shell(npm:*)", function()
-      assert.are.equal("shell(npm:*)", Builder.to_deny_pattern("Bash(npm:*)"))
-    end)
-
-    it("maps Write and Edit to write", function()
-      assert.are.equal("write", Builder.to_deny_pattern("Write"))
-      assert.are.equal("write", Builder.to_deny_pattern("Edit"))
-    end)
-
-    it("maps WebFetch and WebSearch to url", function()
-      assert.are.equal("url", Builder.to_deny_pattern("WebFetch"))
-      assert.are.equal("url", Builder.to_deny_pattern("WebSearch"))
-    end)
-
-    it("returns nil for unmapped tools", function()
-      assert.is_nil(Builder.to_deny_pattern("Read"))
-      assert.is_nil(Builder.to_deny_pattern("Glob"))
-    end)
-  end)
-
-  describe("build_deny_patterns", function()
-    it("deduplicates write from Write and Edit", function()
-      local patterns = Builder.build_deny_patterns({ "Write", "Edit", "Bash" })
-      assert.are.same({ "write", "shell" }, patterns)
-    end)
-
-    it("returns an empty list for nil", function()
-      assert.are.same({}, Builder.build_deny_patterns(nil))
-    end)
-
-    it("warns once per unsupported entry instead of dropping it silently", function()
-      Builder._reset_unmapped_warnings()
-      local messages = {}
-      local original_notify = vim.notify
-      vim.notify = function(msg)
-        table.insert(messages, msg)
-      end
-
-      local first = Builder.build_deny_patterns({ "Grep", "Bash" })
-      local second = Builder.build_deny_patterns({ "Grep" })
-
-      vim.notify = original_notify
-      Builder._reset_unmapped_warnings()
-
-      assert.are.same({ "shell" }, first)
-      assert.are.same({}, second)
-      assert.are.equal(1, #messages)
-      assert.is_true(messages[1]:find("Grep", 1, true) ~= nil)
-    end)
-  end)
-
   describe("build", function()
     it("emits the base flags with the prompt last", function()
       local cmd = Builder.build("hello", {}, nil, {})

--- a/tests/copilot_tool_vocabulary_spec.lua
+++ b/tests/copilot_tool_vocabulary_spec.lua
@@ -1,0 +1,79 @@
+---@diagnostic disable: undefined-field
+local Vocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
+
+describe("copilot_tool_vocabulary", function()
+  before_each(function()
+    Vocabulary._reset_unmapped_warnings()
+  end)
+
+  describe("to_canonical", function()
+    it("maps copilot native tool names onto the canonical vocabulary", function()
+      assert.are.equal("Bash", Vocabulary.to_canonical("bash"))
+      assert.are.equal("Read", Vocabulary.to_canonical("view"))
+      assert.are.equal("Write", Vocabulary.to_canonical("create"))
+      assert.are.equal("Edit", Vocabulary.to_canonical("edit"))
+      assert.are.equal("WebSearch", Vocabulary.to_canonical("web_search"))
+    end)
+
+    it("returns nil for a name it has no mapping for", function()
+      assert.is_nil(Vocabulary.to_canonical("something_new"))
+    end)
+  end)
+
+  describe("to_deny_pattern", function()
+    it("maps Bash to shell", function()
+      assert.are.equal("shell", Vocabulary.to_deny_pattern("Bash"))
+    end)
+
+    it("maps Bash(npm:*) to shell(npm:*)", function()
+      assert.are.equal("shell(npm:*)", Vocabulary.to_deny_pattern("Bash(npm:*)"))
+    end)
+
+    it("maps Write and Edit to write", function()
+      assert.are.equal("write", Vocabulary.to_deny_pattern("Write"))
+      assert.are.equal("write", Vocabulary.to_deny_pattern("Edit"))
+    end)
+
+    it("maps WebFetch and WebSearch to url", function()
+      assert.are.equal("url", Vocabulary.to_deny_pattern("WebFetch"))
+      assert.are.equal("url", Vocabulary.to_deny_pattern("WebSearch"))
+    end)
+
+    it("returns nil for unmapped tools", function()
+      assert.is_nil(Vocabulary.to_deny_pattern("Read"))
+      assert.is_nil(Vocabulary.to_deny_pattern("Glob"))
+    end)
+  end)
+
+  describe("build_deny_patterns", function()
+    it("deduplicates write from Write and Edit", function()
+      local patterns = Vocabulary.build_deny_patterns({ "Write", "Edit", "Bash" })
+      assert.are.same({ "write", "shell" }, patterns)
+    end)
+
+    it("returns an empty list for nil", function()
+      assert.are.same({}, Vocabulary.build_deny_patterns(nil))
+    end)
+
+    it("warns once per unsupported entry instead of dropping it silently", function()
+      Vocabulary._reset_unmapped_warnings()
+      local messages = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg)
+        table.insert(messages, msg)
+      end
+
+      local first = Vocabulary.build_deny_patterns({ "Grep", "Bash" })
+      local second = Vocabulary.build_deny_patterns({ "Grep" })
+
+      vim.notify = original_notify
+      Vocabulary._reset_unmapped_warnings()
+
+      assert.are.same({ "shell" }, first)
+      assert.are.same({}, second)
+      assert.are.equal(1, #messages)
+      assert.is_true(messages[1]:find("Grep", 1, true) ~= nil)
+    end)
+  end)
+
+end)

--- a/tests/lua/core/constants/agents_spec.lua
+++ b/tests/lua/core/constants/agents_spec.lua
@@ -1,0 +1,91 @@
+---@diagnostic disable: undefined-field
+local Agents = require("vibing.core.constants.agents")
+
+describe("agents registry", function()
+  it("lists the backends in a fixed order", function()
+    assert.same({ "claude", "codex", "copilot" }, Agents.ORDER)
+  end)
+
+  it("has a definition for every id in ORDER, and no strays", function()
+    -- The drift this guards: an id in ORDER with no AGENTS entry used to pass validation and then
+    -- fall back to claude without a word (#516).
+    local defined = vim.tbl_keys(Agents.AGENTS)
+    table.sort(defined)
+    local ordered = vim.deepcopy(Agents.ORDER)
+    table.sort(ordered)
+    assert.same(ordered, defined)
+  end)
+
+  it("gives every backend a loadable adapter module and an export name", function()
+    for _, def in ipairs(Agents.list()) do
+      assert.is_string(def.adapter_module)
+      assert.is_string(def.export_name)
+      assert.is_true(pcall(require, def.adapter_module), def.adapter_module .. " does not load")
+    end
+  end)
+
+  it("offers at least one model candidate per backend", function()
+    for _, def in ipairs(Agents.list()) do
+      assert.is_true(#def.models > 0, def.id .. " has no model candidates")
+      for _, model in ipairs(def.models) do
+        assert.is_string(model.value)
+        assert.is_string(model.description)
+      end
+    end
+  end)
+
+  it("defaults to claude", function()
+    assert.equals("claude", Agents.DEFAULT)
+    assert.equals("claude", Agents.get(nil).id)
+    assert.equals("claude", Agents.get("nonexistent").id)
+  end)
+
+  it("validates ids", function()
+    assert.is_true(Agents.is_valid("codex"))
+    assert.is_false(Agents.is_valid("nonexistent"))
+    assert.is_false(Agents.is_valid(nil))
+  end)
+
+  describe("derived tables", function()
+    it("is where modes.lua gets VALID_AGENTS from", function()
+      local Modes = require("vibing.core.constants.modes")
+      assert.same(Agents.ORDER, Modes.VALID_AGENTS)
+    end)
+
+    it("is where modes.lua gets the claude model names from", function()
+      local Modes = require("vibing.core.constants.modes")
+      local expected = vim.tbl_map(function(m)
+        return m.value
+      end, Agents.AGENTS.claude.models)
+      assert.same(expected, Modes.VALID_MODELS)
+    end)
+
+    it("is where the frontmatter provider gets its agent enum from", function()
+      local provider = require("vibing.infrastructure.completion.providers.frontmatter")
+      local values = vim.tbl_map(function(item)
+        return item.word
+      end, provider.get_enum_values("agent"))
+      assert.same(Agents.ORDER, values)
+    end)
+
+    it("is where the frontmatter provider gets its per-agent models from", function()
+      local provider = require("vibing.infrastructure.completion.providers.frontmatter")
+      for _, def in ipairs(Agents.list()) do
+        local values = vim.tbl_map(function(item)
+          return item.word
+        end, provider.get_model_values(def.id))
+        local expected = vim.tbl_map(function(m)
+          return m.value
+        end, def.models)
+        assert.same(expected, values, def.id .. " model candidates drifted")
+      end
+    end)
+
+    it("is where the factory resolves adapter modules from", function()
+      local Factory = require("vibing.infrastructure.adapter.factory")
+      for _, def in ipairs(Agents.list()) do
+        assert.equals(def.adapter_module:match("[^.]+$"), Factory.adapter_name(def.id))
+      end
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
@@ -1,0 +1,108 @@
+---@diagnostic disable: undefined-field
+--- The tool-name translation path had no test before #516: the codex alias table lived in this
+--- handler and was only exercised end-to-end. Now that adapters inject their own vocabulary, this
+--- pins the contract the handler relies on — and that it works for a backend it knows nothing
+--- about.
+local permission = require("vibing.infrastructure.rpc.handlers.permission")
+
+local HANDLE_ID = "vocabulary-spec-handle"
+
+local comm_dir
+
+--- Write the hook payload the way bin/hooks/pre-tool-use.sh does.
+local function write_request(request_id, tool_name, tool_input)
+  local f = assert(io.open(comm_dir .. "/" .. request_id .. ".req", "w"))
+  f:write(vim.json.encode({ tool_name = tool_name, tool_input = tool_input or {} }))
+  f:close()
+end
+
+local function read_response(request_id)
+  local f = io.open(comm_dir .. "/" .. request_id .. ".res", "r")
+  if not f then
+    return nil
+  end
+  local content = f:read("*a")
+  f:close()
+  local ok, decoded = pcall(vim.json.decode, content)
+  return ok and decoded or content
+end
+
+describe("permission handler tool vocabulary", function()
+  local original_comm_dir
+
+  before_each(function()
+    original_comm_dir = vim.env.VIBING_HOOK_COMM_DIR
+    comm_dir = vim.fn.tempname()
+    vim.fn.mkdir(comm_dir, "p")
+    vim.env.VIBING_HOOK_COMM_DIR = comm_dir
+  end)
+
+  after_each(function()
+    permission.clear_active_opts(HANDLE_ID)
+    vim.env.VIBING_HOOK_COMM_DIR = original_comm_dir
+    vim.fn.delete(comm_dir, "rf")
+  end)
+
+  it("denies a native tool name once its vocabulary maps it onto a denied canonical name", function()
+    -- The codex case, expressed generically: apply_patch has to be judged as Edit.
+    permission.set_active_opts(HANDLE_ID, {
+      permissions_deny = { "Edit" },
+      _tool_vocabulary = {
+        to_canonical = function(name)
+          return name == "apply_patch" and "Edit" or nil
+        end,
+      },
+    })
+
+    write_request("req-mapped", "apply_patch", { file_path = "/tmp/x.lua" })
+    local result = permission.check_tool_permission({ request_id = "req-mapped", handle_id = HANDLE_ID })
+
+    assert.equals("denied", result.status)
+  end)
+
+  it("leaves a name the vocabulary does not know alone", function()
+    permission.set_active_opts(HANDLE_ID, {
+      permissions_deny = { "Edit" },
+      _tool_vocabulary = {
+        to_canonical = function()
+          return nil
+        end,
+      },
+    })
+
+    write_request("req-unmapped", "Read", {})
+    local result = permission.check_tool_permission({ request_id = "req-unmapped", handle_id = HANDLE_ID })
+
+    assert.equals("allowed", result.status)
+  end)
+
+  it("works with no vocabulary at all, the way claude_cli registers", function()
+    -- Guards the nil path: a backend that names its tools canonically must not need to supply an
+    -- identity table just to be understood.
+    permission.set_active_opts(HANDLE_ID, { permissions_deny = { "Edit" } })
+
+    write_request("req-none", "Edit", { file_path = "/tmp/x.lua" })
+    local result = permission.check_tool_permission({ request_id = "req-none", handle_id = HANDLE_ID })
+
+    assert.equals("denied", result.status)
+    assert.is_not_nil(read_response("req-none"))
+  end)
+
+  it("ignores a vocabulary that does not implement to_canonical", function()
+    permission.set_active_opts(HANDLE_ID, {
+      permissions_deny = { "Edit" },
+      _tool_vocabulary = {},
+    })
+
+    write_request("req-partial", "Edit", { file_path = "/tmp/x.lua" })
+    local result = permission.check_tool_permission({ request_id = "req-partial", handle_id = HANDLE_ID })
+
+    assert.equals("denied", result.status)
+  end)
+
+  it("is the table codex_cli actually hands over", function()
+    local vocabulary = require("vibing.infrastructure.adapter.modules.codex_tool_vocabulary")
+    assert.equals("Edit", vocabulary.to_canonical("apply_patch"))
+    assert.is_nil(vocabulary.to_canonical("Read"))
+  end)
+end)


### PR DESCRIPTION
Closes #516

#510 がマージされ 3 バックエンドが揃ったので着手しました。

## 背景

「どのバックエンドか」という知識が共有基盤の各所に漏れていました。個々は小さいものの、
4 つ目を足すときに全部触る必要があり、忘れると静かに壊れます。

## 1. 権限ハンドラからバックエンド名を排除

`permission.lua` は codex を名前で知っていました。`set_active_opts` に忍ばせた private な
`_is_codex` フラグと、共有 RPC コードに置かれた `CODEX_TOOL_ALIASES` です。copilot の語彙
（`bash` / `view` / `create` / `edit` / `web_search`）を同じ仕組みに載せると、隣に `_is_copilot` と
2 つ目のテーブルが並ぶことになります。

アダプタが `<backend>_tool_vocabulary` を所有し、汎用の `_tool_vocabulary` として渡す形にしました。
ハンドラは渡されていれば `to_canonical` を呼ぶだけで、**バックエンド名を一切含みません**。

## 2. 同じ対応関係の 3 つの見方を統合

copilot では同じ「ネイティブ名 ⇄ 正規名」の対応が 3 つの形で存在し、**実際にドリフトしていました**。

| 場所 | 方向 | 状態 |
| --- | --- | --- |
| `copilot_item_display.lua` の `TOOL_LABELS` | native → canonical | `edit`→Edit と `create`→Write を区別 |
| `copilot_command_builder.lua` の `to_deny_pattern` | canonical → native | 両方を `write` に潰す |
| 権限判定 | — | 存在しない |

1 バックエンド 1 モジュールに両方向をまとめました。

## 3. バックエンド定義を単一レジストリへ

`factory.lua` / `modes.lua` の `VALID_AGENTS` / 補完プロバイダの agent enum と `MODELS_BY_AGENT` /
`infrastructure/init.lua` の re-export に散っていました。**`VALID_AGENTS` にあって factory に無い
エージェントは、検証を通った上で黙って claude にフォールバック**します。

5 箇所すべてが `core/constants/agents.lua` から派生する形にしました。このモジュールは何も
require しないので、依存が逆流しません。

## 4. `dynamic_permissions` capability

copilot だけ `false`。CLI に実行毎のフック注入フラグがなく、権限は起動時に
`--allow-all-tools` + `--deny-tool` で固定されるため、`permission_mode` / `ask` リスト / 承認 UI が
**実際に何もしません**。アダプタを読まないと分からない状態を、宣言に変えました。

消費側は本 PR では追加していません（`base.lua` には既に読まれていない宣言済み feature があります）。
実際の強制は #512 の担当です。

## テスト

**この翻訳経路にはこれまでテストがありませんでした。** `permission_vocabulary_spec.lua`（新規 5 件）で、
codex の実例を一般化したケース、vocabulary はあるがマッピングが無いケース、**vocabulary が無い
claude の経路**、`to_canonical` を実装していない不完全な vocabulary、そして `codex_cli` が実際に
渡すテーブルとの結合を確認します。

`agents_spec.lua`（新規 11 件）は、ORDER と AGENTS の集合一致（黙ってフォールバックする不整合の
再発防止）、全アダプタモジュールが実際にロードできること、そして **5 つの派生先すべてが
レジストリと一致していること**を固定します。

`copilot_tool_vocabulary_spec.lua` は移設した deny パターンのテストに `to_canonical` の 5 ケースを
追加。全 Lua スイート 871 件パス、失敗 0。

## セルフレビュー

simplify 4 観点 + correctness を実施。correctness は指摘なし（循環 require、参照共有、
フォールバック経路、`supports()` の既存挙動をすべて確認済み）。

反映した simplify 指摘:
- `factory.lua` のコメントが削除済みの `ADAPTER_MODULES` を指したままだった
- `modes.lua` が自分で導入した API を迂回して `Agents.AGENTS` に直接アクセスしていた
- `dynamic_permissions` の理由説明が 3 箇所に重複
- モジュールヘッダが architecture.md と重複する経緯説明を抱えていた
- **本 PR が生んだドリフト**: `VALID_MODELS` を導出したことで `/model` のヘルプ順序が
  `haiku|sonnet|opus|fable` に変わったのに、README / README.ja / commands-reference が旧順序の
  ままだった。補完リストの順序（速い→高性能）が意図的な方なので、ドキュメント側を合わせました

🤖 Generated with [Claude Code](https://claude.com/claude-code)