### PR TITLE
feat: add /effort so reasoning depth is a per-chat knob, not just the model

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -157,6 +157,7 @@ session_id: <cli-session-id>
 created_at: 2024-01-01T12:00:00
 working_dir: .vibing/worktrees/fix-auth-session # Optional: relative path from git root for working directory
 model: sonnet # sonnet, opus, haiku, or fable (from config.agent.default_model)
+effort: xhigh # Optional: low, medium, high, xhigh, max (from config.agent.default_effort)
 permission_mode: acceptEdits # default, acceptEdits, bypassPermissions, plan, dontAsk, or auto
 permissions_allow:
   - Read
@@ -173,7 +174,17 @@ language: ja # Optional: default language for AI responses
 When reopening a saved chat (`:VibingChat <file>` or `:e`), the session resumes via the stored
 `session_id`. The `model` field is automatically populated from
 `config.agent.default_model` on chat creation, and can be changed
-via `/model` slash command. Configured permissions are recorded in frontmatter for
+via `/model` slash command.
+
+`effort` is the second cost/quality knob, passed to the CLI as `--effort`. Unlike `model` it is
+**omitted unless configured**: with no `agent.default_effort` vibing.nvim passes no flag and the
+CLI applies its own default, which Anthropic tunes over time — pinning a level here would freeze
+it. Set it per chat with `/effort`. Lightweight calls (title generation, `/summarize`, daily
+summary) use `agent.utility_effort` (default `low`) instead, pairing with `utility_model` so those
+calls are cheap on both axes. An unrecognised level is dropped with a warning rather than passed
+through: the CLI accepts unknown levels silently and then ignores them.
+
+Configured permissions are recorded in frontmatter for
 transparency and auditability. The optional `language` field ensures consistent AI response language
 across sessions.
 

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -39,6 +39,7 @@ Slash commands can be used within the chat buffer for quick actions:
 | `/save`                   | Save current chat                                                             |
 | `/summarize`              | Summarize conversation                                                        |
 | `/model <model>`          | Set AI model (haiku/sonnet/opus/fable)                                        |
+| `/effort <level>`         | Set reasoning effort (low/medium/high/xhigh/max)                              |
 | `/help`                   | Show available slash commands                                                 |
 | `/permissions` or `/perm` | Interactive Permission Builder - configure tool permissions                   |
 | `/allow [tool]`           | Add tool to allow list, or show current list if no args                       |

--- a/README.ja.md
+++ b/README.ja.md
@@ -198,6 +198,7 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 | `/save`                   | 現在のチャットを保存                                                       |
 | `/summarize`              | 会話を要約                                                                 |
 | `/model <model>`          | AI モデルを設定(haiku/sonnet/opus/fable)                                   |
+| `/effort <level>`         | 推論量を設定(low/medium/high/xhigh/max)                                    |
 | `/help`                   | 利用可能なスラッシュコマンドを表示                                         |
 | `/permissions` or `/perm` | 対話的 Permission Builder — ツールの allow/deny ルールを設定               |
 | `/allow [tool]`           | allow リストに追加(`-tool` で削除)。引数なしで現在のリストを表示           |

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ help tags.
 | `/save`                   | Save current chat                                                             |
 | `/summarize`              | Summarize conversation                                                        |
 | `/model <model>`          | Set AI model (haiku/sonnet/opus/fable)                                        |
+| `/effort <level>`         | Set reasoning effort (low/medium/high/xhigh/max)                              |
 | `/help`                   | Show available slash commands                                                 |
 | `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules              |
 | `/allow [tool]`           | Add tool to allow list (`-tool` removes), or show current list if no args     |

--- a/lua/vibing/application/chat/commands.lua
+++ b/lua/vibing/application/chat/commands.lua
@@ -200,6 +200,7 @@ function M.get_argument_completions(command_name)
   local completions = {
     permission = Modes.PERMISSION_MODES,
     model = Modes.VALID_MODELS,
+    effort = Modes.EFFORT_LEVELS,
   }
   return completions[command_name]
 end

--- a/lua/vibing/application/chat/handlers/effort.lua
+++ b/lua/vibing/application/chat/handlers/effort.lua
@@ -1,0 +1,33 @@
+local notify = require("vibing.core.utils.notify")
+local Modes = require("vibing.core.constants.modes")
+
+---@param args string[]
+---@param chat_buffer Vibing.ChatBuffer
+---@return boolean
+return function(args, chat_buffer)
+  if #args == 0 then
+    notify.warn("/effort <" .. table.concat(Modes.EFFORT_LEVELS, "|") .. ">", "Usage")
+    return false
+  end
+
+  local effort = args[1]
+
+  if not Modes.is_valid_effort(effort) then
+    notify.error(string.format("Invalid effort: %s (valid: %s)", effort, table.concat(Modes.EFFORT_LEVELS, ", ")))
+    return false
+  end
+
+  if not chat_buffer then
+    notify.error("No chat buffer")
+    return false
+  end
+
+  local success = chat_buffer:update_frontmatter("effort", effort)
+  if not success then
+    notify.error("Failed to update frontmatter")
+    return false
+  end
+
+  notify.info(string.format("Effort set to: %s", effort))
+  return true
+end

--- a/lua/vibing/application/chat/init.lua
+++ b/lua/vibing/application/chat/init.lua
@@ -37,6 +37,12 @@ function M.setup()
   })
 
   commands.register({
+    name = "effort",
+    handler = require("vibing.application.chat.handlers.effort"),
+    description = string.format("Set reasoning effort: /effort <%s>", table.concat(Modes.EFFORT_LEVELS, "|")),
+  })
+
+  commands.register({
     name = "help",
     handler = require("vibing.application.chat.handlers.help"),
     description = "Show available slash commands",

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -153,6 +153,7 @@ function M.execute(adapter, callbacks, message, config)
       chat_bufnr = vim.api.nvim_buf_is_valid(bufnr) and bufnr or nil,
       mode = M._validate_frontmatter_mode(frontmatter.mode),
       model = frontmatter.model,
+      effort = frontmatter.effort,
       permissions_allow = frontmatter.permissions_allow,
       permissions_deny = frontmatter.permissions_deny,
       permissions_ask = frontmatter.permissions_ask,

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -26,6 +26,9 @@ local function create_default_frontmatter(config)
     agent = config.adapter or "claude",
     mode = config.agent and config.agent.default_mode or "code",
     model = config.agent and config.agent.default_model or "sonnet",
+    -- nil when default_effort is unset, which leaves the key out of the frontmatter entirely and
+    -- lets the CLI apply its own default.
+    effort = config.agent and config.agent.default_effort,
     permission_mode = config.permissions and config.permissions.mode or "acceptEdits",
     permissions_allow = config.permissions and config.permissions.allow or {},
     permissions_deny = config.permissions and config.permissions.deny or {},

--- a/lua/vibing/application/chat/use_cases/fork.lua
+++ b/lua/vibing/application/chat/use_cases/fork.lua
@@ -48,6 +48,7 @@ function M._copy_frontmatter(source_frontmatter, forked_from, config)
     -- 同じ誤字を二重に通知しても意味がない
     mode = Modes.coerce_agent_mode(source_frontmatter.mode) or (config.agent and config.agent.default_mode or "code"),
     model = source_frontmatter.model or (config.agent and config.agent.default_model or "sonnet"),
+    effort = source_frontmatter.effort or (config.agent and config.agent.default_effort),
     permission_mode = source_frontmatter.permission_mode
       or (config.permissions and config.permissions.mode or "acceptEdits"),
     permissions_allow = source_frontmatter.permissions_allow

--- a/lua/vibing/application/completion/sources/frontmatter.lua
+++ b/lua/vibing/application/completion/sources/frontmatter.lua
@@ -37,7 +37,7 @@ function M.get_trigger_context(line, col)
   local before_cursor_plus = line:sub(1, col + 1) -- Include next char for pattern matching
 
   -- Pattern 1: enum fields. permission_mode は単数形が実行時キー
-  for _, field_name in ipairs({ "permission_mode", "agent", "mode", "model" }) do
+  for _, field_name in ipairs({ "permission_mode", "agent", "mode", "model", "effort" }) do
     local pattern = "^%s*" .. field_name .. ":%s*(.*)$"
     local value = before_cursor:match(pattern)
     if value then

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -77,6 +77,8 @@
 ---@field default_mode "code"|"plan"|"explore" 新規チャットのfrontmatterに記録される`mode`の既定値（意味は core/constants/modes.lua の M.AGENT_MODES 参照）
 ---@field default_model "sonnet"|"opus"|"haiku"|"fable" デフォルトモデル（"sonnet": バランス、"opus": 高性能、"haiku": 高速、"fable": Claude Fable）
 ---@field utility_model "sonnet"|"opus"|"haiku"|"fable" タイトル生成・要約等の軽量ユーティリティ呼び出し専用モデル（デフォルト: "haiku"）
+---@field default_effort ("low"|"medium"|"high"|"xhigh"|"max")? 推論量の既定値（未指定ならCLIの既定に任せる）
+---@field utility_effort ("low"|"medium"|"high"|"xhigh"|"max")? タイトル生成・要約等の軽量呼び出しの推論量（デフォルト: "low"）
 ---@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）
 
 ---@class Vibing.NodeConfig
@@ -183,6 +185,10 @@ M.defaults = {
     default_mode = "code",
     default_model = "sonnet",
     utility_model = "haiku",
+    -- default_effort is deliberately nil: without it vibing.nvim passes no --effort and the CLI
+    -- applies its own default, which moves as Anthropic tunes it. Set it to pin a level.
+    default_effort = nil,
+    utility_effort = "low",
     setting_sources = { "user", "project", "local" },
     -- 使用量リミットで応答が弾かれたとき、リセット時刻を待って自動で継続リクエストを送る。
     -- 無人でトークンを消費するため既定は無効。

--- a/lua/vibing/core/constants/modes.lua
+++ b/lua/vibing/core/constants/modes.lua
@@ -24,6 +24,11 @@ M.VALID_AGENTS = Agents.ORDER
 ---@type string[]
 M.AGENT_MODES = { "code", "plan", "explore" }
 
+---推論量のレベル。claude CLI の `--effort` がそのまま受け取る値。
+---CLI は未知の値を弾かず黙って無視するので、渡す前にここで検証する。
+--- string[]
+M.EFFORT_LEVELS = { "low", "medium", "high", "xhigh", "max" }
+
 ---モデルが有効かチェック
 ---@param model string
 ---@return boolean
@@ -48,6 +53,13 @@ end
 ---エージェントモードが有効かチェック
 ---@param mode string
 ---@return boolean
+---effortレベルが有効かチェック
+--- effort string
+--- boolean
+function M.is_valid_effort(effort)
+  return vim.tbl_contains(M.EFFORT_LEVELS, effort)
+end
+
 function M.is_valid_agent_mode(mode)
   return vim.tbl_contains(M.AGENT_MODES, mode)
 end

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -44,6 +44,40 @@ local function resolve_model(opts, config)
   return opts.model or (config.agent and config.agent.default_model)
 end
 
+--- Resolve the reasoning effort level for this call.
+--- Lightweight calls (title generation, summarize, daily summary) use config.agent.utility_effort,
+--- which pairs with utility_model to make those calls cheap on both axes.
+--- Returns nil when nothing is configured, so no --effort is passed and the CLI's own default
+--- applies — that default moves as Anthropic tunes it, and pinning it here would freeze it.
+--- Invalid values are dropped with a warning: the CLI accepts an unknown level without complaint
+--- and then ignores it, so a typo would otherwise be silent.
+--- @param opts Vibing.AdapterOpts
+--- @param config Vibing.Config
+--- @return string|nil
+local function resolve_effort(opts, config)
+  local agent = config.agent or {}
+  local effort
+  if opts.lightweight then
+    effort = agent.utility_effort
+  else
+    effort = opts.effort or agent.default_effort
+  end
+
+  if effort == nil then
+    return nil
+  end
+
+  local Modes = require("vibing.core.constants.modes")
+  if not Modes.is_valid_effort(effort) then
+    require("vibing.core.utils.notify").warn(
+      string.format("Ignoring unknown effort %s (valid: %s)", tostring(effort), table.concat(Modes.EFFORT_LEVELS, ", "))
+    )
+    return nil
+  end
+
+  return effort
+end
+
 --- Resolve language setting
 --- @param opts Vibing.AdapterOpts
 --- @param config Vibing.Config
@@ -174,6 +208,7 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
   table.insert(cmd, "--include-partial-messages")
 
   add_flag_if_present(cmd, "--model", resolve_model(opts, config))
+  add_flag_if_present(cmd, "--effort", resolve_effort(opts, config))
 
   if session_id then
     table.insert(cmd, "--resume")

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -19,6 +19,13 @@ end
 ---Enum values for frontmatter fields
 local ENUMS = {
   agent = AGENT_ENUM,
+  effort = {
+    { value = "low", description = "Least reasoning, fastest and cheapest" },
+    { value = "medium", description = "Moderate reasoning" },
+    { value = "high", description = "More reasoning for intelligence-sensitive work" },
+    { value = "xhigh", description = "Recommended for coding and agentic work" },
+    { value = "max", description = "Most reasoning, slowest and most expensive" },
+  },
   permission_mode = {
     { value = "default", description = "Ask for confirmation before each tool use" },
     { value = "acceptEdits", description = "Auto-approve Edit/Write, ask for others" },

--- a/lua/vibing/infrastructure/storage/frontmatter.lua
+++ b/lua/vibing/infrastructure/storage/frontmatter.lua
@@ -156,11 +156,12 @@ local function get_sorted_keys(tbl)
     working_dir = 5,
     agent = 6,
     model = 7,
-    permission_mode = 8,
-    permissions_allow = 9,
-    permissions_deny = 10,
-    permissions_ask = 11,
-    language = 12,
+    effort = 8,
+    permission_mode = 9,
+    permissions_allow = 10,
+    permissions_deny = 11,
+    permissions_ask = 12,
+    language = 13,
   }
 
   table.sort(keys, function(a, b)

--- a/tests/chat_init_spec.lua
+++ b/tests/chat_init_spec.lua
@@ -94,7 +94,7 @@ describe("vibing.application.chat.init", function()
       assert.is_not_nil(cmd.description:match("model"))
     end)
 
-    it("should have exactly 13 commands after setup", function()
+    it("should have exactly 14 commands after setup", function()
       ChatInit.setup()
 
       local count = 0
@@ -102,7 +102,7 @@ describe("vibing.application.chat.init", function()
         count = count + 1
       end
 
-      assert.equals(13, count)
+      assert.equals(14, count)
     end)
 
     it("should be idempotent (can be called multiple times)", function()
@@ -114,7 +114,7 @@ describe("vibing.application.chat.init", function()
         count = count + 1
       end
 
-      assert.equals(13, count)
+      assert.equals(14, count)
     end)
 
     it("should register commands with correct descriptions", function()
@@ -127,6 +127,7 @@ describe("vibing.application.chat.init", function()
         save = "Save current chat",
         summarize = "Summarize conversation",
         model = string.format("Set AI model: /model <%s>", table.concat(Modes.VALID_MODELS, "|")),
+        effort = string.format("Set reasoning effort: /effort <%s>", table.concat(Modes.EFFORT_LEVELS, "|")),
       }
 
       for cmd_name, expected_desc in pairs(cmd_descriptions) do
@@ -156,7 +157,7 @@ describe("vibing.application.chat.init", function()
 
       local list = Commands.list()
 
-      assert.equals(13, #list)
+      assert.equals(14, #list)
 
       -- Verify all command names are in the list
       local command_names = {}

--- a/tests/lua/core/constants/effort_spec.lua
+++ b/tests/lua/core/constants/effort_spec.lua
@@ -1,0 +1,85 @@
+---@diagnostic disable: undefined-field
+local Modes = require("vibing.core.constants.modes")
+local cli_command_builder = require("vibing.infrastructure.adapter.modules.cli_command_builder")
+
+local function find_flag(cmd, flag)
+  for i, arg in ipairs(cmd) do
+    if arg == flag then
+      return i
+    end
+  end
+  return nil
+end
+
+describe("effort levels", function()
+  it("matches what claude --effort accepts", function()
+    -- Verified against claude CLI 2.1.220: --effort <level> (low, medium, high, xhigh, max).
+    assert.same({ "low", "medium", "high", "xhigh", "max" }, Modes.EFFORT_LEVELS)
+  end)
+
+  it("validates a level", function()
+    assert.is_true(Modes.is_valid_effort("xhigh"))
+    assert.is_false(Modes.is_valid_effort("extreme"))
+    assert.is_false(Modes.is_valid_effort(nil))
+  end)
+end)
+
+describe("cli_command_builder --effort", function()
+  it("passes nothing when no effort is configured", function()
+    -- The CLI's own default applies, and that default moves as Anthropic tunes it.
+    local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+    assert.is_nil(find_flag(cmd, "--effort"))
+  end)
+
+  it("passes the chat's effort", function()
+    local cmd = cli_command_builder.build("hello", { effort = "xhigh" }, nil, {}, nil)
+    local idx = find_flag(cmd, "--effort")
+    assert.is_not_nil(idx)
+    assert.equals("xhigh", cmd[idx + 1])
+  end)
+
+  it("falls back to config.agent.default_effort", function()
+    local config = { agent = { default_effort = "high" } }
+    local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+    assert.equals("high", cmd[find_flag(cmd, "--effort") + 1])
+  end)
+
+  it("prefers the chat's effort over the configured default", function()
+    local config = { agent = { default_effort = "high" } }
+    local cmd = cli_command_builder.build("hello", { effort = "low" }, nil, config, nil)
+    assert.equals("low", cmd[find_flag(cmd, "--effort") + 1])
+  end)
+
+  it("uses utility_effort for lightweight calls, ignoring the chat's effort", function()
+    -- Pairs with utility_model: title generation and summaries get the cheap model AND the cheap
+    -- effort, rather than inheriting whatever the conversation was set to.
+    local config = { agent = { default_effort = "max", utility_effort = "low" } }
+    local cmd = cli_command_builder.build("hello", { lightweight = true, effort = "max" }, nil, config, nil)
+    assert.equals("low", cmd[find_flag(cmd, "--effort") + 1])
+  end)
+
+  it("drops an unknown level rather than passing it through", function()
+    -- The CLI accepts an unknown level without complaint and then ignores it, so a typo would
+    -- otherwise silently do nothing.
+    local notify = require("vibing.core.utils.notify")
+    local original_warn = notify.warn
+    local warned = nil
+    notify.warn = function(message)
+      warned = message
+    end
+
+    local cmd = cli_command_builder.build("hello", { effort = "extreme" }, nil, {}, nil)
+
+    notify.warn = original_warn
+    assert.is_nil(find_flag(cmd, "--effort"))
+    assert.is_not_nil(warned)
+    assert.is_true(warned:find("extreme", 1, true) ~= nil)
+  end)
+
+  it("sits next to --model so both tiers are visible together", function()
+    local config = { agent = { default_model = "opus", default_effort = "xhigh" } }
+    local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+    assert.equals("opus", cmd[find_flag(cmd, "--model") + 1])
+    assert.equals("xhigh", cmd[find_flag(cmd, "--effort") + 1])
+  end)
+end)


### PR DESCRIPTION
Closes #490

## 前提条件の確認（issue が調査を求めていた点）

issue は「Claude Code CLI 側の effort 指定手段の調査」を前提条件としていました。**実機で確認済みです。**

```
--effort <level>    Effort level for the current session
                    (low, medium, high, xhigh, max)
```

claude CLI 2.1.220 で `--effort low` が正常に通ることを確認しました。issue が挙げていたレベル名と
完全に一致します。

**同時に判明した重要な点:** `--effort bogus` を渡してもエラーになりません。CLI は未知のレベルを
黙って受け取り、そのまま無視します。したがって**バリデーションは vibing.nvim 側の責務**です。

## 変更内容

`effort` は `model` と同じ経路を辿ります — config 既定値 → frontmatter に記録 → スラッシュコマンドで
変更 → frontmatter バッファで補完。

| | |
| --- | --- |
| 定数 | `modes.lua` の `EFFORT_LEVELS` / `is_valid_effort` |
| 設定 | `agent.default_effort` / `agent.utility_effort` |
| frontmatter | `effort:`（`model` の次に並ぶ） |
| コマンド | `/effort <low\|medium\|high\|xhigh\|max>` |
| 補完 | frontmatter の `effort:` で候補と説明を表示 |
| CLI | `--model` の隣に `--effort` |

## `model` から意図的に変えた 2 点

**1. 既定値を持ちません。**

`agent.default_effort` が未設定なら `--effort` を渡さず、CLI 自身の既定が適用されます。この既定は
Anthropic が調整に応じて動かすもので、ここでレベルを固定すると**その時点の値に凍結**してしまいます。
`model` が `"sonnet"` を既定に持つのとは事情が違います。

**2. lightweight 呼び出しは `utility_effort`（既定 `low`）を使い、チャットの設定を無視します。**

`utility_model` が既にチャットのモデルを上書きしているのと同じ扱いです。これでタイトル生成・
`/summarize`・デイリーサマリーが**モデルと推論量の二軸**で安くなります。issue が提案していた
「二軸制御」がこれです。

## 不正な値の扱い

未知のレベルは警告を出して**落とします**（渡しません）。CLI が黙って無視する以上、そのまま通すと
frontmatter の綴り間違いが何の効果もないまま気づかれません。`/effort` コマンド側でも入力時点で
弾きます。

## テスト

`tests/lua/core/constants/effort_spec.lua`（新規 9 件）:

- `EFFORT_LEVELS` が CLI の受け付ける値と一致すること
- 未設定なら `--effort` を渡さないこと
- チャットの effort、config 既定値、そして**チャットが config より優先されること**
- **lightweight がチャットの effort を無視して `utility_effort` を使うこと**
- 未知のレベルが警告付きで落ちること
- `--model` と `--effort` が並んで出ること

`tests/chat_init_spec.lua` のコマンド数を 13 → 14 に更新し、`/effort` の description を検証対象に
追加しました。

全 Lua スイート 862 件パス、失敗 0。`pnpm run check` / `format:check` パス。

## ドキュメント

README / README.ja / `commands-reference.md` のコマンド表、`architecture.md` の frontmatter 例と
解説に追記しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/effort <level>` command to set reasoning effort to low, medium, high, xhigh, or max.
  * Added effort-level completion and frontmatter support for chats.
  * Chat forks preserve the selected effort setting.

* **Bug Fixes**
  * Invalid effort levels are rejected with warnings and excluded from requests.
  * Configured defaults and lightweight-call settings are applied consistently.

* **Documentation**
  * Updated English and Japanese documentation with `/effort` usage and supported levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->