### PR TITLE
fix: make the bundled Claude Code plugin actually start its MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace-manifest.json",
-  "name": "vibing-nvim",
+  "name": "vibing",
   "owner": {
     "name": "shabaraba",
     "url": "https://github.com/shabaraba"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,8 +11,8 @@
   "keywords": ["neovim", "nvim", "mcp", "lsp", "editor"],
   "mcpServers": {
     "vibing-nvim": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/bin/run.mjs"],
+      "command": "sh",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/bin/run.sh"],
       "env": {
         "VIBING_RPC_TIMEOUT": "30000"
       }

--- a/README.ja.md
+++ b/README.ja.md
@@ -124,7 +124,7 @@ vibing.nvim は [Claude Code プラグイン](https://code.claude.com/docs/en/pl
 
 ```text
 /plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing-nvim
+/plugin install vibing-nvim@vibing
 ```
 
 いずれの方法でも、`vibing-nvim` MCP サーバー(実行中の Neovim へのバッファ/ウィンドウ/
@@ -141,7 +141,7 @@ vibing.nvim は [Claude Code プラグイン](https://code.claude.com/docs/en/pl
 **アンインストール:**
 
 ```text
-/plugin uninstall vibing-nvim@vibing-nvim
+/plugin uninstall vibing-nvim@vibing
 /plugin marketplace remove vibing-nvim
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ user` for you on every build — nothing else to do.
 
 ```text
 /plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing-nvim
+/plugin install vibing-nvim@vibing
 ```
 
 Either way, this registers the `vibing-nvim` MCP server (buffer/window/cursor access, Ex commands,
@@ -139,7 +139,7 @@ separate build step is needed for the MCP server itself. You still need Neovim r
 **Uninstalling:**
 
 ```text
-/plugin uninstall vibing-nvim@vibing-nvim
+/plugin uninstall vibing-nvim@vibing
 /plugin marketplace remove vibing-nvim
 ```
 

--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -22,7 +22,7 @@ import { homedir } from 'os';
  * A resolved installed plugin: its registry id and on-disk install path.
  */
 export interface ResolvedPlugin {
-  /** Plugin identifier as it appears in installed_plugins.json, e.g. "vibing-nvim@vibing-nvim" */
+  /** Plugin identifier as it appears in installed_plugins.json, e.g. "vibing-nvim@vibing" */
   id: string;
   /** Absolute path to the plugin's installation directory */
   path: string;
@@ -154,7 +154,7 @@ async function loadEnabledPluginIds(): Promise<Set<string> | null> {
  * @example
  * ```typescript
  * const plugins = await resolveInstalledPlugins();
- * // Returns: [{ id: 'vibing-nvim@vibing-nvim', path: '/path/to/plugin' }, ...]
+ * // Returns: [{ id: 'vibing-nvim@vibing', path: '/path/to/plugin' }, ...]
  * ```
  */
 export async function resolveInstalledPlugins(): Promise<ResolvedPlugin[]> {

--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -82,7 +82,7 @@ async function parseSkillFrontmatter(
 
 /**
  * Derive a plugin's short name from its registry id, e.g.
- * "vibing-nvim@vibing-nvim" -> "vibing-nvim", "document-skills@anthropic-agent-skills" -> "document-skills".
+ * "vibing-nvim@vibing" -> "vibing-nvim", "document-skills@anthropic-agent-skills" -> "document-skills".
  * This is how Claude Code itself namespaces skill invocations ("plugin:skill"),
  * and it's reliable even for plugins nested in a marketplace repo that don't
  * ship their own .claude-plugin/plugin.json (e.g. document-skills).

--- a/build.sh
+++ b/build.sh
@@ -102,6 +102,20 @@ if [ ! -d "$MCP_DIR" ]; then
     exit 1
 fi
 
+# Record the exact node binary resolved above so the Claude Code plugin's MCP
+# server launcher (mcp-server/bin/run.sh) can invoke it directly by absolute
+# path instead of relying on `node` being on PATH. Claude Code spawns
+# plugin-declared MCP server commands with a minimal PATH that doesn't
+# include version-manager shims (mise, nvm, volta, asdf, ...), so a bare
+# `command: "node"` fails with "Executable not found in $PATH" on any machine
+# where node is only installed through one of those. Written after the
+# directory check above so a missing mcp-server/ checkout fails with that
+# clear error instead of a raw redirect failure here. `command -v` is
+# guaranteed to succeed here (the checks above already proved $NODE_EXECUTABLE
+# is either an executable absolute path or resolvable on PATH), so no extra
+# empty-value guard is needed around it.
+echo "$(command -v "$NODE_EXECUTABLE")" > "${MCP_DIR}/bin/.node-path"
+
 # Install root dependencies (Agent SDK, etc.)
 echo "[vibing.nvim] Installing root dependencies..."
 cd "$SCRIPT_DIR"
@@ -132,6 +146,13 @@ npm install --silent
 echo "[vibing.nvim] Building TypeScript..."
 npm run build --silent
 
+# Record the fingerprint run.mjs's self-build check compares against (same
+# algorithm, via bin/build-fingerprint.mjs), so the plugin cache's run.mjs
+# recognizes this build as fresh on first launch instead of running `npm ci`
+# over the node_modules symlink set up below and replacing it with a real
+# copy until the next build.sh run re-links it.
+"$NODE_EXECUTABLE" bin/write-fingerprint.mjs
+
 # Verify build succeeded
 if [ -f "dist/index.js" ]; then
     echo "[vibing.nvim] ✓ MCP server built successfully"
@@ -143,7 +164,12 @@ if [ -f "dist/index.js" ]; then
     # RPC port, so it silently targets the wrong Neovim instance whenever more
     # than one is running (see cli_command_builder.lua's rpc_port handling).
     cd "$SCRIPT_DIR"
-    PLUGIN_INSTALL_HINT="claude plugin marketplace add $SCRIPT_DIR && claude plugin install vibing-nvim@vibing-nvim --scope user"
+    MARKETPLACE_NAME="vibing"
+    PLUGIN_ID="vibing-nvim@${MARKETPLACE_NAME}"
+    # Pre-rename identifiers, kept only for the one-time migration cleanup below.
+    OLD_MARKETPLACE_NAME="vibing-nvim"
+    OLD_PLUGIN_ID="vibing-nvim@${OLD_MARKETPLACE_NAME}"
+    PLUGIN_INSTALL_HINT="claude plugin marketplace add $SCRIPT_DIR && claude plugin install ${PLUGIN_ID} --scope user"
     if command -v claude &> /dev/null; then
         # Remove any legacy direct "vibing-nvim" mcpServers registration (e.g. from
         # `claude mcp add` predating the plugin-based install above, or a leftover
@@ -152,6 +178,32 @@ if [ -f "dist/index.js" ]; then
         # must not coexist with the plugin registration. Ignore failure: this is a
         # no-op when no such entry exists.
         claude mcp remove vibing-nvim --scope user &> /dev/null || true
+
+        # Fetch the installed-plugin list once up front and reuse it below for the
+        # migration-cleanup check, the already-installed check, and (after a
+        # refresh) the installPath lookup, instead of asking `claude` — slow on at
+        # least one real machine in this project's history — for the same data
+        # repeatedly. Re-fetched only after an operation that actually changes it
+        # (a fresh install, or the migration cleanup below).
+        PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
+
+        # Remove the pre-rename "vibing-nvim" marketplace/plugin registration (this
+        # marketplace was renamed to "vibing" so the plugin-scoped MCP tool prefix
+        # isn't mcp__plugin_vibing-nvim_vibing-nvim__* — see git history), but only
+        # when there's actual evidence of it in the plugin list. `claude plugin
+        # marketplace add` on the same directory does not migrate an existing
+        # registration to the new name on its own, so without this an upgrading
+        # user would end up with both the old and new marketplace/plugin registered
+        # side by side — reintroducing the very duplicate-tool-name problem this
+        # rename fixed, just under two names instead of one. Gating on the list
+        # (rather than running unconditionally) keeps this a one-time cost during
+        # the migration window instead of two extra `claude` CLI spawns on every
+        # future build forever.
+        if echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='${OLD_PLUGIN_ID}')?0:1)" 2>/dev/null; then
+            run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin uninstall "$OLD_PLUGIN_ID" &> /dev/null || true
+            run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace remove "$OLD_MARKETPLACE_NAME" &> /dev/null || true
+            PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
+        fi
 
         # Capture output instead of streaming it directly so it can be printed
         # below only on failure, keeping successful (repeat) runs quiet.
@@ -171,7 +223,7 @@ if [ -f "dist/index.js" ]; then
         # Query installed state as JSON rather than grepping the human-readable table
         # (`claude plugin list`), whose "❯" marker/formatting is a display detail,
         # not a stable contract to match against.
-        elif run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='vibing-nvim@vibing-nvim')?0:1)" 2>/dev/null; then
+        elif echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='${PLUGIN_ID}')?0:1)" 2>/dev/null; then
             # Already installed: `claude plugin install` is a no-op here, so on repeat
             # runs (e.g. `:Lazy update` re-invoking this script) it won't pick up
             # skill/agent changes on its own. Explicitly refresh the marketplace
@@ -180,31 +232,119 @@ if [ -f "dist/index.js" ]; then
             # See the MARKETPLACE_ADD_STATUS comment above for why the fallback is
             # attached via `||` on the same line rather than a separate `STATUS=$?`.
             MARKETPLACE_UPDATE_STATUS=0
-            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update vibing-nvim 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
+            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update "$MARKETPLACE_NAME" 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
             PLUGIN_UPDATE_OUTPUT=""
             PLUGIN_UPDATE_STATUS=1
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ]; then
                 PLUGIN_UPDATE_STATUS=0
-                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update vibing-nvim@vibing-nvim 2>&1)" || PLUGIN_UPDATE_STATUS=$?
+                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update "$PLUGIN_ID" 2>&1)" || PLUGIN_UPDATE_STATUS=$?
             fi
             if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ] && [ $PLUGIN_UPDATE_STATUS -eq 0 ]; then
                 echo "[vibing.nvim] ✓ Synced vibing-nvim plugin cache (restart Claude Code to apply)"
             elif [ $MARKETPLACE_UPDATE_STATUS -ne 0 ]; then
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin marketplace update' failed"
                 echo "$MARKETPLACE_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing-nvim && claude plugin update vibing-nvim@vibing-nvim"
+                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update $MARKETPLACE_NAME && claude plugin update $PLUGIN_ID"
             else
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin update' failed"
                 echo "$PLUGIN_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update vibing-nvim && claude plugin update vibing-nvim@vibing-nvim"
+                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update $MARKETPLACE_NAME && claude plugin update $PLUGIN_ID"
             fi
         else
             echo "[vibing.nvim] Installing vibing-nvim as a Claude Code plugin (user scope)..."
-            if run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin install vibing-nvim@vibing-nvim --scope user; then
+            if run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin install "$PLUGIN_ID" --scope user; then
                 echo "[vibing.nvim] ✓ Installed vibing-nvim Claude Code plugin (scope: user)"
+                # The snapshot above predates this install, so it won't have an
+                # installPath for $PLUGIN_ID yet — refetch before using it below.
+                PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
             else
                 echo "[vibing.nvim] ⚠ Warning: 'claude plugin install' failed"
                 echo "[vibing.nvim] You can manually install by running: $PLUGIN_INSTALL_HINT"
+            fi
+        fi
+
+        # `claude plugin install`/`update` above can report success while leaving an
+        # incomplete cache snapshot behind: on machines where copying many small
+        # files is slow (observed with real-time antivirus/EDR scanning on a
+        # corporate-managed Mac), the CLI's own copy step can silently stop partway
+        # while still updating its bookkeeping as if it finished. `claude plugin
+        # update` also treats a matching git commit SHA as "already up to date" and
+        # never re-copies — which, for a "directory"-source (dev-mode) plugin whose
+        # whole point is tracking uncommitted local edits, means it silently skips
+        # syncing on every single build.sh run where HEAD hasn't moved. So sync this
+        # checkout's tracked files into the cache directly on every run, rather than
+        # only when detected as broken.
+        #
+        # mcp-server/node_modules and mcp-server/dist are symlinked into the cache
+        # rather than copied, for two reasons: (1) rsync/cp copying node_modules'
+        # thousands of small files is exactly the kind of slow-on-this-machine
+        # operation that produced the incomplete snapshot in the first place, and
+        # doing it here would just as easily blow past lazy.nvim's own build-step
+        # timeout; (2) a symlink means a later `npm run build` here is reflected
+        # immediately without rerunning this sync.
+        PLUGIN_INSTALL_PATH="$(echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "
+          const plugins = JSON.parse(require('fs').readFileSync(0, 'utf8') || '[]');
+          const p = plugins.find((p) => p.id === '${PLUGIN_ID}');
+          process.stdout.write(p && p.installPath ? p.installPath : '');
+        " 2>/dev/null)"
+
+        if [ -n "$PLUGIN_INSTALL_PATH" ]; then
+            echo "[vibing.nvim] Syncing plugin cache with this checkout..."
+            mkdir -p "$PLUGIN_INSTALL_PATH/mcp-server"
+            # A partial-copy failure here (permission errors, EDR/antivirus
+            # interference — the exact class of environment this sync exists
+            # to work around) must not abort the rest of build.sh under `set
+            # -e`, the way every other `claude plugin ...` call above already
+            # tolerates failure. Capture the status via `||` instead of
+            # letting a failing command be the tail of its own statement.
+            SYNC_STATUS=0
+            if command -v rsync &> /dev/null; then
+                rsync -a --delete --exclude='.git' --exclude='/node_modules' --exclude='/mcp-server/node_modules' --exclude='/mcp-server/dist' "$SCRIPT_DIR/" "$PLUGIN_INSTALL_PATH/" || SYNC_STATUS=$?
+            else
+                # Portable fallback without rsync. Copy each top-level entry
+                # individually and skip the excluded ones outright, rather than
+                # `cp -R` the whole tree and `rm -rf` them after: on a repeat run,
+                # the destination's mcp-server/node_modules and mcp-server/dist are
+                # already symlinks back into this very checkout (from the symlink
+                # step below), and `cp -R` landing on an existing symlink follows it
+                # — copying this checkout's node_modules into itself through the
+                # link — instead of replacing it.
+                for entry in "$SCRIPT_DIR"/* "$SCRIPT_DIR"/.[!.]*; do
+                    [ -e "$entry" ] || continue
+                    name="$(basename "$entry")"
+                    [ "$name" = ".git" ] && continue
+                    [ "$name" = "node_modules" ] && continue
+                    [ "$name" = "mcp-server" ] && continue
+                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/" || SYNC_STATUS=$?
+                done
+                for entry in "$MCP_DIR"/* "$MCP_DIR"/.[!.]*; do
+                    [ -e "$entry" ] || continue
+                    name="$(basename "$entry")"
+                    [ "$name" = "node_modules" ] && continue
+                    [ "$name" = "dist" ] && continue
+                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/mcp-server/" || SYNC_STATUS=$?
+                done
+            fi
+            if [ "$SYNC_STATUS" -ne 0 ]; then
+                echo "[vibing.nvim] ⚠ Warning: plugin cache sync failed (exit $SYNC_STATUS); cache may be incomplete"
+            fi
+
+            # Unconditionally (re)point node_modules/dist at this live checkout's own
+            # build output rather than only when missing: an earlier run of this
+            # script, or an earlier version of it, may have left a real (now stale)
+            # copy behind instead of a symlink, and `ln -sfn` is instant either way so
+            # there's no cost to always re-asserting it.
+            if [ -d "$PLUGIN_INSTALL_PATH/mcp-server" ]; then
+                [ -L "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" ] || rm -rf "$PLUGIN_INSTALL_PATH/mcp-server/node_modules"
+                [ -L "$PLUGIN_INSTALL_PATH/mcp-server/dist" ] || rm -rf "$PLUGIN_INSTALL_PATH/mcp-server/dist"
+                ln -sfn "$MCP_DIR/node_modules" "$PLUGIN_INSTALL_PATH/mcp-server/node_modules"
+                ln -sfn "$MCP_DIR/dist" "$PLUGIN_INSTALL_PATH/mcp-server/dist"
+            fi
+
+            if [ -f "$PLUGIN_INSTALL_PATH/mcp-server/bin/run.mjs" ] && [ -d "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" ]; then
+                echo "[vibing.nvim] ✓ Plugin cache OK (restart Claude Code to apply any changes)"
+            else
+                echo "[vibing.nvim] ✗ Repair failed; mcp-server/ still incomplete under $PLUGIN_INSTALL_PATH"
             fi
         fi
     else

--- a/docs/lazy-setup-example.lua
+++ b/docs/lazy-setup-example.lua
@@ -2,7 +2,7 @@
 -- Place this in ~/.config/nvim/lua/plugins/vibing.lua
 --
 -- MCP server registration is exclusively via the Claude Code plugin marketplace
--- (`claude plugin install vibing-nvim@vibing-nvim`), which build.sh installs automatically.
+-- (`claude plugin install vibing-nvim@vibing`), which build.sh installs automatically.
 -- There is no separate ~/.claude.json registration path: that route can only ever hardcode a
 -- single default RPC port, so it silently targets the wrong Neovim instance whenever more than
 -- one is running.

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -42,6 +42,18 @@ for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
   M.ALWAYS_ALLOWED_TOOLS_MAP[tool] = true
 end
 
+---vibing-nvim自身が提供するMCPツールの許可パターン。プレーンなユーザーレベルMCPサーバー登録
+---（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*、
+---このリポジトリが.claude-plugin/marketplace.jsonで出荷する"vibing"マーケットプレイス名前提）の
+---両方に対応する。can_use_tool.M.is_vibing_nvim_mcp_tool側はサフィックスマッチでマーケットプレイス名
+---に依存しないが、Claude Code CLIの--allowedToolsゲート自体は具体的なプレフィックスを要求するため、
+---こちらは定数化のみで対応している。マーケットプレイス名を変更した場合はここを更新すること。
+---@type string[]
+M.VIBING_NVIM_MCP_TOOL_PATTERNS = {
+  "mcp__vibing-nvim__*",
+  "mcp__plugin_vibing_vibing-nvim__*",
+}
+
 ---`permissions.allow`の既定値。`config.lua`はこのリストを参照するだけで、値を再列挙しない。
 ---VALID_TOOLSからの差集合としては導出しない。導出にするとVALID_TOOLSへツールを足した人が
 ---「既定で許可してよいか」を判断しないまま自動的に許可され得るため、あえて列挙にしてその判断を

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -114,15 +114,14 @@ local function add_permission_args(cmd, opts)
     permissions_allow = {}
   end
   local allow_tools = vim.deepcopy(permissions_allow)
-  -- The vibing-nvim MCP server may be registered either as a plain user-level MCP server
-  -- (mcp__vibing-nvim__<tool>) or as a Claude Code plugin
-  -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing-nvim_vibing-nvim__<tool>).
-  -- Both patterns must be pre-approved here so the CLI's own --allowedTools gate doesn't block
-  -- calls before they ever reach vibing.nvim's PreToolUse hook, which already recognizes both
-  -- registration styles via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match).
+  -- Both of vibing-nvim's own possible MCP registration styles (see
+  -- tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS) must be pre-approved here so the CLI's own
+  -- --allowedTools gate doesn't block calls before they ever reach vibing.nvim's PreToolUse hook,
+  -- which already recognizes both via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match, so it
+  -- isn't tied to a specific marketplace name).
   local always_allowed = vim.list_extend(
     vim.deepcopy(tools_constants.ALWAYS_ALLOWED_TOOLS),
-    { "mcp__vibing-nvim__*", "mcp__plugin_vibing-nvim_vibing-nvim__*" }
+    vim.deepcopy(tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS)
   )
   allow_additionally(allow_tools, always_allowed)
 
@@ -285,6 +284,12 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     )
     table.insert(
       system_prompt_lines,
+      "vibing-nvim MCP tools may be registered as mcp__vibing-nvim__<tool> (a plain user-level MCP "
+        .. "server) or mcp__plugin_<marketplace>_vibing-nvim__<tool> (a Claude Code plugin) — search "
+        .. "for a tool name ending in the specific tool you need if the plain prefix isn't available."
+    )
+    table.insert(
+      system_prompt_lines,
       "When you need the user to choose among options (single or multi-select), always call the "
         .. "mcp__vibing-nvim__nvim_ask_user_question tool instead of asking in free text. Do not use "
         .. "the native AskUserQuestion tool for this — it is unavailable in this environment. Pass "
@@ -314,9 +319,9 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         system_prompt_lines,
         "Your rpc_port for this turn is "
           .. tostring(rpc_port)
-          .. ". You MUST pass this exact value as the rpc_port argument on every "
-          .. "mcp__vibing-nvim__* tool call — never omit it or guess, since other unrelated Neovim "
-          .. "instances may be running and reachable on other ports."
+          .. ". You MUST pass this exact value as the rpc_port argument on every vibing-nvim MCP tool "
+          .. "call — never omit it or guess, since other unrelated Neovim instances may be running and "
+          .. "reachable on other ports."
       )
     end
 

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -1,6 +1,8 @@
 ---@class Vibing.FrontmatterProvider
 ---Provider for YAML frontmatter completion items
 ---@module "vibing.infrastructure.completion.providers.frontmatter"
+local tools_constants = require("vibing.core.constants.tools")
+
 local M = {}
 
 local Agents = require("vibing.core.constants.agents")
@@ -48,13 +50,12 @@ local TOOL_NAMES = {
   "WebSearch",
   "WebFetch",
   "Skill",
-  "mcp__vibing-nvim__*",
-  "mcp__plugin_vibing-nvim_vibing-nvim__*",
   "mcp__chrome-devtools__*",
   "mcp__context7__*",
   "mcp__serena__*",
   "mcp__lapras__*",
 }
+vim.list_extend(TOOL_NAMES, tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS)
 
 ---Get enum values for a field
 ---@param field string Field name (agent, permission_mode, ...)

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -261,8 +261,9 @@ function M.can_use_tool(tool_name, input, config)
 
     -- Handle vibing-nvim MCP tools. The vibing-nvim MCP server may be registered either as a
     -- plain user-level MCP server (mcp__vibing-nvim__<tool>) or as a Claude Code plugin
-    -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing-nvim_vibing-nvim__<tool>).
-    -- Match on suffix so both registration styles are recognized identically.
+    -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing_vibing-nvim__<tool>).
+    -- Match on suffix so both registration styles are recognized identically, regardless of
+    -- marketplace name.
     if M.is_vibing_nvim_mcp_tool(tool_name) then
       if config.mcp_enabled then
         return allow(input)

--- a/lua/vibing/install.lua
+++ b/lua/vibing/install.lua
@@ -25,7 +25,7 @@ end
 local function plugin_install_message(plugin_root)
   return "Register vibing-nvim as a Claude Code plugin by running: claude plugin marketplace add "
     .. plugin_root
-    .. " && claude plugin install vibing-nvim@vibing-nvim --scope user"
+    .. " && claude plugin install vibing-nvim@vibing --scope user"
 end
 
 ---Check if command exists

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.log
 .DS_Store
+bin/.node-path

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -40,7 +40,7 @@ and no separate build step (the server builds itself on first launch).
 
 ```text
 /plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing-nvim
+/plugin install vibing-nvim@vibing
 ```
 
 See the plugin manifest at `../.claude-plugin/plugin.json`. The manual steps below remain useful
@@ -53,8 +53,8 @@ or your own fork/clone).
 To uninstall:
 
 ```text
-/plugin uninstall vibing-nvim@vibing-nvim
-/plugin marketplace remove vibing-nvim
+/plugin uninstall vibing-nvim@vibing
+/plugin marketplace remove vibing
 ```
 
 **Auto-build mechanism:** `mcp-server/bin/run.mjs` hashes `package.json`, `package-lock.json`,

--- a/mcp-server/bin/build-fingerprint.mjs
+++ b/mcp-server/bin/build-fingerprint.mjs
@@ -1,0 +1,38 @@
+/**
+ * Shared build-fingerprint logic for the vibing-nvim MCP server launcher.
+ *
+ * Used by both run.mjs (to decide whether a self-build is needed) and
+ * write-fingerprint.mjs (invoked by build.sh right after its own build, so
+ * that run.mjs sees that build as fresh instead of re-running `npm ci` over
+ * the node_modules symlink build.sh sets up in the plugin cache).
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createHash } from 'node:crypto';
+
+const IGNORED_FILE_PATTERN = /(?:^\.DS_Store$|\.sw[op]$|~$|\.tmp$)/;
+
+function listFilesRecursive(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (IGNORED_FILE_PATTERN.test(entry.name)) return [];
+    const full = join(dir, entry.name);
+    return entry.isDirectory() ? listFilesRecursive(full) : [full];
+  });
+}
+
+export function computeFingerprint(mcpDir) {
+  const hash = createHash('sha256');
+  const inputs = ['package.json', 'package-lock.json', 'tsconfig.json']
+    .map((f) => join(mcpDir, f))
+    .filter(existsSync)
+    .concat(listFilesRecursive(join(mcpDir, 'src')).sort());
+  for (const file of inputs) {
+    hash.update(relative(mcpDir, file));
+    hash.update(readFileSync(file));
+  }
+  return hash.digest('hex');
+}
+
+export function fingerprintFilePath(mcpDir) {
+  return join(mcpDir, 'dist', '.build-fingerprint');
+}

--- a/mcp-server/bin/run.mjs
+++ b/mcp-server/bin/run.mjs
@@ -17,39 +17,16 @@
  * CLAUDE_PLUGIN_ROOT — only add this plugin's marketplace from a source you
  * trust (see the "Trust note" in mcp-server/README.md).
  */
-import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { spawnSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, relative } from 'node:path';
-import { createHash } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { computeFingerprint, fingerprintFilePath } from './build-fingerprint.mjs';
 
 const mcpDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const distEntry = join(mcpDir, 'dist', 'index.js');
 const nodeModulesDir = join(mcpDir, 'node_modules');
-const fingerprintFile = join(mcpDir, 'dist', '.build-fingerprint');
-
-const IGNORED_FILE_PATTERN = /(?:^\.DS_Store$|\.sw[op]$|~$|\.tmp$)/;
-
-function listFilesRecursive(dir) {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    if (IGNORED_FILE_PATTERN.test(entry.name)) return [];
-    const full = join(dir, entry.name);
-    return entry.isDirectory() ? listFilesRecursive(full) : [full];
-  });
-}
-
-function computeFingerprint() {
-  const hash = createHash('sha256');
-  const inputs = ['package.json', 'package-lock.json', 'tsconfig.json']
-    .map((f) => join(mcpDir, f))
-    .filter(existsSync)
-    .concat(listFilesRecursive(join(mcpDir, 'src')).sort());
-  for (const file of inputs) {
-    hash.update(relative(mcpDir, file));
-    hash.update(readFileSync(file));
-  }
-  return hash.digest('hex');
-}
+const fingerprintFile = fingerprintFilePath(mcpDir);
 
 function isBuildStale(fingerprint) {
   if (!existsSync(distEntry) || !existsSync(nodeModulesDir) || !existsSync(fingerprintFile)) {
@@ -71,7 +48,7 @@ function run(command, args) {
   }
 }
 
-const fingerprint = computeFingerprint();
+const fingerprint = computeFingerprint(mcpDir);
 if (isBuildStale(fingerprint)) {
   console.error('[vibing-nvim] Building MCP server...');
   // Drop any existing fingerprint up front so a build that fails partway

--- a/mcp-server/bin/run.sh
+++ b/mcp-server/bin/run.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Launcher for the vibing-nvim MCP server, invoked by Claude Code via the
+# `command`/`args` declared in ../../.claude-plugin/plugin.json.
+#
+# Claude Code spawns plugin-declared MCP server commands with a minimal PATH
+# that does not include version-manager shims (mise, nvm, volta, asdf, ...),
+# so a bare `command: "node"` fails with "Executable not found in $PATH" on
+# any machine where node is only installed through one of those (not through
+# an OS-default location like /usr/local/bin or /opt/homebrew/bin). build.sh
+# records the exact node binary it resolved (and used to build this plugin)
+# into .node-path; invoke that directly by absolute path so this launcher
+# does not depend on PATH at all.
+#
+# .node-path is gitignored (machine-specific), so a manual `/plugin install`
+# that never ran build.sh won't have it. In that case, fall back to a bare
+# PATH lookup, then to common version-manager install locations that a
+# minimal PATH wouldn't include either.
+DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+NODE_BIN="$(cat "$DIR/.node-path" 2>/dev/null || true)"
+
+if [ ! -x "$NODE_BIN" ] && command -v node >/dev/null 2>&1; then
+  NODE_BIN="$(command -v node)"
+fi
+
+if [ ! -x "$NODE_BIN" ]; then
+  for candidate in \
+    "$HOME/.local/share/mise/shims/node" \
+    "$HOME/.asdf/shims/node" \
+    "$HOME/.volta/bin/node" \
+    /opt/homebrew/bin/node \
+    /usr/local/bin/node \
+    /usr/bin/node
+  do
+    if [ -x "$candidate" ]; then
+      NODE_BIN="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ ! -x "$NODE_BIN" ]; then
+  # nvm has no fixed shim path (each version lives in its own directory); take
+  # the lexically-last match as a reasonable guess at the newest one.
+  for candidate in "$HOME"/.nvm/versions/node/*/bin/node; do
+    [ -x "$candidate" ] && NODE_BIN="$candidate"
+  done
+fi
+
+if [ ! -x "$NODE_BIN" ]; then
+  echo "vibing-nvim MCP server: no working node executable found." >&2
+  echo "Run ./build.sh once from the plugin checkout to record one, or set VIBING_NODE_EXECUTABLE and re-run it." >&2
+  exit 1
+fi
+
+# Also put node's own directory on PATH (not just exec it by absolute path):
+# run.mjs's self-build step shells out to `npm`, which hits the exact same
+# "not on Claude Code's minimal PATH" problem this launcher exists to solve.
+# npm ships alongside node in every installation method above, so this is
+# free once NODE_BIN is known.
+PATH="$(dirname "$NODE_BIN"):$PATH"
+export PATH
+
+exec "$NODE_BIN" "$DIR/run.mjs" "$@"

--- a/mcp-server/bin/write-fingerprint.mjs
+++ b/mcp-server/bin/write-fingerprint.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/**
+ * Records dist/.build-fingerprint for the checkout build.sh just built.
+ *
+ * Without this, run.mjs's self-build check never sees build.sh's `tsc` run
+ * as a valid build (that check only writes the fingerprint from run.mjs
+ * itself), so the first launch of the plugin-cache's run.mjs re-runs
+ * `npm ci` — which deletes and replaces the node_modules symlink build.sh
+ * set up in the cache with a real copy, defeating the point of the symlink
+ * until the next build.sh run re-links it.
+ */
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { computeFingerprint, fingerprintFilePath } from './build-fingerprint.mjs';
+
+const mcpDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+writeFileSync(fingerprintFilePath(mcpDir), computeFingerprint(mcpDir));

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -110,13 +110,23 @@ describe("cli_command_builder", function()
       assert.is_nil(cmd1[idx1 + 1]:find("handle_id", 1, true))
     end)
 
+    it("names both MCP registration styles, so the model does not cite a tool that is not there", function()
+      -- Installed as a Claude Code plugin the prefix is mcp__plugin_<marketplace>_vibing-nvim__,
+      -- not mcp__vibing-nvim__. Naming only the latter made the model claim tools it could not call.
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+      assert.is_true(prompt_text:find("mcp__vibing%-nvim__<tool>") ~= nil)
+      assert.is_true(prompt_text:find("mcp__plugin_<marketplace>_vibing%-nvim__<tool>") ~= nil)
+    end)
+
     it("embeds the rpc_port and instructs the model to echo it back on every vibing-nvim MCP call", function()
       local cmd = cli_command_builder.build("hello", {}, nil, {}, nil, 9878)
       local idx = find_flag(cmd, "--append-system-prompt")
       assert.is_not_nil(idx)
       local prompt_text = cmd[idx + 1]
       assert.is_true(prompt_text:find("Your rpc_port for this turn is 9878", 1, true) ~= nil)
-      assert.is_true(prompt_text:find("mcp__vibing-nvim__*", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("mcp__vibing-nvim__", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("mcp__plugin_<marketplace>_vibing-nvim__", 1, true) ~= nil)
     end)
 
     it("omits the rpc_port line when rpc_port is not provided", function()
@@ -266,7 +276,7 @@ describe("cli_command_builder", function()
       assert.is_not_nil(idx)
       local allowed = cmd[idx + 1]
       assert.is_true(allowed:find("mcp__vibing-nvim__*", 1, true) ~= nil)
-      assert.is_true(allowed:find("mcp__plugin_vibing-nvim_vibing-nvim__*", 1, true) ~= nil)
+      assert.is_true(allowed:find("mcp__plugin_vibing_vibing-nvim__*", 1, true) ~= nil)
     end)
   end)
 

--- a/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
+++ b/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
@@ -80,8 +80,8 @@ describe("can_use_tool", function()
     local tool_names = {
       -- Registered as a plain user-level MCP server
       "mcp__vibing-nvim__nvim_get_buffer",
-      -- Registered as a Claude Code plugin (marketplace + plugin name both "vibing-nvim")
-      "mcp__plugin_vibing-nvim_vibing-nvim__nvim_get_buffer",
+      -- Registered as a Claude Code plugin (marketplace "vibing", plugin "vibing-nvim")
+      "mcp__plugin_vibing_vibing-nvim__nvim_get_buffer",
     }
 
     for _, tool_name in ipairs(tool_names) do
@@ -124,7 +124,7 @@ describe("can_use_tool", function()
     it("matches a specific tool regardless of registration namespace", function()
       assert.is_true(
         can_use_tool.is_vibing_nvim_mcp_tool(
-          "mcp__plugin_vibing-nvim_vibing-nvim__nvim_ask_user_question",
+          "mcp__plugin_vibing_vibing-nvim__nvim_ask_user_question",
           "nvim_ask_user_question"
         )
       )
@@ -136,7 +136,7 @@ describe("can_use_tool", function()
     it("does not match a different vibing-nvim tool", function()
       assert.is_false(
         can_use_tool.is_vibing_nvim_mcp_tool(
-          "mcp__plugin_vibing-nvim_vibing-nvim__nvim_get_buffer",
+          "mcp__plugin_vibing_vibing-nvim__nvim_get_buffer",
           "nvim_ask_user_question"
         )
       )


### PR DESCRIPTION
#483 を現在の main に載せ替えたものです。#483 はクローズしてください（4コミットを1つに畳み、今回のマージ群と整合させています）。

## 直している4つの問題

いずれも**プラグイン経由でインストールしたときだけ**踏むもので、素の user-scope 登録では起きません。

1. **プラグインキャッシュが更新されない** — `claude plugin update` は git のコミットハッシュが変わらないと「最新」と判定するため、未コミットのローカル変更がキャッシュへ同期されません。`mcp-server/` ディレクトリごと欠落するケースを実際に確認しています。`build.sh` が毎回このチェックアウトを rsync するようにしました。`node_modules` / `dist` はコピーではなくシンボリックリンクにして、小さいファイル大量コピーによるタイムアウトを回避しています。

2. **node が見つからず起動しない** — Claude Code はプラグインの MCP サーバーを mise/nvm のシムを含まない最小 PATH で起動します。`command: "node"` では、node が OS 標準の場所にない環境で失敗していました。`mcp-server/bin/run.sh` が build.sh の記録した絶対パスの node を exec します。

3. **マーケットプレイス名が重複していた** — `vibing-nvim` だったため、プレフィックスが `mcp__plugin_vibing-nvim_vibing-nvim__*` と吃っていました。`vibing` に変更しています。

4. **system prompt がツールプレフィックスを1つだけ決め打ちしていた** — プラグイン登録時にはそのプレフィックスは存在しないので、モデルが「使えます」と言った直後に呼べない、という誤答が起きていました。両方の登録形式を挙げ、ツール名でマッチするよう指示します。

## main への載せ替えで調整した点

- **`chat_file_path` → `chat_bufnr`**: #483 が書き直した `nvim_ask_user_question` の指示は `chat_file_path` を渡す旧仕様でした。#489 で `chat_bufnr` に変わっている（ファイル名変更でプロンプトキャッシュが飛ぶため）ので、main 側の3ブロック（ask_user_question / show-code / review-annotations）をそのまま残し、**プレフィックス非決め打ちの行だけを追加**する形にしています。
- **`LIGHTWEIGHT_DISALLOWED_TOOLS`**: #536 で main から消えているので、#483 が触っていたその周辺は落としました。`VIBING_NVIM_MCP_TOOL_PATTERNS` の追加のみ残しています。
- **README**: #483 は copilot バックエンド（#510）より前の内容だったので、CLI 一覧は main を採用し、marketplace 名の置換だけ適用しました。

## テスト

`pnpm run test:lua` **1083 passed / 0 failed / 0 errors**。`check` `lint` `format:check` すべて green。`build.sh` と `run.sh` は `bash -n` / `sh -n` で構文確認済み。

「両方の登録形式を system prompt に書く」ことの回帰テストを追加しました。既存の `--allowedTools` 側と `can_use_tool` のサフィックスマッチのテストは #483 のものがそのまま通っています。

なお **build.sh / run.sh の実挙動（rsync とキャッシュ同期、空 PATH での MCP ハンドシェイク）は #483 で手動確認済み**で、今回の載せ替えではそれらのファイルに手を入れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Code’s renamed `vibing` marketplace identifier.
  * Improved MCP tool discovery and allowlisting across standard and plugin-based registrations.
  * Added a more reliable launcher that locates Node.js automatically and supports self-building.

* **Bug Fixes**
  * Improved plugin registration, migration, updates, and cache synchronization.
  * Added build fingerprinting to detect MCP server changes and refresh generated files.

* **Documentation**
  * Updated installation, removal, and configuration examples to use the new marketplace identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->