### PR TITLE
feat: let the agent read the debugger instead of guessing from the source

### DIFF
--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -15,6 +15,8 @@
 | `:VibingClearContext`                 | Clear all context                                                                                   |
 | `:VibingCancel`                       | Cancel current request                                                                              |
 | `:VibingClearAnnotations`             | Remove inline review annotations from every buffer                                                  |
+| `:VibingDebugAnalyze`                 | Ask the agent to analyze the stopped debug session (needs nvim-dap)                                 |
+| `:VibingDebugHelp`                    | Ask the agent what to check next in the stopped debug session                                       |
 | `:VibingPendingResumes`               | List chats waiting on a usage limit reset                                                           |
 | `:VibingCancelResume [all]`           | Cancel the pending auto-resume for this chat (or every one with `all`)                              |
 | `:VibingReloadCommands`               | Reload custom slash commands                                                                        |

--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -69,6 +69,42 @@ The pacing question in the skill inherits AskUserQuestion's turn-killing behavio
 skill is instructed to write the tour's position and remaining stops into its chat message before
 every ask — the transcript is the only place that state survives.
 
+## Debugger Analysis (nvim-dap)
+
+When the debugger is stopped, the agent can look at the actual runtime state instead of reasoning
+about the source: `nvim_dap_get_state`, `nvim_dap_get_stack_trace`, `nvim_dap_get_variables`,
+`nvim_dap_set_breakpoint`, `nvim_dap_evaluate` (`infrastructure/rpc/handlers/dap.lua`).
+
+nvim-dap is an **optional** dependency. Every entry point reports "nvim-dap is not installed" or
+"no debug session is running" rather than erroring, so the agent gets an explanation it can act on
+— which is also why `nvim_dap_get_state` exists and its description tells the model to call it
+first.
+
+DAP requests are callback-based while RPC handlers return a value, so each request is awaited with
+`vim.wait`. That is only safe because the RPC server already dispatches handlers inside
+`vim.schedule`: we are on the main loop, and `vim.wait` keeps processing events, which is what lets
+the adapter's reply arrive at all.
+
+`vim.wait` does still block the editor, though, so a handler that issues several requests spends
+**one shared budget** across them (`deadline()` in `dap.lua`). `dap_get_variables` asks for scopes
+and then for the variables of each scope; with a per-request timeout a slow adapter and a frame
+with four scopes would freeze Neovim for 25 seconds on a single tool call.
+
+`dap_get_variables` expands only the top level of each scope. A deep object graph would flood the
+chat, and the agent can follow up with `dap_evaluate` on whatever it actually wants. Note that
+`dap_evaluate` runs **in the debuggee** — an expression with side effects will have them, and the
+tool description says so.
+
+`:VibingDebugAnalyze` and `:VibingDebugHelp` send a request to the chat. They send only the
+request, never a state dump: the agent fetches whatever depth it needs through the tools above.
+`config.dap.enabled` additionally subscribes to nvim-dap's stopped event; `auto_analyze_on_error`
+(default `true`) fires on exceptions, `auto_analyze_on_breakpoint` (default `false`) on ordinary
+breakpoints — a breakpoint is something the user placed on purpose, and spending tokens unattended
+every time one is hit gets in the way. The whole feature is off until `dap.enabled` is set.
+
+**Implementation:** `application/debug/analyze.lua` (commands + stopped-event listener),
+`infrastructure/rpc/handlers/dap.lua`, `mcp-server/src/{tools,handlers}/dap.ts`.
+
 ## Message Timestamps
 
 Chat messages include timestamps in their headers (`## 2025-12-28 14:30:00 User`) for chronology

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -32,6 +32,9 @@ Prefix with `mcp__vibing-nvim__`:
   `features.md`), `nvim_chat_send_message`
 - **Instances**: `nvim_list_instances`
 - **Quickfix**: `nvim_set_qflist` (pushes a new list; the previous one survives under `:colder`)
+- **Debugger**: `nvim_dap_get_state`, `nvim_dap_get_stack_trace`, `nvim_dap_get_variables`,
+  `nvim_dap_set_breakpoint`, `nvim_dap_evaluate` (nvim-dap is optional — every one of these
+  reports it as missing rather than failing)
 - **LSP**: `nvim_lsp_definition`, `nvim_lsp_references`, `nvim_lsp_hover`, `nvim_diagnostics`,
   `nvim_lsp_document_symbols`, `nvim_lsp_type_definition`, `nvim_lsp_call_hierarchy_incoming`,
   `nvim_lsp_call_hierarchy_outgoing`

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,9 @@ build/
 bin/mote-*
 
 # Debug
-debug/
+# ルート直下のdebug/だけを対象にする。パターンだけだと
+# lua/vibing/application/debug/ のような正規のソースまで飲み込む
+/debug/
 *.debug
 
 # Temporary

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ Complete reference for every `require("vibing").setup()` option. Defaults shown 
 - [Node.js Executable](#nodejs-executable)
 - [Language](#language)
 - [Project System Prompt](#project-system-prompt)
+- [Debugger (nvim-dap)](#debugger-nvim-dap)
 - [Daily Summary](#daily-summary)
 
 ## Defaults at a Glance
@@ -552,6 +553,28 @@ Notes:
   directory's `.vibing/system-prompt.md` when it exists and has content, and otherwise falls back
   to the project root's file — so a worktree can override the project prompt without having to
   copy it.
+
+## Debugger (nvim-dap)
+
+```lua
+dap = {
+  enabled = false,             -- Subscribe to nvim-dap's stopped event.
+                               -- Everything below is inert until this is true; the MCP
+                               -- nvim_dap_* tools work regardless, on demand.
+  auto_analyze_on_error = true,      -- Analyze automatically when the program stops on an
+                                     -- exception — something is already wrong there
+  auto_analyze_on_breakpoint = false, -- ...but not on an ordinary breakpoint, which you placed
+                                     -- on purpose and may hit in a loop
+}
+```
+
+`:VibingDebugAnalyze` and `:VibingDebugHelp` work without `enabled`; the flag only controls whether
+stopping fires a request by itself. Requires [nvim-dap](https://github.com/mfussenegger/nvim-dap);
+without it, both commands and all `nvim_dap_*` tools say so rather than failing.
+
+What gets sent is only the request — never a dump of the stack and variables. The agent pulls
+whatever depth it needs through the tools, so a large object graph never lands in the prompt
+uninvited. See `.claude/rules/features.md` → "Debugger Analysis".
 
 ## Daily Summary
 

--- a/lua/vibing/application/debug/analyze.lua
+++ b/lua/vibing/application/debug/analyze.lua
@@ -1,0 +1,117 @@
+---@class Vibing.Application.Debug.Analyze
+---デバッガが止まっている状態をチャットに投げて解析させる。
+---
+---状態そのものは送らない。送るのは「今の停止状態を調べてくれ」という依頼だけで、スタックも
+---変数もエージェント自身がMCPツールで取りに行く。そのほうが必要な深さを本人が決められるし、
+---巨大な変数ダンプをプロンプトに焼き込まずに済む。
+local M = {}
+
+local notify = require("vibing.core.utils.notify")
+
+local ANALYZE_PROMPT = "The debugger is stopped. Use the nvim_dap_* tools to look at the stack "
+  .. "trace and the variables in the current frame, then tell me what state the program is in and "
+  .. "whether anything looks wrong. Name the specific variable and value if it does."
+
+local HELP_PROMPT = "The debugger is stopped and I am stuck. Use the nvim_dap_* tools to inspect "
+  .. "the current frame, then suggest what to check next — which expression to evaluate, or where "
+  .. "to put the next breakpoint, and why."
+
+---@return boolean stopped
+---@return string? reason
+local function is_stopped()
+  local ok, dap = pcall(require, "dap")
+  if not ok then
+    return false, "nvim-dap is not installed"
+  end
+  local session = dap.session()
+  if not session then
+    return false, "no debug session is running"
+  end
+  if not session.stopped_thread_id and not session.current_frame then
+    return false, "the program is running — stop at a breakpoint first"
+  end
+  return true, nil
+end
+
+---@param prompt string
+---@return boolean sent
+local function send(prompt)
+  local stopped, reason = is_stopped()
+  if not stopped then
+    notify.warn(reason, "Debug")
+    return false
+  end
+
+  local view = require("vibing.presentation.chat.view")
+  local current = view.get_current()
+  if not current then
+    require("vibing.presentation.chat.controller").handle_open("")
+    current = view.get_current()
+  end
+  if not current then
+    notify.error("Could not open a chat to analyze in", "Debug")
+    return false
+  end
+
+  -- 送信経路はnvim_chat_send_messageと同じProgrammaticSender。バッファ側のロックや
+  -- カーソル復帰をここで書き直さない
+  local sender = require("vibing.presentation.chat.modules.programmatic_sender")
+  local ok, err = pcall(sender.send, current.buf, prompt)
+  if not ok then
+    notify.error("Could not send the analysis request: " .. tostring(err), "Debug")
+    return false
+  end
+
+  return true
+end
+
+---:VibingDebugAnalyze
+---@return boolean sent
+function M.analyze()
+  return send(ANALYZE_PROMPT)
+end
+
+---:VibingDebugHelp
+---@return boolean sent
+function M.help()
+  return send(HELP_PROMPT)
+end
+
+---@param config table config.dap
+---@return boolean armed
+function M.setup(config)
+  config = config or {}
+  if not config.enabled then
+    return false
+  end
+
+  local ok, dap = pcall(require, "dap")
+  if not ok then
+    -- 明示的にenabledにした人が黙って何も起きない状態にならないように言う
+    notify.warn("dap.enabled is set but nvim-dap is not installed", "Debug")
+    return false
+  end
+
+  -- 例外で止まったのか、ただのブレークポイントなのかで既定を変える。例外は起きた時点で
+  -- 何かが壊れているが、ブレークポイントは意図して置いたものなので、止まるたびに無人で
+  -- トークンを使われると邪魔になる
+  dap.listeners.after.event_stopped["vibing"] = function(_, body)
+    local wanted
+    if body and body.reason == "exception" then
+      wanted = config.auto_analyze_on_error
+    else
+      wanted = config.auto_analyze_on_breakpoint
+    end
+    if not wanted then
+      return
+    end
+
+    vim.schedule(function()
+      M.analyze()
+    end)
+  end
+
+  return true
+end
+
+return M

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -48,6 +48,7 @@
 ---@field mcp Vibing.McpConfig MCP統合設定（RPCポート、自動起動）
 ---@field language? string|Vibing.LanguageConfig AI応答のデフォルト言語（"ja", "en"等、またはLanguageConfig）
 ---@field daily_summary? Vibing.DailySummaryConfig Daily Summary機能設定
+---@field dap? Vibing.DapConfig nvim-dap連携設定
 
 ---@class Vibing.PermissionRule
 ---粒度の細かい権限制御ルール
@@ -133,6 +134,14 @@
 ---@field chat? string chatアクションでの言語（指定されていない場合はdefaultを使用）
 
 ---@alias Vibing.FileFinderStrategy "auto"|"fd"|"find"|"locate"|"ripgrep"
+
+---@class Vibing.DapConfig
+---nvim-dap連携設定
+---デバッガが停止したときに、その状態をエージェントに解析させる
+---nvim-dapは任意依存。未インストールなら各機能は「入っていない」と報告して何もしない
+---@field enabled boolean? 停止イベントの購読を有効にするか（デフォルト: false）
+---@field auto_analyze_on_error boolean? 例外で止まったとき自動で解析を投げるか（デフォルト: true）
+---@field auto_analyze_on_breakpoint boolean? ブレークポイントで止まったとき自動で投げるか（デフォルト: false）
 
 ---@class Vibing.DailySummaryConfig
 ---Daily Summary機能設定
@@ -276,6 +285,13 @@ M.defaults = {
     save_dir = nil,
     search_dirs = {},
     file_finder_strategy = "auto",
+  },
+  -- nvim-dapで止まったときの自動解析。既定は無効で、有効にしても既定はエラー時のみ。
+  -- ブレークポイントは意図して置くものなので、止まるたびに無人でトークンを使われると邪魔になる
+  dap = {
+    enabled = false,
+    auto_analyze_on_error = true,
+    auto_analyze_on_breakpoint = false,
   },
 }
 

--- a/lua/vibing/infrastructure/rpc/handlers/dap.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/dap.lua
@@ -1,0 +1,269 @@
+--- Debug adapter (nvim-dap) access for the agent.
+---
+--- nvim-dap is an optional dependency: every entry point reports it as missing rather than
+--- erroring, so a user without it sees an explanation instead of a stack trace.
+---
+--- DAP requests are callback-based while RPC handlers return a value, so each request is awaited
+--- with vim.wait. That is safe here because the RPC server already dispatches handlers inside
+--- vim.schedule -- we are on the main loop, and vim.wait keeps processing events, which is what
+--- lets the debug adapter's reply arrive at all.
+local M = {}
+
+local REQUEST_TIMEOUT_MS = 5000
+
+---@return table? dap
+---@return string? reason
+local function get_dap()
+  local ok, dap = pcall(require, "dap")
+  if not ok then
+    return nil, "nvim-dap is not installed"
+  end
+  return dap, nil
+end
+
+---@return table? session
+---@return string? reason
+local function get_session()
+  local dap, reason = get_dap()
+  if not dap then
+    return nil, reason
+  end
+  local session = dap.session()
+  if not session then
+    return nil, "no debug session is running"
+  end
+  return session, nil
+end
+
+--- dap_get_state hands the reason back as data; every other entry point raises it, so the MCP
+--- layer turns it into a tool error the agent can read. Level 2 puts the calling handler's line
+--- in the message rather than this helper's.
+---@return table dap
+local function require_dap()
+  local dap, reason = get_dap()
+  if not dap then
+    error(reason, 2)
+  end
+  return dap
+end
+
+---@return table session
+local function require_session()
+  local session, reason = get_session()
+  if not session then
+    error(reason, 2)
+  end
+  return session
+end
+
+--- Await one DAP request.
+--- `budget_ms` exists because vim.wait blocks the editor: a handler that issues several requests
+--- must spend one shared budget across them, not a fresh 5s each, or a slow adapter freezes
+--- Neovim for as long as it has scopes to ask about.
+---@param session table
+---@param command string
+---@param arguments table
+---@param budget_ms number? defaults to the per-request timeout
+---@return table? body
+---@return string? err
+local function request(session, command, arguments, budget_ms)
+  budget_ms = math.max(budget_ms or REQUEST_TIMEOUT_MS, 0)
+  local done, body, err = false, nil, nil
+
+  session:request(command, arguments, function(request_err, response)
+    err = request_err and (request_err.message or vim.inspect(request_err))
+    body = response
+    done = true
+  end)
+
+  if not vim.wait(budget_ms, function()
+    return done
+  end, 20) then
+    return nil, string.format("%s timed out after %dms", command, budget_ms)
+  end
+
+  return body, err
+end
+
+--- Counts down one wall-clock budget across several requests.
+---@param total_ms number
+---@return fun(): number remaining
+local function deadline(total_ms)
+  local started = vim.uv.now()
+  return function()
+    return math.max(total_ms - (vim.uv.now() - started), 0)
+  end
+end
+
+--- The part of a stack frame the agent needs to name a location. `source.name` is the fallback
+--- for frames the adapter has no file for (a REPL frame, generated code).
+---@param frame table
+---@return table
+local function to_frame(frame)
+  return {
+    id = frame.id,
+    name = frame.name,
+    line = frame.line,
+    column = frame.column,
+    source = frame.source and (frame.source.path or frame.source.name),
+  }
+end
+
+--- Top level of one scope. A scope that has no children, or whose read fails, is still reported
+--- with an empty variable list: its name alone tells the agent the scope exists.
+---@param session table
+---@param scope table
+---@param remaining fun(): number wall-clock left for the whole dap_get_variables call
+---@return table[]
+local function read_scope(session, scope, remaining)
+  if not scope.variablesReference or scope.variablesReference <= 0 then
+    return {}
+  end
+
+  local body, err = request(session, "variables", { variablesReference = scope.variablesReference }, remaining())
+  if err then
+    return {}
+  end
+
+  local variables = {}
+  for _, variable in ipairs(body and body.variables or {}) do
+    table.insert(variables, {
+      name = variable.name,
+      value = variable.value,
+      type = variable.type,
+    })
+  end
+  return variables
+end
+
+--- What the debugger is doing right now.
+--- Answers "is there anything to inspect" without the agent having to guess from a failed call.
+---@return table { running: boolean, reason: string?, adapter: string?, config_name: string?,
+---   stopped_thread_id: number?, current_frame: table? }
+function M.dap_get_state()
+  local session, reason = get_session()
+  if not session then
+    return { running = false, reason = reason }
+  end
+
+  return {
+    running = true,
+    adapter = session.config and session.config.type,
+    config_name = session.config and session.config.name,
+    stopped_thread_id = session.stopped_thread_id,
+    current_frame = session.current_frame and to_frame(session.current_frame),
+  }
+end
+
+---@param params table? { thread_id: number? }
+---@return table { frames: table[] }
+function M.dap_get_stack_trace(params)
+  local session = require_session()
+
+  local thread_id = (params and params.thread_id) or session.stopped_thread_id
+  if not thread_id then
+    error("no stopped thread — the program is still running")
+  end
+
+  local body, err = request(session, "stackTrace", { threadId = thread_id })
+  if err then
+    error(err)
+  end
+
+  local frames = {}
+  for _, frame in ipairs(body and body.stackFrames or {}) do
+    table.insert(frames, to_frame(frame))
+  end
+
+  return { frames = frames }
+end
+
+--- Variables visible in one stack frame, grouped by scope.
+--- Only the top level of each scope is expanded: a deep object graph would flood the chat, and the
+--- agent can follow up with dap_evaluate on whatever it actually wants.
+---@param params table? { frame_id: number? }
+---@return table { scopes: { name: string, variables: { name: string, value: string, type: string? }[] }[] }
+function M.dap_get_variables(params)
+  local session = require_session()
+
+  local frame_id = (params and params.frame_id) or (session.current_frame and session.current_frame.id)
+  if not frame_id then
+    error("no current frame — the program is not stopped")
+  end
+
+  -- One budget for the scopes request and every variables request under it. A frame can have
+  -- several scopes, and per-request timeouts would multiply into tens of seconds of frozen editor.
+  local remaining = deadline(REQUEST_TIMEOUT_MS)
+
+  local body, err = request(session, "scopes", { frameId = frame_id }, remaining())
+  if err then
+    error(err)
+  end
+
+  local scopes = {}
+  for _, scope in ipairs(body and body.scopes or {}) do
+    table.insert(scopes, { name = scope.name, variables = read_scope(session, scope, remaining) })
+  end
+
+  return { scopes = scopes }
+end
+
+---@param params table { file: string, line: number, condition: string? }
+---@return table { success: boolean, file: string, line: number }
+function M.dap_set_breakpoint(params)
+  local dap = require_dap()
+
+  local file = params and params.file
+  local line = params and params.line
+  if type(file) ~= "string" or file == "" then
+    error("file is required")
+  end
+  if type(line) ~= "number" or line < 1 or line ~= math.floor(line) then
+    error("line must be a positive integer")
+  end
+
+  local path = vim.fn.fnamemodify(file, ":p")
+  if vim.fn.filereadable(path) == 0 then
+    error("file does not exist: " .. file)
+  end
+
+  -- The buffer has to exist for nvim-dap to attach the breakpoint to it, but it does not have to
+  -- be displayed — setting a breakpoint should not yank the user's window somewhere else.
+  local bufnr = vim.fn.bufadd(path)
+  vim.fn.bufload(bufnr)
+
+  local breakpoints = require("dap.breakpoints")
+  breakpoints.set({ condition = params.condition }, bufnr, line)
+
+  -- A live session only learns about the new breakpoint when it is pushed to it.
+  local session = dap.session()
+  if session then
+    breakpoints.set_breakpoints(session, bufnr)
+  end
+
+  return { success = true, file = path, line = line }
+end
+
+---@param params table { expression: string, frame_id: number? }
+---@return table { result: string, type: string? }
+function M.dap_evaluate(params)
+  local session = require_session()
+
+  local expression = params and params.expression
+  if type(expression) ~= "string" or expression == "" then
+    error("expression is required")
+  end
+
+  local body, err = request(session, "evaluate", {
+    expression = expression,
+    frameId = params.frame_id or (session.current_frame and session.current_frame.id),
+    context = "repl",
+  })
+  if err then
+    error(err)
+  end
+
+  return { result = body and body.result or "", type = body and body.type }
+end
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -12,6 +12,7 @@ local message = require("vibing.infrastructure.rpc.handlers.message")
 local permission = require("vibing.infrastructure.rpc.handlers.permission")
 local rate_limit = require("vibing.infrastructure.rpc.handlers.rate_limit")
 local qflist = require("vibing.infrastructure.rpc.handlers.qflist")
+local dap = require("vibing.infrastructure.rpc.handlers.dap")
 
 -- Export all handlers
 M.buf_get_lines = buffer.buf_get_lines
@@ -59,5 +60,11 @@ M.ask_user_question = permission.ask_user_question
 M.stop_failure = rate_limit.stop_failure
 
 M.set_qflist = qflist.set_qflist
+
+M.dap_get_state = dap.dap_get_state
+M.dap_get_stack_trace = dap.dap_get_stack_trace
+M.dap_get_variables = dap.dap_get_variables
+M.dap_set_breakpoint = dap.dap_set_breakpoint
+M.dap_evaluate = dap.dap_evaluate
 
 return M

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -71,6 +71,16 @@ function M.setup(opts)
     end)
   end
 
+  -- nvim-dapの停止イベントを購読する。nvim-dapがまだロードされていない可能性があるので
+  -- VimEnter後に遅らせる（未インストールならsetup側がfalseを返して何もしない）
+  if M.config.dap and M.config.dap.enabled then
+    vim.schedule(function()
+      pcall(function()
+        require("vibing.application.debug.analyze").setup(M.config.dap)
+      end)
+    end)
+  end
+
   -- 終了時にクリーンアップ
   local augroup = vim.api.nvim_create_augroup("VibingCleanup", { clear = true })
   vim.api.nvim_create_autocmd("VimLeavePre", {
@@ -142,6 +152,14 @@ function M._register_commands()
   vim.api.nvim_create_user_command("VibingToggleChat", function()
     require("vibing.presentation.chat.controller").handle_toggle()
   end, { desc = "Toggle Vibing chat window" })
+
+  vim.api.nvim_create_user_command("VibingDebugAnalyze", function()
+    require("vibing.application.debug.analyze").analyze()
+  end, { desc = "Ask the agent to analyze the stopped debug session" })
+
+  vim.api.nvim_create_user_command("VibingDebugHelp", function()
+    require("vibing.application.debug.analyze").help()
+  end, { desc = "Ask the agent what to check next in the stopped debug session" })
 
   vim.api.nvim_create_user_command("VibingChatFork", function(opts)
     require("vibing.presentation.chat.controller").handle_fork(opts.args)

--- a/mcp-server/src/__tests__/dap-tools.test.ts
+++ b/mcp-server/src/__tests__/dap-tools.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { allTools } from '../tools/index.js';
+import { handlers } from '../handlers/index.js';
+import * as rpc from '../rpc.js';
+
+vi.mock('../rpc.js', () => ({
+  callNeovim: vi.fn(),
+}));
+
+const DAP_TOOLS = [
+  'nvim_dap_get_state',
+  'nvim_dap_get_stack_trace',
+  'nvim_dap_get_variables',
+  'nvim_dap_set_breakpoint',
+  'nvim_dap_evaluate',
+];
+
+describe('dap tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ running: false });
+  });
+
+  describe('registration', () => {
+    it.each(DAP_TOOLS)('registers %s with a handler', (name) => {
+      expect(allTools.find((tool) => tool.name === name)).toBeDefined();
+      expect(typeof handlers[name]).toBe('function');
+    });
+
+    it.each(DAP_TOOLS)('%s requires rpc_port — it targets one debug session', (name) => {
+      const tool = allTools.find((t) => t.name === name);
+      const schema = tool?.inputSchema as { required?: string[] };
+      expect(schema.required).toContain('rpc_port');
+    });
+
+    it('requires file and line to set a breakpoint', () => {
+      const tool = allTools.find((t) => t.name === 'nvim_dap_set_breakpoint');
+      const schema = tool?.inputSchema as { required?: string[] };
+      expect(schema.required).toContain('file');
+      expect(schema.required).toContain('line');
+    });
+
+    it('warns that evaluate runs in the debuggee', () => {
+      const tool = allTools.find((t) => t.name === 'nvim_dap_evaluate');
+      expect(tool?.description).toMatch(/side effects/);
+    });
+  });
+
+  describe('forwarding', () => {
+    it('asks Neovim for the debugger state', async () => {
+      await handlers.nvim_dap_get_state({ rpc_port: 9876 });
+      expect(rpc.callNeovim).toHaveBeenCalledWith('dap_get_state', {}, 9876);
+    });
+
+    it('passes the optional thread and frame ids through', async () => {
+      await handlers.nvim_dap_get_stack_trace({ thread_id: 3, rpc_port: 9876 });
+      expect(rpc.callNeovim).toHaveBeenCalledWith('dap_get_stack_trace', { thread_id: 3 }, 9876);
+
+      await handlers.nvim_dap_get_variables({ frame_id: 7, rpc_port: 9876 });
+      expect(rpc.callNeovim).toHaveBeenCalledWith('dap_get_variables', { frame_id: 7 }, 9876);
+    });
+
+    it('forwards a breakpoint with its condition', async () => {
+      await handlers.nvim_dap_set_breakpoint({
+        file: 'src/app.py',
+        line: 12,
+        condition: 'x < 0',
+        rpc_port: 9876,
+      });
+
+      expect(rpc.callNeovim).toHaveBeenCalledWith(
+        'dap_set_breakpoint',
+        { file: 'src/app.py', line: 12, condition: 'x < 0' },
+        9876
+      );
+    });
+
+    it('returns the state as readable JSON', async () => {
+      vi.mocked(rpc.callNeovim).mockResolvedValue({ running: true, adapter: 'python' });
+
+      const result = await handlers.nvim_dap_get_state({ rpc_port: 9876 });
+      expect(result.content[0].text).toContain('python');
+      expect(result._meta.running).toBe(true);
+    });
+  });
+
+  describe('rejects before touching Neovim', () => {
+    const rejected: Array<[string, string, Record<string, unknown>]> = [
+      ['no rpc_port', 'nvim_dap_get_state', {}],
+      ['an empty expression', 'nvim_dap_evaluate', { expression: '', rpc_port: 9876 }],
+      ['no expression at all', 'nvim_dap_evaluate', { rpc_port: 9876 }],
+      ['no line', 'nvim_dap_set_breakpoint', { file: 'a.py', rpc_port: 9876 }],
+      ['a zero line', 'nvim_dap_set_breakpoint', { file: 'a.py', line: 0, rpc_port: 9876 }],
+      ['a fractional line', 'nvim_dap_set_breakpoint', { file: 'a.py', line: 1.5, rpc_port: 9876 }],
+      [
+        'a path traversal attempt',
+        'nvim_dap_set_breakpoint',
+        { file: '../../../etc/passwd', line: 1, rpc_port: 9876 },
+      ],
+    ];
+
+    it.each(rejected)('rejects %s', async (_label, name, args) => {
+      await expect(handlers[name](args)).rejects.toThrow();
+      expect(rpc.callNeovim).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mcp-server/src/handlers/dap.ts
+++ b/mcp-server/src/handlers/dap.ts
@@ -1,0 +1,61 @@
+import { callNeovim } from '../rpc.js';
+import { validateFilePath } from '../validation/schema.js';
+import { z } from 'zod';
+
+/**
+ * Handlers for the nvim_dap_* tools.
+ *
+ * Nothing here knows whether nvim-dap is installed or stopped — `handlers/dap.lua` answers that,
+ * either as `{ running = false, reason = ... }` from get_state or as an error the model reads.
+ * This layer only rejects arguments that could not work at all, before touching Neovim.
+ */
+
+// Every dap tool targets exactly one debug session, so rpc_port is the one shared requirement.
+const baseArgsSchema = z.object({ rpc_port: z.number() });
+
+const stackTraceArgsSchema = baseArgsSchema.extend({ thread_id: z.number().int().optional() });
+const variablesArgsSchema = baseArgsSchema.extend({ frame_id: z.number().int().optional() });
+const evaluateArgsSchema = baseArgsSchema.extend({
+  expression: z.string().min(1),
+  frame_id: z.number().int().optional(),
+});
+const setBreakpointArgsSchema = baseArgsSchema.extend({
+  file: z.string().min(1),
+  line: z.number().int().positive(),
+  condition: z.string().optional(),
+});
+
+function asJson(result: unknown) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    _meta: result,
+  };
+}
+
+export async function handleDapGetState(args: any): Promise<any> {
+  const { rpc_port } = baseArgsSchema.parse(args);
+  return asJson(await callNeovim('dap_get_state', {}, rpc_port));
+}
+
+export async function handleDapGetStackTrace(args: any): Promise<any> {
+  const { thread_id, rpc_port } = stackTraceArgsSchema.parse(args);
+  return asJson(await callNeovim('dap_get_stack_trace', { thread_id }, rpc_port));
+}
+
+export async function handleDapGetVariables(args: any): Promise<any> {
+  const { frame_id, rpc_port } = variablesArgsSchema.parse(args);
+  return asJson(await callNeovim('dap_get_variables', { frame_id }, rpc_port));
+}
+
+export async function handleDapSetBreakpoint(args: any): Promise<any> {
+  const { file, line, condition, rpc_port } = setBreakpointArgsSchema.parse(args);
+  // Path shape only; whether it exists is decided by Neovim, whose cwd may be a worktree this
+  // process cannot see.
+  validateFilePath({ filepath: file });
+  return asJson(await callNeovim('dap_set_breakpoint', { file, line, condition }, rpc_port));
+}
+
+export async function handleDapEvaluate(args: any): Promise<any> {
+  const { expression, frame_id, rpc_port } = evaluateArgsSchema.parse(args);
+  return asJson(await callNeovim('dap_evaluate', { expression, frame_id }, rpc_port));
+}

--- a/mcp-server/src/handlers/index.ts
+++ b/mcp-server/src/handlers/index.ts
@@ -8,6 +8,7 @@ import * as chat from './chat.js';
 import * as highlight from './highlight.js';
 import * as annotations from './annotations.js';
 import * as qflist from './qflist.js';
+import * as dap from './dap.js';
 
 export const handlers: Record<string, (args: any) => Promise<any>> = {
   // Buffer operations
@@ -61,4 +62,11 @@ export const handlers: Record<string, (args: any) => Promise<any>> = {
   nvim_clear_annotations: annotations.handleClearAnnotations,
   // Quickfix
   nvim_set_qflist: qflist.handleSetQflist,
+
+  // Debugger (nvim-dap)
+  nvim_dap_get_state: dap.handleDapGetState,
+  nvim_dap_get_stack_trace: dap.handleDapGetStackTrace,
+  nvim_dap_get_variables: dap.handleDapGetVariables,
+  nvim_dap_set_breakpoint: dap.handleDapSetBreakpoint,
+  nvim_dap_evaluate: dap.handleDapEvaluate,
 };

--- a/mcp-server/src/tools/dap.ts
+++ b/mcp-server/src/tools/dap.ts
@@ -1,0 +1,81 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { withRpcPort, requireRpcPort } from './common.js';
+
+export const dapTools: Tool[] = [
+  {
+    name: 'nvim_dap_get_state',
+    description:
+      'Ask whether a debug session is running and where it is stopped. Call this first — the ' +
+      'other dap tools need a stopped program, and this says so plainly instead of failing.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({}),
+      required: requireRpcPort(),
+    },
+  },
+  {
+    name: 'nvim_dap_get_stack_trace',
+    description: 'Stack frames of the stopped thread, innermost first.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({
+        thread_id: {
+          type: 'number',
+          description: 'Defaults to the thread that is stopped.',
+        },
+      }),
+      required: requireRpcPort(),
+    },
+  },
+  {
+    name: 'nvim_dap_get_variables',
+    description:
+      'Variables in a stack frame, grouped by scope (locals, globals, ...). Only the top level of ' +
+      'each scope is expanded; use nvim_dap_evaluate to look inside a specific value.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({
+        frame_id: {
+          type: 'number',
+          description: 'Defaults to the frame the debugger is currently stopped in.',
+        },
+      }),
+      required: requireRpcPort(),
+    },
+  },
+  {
+    name: 'nvim_dap_set_breakpoint',
+    description:
+      'Set a breakpoint. Works whether or not a session is running; a live session picks it up ' +
+      'immediately. Does not move the user to the file.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({
+        file: { type: 'string', description: 'Existing file, absolute or relative to the cwd.' },
+        line: { type: 'number', description: '1-based line number.' },
+        condition: {
+          type: 'string',
+          description: 'Optional expression; the program only stops when it is true.',
+        },
+      }),
+      required: requireRpcPort(['file', 'line']),
+    },
+  },
+  {
+    name: 'nvim_dap_evaluate',
+    description:
+      'Evaluate an expression in the debug session, in the language being debugged. This runs in ' +
+      'the debuggee — an expression with side effects will have them.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({
+        expression: { type: 'string', description: 'Expression in the debuggee language.' },
+        frame_id: {
+          type: 'number',
+          description: 'Defaults to the frame the debugger is currently stopped in.',
+        },
+      }),
+      required: requireRpcPort(['expression']),
+    },
+  },
+];

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -8,6 +8,7 @@ import { chatTools } from './chat.js';
 import { highlightTools } from './highlight.js';
 import { annotationTools } from './annotations.js';
 import { qflistTools } from './qflist.js';
+import { dapTools } from './dap.js';
 
 export const allTools = [
   ...bufferTools,
@@ -20,4 +21,5 @@ export const allTools = [
   ...highlightTools,
   ...annotationTools,
   ...qflistTools,
+  ...dapTools,
 ];

--- a/tests/lua/infrastructure/rpc/handlers/dap_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/dap_spec.lua
@@ -1,0 +1,303 @@
+describe("rpc handler dap", function()
+  local dap_handler
+
+  --- Install a fake nvim-dap. The real one needs a running debug adapter, which a headless test
+  --- has no way to provide — what these specs pin down is the shape of what we hand the agent and
+  --- how we behave when there is nothing to inspect.
+  ---@param session table|nil
+  ---@param breakpoints table|nil captures set() calls
+  local function install_dap(session, breakpoints)
+    package.loaded["dap"] = {
+      session = function()
+        return session
+      end,
+    }
+    package.loaded["dap.breakpoints"] = {
+      set = function(opts, bufnr, line)
+        if breakpoints then
+          table.insert(breakpoints, { opts = opts, bufnr = bufnr, line = line })
+        end
+      end,
+      set_breakpoints = function() end,
+    }
+  end
+
+  --- A session that answers requests from a canned table.
+  ---@param responses table<string, table>
+  ---@param fields table|nil session field overrides. `false` clears a field — plain nil cannot,
+  ---  since vim.tbl_extend drops nil values instead of applying them as removals.
+  local function fake_session(responses, fields)
+    local session = {
+      stopped_thread_id = 1,
+      current_frame = { id = 7, name = "main", line = 42, source = { path = "/tmp/app.py" } },
+      config = { type = "python", name = "Launch file" },
+    }
+    for key, value in pairs(fields or {}) do
+      session[key] = value ~= false and value or nil
+    end
+
+    session.request = function(_, command, _, callback)
+      local response = responses[command]
+      if response == nil then
+        callback({ message = command .. " not supported" }, nil)
+      else
+        callback(nil, response)
+      end
+    end
+
+    return session
+  end
+
+  before_each(function()
+    package.loaded["vibing.infrastructure.rpc.handlers.dap"] = nil
+    dap_handler = require("vibing.infrastructure.rpc.handlers.dap")
+  end)
+
+  after_each(function()
+    package.loaded["dap"] = nil
+    package.loaded["dap.breakpoints"] = nil
+  end)
+
+  describe("without nvim-dap installed", function()
+    before_each(function()
+      package.loaded["dap"] = nil
+      -- Make `require("dap")` fail the way a missing plugin does.
+      package.preload["dap"] = function()
+        error("module 'dap' not found")
+      end
+    end)
+
+    after_each(function()
+      package.preload["dap"] = nil
+    end)
+
+    it("reports it as missing instead of erroring", function()
+      local state = dap_handler.dap_get_state()
+      assert.is_false(state.running)
+      assert.is_truthy(state.reason:find("not installed", 1, true))
+    end)
+
+    it("says so from the tools that need a session too", function()
+      local ok, err = pcall(dap_handler.dap_get_stack_trace, {})
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("not installed", 1, true))
+    end)
+  end)
+
+  describe("dap_get_state", function()
+    it("says there is nothing to inspect when no session is running", function()
+      install_dap(nil)
+      local state = dap_handler.dap_get_state()
+
+      assert.is_false(state.running)
+      assert.is_truthy(state.reason:find("no debug session", 1, true))
+    end)
+
+    it("describes where the debugger is stopped", function()
+      install_dap(fake_session({}))
+      local state = dap_handler.dap_get_state()
+
+      assert.is_true(state.running)
+      assert.equals("python", state.adapter)
+      assert.equals(1, state.stopped_thread_id)
+      assert.equals(42, state.current_frame.line)
+      assert.equals("/tmp/app.py", state.current_frame.source)
+    end)
+
+    it("reports a running-but-not-stopped session without a frame", function()
+      install_dap(fake_session({}, { stopped_thread_id = false, current_frame = false }))
+      local state = dap_handler.dap_get_state()
+
+      assert.is_true(state.running)
+      assert.is_nil(state.current_frame)
+    end)
+  end)
+
+  describe("dap_get_stack_trace", function()
+    it("flattens the frames into what the agent needs to name a location", function()
+      install_dap(fake_session({
+        stackTrace = {
+          stackFrames = {
+            { id = 7, name = "divide", line = 12, column = 5, source = { path = "/tmp/app.py" } },
+            { id = 8, name = "main", line = 40, source = { name = "<stdin>" } },
+          },
+        },
+      }))
+
+      local frames = dap_handler.dap_get_stack_trace({}).frames
+      assert.equals(2, #frames)
+      assert.equals("divide", frames[1].name)
+      assert.equals("/tmp/app.py", frames[1].source)
+      -- source.name is the fallback when the adapter has no path for the frame
+      assert.equals("<stdin>", frames[2].source)
+    end)
+
+    it("refuses when nothing is stopped", function()
+      install_dap(fake_session({}, { stopped_thread_id = false }))
+      local ok, err = pcall(dap_handler.dap_get_stack_trace, {})
+
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("no stopped thread", 1, true))
+    end)
+
+    it("surfaces the adapter's own error", function()
+      install_dap(fake_session({}))
+      local ok, err = pcall(dap_handler.dap_get_stack_trace, {})
+
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("stackTrace not supported", 1, true))
+    end)
+  end)
+
+  describe("dap_get_variables", function()
+    it("groups the variables by scope", function()
+      install_dap(fake_session({
+        scopes = { scopes = { { name = "Locals", variablesReference = 3 } } },
+        variables = {
+          variables = {
+            { name = "x", value = "-1", type = "int" },
+            { name = "items", value = "[]", type = "list" },
+          },
+        },
+      }))
+
+      local scopes = dap_handler.dap_get_variables({}).scopes
+      assert.equals(1, #scopes)
+      assert.equals("Locals", scopes[1].name)
+      assert.equals("x", scopes[1].variables[1].name)
+      assert.equals("-1", scopes[1].variables[1].value)
+    end)
+
+    it("keeps a scope that cannot be expanded, rather than dropping it", function()
+      -- variablesReference 0 means "no children"; the scope still tells the agent it exists.
+      install_dap(fake_session({ scopes = { scopes = { { name = "Globals", variablesReference = 0 } } } }))
+
+      local scopes = dap_handler.dap_get_variables({}).scopes
+      assert.equals("Globals", scopes[1].name)
+      assert.same({}, scopes[1].variables)
+    end)
+
+    it("spends one budget across every scope, not a fresh timeout each", function()
+      -- vim.wait blocks the editor. A frame with several scopes must not multiply into tens of
+      -- seconds of frozen Neovim just because the adapter is slow.
+      local budgets = {}
+      local session = fake_session({
+        scopes = { scopes = { { name = "A", variablesReference = 1 }, { name = "B", variablesReference = 2 } } },
+      })
+      -- Never answer, so each request burns its whole budget.
+      session.request = function(_, command, _, _)
+        if command == "scopes" then
+          return
+        end
+      end
+      -- Record what each wait was given.
+      local real_wait = vim.wait
+      vim.wait = function(ms, ...)
+        table.insert(budgets, ms)
+        return real_wait(0, ...)
+      end
+      install_dap(session)
+
+      pcall(dap_handler.dap_get_variables, {})
+      vim.wait = real_wait
+
+      assert.is_true(#budgets > 0)
+      local total = 0
+      for _, ms in ipairs(budgets) do
+        total = total + ms
+      end
+      -- Every budget is carved out of the same 5s, so they cannot add up past it.
+      assert.is_true(total <= 5000, "budgets summed to " .. total)
+    end)
+
+    it("refuses when the program is not stopped", function()
+      install_dap(fake_session({}, { current_frame = false }))
+      local ok, err = pcall(dap_handler.dap_get_variables, {})
+
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("no current frame", 1, true))
+    end)
+  end)
+
+  describe("dap_set_breakpoint", function()
+    local file
+
+    before_each(function()
+      file = vim.fn.tempname() .. ".py"
+      vim.fn.writefile({ "def f():", "    return 1" }, file)
+    end)
+
+    after_each(function()
+      vim.fn.delete(file)
+    end)
+
+    it("works without a session, since breakpoints outlive one", function()
+      local set = {}
+      install_dap(nil, set)
+
+      local result = dap_handler.dap_set_breakpoint({ file = file, line = 2 })
+
+      assert.is_true(result.success)
+      assert.equals(2, set[1].line)
+    end)
+
+    it("passes a condition through", function()
+      local set = {}
+      install_dap(nil, set)
+
+      dap_handler.dap_set_breakpoint({ file = file, line = 2, condition = "x < 0" })
+
+      assert.equals("x < 0", set[1].opts.condition)
+    end)
+
+    it("does not display the file it attaches to", function()
+      local set = {}
+      install_dap(nil, set)
+      local windows_before = #vim.api.nvim_list_wins()
+
+      dap_handler.dap_set_breakpoint({ file = file, line = 1 })
+
+      assert.equals(windows_before, #vim.api.nvim_list_wins())
+      assert.is_true(vim.api.nvim_buf_is_loaded(set[1].bufnr))
+    end)
+
+    it("rejects a file that is not there", function()
+      install_dap(nil)
+      local ok, err = pcall(dap_handler.dap_set_breakpoint, { file = file .. ".missing", line = 1 })
+
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("does not exist", 1, true))
+    end)
+
+    it("rejects a line that cannot be one", function()
+      install_dap(nil)
+      assert.is_false(pcall(dap_handler.dap_set_breakpoint, { file = file, line = 0 }))
+      assert.is_false(pcall(dap_handler.dap_set_breakpoint, { file = file, line = 1.5 }))
+      assert.is_false(pcall(dap_handler.dap_set_breakpoint, { file = file }))
+    end)
+  end)
+
+  describe("dap_evaluate", function()
+    it("returns what the debuggee answered", function()
+      install_dap(fake_session({ evaluate = { result = "-1", type = "int" } }))
+
+      local result = dap_handler.dap_evaluate({ expression = "x" })
+      assert.equals("-1", result.result)
+      assert.equals("int", result.type)
+    end)
+
+    it("rejects an empty expression", function()
+      install_dap(fake_session({}))
+      assert.is_false(pcall(dap_handler.dap_evaluate, { expression = "" }))
+      assert.is_false(pcall(dap_handler.dap_evaluate, {}))
+    end)
+
+    it("refuses without a session", function()
+      install_dap(nil)
+      local ok, err = pcall(dap_handler.dap_evaluate, { expression = "x" })
+
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("no debug session", 1, true))
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #190

> **Stacked PR**: base は `feat-code-tour`（#551）→ `refactor-mcp-tool-surface`（#549）です。どちらも MCP ツール表面を触るため、その上に積んでいます。マージ順に応じて base を付け替えてください。

## 背景

ブレークポイントで止まっているとき、「なぜ壊れているか」の答えはデバッグセッションの中にあります。エージェントにはそれを覗く手段がありませんでした。

## MCP ツール（5つ）

| ツール | 用途 |
| --- | --- |
| `nvim_dap_get_state` | セッションが動いているか、どこで止まっているか |
| `nvim_dap_get_stack_trace` | 停止中スレッドのスタックフレーム |
| `nvim_dap_get_variables` | フレーム内の変数（スコープ別） |
| `nvim_dap_set_breakpoint` | ブレークポイント設定（条件付き可） |
| `nvim_dap_evaluate` | デバッグ対象言語での式評価 |

nvim-dap は**任意依存**です。すべての入口が「nvim-dap が入っていない」「セッションが動いていない」を**エラーではなく読める理由として返します**。`nvim_dap_get_state` が存在し、その description が「まず これを呼べ」と書いてあるのもそのためです。行動に移せる説明のほうが、解釈の要る失敗より役に立ちます。

## vim.wait をブロッキングに使うこと、およびその代償

DAP はコールバック方式、RPC ハンドラは値を返す方式なので、各リクエストは `vim.wait` で待ちます。これが成立するのは RPC サーバーが既に `vim.schedule` 内でディスパッチしているから（メインループ上にいて、`vim.wait` がイベントを回すので応答が届く）です。

ただし **`vim.wait` はエディタをブロックします**。そこで `dap_get_variables` は scopes リクエストと各スコープの variables リクエスト**全体で1つの予算**を使い切ります（`deadline()`）。リクエストごとに個別タイムアウトを持たせると、遅いアダプタ＋4スコープのフレームで、たった1回のツール呼び出しに対して Neovim が25秒固まります。**これはセルフレビューで指摘されて直した点**です。

## コマンドと自動解析

`:VibingDebugAnalyze` / `:VibingDebugHelp` は**依頼だけを送り、状態のダンプは送りません**。深さはエージェントがツールで取りに行くので、巨大なオブジェクトグラフが勝手にプロンプトに載ることがありません。

`config.dap.enabled` で停止イベントを購読します。**例外は既定で解析し、通常のブレークポイントはしません** — ブレークポイントは意図して置くもので、ループ内で何度も踏まれうるためです。機能全体が `dap.enabled`（既定 `false`）の後ろにあります。

## .gitignore の修正

`debug/` → `/debug/`。広すぎるパターンが `lua/vibing/application/debug/` を飲み込んでおり、**この機能の中核ファイルがコミットされないところでした**（simplify 実行時に検出）。

## テスト

- `tests/lua/infrastructure/rpc/handlers/dap_spec.lua`（20件）— 偽 nvim-dap で、未インストール時・セッション無し時・停止していない時の degradation、フレーム/スコープ整形、ブレークポイントがウィンドウを奪わないこと、共有予算が5秒を超えないこと
- `mcp-server/src/__tests__/dap-tools.test.ts` — 登録・転送・7種の reject（path traversal 含む）

`pnpm run test:lua` 884 passed / 0 failed / 0 errors、`mcp-server` 101 passed、`check` / `lint` / `format:check` / `build` すべて green。

## ドキュメント

`.claude/rules/features.md`（"Debugger Analysis" — vim.wait と共有予算の理由を含む）、`mcp-integration.md`、`commands-reference.md`、`docs/configuration.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)