### PR TITLE
feat: walk the user through code instead of listing file paths at them

### DIFF
--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -45,6 +45,30 @@ Only the subagent's assistant text is surfaced; the prompt echo, thinking blocks
 tool results stay hidden. `tests/fixtures/subagent_stream.jsonl` is a real captured stream used to
 replay the whole path in `cli_event_processor_subagent_spec.lua`.
 
+## Code Tour
+
+`skills/vibing-code-tour/SKILL.md` turns "explain how X works" into a walkthrough the editor
+performs: each stop is a real file opened at a real line (`nvim_win_open_file` +
+`nvim_set_cursor`), and the whole route is left in the quickfix list so the user can replay it
+with `:cnext`/`:cprev` afterwards.
+
+The quickfix half is the MCP tool `nvim_set_qflist` (`mcp-server/src/tools/qflist.ts` →
+`infrastructure/rpc/handlers/qflist.lua`). It always pushes a **new** list
+(`vim.fn.setqflist({}, " ", ...)`), so whatever the user had in quickfix stays reachable under
+`:colder` — which is also why the skill must call it exactly once per tour, or `:cnext` walks a
+different list than the one being narrated. `open: true` opens the quickfix window but restores
+focus, matching `win_open_file`. `col` is 1-based here (native quickfix), unlike the 0-based `col`
+everywhere else in this tool surface.
+
+A stop naming a file that does not exist rejects the whole call: the tool result does reach the
+model, so a hard error is actionable, while a silently shortened tour is not. That existence check
+is Lua-side, not in the MCP server, because relative paths resolve against the target instance's
+cwd — often a worktree the server process knows nothing about.
+
+The pacing question in the skill inherits AskUserQuestion's turn-killing behavior (below), so the
+skill is instructed to write the tour's position and remaining stops into its chat message before
+every ask — the transcript is the only place that state survives.
+
 ## Message Timestamps
 
 Chat messages include timestamps in their headers (`## 2025-12-28 14:30:00 User`) for chronology

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -31,6 +31,7 @@ Prefix with `mcp__vibing-nvim__`:
 - **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
   `features.md`), `nvim_chat_send_message`
 - **Instances**: `nvim_list_instances`
+- **Quickfix**: `nvim_set_qflist` (pushes a new list; the previous one survives under `:colder`)
 - **LSP**: `nvim_lsp_definition`, `nvim_lsp_references`, `nvim_lsp_hover`, `nvim_diagnostics`,
   `nvim_lsp_document_symbols`, `nvim_lsp_type_definition`, `nvim_lsp_call_hierarchy_incoming`,
   `nvim_lsp_call_hierarchy_outgoing`

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -11,6 +11,7 @@ local annotations = require("vibing.infrastructure.rpc.handlers.annotations")
 local message = require("vibing.infrastructure.rpc.handlers.message")
 local permission = require("vibing.infrastructure.rpc.handlers.permission")
 local rate_limit = require("vibing.infrastructure.rpc.handlers.rate_limit")
+local qflist = require("vibing.infrastructure.rpc.handlers.qflist")
 
 -- Export all handlers
 M.buf_get_lines = buffer.buf_get_lines
@@ -56,5 +57,7 @@ M.check_tool_permission = permission.check_tool_permission
 M.ask_user_question = permission.ask_user_question
 
 M.stop_failure = rate_limit.stop_failure
+
+M.set_qflist = qflist.set_qflist
 
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/qflist.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/qflist.lua
@@ -1,0 +1,103 @@
+local M = {}
+
+-- Reject a non-positive-integer stop field. `index` is the stop's 1-based position and is named
+-- in the error so the caller knows which of its stops to fix.
+-- @throws If `value` is not a positive integer.
+local function assert_positive_integer(value, index, field)
+  if type(value) ~= "number" or value < 1 or value ~= math.floor(value) then
+    error(string.format("items[%d].%s must be a positive integer", index, field))
+  end
+end
+
+-- Validate one tour stop and normalize it into a quickfix item.
+-- @param item Table: raw stop from the MCP payload.
+-- @param index Number: 1-based position of the stop.
+-- @return Table quickfix item.
+-- @throws If a required field is missing/mistyped, or the file does not exist.
+local function to_qf_item(item, index)
+  if type(item) ~= "table" then
+    error(string.format("items[%d] must be an object", index))
+  end
+
+  local filename = item.filename
+  if type(filename) ~= "string" or filename == "" then
+    error(string.format("items[%d].filename is required and must be a non-empty string", index))
+  end
+
+  -- An `lnum` past the end of the file is deliberately not rejected: catching it would mean
+  -- reading every referenced file just to count lines, and Vim clamps the cursor on jump anyway.
+  assert_positive_integer(item.lnum, index, "lnum")
+  if item.col ~= nil then
+    assert_positive_integer(item.col, index, "col")
+  end
+
+  -- Existence is checked here rather than in the MCP server because a relative path resolves
+  -- against this instance's cwd, which for a worktree chat is not the server process's cwd.
+  if vim.fn.filereadable(vim.fn.fnamemodify(filename, ":p")) == 0 then
+    error(string.format("items[%d].filename does not exist: %s", index, filename))
+  end
+
+  -- The RPC port takes requests from anything that can reach it, not only the MCP handler that
+  -- already ran this through Zod, so the label is type-checked here too rather than handed to
+  -- setqflist as whatever arrived.
+  if item.text ~= nil and type(item.text) ~= "string" then
+    error(string.format("items[%d].text must be a string", index))
+  end
+
+  return {
+    filename = filename,
+    lnum = item.lnum,
+    col = item.col,
+    text = item.text or "",
+  }
+end
+
+-- Push a route of file:line stops as a NEW quickfix list.
+-- @param params Table with call parameters.
+-- @param params.items Table: array of stops (required, non-empty). Each stop takes `filename`
+--   (string, required, must exist), `lnum` (number, required, 1-based), `col` (number, optional,
+--   1-based) and `text` (string, optional).
+-- @param params.title String: quickfix list title (optional, defaults to "vibing.nvim").
+-- @param params.open Boolean: also open the quickfix window (optional). Focus is restored to the
+--   window that was current, matching win_open_file.
+-- @return Table with fields:
+--   success boolean: true on success.
+--   count number: number of stops pushed.
+--   title string: the title the list was given.
+--   qf_winnr number|nil: quickfix window id, only when `open` was requested.
+-- @throws If `items` is missing, not an array, empty, or contains an invalid stop.
+function M.set_qflist(params)
+  local items = params and params.items
+  if type(items) ~= "table" or #items == 0 then
+    error("items must be a non-empty array")
+  end
+
+  local qf_items = {}
+  for index, item in ipairs(items) do
+    table.insert(qf_items, to_qf_item(item, index))
+  end
+
+  local title = params.title
+  if type(title) ~= "string" or title == "" then
+    title = "vibing.nvim"
+  end
+
+  -- " " pushes a fresh list onto the quickfix stack instead of replacing the current one, so
+  -- whatever the user had in quickfix before the tour is still reachable with :colder.
+  vim.fn.setqflist({}, " ", { title = title, items = qf_items })
+
+  local result = { success = true, count = #qf_items, title = title }
+
+  if params.open then
+    local original_win = vim.api.nvim_get_current_win()
+    vim.cmd("copen")
+    result.qf_winnr = vim.api.nvim_get_current_win()
+    if original_win ~= result.qf_winnr and vim.api.nvim_win_is_valid(original_win) then
+      vim.api.nvim_set_current_win(original_win)
+    end
+  end
+
+  return result
+end
+
+return M

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -279,6 +279,17 @@ The MCP server exposes the following tools to Claude:
   - `col` (required): Column number (0-indexed)
   - Returns: `{ calls: [{ to, fromRanges }] }`
 
+### Quickfix
+
+- **nvim_set_qflist** - Push a route of file:line stops as a NEW quickfix list
+  - `items` (required): `[{ filename, lnum, col?, text? }]` in visiting order. `lnum`/`col` are
+    1-based here, matching native quickfix — not the 0-based `col` the cursor and LSP tools use
+  - `title` (optional): quickfix list title (default `"vibing.nvim"`)
+  - `open` (optional): also open the quickfix window, without moving focus
+  - Returns: `{ success, count, title, qf_winnr? }`
+  - The previous quickfix list is never overwritten — it stays reachable with `:colder`. Any
+    invalid or nonexistent stop rejects the whole call rather than being dropped
+
 ## Usage Examples
 
 ### From Claude Code
@@ -299,6 +310,16 @@ await use_mcp_tool('vibing-nvim', 'nvim_execute', {
 
 // List all buffers
 const buffers = await use_mcp_tool('vibing-nvim', 'nvim_list_buffers', {});
+
+// Leave a code tour route in quickfix for the user to replay with :cnext
+await use_mcp_tool('vibing-nvim', 'nvim_set_qflist', {
+  title: 'Code tour: request handling',
+  open: true,
+  items: [
+    { filename: 'src/server.ts', lnum: 42, text: 'request enters here' },
+    { filename: 'src/router.ts', lnum: 17, text: 'dispatched by path' },
+  ],
+});
 
 // List all windows
 const windows = await use_mcp_tool('vibing-nvim', 'nvim_list_windows', {});

--- a/mcp-server/src/__tests__/qflist-tools.test.ts
+++ b/mcp-server/src/__tests__/qflist-tools.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { allTools } from '../tools/index.js';
+import { handlers } from '../handlers/index.js';
+import * as rpc from '../rpc.js';
+
+vi.mock('../rpc.js', () => ({
+  callNeovim: vi.fn(),
+}));
+
+const VALID_ITEM = { filename: 'lua/vibing/init.lua', lnum: 12, col: 3, text: 'entry point' };
+
+function call(args: Record<string, unknown>) {
+  return handlers.nvim_set_qflist(args);
+}
+
+describe('nvim_set_qflist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true, count: 1, title: 'Code tour' });
+  });
+
+  describe('registration', () => {
+    it('is registered as a tool with items and rpc_port required', () => {
+      const tool = allTools.find((t) => t.name === 'nvim_set_qflist');
+      expect(tool).toBeDefined();
+      const inputSchema = tool?.inputSchema as {
+        required?: string[];
+        properties: Record<string, unknown>;
+      };
+      expect(inputSchema.required).toContain('items');
+      expect(inputSchema.required).toContain('rpc_port');
+      expect(inputSchema.properties.title).toBeDefined();
+      expect(inputSchema.properties.open).toBeDefined();
+    });
+
+    it('has a handler', () => {
+      expect(typeof handlers.nvim_set_qflist).toBe('function');
+    });
+
+    it('warns in its description that col is 1-based here, unlike the cursor/LSP tools', () => {
+      const tool = allTools.find((t) => t.name === 'nvim_set_qflist');
+      expect(tool?.description).toMatch(/1-based/);
+      expect(tool?.description).toMatch(/nvim_set_cursor/);
+    });
+  });
+
+  describe('forwarding', () => {
+    it('passes the route through to the Neovim instance on the given port', async () => {
+      await call({
+        items: [VALID_ITEM],
+        title: 'Code tour: auth',
+        open: true,
+        rpc_port: 9876,
+      });
+
+      expect(rpc.callNeovim).toHaveBeenCalledWith(
+        'set_qflist',
+        { items: [VALID_ITEM], title: 'Code tour: auth', open: true },
+        9876
+      );
+    });
+
+    it('accepts a stop with only the required fields', async () => {
+      await call({ items: [{ filename: 'a.lua', lnum: 1 }], rpc_port: 9876 });
+
+      expect(rpc.callNeovim).toHaveBeenCalledWith(
+        'set_qflist',
+        { items: [{ filename: 'a.lua', lnum: 1 }], title: undefined, open: undefined },
+        9876
+      );
+    });
+
+    it('reports the count and whether the window was opened', async () => {
+      vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true, count: 4, title: 'Tour' });
+
+      const opened = await call({ items: [VALID_ITEM], open: true, rpc_port: 9876 });
+      expect(opened.content[0].text).toContain('4 stop(s)');
+      expect(opened.content[0].text).toContain('opened');
+
+      const quiet = await call({ items: [VALID_ITEM], rpc_port: 9876 });
+      expect(quiet.content[0].text).not.toContain('opened');
+    });
+  });
+
+  describe('rejects before touching Neovim', () => {
+    // Each of these would otherwise reach the editor and produce a quickfix list with dead
+    // entries, which the user only discovers when :cnext lands nowhere.
+    const rejected: Array<[string, Record<string, unknown>]> = [
+      ['no rpc_port, which would leave the target instance ambiguous', { items: [VALID_ITEM] }],
+      ['an empty route', { items: [], rpc_port: 9876 }],
+      ['a stop with no filename', { items: [{ lnum: 1 }], rpc_port: 9876 }],
+      ['a stop with no lnum', { items: [{ filename: 'a.lua' }], rpc_port: 9876 }],
+      ['a zero lnum', { items: [{ filename: 'a.lua', lnum: 0 }], rpc_port: 9876 }],
+      ['a negative lnum', { items: [{ filename: 'a.lua', lnum: -1 }], rpc_port: 9876 }],
+      ['a fractional lnum', { items: [{ filename: 'a.lua', lnum: 1.5 }], rpc_port: 9876 }],
+      ['a zero col', { items: [{ filename: 'a.lua', lnum: 1, col: 0 }], rpc_port: 9876 }],
+      [
+        'a path traversal attempt',
+        { items: [{ filename: '../../../etc/passwd', lnum: 1 }], rpc_port: 9876 },
+      ],
+    ];
+
+    it.each(rejected)('rejects %s', async (_label, args) => {
+      await expect(call(args)).rejects.toThrow();
+      expect(rpc.callNeovim).not.toHaveBeenCalled();
+    });
+
+    it('rejects the whole call when only one stop is bad', async () => {
+      await expect(
+        call({ items: [VALID_ITEM, { filename: 'b.lua', lnum: 0 }], rpc_port: 9876 })
+      ).rejects.toThrow();
+      expect(rpc.callNeovim).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mcp-server/src/handlers/index.ts
+++ b/mcp-server/src/handlers/index.ts
@@ -7,6 +7,7 @@ import * as instances from './instances.js';
 import * as chat from './chat.js';
 import * as highlight from './highlight.js';
 import * as annotations from './annotations.js';
+import * as qflist from './qflist.js';
 
 export const handlers: Record<string, (args: any) => Promise<any>> = {
   // Buffer operations
@@ -58,4 +59,6 @@ export const handlers: Record<string, (args: any) => Promise<any>> = {
   // Annotations
   nvim_annotate: annotations.handleAnnotate,
   nvim_clear_annotations: annotations.handleClearAnnotations,
+  // Quickfix
+  nvim_set_qflist: qflist.handleSetQflist,
 };

--- a/mcp-server/src/handlers/qflist.ts
+++ b/mcp-server/src/handlers/qflist.ts
@@ -1,0 +1,49 @@
+import { callNeovim } from '../rpc.js';
+import { validateFilePath } from '../validation/schema.js';
+import { z } from 'zod';
+
+const qflistItemSchema = z.object({
+  filename: z.string().min(1),
+  lnum: z.number().int().positive(),
+  col: z.number().int().positive().optional(),
+  text: z.string().optional(),
+});
+
+const setQflistArgsSchema = z.object({
+  items: z.array(qflistItemSchema).min(1),
+  title: z.string().optional(),
+  open: z.boolean().optional(),
+  rpc_port: z.number(),
+});
+
+/**
+ * Handler for nvim_set_qflist
+ *
+ * Only the path *shape* is checked here — traversal and sensitive prefixes. Whether a path exists
+ * is decided by `handlers/qflist.lua`, because a relative path resolves against the target
+ * instance's cwd (a worktree, often enough), which this process has no view of.
+ *
+ * One bad stop fails the whole call rather than being dropped. Unlike nvim_ask_user_question,
+ * this tool's result does come back to the model, so a hard error is something it can act on;
+ * a silently shortened tour is not.
+ */
+export async function handleSetQflist(args: any): Promise<any> {
+  const { items, title, open, rpc_port } = setQflistArgsSchema.parse(args);
+
+  for (const item of items) {
+    validateFilePath({ filepath: item.filename });
+  }
+
+  const result = await callNeovim('set_qflist', { items, title, open }, rpc_port);
+  const opened = open ? ' and opened' : '';
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Quickfix list "${result.title}" set with ${result.count} stop(s)${opened}.`,
+      },
+    ],
+    _meta: result,
+  };
+}

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -7,6 +7,7 @@ import { instanceTools } from './instances.js';
 import { chatTools } from './chat.js';
 import { highlightTools } from './highlight.js';
 import { annotationTools } from './annotations.js';
+import { qflistTools } from './qflist.js';
 
 export const allTools = [
   ...bufferTools,
@@ -18,4 +19,5 @@ export const allTools = [
   ...chatTools,
   ...highlightTools,
   ...annotationTools,
+  ...qflistTools,
 ];

--- a/mcp-server/src/tools/qflist.ts
+++ b/mcp-server/src/tools/qflist.ts
@@ -1,0 +1,49 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { withRpcPort, requireRpcPort } from './common.js';
+
+export const qflistTools: Tool[] = [
+  {
+    name: 'nvim_set_qflist',
+    description:
+      'Push a route of file:line stops into the quickfix list so the user can replay it with ' +
+      ':cnext/:cprev after you are done explaining. Always creates a NEW list, so whatever was ' +
+      'in quickfix before stays reachable with :colder. Call it once per tour, with every stop ' +
+      'in visiting order — a second call pushes a second list and desyncs :cnext from the tour ' +
+      'you are narrating. Note col is 1-based here (native quickfix), unlike the 0-based col in ' +
+      'nvim_set_cursor and the nvim_lsp_* results.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({
+        items: {
+          type: 'array',
+          description: 'Stops in visiting order. Must not be empty.',
+          items: {
+            type: 'object',
+            properties: {
+              filename: {
+                type: 'string',
+                description: 'Existing file, absolute or relative to the Neovim cwd.',
+              },
+              lnum: { type: 'number', description: '1-based line number.' },
+              col: { type: 'number', description: 'Optional 1-based column.' },
+              text: {
+                type: 'string',
+                description: 'Short label shown for this stop in the quickfix window.',
+              },
+            },
+            required: ['filename', 'lnum'],
+          },
+        },
+        title: {
+          type: 'string',
+          description: 'Quickfix list title, e.g. "Code tour: auth flow".',
+        },
+        open: {
+          type: 'boolean',
+          description: 'Open the quickfix window too. Focus stays where it is.',
+        },
+      }),
+      required: requireRpcPort(['items']),
+    },
+  },
+];

--- a/skills/vibing-code-tour/SKILL.md
+++ b/skills/vibing-code-tour/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: vibing-code-tour
+description: Walk the user through a real execution path by opening the actual files and jumping to the actual lines in their running Neovim, instead of describing the path in chat text. Use when someone asks to be walked through how something works ("walk me through the auth flow", "give me a tour of how a request gets handled", "show me step by step where this bug comes from").
+---
+
+# vibing-code-tour
+
+A list of `file:line` references in a chat message is something the user still has to go open
+themselves. This skill instead drives their editor: each stop of the explanation is a real file
+opened at a real line, and the whole route is left behind in the quickfix list so they can walk it
+again afterwards with `:cnext` / `:cprev`.
+
+Requires the `vibing-nvim` MCP tools (a running Neovim). Without them, fall back to explaining the
+flow as text with `file:line` references, and say that's what you're doing.
+
+## When to use it
+
+- A flow that crosses three or more files, or several hops of a call chain
+- Onboarding-style questions: "how does X work", "where does this request go"
+- Tracing a bug back to its origin, when the answer is a path rather than a spot
+
+Not for single-symbol questions ("where is X defined") — use the `nvim-lsp-navigation` skill for
+those.
+
+## Workflow
+
+### 1. Find the route
+
+Establish the path with the LSP tools (see `nvim-lsp-navigation` for which tool answers which
+question), falling back to `Grep`/`Glob` where LSP has nothing to say. `nvim_load_buffer` loads a
+file in the background so you can analyze it without disturbing what the user is looking at.
+
+Build an ordered list of stops as you go: `{ filename, lnum, col, text }`, where `text` is a short
+label — it is what shows in the quickfix window, so make it say what happens at that line, not
+what the file is called.
+
+### 2. Publish the route, once
+
+One `nvim_set_qflist` call with every stop in visiting order, a `title` naming the tour, and
+`open: true`.
+
+Call it exactly once per tour. Each call pushes a **new** quickfix list, so a second call leaves
+`:cnext` walking a different list than the one you are narrating. (The same property is why this
+is safe to call at all: whatever the user had in quickfix before is still there under `:colder`.)
+
+Note `col` is 1-based here, matching native quickfix — unlike the 0-based `col` that
+`nvim_set_cursor` and the `nvim_lsp_*` tools use. Add 1 when you carry a position over from an LSP
+result.
+
+### 3. Walk it
+
+For each stop:
+
+1. `nvim_list_windows` to find a window that isn't the chat buffer — never assume `winnr: 0`
+2. `nvim_win_open_file` with that `winnr`, then `nvim_set_cursor` (1-based line, **0-based** col)
+3. Explain that stop in chat: what this code does, and why the flow moves from here to the next
+   stop
+
+### 4. Let the user set the pace
+
+Every stop or two, ask with `nvim_ask_user_question` — options along the lines of "next", "go
+deeper here", "stop".
+
+**This ends your turn.** `nvim_ask_user_question` cancels the in-flight turn to render the choice
+list, so nothing after it runs and the tool never returns an answer to you; the user's reply
+arrives as the next turn (see `.claude/rules/features.md` → AskUserQuestion Support).
+
+The consequence for a tour: **nothing you are holding in your head survives the question.** Before
+every ask, write the tour state into your chat message as plain text — which stop you are on, how
+many there are, and the remaining stops with their `file:line`. The next turn resumes the same
+session, so that text is what you will read to pick the tour back up. There is no way to query the
+quickfix list back out of Neovim; the transcript is the only copy of the route.
+
+### 5. Close out
+
+When the tour ends — finished, or the user stopped it — tell them the route is still in quickfix:
+`:cnext` / `:cprev` to walk it, `:cc N` to jump to one stop, `:copen` to see the list, and
+`:colder` to get back to whatever quickfix list they had before the tour.

--- a/tests/lua/infrastructure/rpc/handlers/qflist_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/qflist_spec.lua
@@ -1,0 +1,123 @@
+describe("rpc handler set_qflist", function()
+  local qflist = require("vibing.infrastructure.rpc.handlers.qflist")
+
+  local existing_file
+
+  before_each(function()
+    existing_file = vim.fn.tempname() .. ".lua"
+    vim.fn.writefile({ "local M = {}", "return M" }, existing_file)
+    -- Start from a known-empty quickfix stack so :colder assertions mean what they say.
+    vim.fn.setqflist({}, "f")
+  end)
+
+  after_each(function()
+    vim.fn.delete(existing_file)
+    vim.fn.setqflist({}, "f")
+    vim.cmd("cclose")
+  end)
+
+  local function stop(overrides)
+    return vim.tbl_extend("force", { filename = existing_file, lnum = 2, text = "returns M" }, overrides or {})
+  end
+
+  it("pushes the stops as a quickfix list", function()
+    local result = qflist.set_qflist({ items = { stop(), stop({ lnum = 1, text = "declares M" }) } })
+
+    assert.is_true(result.success)
+    assert.equals(2, result.count)
+
+    local items = vim.fn.getqflist()
+    assert.equals(2, #items)
+    assert.equals(2, items[1].lnum)
+    assert.equals("returns M", items[1].text)
+    -- resolve() because the temp dir reaches Neovim through a /var -> /private/var symlink on macOS.
+    assert.equals(vim.fn.resolve(existing_file), vim.fn.resolve(vim.api.nvim_buf_get_name(items[1].bufnr)))
+  end)
+
+  it("titles the list, defaulting when none is given", function()
+    qflist.set_qflist({ items = { stop() }, title = "Code tour: auth" })
+    assert.equals("Code tour: auth", vim.fn.getqflist({ title = 0 }).title)
+
+    qflist.set_qflist({ items = { stop() } })
+    assert.equals("vibing.nvim", vim.fn.getqflist({ title = 0 }).title)
+  end)
+
+  it("keeps whatever list the user already had reachable with :colder", function()
+    vim.fn.setqflist({}, " ", { title = "the user's own search", items = { stop({ lnum = 1 }) } })
+
+    qflist.set_qflist({ items = { stop() }, title = "Code tour" })
+    assert.equals("Code tour", vim.fn.getqflist({ title = 0 }).title)
+
+    vim.cmd("colder")
+    assert.equals("the user's own search", vim.fn.getqflist({ title = 0 }).title)
+  end)
+
+  it("passes col through when given", function()
+    qflist.set_qflist({ items = { stop({ col = 7 }) } })
+    assert.equals(7, vim.fn.getqflist()[1].col)
+  end)
+
+  describe("open", function()
+    local function quickfix_windows()
+      return vim.tbl_filter(function(winnr)
+        return vim.bo[vim.api.nvim_win_get_buf(winnr)].buftype == "quickfix"
+      end, vim.api.nvim_list_wins())
+    end
+
+    it("opens the quickfix window without taking focus", function()
+      local before = vim.api.nvim_get_current_win()
+
+      local result = qflist.set_qflist({ items = { stop() }, open = true })
+
+      assert.equals(before, vim.api.nvim_get_current_win())
+      assert.equals(1, #quickfix_windows())
+      assert.equals(quickfix_windows()[1], result.qf_winnr)
+    end)
+
+    it("leaves the window closed by default", function()
+      local result = qflist.set_qflist({ items = { stop() } })
+
+      assert.equals(0, #quickfix_windows())
+      assert.is_nil(result.qf_winnr)
+    end)
+  end)
+
+  describe("rejects a route it cannot render", function()
+    local function assert_rejects(params, pattern)
+      local ok, err = pcall(qflist.set_qflist, params)
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find(pattern))
+    end
+
+    it("with no items at all", function()
+      assert_rejects({}, "non%-empty")
+      assert_rejects({ items = {} }, "non%-empty")
+      assert_rejects({ items = "nope" }, "non%-empty")
+    end)
+
+    it("with a malformed stop", function()
+      assert_rejects({ items = { "not a table" } }, "must be an object")
+      assert_rejects({ items = { { lnum = 1 } } }, "filename is required")
+      assert_rejects({ items = { { filename = existing_file } } }, "lnum must be a positive integer")
+      assert_rejects({ items = { stop({ lnum = 0 }) } }, "lnum must be a positive integer")
+      assert_rejects({ items = { stop({ lnum = 1.5 }) } }, "lnum must be a positive integer")
+      assert_rejects({ items = { stop({ col = 0 }) } }, "col must be a positive integer")
+      assert_rejects({ items = { stop({ text = 42 }) } }, "text must be a string")
+    end)
+
+    it("naming a file that is not there", function()
+      -- A hallucinated path would otherwise become a quickfix entry that jumps nowhere.
+      assert_rejects({ items = { stop({ filename = existing_file .. ".missing" }) } }, "does not exist")
+    end)
+
+    it("without clobbering the current list", function()
+      vim.fn.setqflist({}, " ", { title = "kept", items = { stop() } })
+      pcall(qflist.set_qflist, { items = { stop({ lnum = 0 }) } })
+      assert.equals("kept", vim.fn.getqflist({ title = 0 }).title)
+    end)
+
+    it("names the offending index so the caller can fix that one stop", function()
+      assert_rejects({ items = { stop(), stop({ lnum = 0 }) } }, "items%[2%]")
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #497

> **Stacked PR**: base は `refactor-mcp-tool-surface`（#549）です。#549 が MCP ツール表面（`registry/` 削除）を作り替えているため、その上に積んでいます。#549 マージ後に base を main に切り替えてください。

## 背景

「認証フローを説明して」への回答が、いまはチャット内のテキスト（パスの羅列＋説明）で終わります。エディタを操作できるのだから、実際にファイルを順に開き、該当行にジャンプしながら説明したほうが速い。しかも経路を quickfix に残しておけば、ツアーが終わったあともユーザーが自分のペースで `:cnext` / `:cprev` で辿り直せます。

## 変更内容

### 1. MCP ツール `nvim_set_qflist`

`{ filename, lnum, col?, text? }` の配列を quickfix に積みます。

- **常に新規リストとして push**（`vim.fn.setqflist({}, " ", ...)`）。ユーザーが元々持っていた quickfix リストは `:colder` で戻れます。スキル側に「1ツアーにつき1回だけ呼べ」と書いてあるのはこのため — 2回呼ぶと `:cnext` が語っているのと別のリストを歩き始めます
- `open: true` で quickfix ウィンドウを開きますが、**フォーカスは元のウィンドウに戻します**（`win_open_file` と同じ流儀）
- `col` はこのツールだけ **1-based**。native quickfix がそうだからで、ハンドラ内で黙って +1 するほうが罠になると判断しました。ツール description とスキル両方に明記しています

### 2. バンドルスキル `skills/vibing-code-tour/SKILL.md`

調査（LSP）→ 経路を qflist へ → 開いてジャンプして説明 → `nvim_ask_user_question` でペース制御 → `:cnext` の案内、という5ステップ。

`nvim_ask_user_question` は**ターンを殺す**ので、質問より後ろは何も実行されず、頭の中の状態は全部消えます。スキルには「毎回聞く前に、現在のステップ・総数・残りの stop を chat メッセージに書き出せ」と指示しています。次ターンでそれを読み直すのが唯一の復帰手段です（quickfix を読み返す API はこの PR では追加していません）。

## 設計上の判断

**バリデーションを2層に分けた理由**: パスの*形*（traversal・機密パス）は MCP ハンドラ側、**存在確認は Lua 側**。相対パスは対象 Neovim インスタンスの cwd（往々にして worktree）に対して解決されるので、MCP サーバープロセスからは判断できません。

**1つでも不正な stop があれば呼び出し全体を失敗させます**。`nvim_ask_user_question` と違いこのツールの結果はモデルに返るので、ハードエラーなら直せます。黙って短くなったツアーは気づけません。

**`rpc_port` は必須**。単一インスタンスの状態を書き換えるツールなので、`nvim_list_instances` 以外の全ツールと同じ扱いです。

## テスト

- `tests/lua/infrastructure/rpc/handlers/qflist_spec.lua`（11件）— 積める／タイトル／**`:colder` で元のリストに戻れる**／フォーカスを奪わない／不正な stop での全 reject と、その際に現在のリストを壊さないこと
- `mcp-server/src/__tests__/qflist-tools.test.ts`（登録・転送・9種の reject）

`pnpm run test:lua` 864 passed / 0 failed、`mcp-server` 78 passed、`pnpm run check` / `lint` / `format:check` すべて green。

## ドキュメント

`.claude/rules/mcp-integration.md`（ツール一覧）、`.claude/rules/features.md`（Code Tour セクション）、`mcp-server/README.md`（Quickfix セクション＋使用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)