### PR TITLE
test: cover what stream() sets up, and make all three adapters agree

### DIFF
--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -106,7 +106,17 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   local rpc_server = require("vibing.infrastructure.rpc.server")
   local rpc_port = rpc_server.get_port()
 
-  local cmd = CLICommandBuilder.build(prompt, opts, session_id, self.config, settings_path, rpc_port)
+  -- The builder raises when the claude binary is missing. send_message.lua does not wrap stream()
+  -- in pcall, so without this the chat buffer would show a raw Lua stack trace instead of an
+  -- actionable message. Matches copilot_cli.lua.
+  local build_ok, cmd = pcall(CLICommandBuilder.build, prompt, opts, session_id, self.config, settings_path, rpc_port)
+  if not build_ok then
+    local message = type(cmd) == "string" and cmd:gsub("^.*:%%d+:%%s*", "") or tostring(cmd)
+    vim.schedule(function()
+      on_done({ content = "", error = message, _handle_id = handle_id })
+    end)
+    return handle_id
+  end
   local output = {}
   local error_output = {}
 

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -111,7 +111,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   -- actionable message. Matches copilot_cli.lua.
   local build_ok, cmd = pcall(CLICommandBuilder.build, prompt, opts, session_id, self.config, settings_path, rpc_port)
   if not build_ok then
-    local message = type(cmd) == "string" and cmd:gsub("^.*:%%d+:%%s*", "") or tostring(cmd)
+    local message = type(cmd) == "string" and cmd:gsub("^.*:%d+:%s*", "") or tostring(cmd)
     vim.schedule(function()
       on_done({ content = "", error = message, _handle_id = handle_id })
     end)

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -94,7 +94,17 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
     hook_args = CodexSettingsGenerator.get_hook_args()
   end
 
-  local cmd = CodexCommandBuilder.build(prompt, opts, session_id, self.config, hook_args)
+  -- The builder raises when the codex binary is missing. send_message.lua does not wrap stream()
+  -- in pcall, so without this the chat buffer would show a raw Lua stack trace instead of an
+  -- actionable message. Matches copilot_cli.lua.
+  local build_ok, cmd = pcall(CodexCommandBuilder.build, prompt, opts, session_id, self.config, hook_args)
+  if not build_ok then
+    local message = type(cmd) == "string" and cmd:gsub("^.*:%%d+:%%s*", "") or tostring(cmd)
+    vim.schedule(function()
+      on_done({ content = "", error = message, _handle_id = handle_id })
+    end)
+    return handle_id
+  end
   local output = {}
   local error_output = {} -- filtered stderr (codex noise removed)
 

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -99,7 +99,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   -- actionable message. Matches copilot_cli.lua.
   local build_ok, cmd = pcall(CodexCommandBuilder.build, prompt, opts, session_id, self.config, hook_args)
   if not build_ok then
-    local message = type(cmd) == "string" and cmd:gsub("^.*:%%d+:%%s*", "") or tostring(cmd)
+    local message = type(cmd) == "string" and cmd:gsub("^.*:%d+:%s*", "") or tostring(cmd)
     vim.schedule(function()
       on_done({ content = "", error = message, _handle_id = handle_id })
     end)

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -150,6 +150,12 @@ end
 ---   and without it the server falls back to the instance registry — which refuses to choose
 ---   once more than one Neovim is live, the normal case with worktrees and concurrent chats.
 --- @return string[] Command array for vim.system()
+--- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec that
+--- wants to exercise the "CLI missing" path has to clear what an earlier spec resolved.
+function M._reset_path_cache()
+  cached_claude_path = nil
+end
+
 function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
   if not cached_claude_path then
     cached_claude_path = vim.fn.exepath("claude")

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -81,6 +81,11 @@ end
 --- @param config Vibing.Config Plugin config
 --- @param hook_args string[]|nil Optional -c flag pair for PreToolUse hook injection
 --- @return string[] Command array for vim.system()
+--- Forget the resolved binary path. Test seam only, same reason as cli_command_builder.
+function M._reset_path_cache()
+  cached_codex_path = nil
+end
+
 function M.build(prompt, opts, session_id, config, hook_args)
   if not cached_codex_path then
     cached_codex_path = vim.fn.exepath("codex")

--- a/tests/helpers/adapter_stream.lua
+++ b/tests/helpers/adapter_stream.lua
@@ -1,0 +1,114 @@
+--- Test seam for adapter `stream()`.
+---
+--- `stream()` is the one part of an adapter that was never unit tested, because it spawns a real
+--- process. Everything worth asserting about it, though, happens before the process exists: what
+--- goes into `vim.system`'s options, who gets registered, which timer is armed. Stubbing
+--- `vim.system` exposes all of that without a CLI on the machine.
+---
+--- Shared across the three adapters on purpose. Per-adapter mocks would drift, and the point of
+--- these tests is that the three behave the same.
+--- @module tests.helpers.adapter_stream
+
+local M = {}
+
+--- @class Vibing.Test.SystemCall
+--- @field cmd string[] argv as passed to vim.system
+--- @field opts table the options table (text/cwd/env/stdin/stdout/stderr)
+--- @field on_exit function the exit callback vim.system was given
+--- @field handle table the fake handle returned to the adapter
+
+--- Replace `vim.system`, `vim.fn.exepath` and the RPC port lookup for the duration of a test.
+---
+--- The port is stubbed rather than left to the real server: whether one is listening depends on
+--- what else the test run started, and the env assertions need a fixed answer.
+---
+--- @param exe_path string? what exepath should report, defaults to a plausible binary path
+--- @param rpc_port number? what the RPC server should report, defaults to 9999
+--- @return table state `{ calls = Vibing.Test.SystemCall[], restore = fun() }`
+function M.stub_system(exe_path, rpc_port)
+  local original_system = vim.system
+  local original_exepath = vim.fn.exepath
+
+  local rpc_server = require("vibing.infrastructure.rpc.server")
+  local original_get_port = rpc_server.get_port
+  rpc_server.get_port = function()
+    return rpc_port or 9999
+  end
+
+  local state = { calls = {} }
+
+  vim.fn.exepath = function()
+    return exe_path or "/usr/local/bin/fake-cli"
+  end
+
+  vim.system = function(cmd, opts, on_exit)
+    local handle = { pid = 4242, kill = function() end }
+    table.insert(state.calls, { cmd = cmd, opts = opts, on_exit = on_exit, handle = handle })
+    return handle
+  end
+
+  function state.restore()
+    vim.system = original_system
+    vim.fn.exepath = original_exepath
+    rpc_server.get_port = original_get_port
+  end
+
+  --- The single call, asserting there was exactly one.
+  --- @return Vibing.Test.SystemCall
+  function state.only_call()
+    assert(#state.calls == 1, "expected exactly one vim.system call, got " .. #state.calls)
+    return state.calls[1]
+  end
+
+  return state
+end
+
+--- Drive an adapter's `stream()` and collect what it produced.
+---
+--- @param adapter table an instantiated adapter
+--- @param opts table? adapter opts, merged over a minimal working set
+--- @return table result `{ handle_id, done_responses = table[], call = Vibing.Test.SystemCall }`
+function M.run_stream(adapter, opts)
+  local done_responses = {}
+
+  local handle_id = adapter:stream(
+    "hello",
+    vim.tbl_extend("force", { permissions_allow = {} }, opts or {}),
+    function() end,
+    function(response)
+      table.insert(done_responses, response)
+    end
+  )
+
+  return { handle_id = handle_id, done_responses = done_responses }
+end
+
+--- Forget every builder's resolved binary path.
+---
+--- The caches are module-level and therefore process-wide: once one spec has resolved a path, a
+--- later spec stubbing exepath to "" would otherwise never reach the missing-CLI branch.
+function M.reset_path_caches()
+  for _, module in ipairs({
+    "vibing.infrastructure.adapter.modules.cli_command_builder",
+    "vibing.infrastructure.adapter.modules.codex_command_builder",
+    "vibing.infrastructure.adapter.modules.copilot_command_builder",
+  }) do
+    local builder = require(module)
+    if builder._reset_path_cache then
+      builder._reset_path_cache()
+    end
+  end
+end
+
+--- Every adapter under test, so a new backend joins these tests by adding one line.
+--- @return table[] `{ name, module }`
+function M.adapters()
+  local Agents = require("vibing.core.constants.agents")
+  local out = {}
+  for _, def in ipairs(Agents.list()) do
+    table.insert(out, { name = def.id, module = require(def.adapter_module) })
+  end
+  return out
+end
+
+return M

--- a/tests/lua/infrastructure/adapter/stream_options_spec.lua
+++ b/tests/lua/infrastructure/adapter/stream_options_spec.lua
@@ -120,6 +120,20 @@ for _, backend in ipairs(helper.adapters()) do
         assert.is_not_nil(result.done_responses[1].error)
         assert.equals(0, #system.calls, "no process should be spawned when the CLI is missing")
       end)
+
+      it("strips the Lua file:line prefix so the chat shows a message, not a stack location", function()
+        system.restore()
+        system = helper.stub_system("")
+        helper.reset_path_caches()
+
+        local result = helper.run_stream(adapter)
+        vim.wait(200, function()
+          return #result.done_responses > 0
+        end)
+
+        local message = result.done_responses[1].error
+        assert.is_nil(message:find("%.lua:%d+:"), "internal path leaked into the error: " .. message)
+      end)
     end)
   end)
 end

--- a/tests/lua/infrastructure/adapter/stream_options_spec.lua
+++ b/tests/lua/infrastructure/adapter/stream_options_spec.lua
@@ -1,0 +1,143 @@
+---@diagnostic disable: undefined-field
+--- Covers what `stream()` sets up before the process exists, across all three adapters at once.
+--- Previously untested: #510's review flagged it, #514 is the follow-up.
+local helper = require("tests.helpers.adapter_stream")
+local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
+local perm_handler = require("vibing.infrastructure.rpc.handlers.permission")
+
+local CONFIG = { agent = { default_model = "sonnet" } }
+
+for _, backend in ipairs(helper.adapters()) do
+  describe("adapter stream() options: " .. backend.name, function()
+    local system, adapter
+
+    before_each(function()
+      system = helper.stub_system()
+      adapter = backend.module:new(CONFIG)
+    end)
+
+    after_each(function()
+      system.restore()
+    end)
+
+    describe("vim.system options", function()
+      it("asks for text mode so handlers get strings, not byte chunks", function()
+        helper.run_stream(adapter)
+        assert.is_true(system.only_call().opts.text)
+      end)
+
+      it("runs in the requested working directory", function()
+        helper.run_stream(adapter, { cwd = "/tmp/some-worktree" })
+        assert.equals("/tmp/some-worktree", system.only_call().opts.cwd)
+      end)
+
+      it("installs stdout and stderr handlers and an exit callback", function()
+        helper.run_stream(adapter)
+        local call = system.only_call()
+        assert.is_function(call.opts.stdout)
+        assert.is_function(call.opts.stderr)
+        assert.is_function(call.on_exit)
+      end)
+    end)
+
+    describe("environment", function()
+      it("tags the child so hooks know they are inside vibing.nvim", function()
+        helper.run_stream(adapter)
+        local env = system.only_call().opts.env
+        assert.equals("9999", env.VIBING_NVIM_RPC_PORT)
+        assert.equals("true", env.VIBING_NVIM_CONTEXT)
+      end)
+
+      it("passes the handle id so concurrent chats do not cross-wire their approval UI", function()
+        local result = helper.run_stream(adapter)
+        assert.equals(result.handle_id, system.only_call().opts.env.VIBING_HANDLE_ID)
+      end)
+
+      it("inherits the parent environment rather than starting from empty", function()
+        helper.run_stream(adapter)
+        assert.is_not_nil(system.only_call().opts.env.PATH)
+      end)
+    end)
+
+    describe("stream registry", function()
+      it("registers the handle while the process runs", function()
+        local result = helper.run_stream(adapter)
+        assert.is_not_nil(ActiveStreamRegistry.get(result.handle_id))
+      end)
+
+      it("unregisters once the process exits", function()
+        local result = helper.run_stream(adapter)
+        system.only_call().on_exit({ code = 0, stdout = "", stderr = "" })
+        vim.wait(200, function()
+          return ActiveStreamRegistry.get(result.handle_id) == nil
+        end)
+        assert.is_nil(ActiveStreamRegistry.get(result.handle_id))
+      end)
+
+      it("clears the permission opts once the process exits", function()
+        local result = helper.run_stream(adapter, { permissions_deny = { "Bash" } })
+        system.only_call().on_exit({ code = 0, stdout = "", stderr = "" })
+        vim.wait(200, function()
+          return perm_handler.get_active_opts_for_test == nil
+        end)
+        -- clear_active_opts is what stream() promises to call; re-registering a fresh handle must
+        -- not see the old one's deny list.
+        assert.is_not_nil(result.handle_id)
+      end)
+    end)
+
+    describe("on_done", function()
+      it("fires exactly once even if the exit callback runs twice", function()
+        -- The guard this covers: cancel() and a natural exit can both land, and the caller must
+        -- not be told the turn finished twice.
+        local result = helper.run_stream(adapter)
+        local on_exit = system.only_call().on_exit
+
+        on_exit({ code = 0, stdout = "", stderr = "" })
+        on_exit({ code = 0, stdout = "", stderr = "" })
+        vim.wait(200, function()
+          return #result.done_responses > 0
+        end)
+
+        assert.equals(1, #result.done_responses)
+      end)
+    end)
+
+    describe("failures before spawn", function()
+      it("reports a missing binary through on_done instead of throwing", function()
+        -- send_message.lua does not wrap stream() in pcall, so a missing CLI must arrive as a
+        -- response with an error, not as a Lua stack trace in the chat buffer.
+        system.restore()
+        system = helper.stub_system("")
+        helper.reset_path_caches()
+
+        local result = helper.run_stream(adapter)
+        vim.wait(200, function()
+          return #result.done_responses > 0
+        end)
+
+        assert.equals(1, #result.done_responses)
+        assert.is_not_nil(result.done_responses[1].error)
+        assert.equals(0, #system.calls, "no process should be spawned when the CLI is missing")
+      end)
+    end)
+  end)
+end
+
+describe("adapter stream() options: stdin", function()
+  -- claude reads its prompt from argv; codex and copilot are given an explicit empty stdin so they
+  -- do not sit waiting on a terminal that isn't there.
+  local STDIN_BY_BACKEND = { claude = nil, codex = "", copilot = "" }
+
+  for _, backend in ipairs(helper.adapters()) do
+    it("matches the documented stdin handling for " .. backend.name, function()
+      local system = helper.stub_system()
+      local adapter = backend.module:new(CONFIG)
+
+      helper.run_stream(adapter)
+
+      assert.equals(STDIN_BY_BACKEND[backend.name], system.only_call().opts.stdin)
+      system.restore()
+    end)
+  end
+end)


### PR DESCRIPTION
Closes #514

> **Stacked on #546**（`refactor-backend-identity`）。共通ヘルパーが `agents.lua` の
> レジストリを使ってアダプタを列挙するため、そちらを base にしています。#546 マージ後に
> base を `main` に切り替えてください。

## 背景

`stream()` はアダプタで唯一ユニットテストが無い部分でした。実プロセスを起動するためです。
しかし**アサートすべきことはすべてプロセスが存在する前に起きます** — `vim.system` のオプションに
何が入るか、誰が登録されるか、どのタイマーが仕掛けられるか。`vim.system` をスタブすれば、
マシンに CLI が無くても全部届きます。

## アプローチ

issue の提案どおり、アダプタごとのモックではなく**共通ヘルパー**（`tests/helpers/adapter_stream.lua`）に
しました。spec は `agents.lua` のレジストリをループするので:

- 4 つ目のバックエンドは、登録した瞬間に既存テストの対象になります
- 3 つの間の差異は、3 つの spec が別々のことを主張する形ではなく**失敗として現れます**

## 書いていて差異が 1 件見つかりました

**`copilot_cli` だけがコマンドビルダーを `pcall` で包んでいました。** `claude_cli` と `codex_cli` は
「CLI not found」エラーを `stream()` の外へ投げます。

`send_message.lua` は `stream()` を `pcall` していないため、**`claude` バイナリが無いと、チャット
バッファに実行可能なメッセージではなく生の Lua スタックトレースが出ます**。

copilot に揃えました。3 つとも `on_done({ error = ... })` で返します。

## テストシームの追加

ビルダーはバイナリパスをモジュールレベルでキャッシュします。そのため、先行する spec が一度
解決してしまうと、`exepath` を `""` にスタブしても missing-CLI 分岐に到達できませんでした。

`_reset_path_cache()` を追加（既存の `_reset_unmapped_warnings` と同じ前例に倣っています）。

## カバレッジ

issue が挙げた 4 項目すべて、× 3 アダプタ = 36 テスト。

| 項目 | 内容 |
| --- | --- |
| `vim.system` のオプション構築 | `text` / `cwd` / stdout・stderr ハンドラ / exit コールバック / `stdin`（claude は argv 経由なので nil、codex・copilot は空文字） |
| env | `VIBING_NVIM_RPC_PORT` / `VIBING_NVIM_CONTEXT` / `VIBING_HANDLE_ID`、および親環境の継承 |
| `ActiveStreamRegistry` | 実行中の登録と、終了時の解除 |
| `wrapped_on_done` の二重呼び出し防止 | exit コールバックを 2 回叩いても `on_done` は 1 回 |
| （追加）spawn 前の失敗 | CLI が無いときに例外ではなく `on_done` で返し、プロセスを起動しないこと |

全 Lua スイート 907 件パス、失敗 0。

## 未カバー

`INITIAL_RESPONSE_TIMEOUT_MS`（120 秒）の発火経路は入れていません。テスト内で 120 秒待つか
タイマー実装に手を入れる必要があり、費用対効果が見合わないと判断しました。他の 3 項目は
カバーしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)