### PR TITLE
fix: stop a stray narration line becoming the chat's filename

### DIFF
--- a/lua/vibing/application/chat/handlers/set_file_title.lua
+++ b/lua/vibing/application/chat/handlers/set_file_title.lua
@@ -88,10 +88,10 @@ return function(_, chat_buffer)
   local is_existing_file = old_file_path and vim.fn.filereadable(old_file_path) == 1
 
   -- Resolve the adapter for THIS chat's agent (frontmatter "agent"), not the
-  -- global default. The session_id we pass below belongs to that agent; sending a
-  -- codex session_id to the claude adapter (or vice versa) makes --resume fail
-  -- with "no such session". If the agent has no session_id, generation still
-  -- works via the full-conversation fallback in title_generator.
+  -- global default, so the lightweight utility call runs on the right CLI
+  -- (e.g. a codex chat generates its title via the codex adapter, not claude).
+  -- Title generation never resumes/forks the session (it sends a fresh bounded
+  -- excerpt), so no session_id is threaded through here.
   -- Resolution failure must never block title generation, so fall back to the
   -- default adapter (nil → title_generator uses vibing.get_adapter()).
   local title_adapter = nil
@@ -220,7 +220,7 @@ return function(_, chat_buffer)
         notify.warn(string.format("Failed to update %d file(s)", total_failed), "Link Sync")
       end
     end
-  end, chat_buffer:get_session_id(), title_adapter)
+  end, title_adapter)
 
   return true
 end

--- a/lua/vibing/core/utils/filename.lua
+++ b/lua/vibing/core/utils/filename.lua
@@ -4,6 +4,18 @@
 ---メッセージ内容から意味のあるファイル名を自動生成
 local M = {}
 
+---文字数（バイト数ではなく）で切り詰める。日本語や絵文字などのマルチバイト文字の
+---途中で切って不正なUTF-8ファイル名を作らないようにする（macOSは不正なUTF-8名のrenameを拒否する）。
+---@param text string
+---@param max_chars integer
+---@return string
+local function truncate_chars(text, max_chars)
+  if vim.fn.strchars(text) > max_chars then
+    return vim.fn.strcharpart(text, 0, max_chars)
+  end
+  return text
+end
+
 ---テキストをファイル名として安全な文字列に変換
 ---ファイル名として使用できない文字のみ削除、日本語などマルチバイト文字は保持
 ---@param text string 変換元のテキスト（通常は最初のユーザーメッセージまたはAI生成タイトル）
@@ -17,12 +29,10 @@ function M.sanitize(text)
   text = text:gsub("_+", "_")
   -- 先頭と末尾のアンダースコアを削除
   text = text:gsub("^_+", ""):gsub("_+$", "")
-  -- 最大32文字に制限（バイト数ではなく文字数）
-  -- Note: Luaの#演算子はバイト数を返すため、日本語などマルチバイト文字では文字数と一致しない
-  -- しかし、ファイル名の長さ制限は通常バイト数ベースなので、ここではそのまま使用
-  if #text > 64 then
-    text = text:sub(1, 64)
-  end
+  -- 最大64文字に制限（バイト数ではなく文字数境界で切る）。
+  -- byte境界で切るとマルチバイト文字の途中で切れて不正なUTF-8ファイル名になり、
+  -- macOSではrenameが失敗する。64文字なら最大でも約256バイトでファイル名長制限に収まる。
+  text = truncate_chars(text, 64)
   return text
 end
 
@@ -37,11 +47,9 @@ function M.generate_from_message(message)
     return os.date("chat_%Y%m%d_%H%M%S")
   end
 
-  -- 最初の行または最初の50文字を取得
+  -- 最初の行または最初の50文字を取得（文字境界で切る）
   local first_line = message:match("^([^\n]+)") or message
-  if #first_line > 50 then
-    first_line = first_line:sub(1, 50)
-  end
+  first_line = truncate_chars(first_line, 50)
 
   -- サニタイズしてトピック名を生成
   local topic = M.sanitize(first_line)

--- a/lua/vibing/core/utils/title_generator.lua
+++ b/lua/vibing/core/utils/title_generator.lua
@@ -27,6 +27,35 @@ local function truncate(s, n)
   return s
 end
 
+-- チャットバッファ上でツール呼び出しをレンダリングするときの行頭マーカー。
+-- 軽量呼び出しでツールを無効化していても（denylist が腐って）モデルが narration や
+-- ツール実況を返した場合に、その行をタイトル候補から除外するための防御。
+local TOOL_RENDER_MARKERS = { "⏺", "📄", "💻", "🔧", "✳", "☒", "☐", "⎿", "→" }
+
+---AI応答から「タイトルとして使える最初の1行」を取り出す。
+---ツール実況行（⏺ ToolSearch(...) 等）や空行を飛ばし、最初の意味のあるテキスト行を返す。
+---これによりモデルがタイトル以外を返しても、複数行のゴミがそのままファイル名になるのを防ぐ。
+---@param text string
+---@return string
+local function first_title_line(text)
+  for _, line in ipairs(vim.split(text or "", "\n", { plain = true })) do
+    local trimmed = vim.trim(line)
+    if trimmed ~= "" then
+      local is_marker = false
+      for _, marker in ipairs(TOOL_RENDER_MARKERS) do
+        if trimmed:sub(1, #marker) == marker then
+          is_marker = true
+          break
+        end
+      end
+      if not is_marker then
+        return trimmed
+      end
+    end
+  end
+  return vim.trim((text or ""):match("^([^\n]*)") or "")
+end
+
 ---会話から「最初のユーザーメッセージ＋末尾数メッセージ」の抜粋を作る。
 ---各メッセージと全体の両方に上限を設け、長い会話でも context を超えないようにする。
 ---@param conversation {role: string, content: string}[]
@@ -61,13 +90,11 @@ end
 ---会話の抜粋（最初のユーザーメッセージ＋末尾数メッセージ、各上限付き）をアダプタに送り、
 ---簡潔なファイル名用タイトルを生成する。結果はコールバックで非同期に返される。
 ---セッションの resume/fork は行わない（全履歴を読み込んで context を超過し
----"Prompt is too long" になるのを避けるため）。そのため session_id は使用しない。
+---"Prompt is too long" になるのを避けるため）。抜粋を都度フレッシュに送るだけなので session_id は不要。
 ---@param conversation {role: string, content: string}[] 会話履歴
 ---@param callback fun(title: string?, error: string?) 結果コールバック
----@param session_id string? 後方互換のため受け取るが未使用（resume/forkは廃止）
 ---@param adapter table? タイトル生成に使うアダプタ。省略時はグローバル既定を使う。
-function M.generate_from_conversation(conversation, callback, session_id, adapter)
-  local _ = session_id -- 後方互換で受け取るのみ（resume/fork廃止のため未使用）
+function M.generate_from_conversation(conversation, callback, adapter)
   if not conversation or #conversation == 0 then
     callback(nil, "No conversation to generate title from")
     return
@@ -119,6 +146,10 @@ function M.generate_from_conversation(conversation, callback, session_id, adapte
 
     -- デバッグ: AIの生成結果をログ出力
     vim.notify(string.format("[vibing] AI generated title: '%s'", title), vim.log.levels.DEBUG)
+
+    -- 防御: モデルがタイトル以外（narration やツール実況）を返しても、
+    -- 最初の意味のある1行だけをタイトルにする。複数行がそのままファイル名になるのを防ぐ。
+    title = first_title_line(title)
 
     title = filename_util.sanitize(title)
 

--- a/tests/lua/application/chat/handlers/set_file_title_spec.lua
+++ b/tests/lua/application/chat/handlers/set_file_title_spec.lua
@@ -67,10 +67,9 @@ describe("set_file_title handler - streaming guard", function()
   it("resolves the per-chat agent adapter (codex chat -> codex adapter)", function()
     require("vibing").setup({})
 
-    local passed_session_id, passed_adapter
+    local passed_adapter
     local original_generate = require("vibing.core.utils.title_generator").generate_from_conversation
-    require("vibing.core.utils.title_generator").generate_from_conversation = function(_, _, session_id, adapter)
-      passed_session_id = session_id
+    require("vibing.core.utils.title_generator").generate_from_conversation = function(_, _, adapter)
       passed_adapter = adapter
     end
 
@@ -93,9 +92,9 @@ describe("set_file_title handler - streaming guard", function()
 
     handler({}, chat_buffer)
 
-    -- The codex chat's session_id must be routed to the codex adapter, not the
-    -- global default (claude), otherwise --resume fails with "no such session".
-    assert.equals("codex-session-123", passed_session_id)
+    -- The lightweight title call must run on the per-chat agent's adapter (codex),
+    -- not the global default (claude). Title generation does not resume, so no
+    -- session_id is threaded through.
     assert.is_not_nil(passed_adapter)
     assert.equals("codex_cli", passed_adapter.name)
 

--- a/tests/lua/core/utils/title_generator_spec.lua
+++ b/tests/lua/core/utils/title_generator_spec.lua
@@ -47,10 +47,36 @@ describe("title_generator.generate_from_conversation", function()
     assert.equals("My_Title", result_title)
   end)
 
+  it("uses only the first meaningful line when the model returns tool narration", function()
+    -- Defense in depth: even if the lightweight sandbox leaks tools and the model
+    -- starts "continuing the session" (tool render markers + narration), the title
+    -- must be the first clean line, not the whole multi-line transcript.
+    package.loaded["vibing"] = {
+      get_config = function()
+        return { language = nil, permissions = { mode = "acceptEdits", allow = {}, deny = {} } }
+      end,
+      get_adapter = function()
+        return {
+          stream = function(_, _, _, on_chunk, on_done)
+            on_chunk("Fix login bug\n⏺ ToolSearch(select:TaskList,TaskCreate)\n📄 Read()\nmore narration")
+            on_done({ content = "" })
+          end,
+        }
+      end,
+    }
+
+    local result_title
+    title_generator.generate_from_conversation(CONVERSATION, function(title)
+      result_title = title
+    end)
+
+    assert.equals("Fix_login_bug", result_title)
+  end)
+
   it("never resumes/forks a session (avoids 'Prompt is too long')", function()
-    -- Even when a session_id is passed (backward-compat arg), title generation
-    -- must send a fresh excerpt prompt instead of resuming the full session.
-    title_generator.generate_from_conversation(CONVERSATION, function() end, "session-abc")
+    -- Title generation must send a fresh excerpt prompt instead of resuming the
+    -- full session, so no session_id/fork opts are ever set.
+    title_generator.generate_from_conversation(CONVERSATION, function() end)
 
     assert.is_nil(captured_opts._session_id)
     assert.is_nil(captured_opts._is_fork)
@@ -67,7 +93,7 @@ describe("title_generator.generate_from_conversation", function()
     end
     long[#long + 1] = { role = "user", content = "LAST_RECENT_MESSAGE" }
 
-    title_generator.generate_from_conversation(long, function() end, "session-abc")
+    title_generator.generate_from_conversation(long, function() end)
 
     -- First user message is kept as a topic anchor and the tail is included...
     assert.is_not_nil(captured_prompt:find("FIRST_TOPIC_ANCHOR", 1, true))


### PR DESCRIPTION
## 症状

`:VibingSetFileTitle` でファイル名生成が壊れ、rename が失敗する（`Failed to rename file` / `E13: File exists`）。生成された「タイトル」がタイトルではなく、会話の続きを実行し始めた実況テキスト（`⏺ ToolSearch(...)` `⏺ TaskList()` …）の複数行になっていました。

## 根本原因は #536 で解決済み（この PR からは外しました）

当初この PR は `LIGHTWEIGHT_DISALLOWED_TOOLS` に `ToolSearch` と `Task*` を足す修正でした。**その定数は #536 で main から消えています。** lightweight 呼び出しは `--tools ""` を渡すようになり、何も列挙しないので追従漏れが起きません（実 CLI で Write/Bash を明示的に命令しても何も起きないことを検証済み）。

この PR 自身が挙げていた「denylist は腐る」という懸念こそが #536 の動機でした。したがって **denylist への追加と、それに紐づく `--disallowedTools` の spec アサーションは削除**しています。

## 残した二次防御

根本原因が直っていても、以下は独立に価値があるので残しました。

- **`title_generator`**: ツール実況行・空行を飛ばし、最初の意味のある1行だけをタイトルにする。万一ツールが漏れても、実況行がファイル名にならない
- **`filename`**: 切り詰めをバイト境界 → 文字境界（`strcharpart`）に変更。マルチバイト文字の途中で切れると不正な UTF-8 になり、**macOS では見た目が変なだけでなく rename 自体が失敗**していました。これが E13 の直接の引き金です
- **cleanup**: タイトル生成の未使用 `session_id` 引数と、resume を示唆する誤解を招くコメントを除去（実行時は元々 resume していないので挙動変化なし）

## テスト

`title_generator` にツール実況混じり応答から1行目だけを拾う regression を追加。影響 spec を新シグネチャに追従。

`pnpm run test:lua` 943 passed / 0 failed / 0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)