### PR TITLE
feat: add Grok Build CLI as a fourth backend

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -46,24 +46,35 @@ The instance registry has the same treatment via `$VIBING_INSTANCES_DIR` (honour
 its owning Neovim is gone: it cross-checks `registry.list()`, which already filters to live PIDs,
 so a concurrent instance's in-flight `.req`/`.res` files are never deleted.
 
-**Backends:** `claude_cli.lua` (default), `codex_cli.lua` and `copilot_cli.lua` implement the
-adapter interface; `init.lua` picks one from `config.adapter`, and `send_message.lua` can switch
+**Backends:** `claude_cli.lua` (default), `codex_cli.lua`, `copilot_cli.lua` and `grok_cli.lua`
+implement the adapter interface; `init.lua` picks one from `config.adapter`, and `send_message.lua` can switch
 per request for non-claude agent types. Implementing the interface is not the same as feature
 parity — `AskUserQuestion` is Claude-only, for reasons `features.md` records.
 
 `lua/vibing/core/constants/agents.lua` is the single definition of what a backend is — module
 path, export name, description, model candidates. `factory.lua`, `modes.lua` (`VALID_AGENTS`,
 `VALID_MODELS`), `completion/providers/frontmatter.lua` and `infrastructure/init.lua` all derive
-from it, so adding a fourth backend is a one-file change. It deliberately requires nothing, which
+from it, so adding a backend is a one-file change (grok was added that way). It deliberately requires nothing, which
 is what keeps the dependency one-way.
 
 Two things stop backend identity leaking into shared code:
 
 - **Tool vocabulary.** Backends name their tools differently (codex calls an edit `apply_patch`,
-  copilot uses `bash`/`view`/`create`/`edit`/`web_search`). Each adapter owns a
-  `<backend>_tool_vocabulary.lua` and passes it to `set_active_opts` as a generic
-  `_tool_vocabulary`; `rpc/handlers/permission.lua` just calls `to_canonical` if it was given one.
-  The handler contains no backend name.
+  copilot uses `bash`/`view`/`create`/`edit`/`web_search`, grok `search_replace`/
+  `run_terminal_command`). Each adapter owns a `<backend>_tool_vocabulary.lua` and passes it to
+  `set_active_opts` as a generic `_tool_vocabulary`; `rpc/handlers/permission.lua` just calls
+  `to_canonical`, and `normalize_input` when the module offers one. The handler contains no
+  backend name.
+
+  `normalize_input` exists because granular `paths` rules read `input.file_path`. Grok sends
+  `path`/`target_file`/`filePath` instead, so without it a `paths` rule would silently match
+  nothing on that backend.
+
+- **No MCP on every backend.** Grok, like codex, registers no `chat_bufnr` and reaches no
+  vibing-nvim MCP server, so `grok_command_builder` deliberately keeps `--rules` to the
+  backend-agnostic conventions. Naming `nvim_ask_user_question` there would hand the model a tool
+  it cannot call — see `features.md` → AskUserQuestion Support.
+
 - **`dynamic_permissions` capability.** `adapter:supports("dynamic_permissions")` is `false` for
   copilot, because its CLI has no per-run hook flag: permissions are fixed at launch with
   `--allow-all-tools` + `--deny-tool`, so `permission_mode`, the `ask` list and the approval UI do

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -63,17 +63,34 @@ Two things stop backend identity leaking into shared code:
   copilot uses `bash`/`view`/`create`/`edit`/`web_search`, grok `search_replace`/
   `run_terminal_command`). Each adapter owns a `<backend>_tool_vocabulary.lua` and passes it to
   `set_active_opts` as a generic `_tool_vocabulary`; `rpc/handlers/permission.lua` just calls
-  `to_canonical`, and `normalize_input` when the module offers one. The handler contains no
-  backend name.
+  `normalize_payload`, `to_canonical` and `normalize_input` when the module offers them. The
+  handler contains no backend name.
 
-  `normalize_input` exists because granular `paths` rules read `input.file_path`. Grok sends
-  `path`/`target_file`/`filePath` instead, so without it a `paths` rule would silently match
-  nothing on that backend.
+  The three are separate because backends disagree at three different levels, and the order
+  matters — each step feeds the next:
+
+  1. `normalize_payload` — the hook payload's own key names. Claude sends
+     `tool_name`/`tool_input`; grok sends `toolName`/`toolInput`. Read straight through, the
+     handler sees a nil tool name, so the two steps below get nothing to work on, every rule
+     misses, and the turn stalls until the hook fails closed. This must run **first**.
+  2. `to_canonical` — the tool's name (`apply_patch` → `Edit`).
+  3. `normalize_input` — where the path lives inside the input. Granular `paths` rules read
+     `input.file_path`; grok sends `path`/`target_file`/`filePath`.
+
+  All three shapes were captured from the real CLIs, not read off their docs.
 
 - **No MCP on every backend.** Grok, like codex, registers no `chat_bufnr` and reaches no
   vibing-nvim MCP server, so `grok_command_builder` deliberately keeps `--rules` to the
   backend-agnostic conventions. Naming `nvim_ask_user_question` there would hand the model a tool
   it cannot call — see `features.md` → AskUserQuestion Support.
+
+- **Grok's hooks need a git repository.** `grok_settings_generator.lua` writes
+  `<cwd>/.grok/hooks/` and marks the cwd trusted in `<$GROK_HOME|~/.grok>/trusted_folders.toml`,
+  but grok discovers project hooks only inside a git repo (verified with `grok inspect`: the
+  `project` entry appears under "Hooks" after `git init` and is absent before). Outside one the
+  file is written and never read, which would silently allow every tool, so `ensure()` warns
+  once per cwd instead. `$GROK_HOME` is grok's own documented override and is honoured — which is
+  also the seam the specs use, since folder trust cascades to subdirectories and never expires.
 
 - **`dynamic_permissions` capability.** `adapter:supports("dynamic_permissions")` is `false` for
   copilot, because its CLI has no per-run hook flag: permissions are fixed at launch with

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ package-lock.json.backup
 # vibing.nvim data
 .vibing/
 
+# Generated Grok PreToolUse hook, written by grok_settings_generator at request time
+# (the Claude equivalent lives under .vibing/, already ignored above)
+.grok/
+
 # Serena MCP memory
 .serena/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,6 @@ pnpm-lock.yaml
 
 # Lua files (handled by luac)
 *.lua
+
+# Generated at request time by the Grok adapter
+.grok/

--- a/README.ja.md
+++ b/README.ja.md
@@ -45,7 +45,8 @@ CLI バックエンドと MCP 統合を通じて、AI に**実行中の Neovim �
 - **🤖 Neovim をエージェントのツールに** — MCP 経由で AI がバッファの読み書き、コマンド実行、
   LSP クエリ(診断・定義・参照・シンボル)を*実行中の*エディタに対して行える
 - **🔀 マルチバックエンド** — Claude CLI(`claude -p --output-format stream-json`)、
-  Codex CLI(`codex exec --json`)、GitHub Copilot CLI(`copilot -p --output-format json`)。
+  Codex CLI(`codex exec --json`)、GitHub Copilot CLI(`copilot -p --output-format json`)、
+  Grok Build CLI(`grok --single --output-format streaming-json`)。
   `adapter` 設定でグローバルに、チャットごとには frontmatter の `agent` フィールドで切り替え
 - **💾 ファイルベースのセッション永続化** — チャットは `.vibing/chat/` 配下の YAML frontmatter
   付き Markdown ファイル。持ち運び可能・再開可能(CLI セッション状態を完全復元)・監査可能・
@@ -79,6 +80,7 @@ vibing.nvim は補完プラグイン(Copilot、Codeium)や他のチャットプ�
   - **Claude CLI**(`claude`)— `npm install -g @anthropic-ai/claude-code`
   - **Codex CLI**(`codex`)— `npm install -g @openai/codex`
   - **GitHub Copilot CLI**(`copilot`)— `npm install -g @github/copilot`
+  - **Grok Build CLI**(`grok`)— [xAI のインストール手順](https://github.com/xai-org/grok-cli)を参照
     (Node.js 22+ が必要。MCP サーバー自体の要件 18+ より高い)
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim) を使う場合
@@ -348,6 +350,7 @@ graph TB
 - **Claude CLI**(`claude -p --output-format stream-json`)— Claude Code のフル機能
 - **Codex CLI**(`codex exec --json`)— OpenAI Codex バックエンド
 - **GitHub Copilot CLI**(`copilot -p --output-format json`)— GitHub Copilot バックエンド
+- **Grok Build CLI**(`grok --single --output-format streaming-json`)— xAI Grok バックエンド
 
 setup の `adapter = "claude"|"codex"|"copilot"` でグローバルに、チャットファイルの frontmatter に
 `agent: claude` / `agent: codex` / `agent: copilot` を書けばチャット単位で切り替えられます。
@@ -395,6 +398,7 @@ MIT License — 詳細は LICENSE ファイルを参照してください。
 - [Claude AI](https://claude.ai)
 - [Codex CLI](https://github.com/openai/codex)
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Grok CLI](https://github.com/xai-org/grok-cli)
 - [GitHub リポジトリ](https://github.com/shabaraba/vibing.nvim)
 
 ---

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ access to your Neovim instance** through CLI backends and MCP integration.
 - **🤖 Neovim as an agent tool** — via MCP, the AI reads and writes buffers, executes commands,
   and queries LSP (diagnostics, definitions, references, symbols) in your _running_ editor
 - **🔀 Multi-backend** — Claude CLI (`claude -p --output-format stream-json`), Codex CLI
-  (`codex exec --json`), or GitHub Copilot CLI (`copilot -p --output-format json`); switch
-  globally via `adapter` or per-chat via the `agent` frontmatter field
+  (`codex exec --json`), GitHub Copilot CLI (`copilot -p --output-format json`), or Grok Build CLI
+  (`grok --single --output-format streaming-json`); switch globally via `adapter` or per-chat via
+  the `agent` frontmatter field
 - **💾 File-based session persistence** — chats are plain Markdown files with YAML frontmatter
   saved under `.vibing/chat/`: portable, resumable (full CLI session state), auditable, and
   version-controllable
@@ -79,6 +80,7 @@ they compose well.
   - **Codex CLI** (`codex`) — `npm install -g @openai/codex`
   - **GitHub Copilot CLI** (`copilot`) — `npm install -g @github/copilot` (needs Node.js 22+,
     higher than the 18+ the MCP server itself requires)
+  - **Grok Build CLI** (`grok`) — see [xAI's install docs](https://github.com/xai-org/grok-cli)
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
@@ -350,8 +352,9 @@ graph TB
 - **Claude CLI** (`claude -p --output-format stream-json`) — full Claude Code capabilities
 - **Codex CLI** (`codex exec --json`) — OpenAI Codex backend
 - **GitHub Copilot CLI** (`copilot -p --output-format json`) — GitHub Copilot backend
+- **Grok Build CLI** (`grok --single --output-format streaming-json`) — xAI Grok backend
 
-Switch globally with `adapter = "claude"|"codex"|"copilot"` in setup, or per-chat by adding
+Switch globally with `adapter = "claude"|"codex"|"copilot"|"grok"` in setup, or per-chat by adding
 `agent: claude`, `agent: codex`, or `agent: copilot` to a chat file's YAML frontmatter.
 
 > **Note:** the Copilot backend does not yet support the in-chat Tool Approval UI. It runs with
@@ -398,6 +401,7 @@ MIT License - see LICENSE file for details
 - [Claude AI](https://claude.ai)
 - [Codex CLI](https://github.com/openai/codex)
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Grok CLI](https://github.com/xai-org/grok-cli)
 - [GitHub Repository](https://github.com/shabaraba/vibing.nvim)
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ Complete reference for every `require("vibing").setup()` option. Defaults shown 
 
 - [Defaults at a Glance](#defaults-at-a-glance)
 - [Adapter](#adapter)
+- [Grok CLI](#grok-cli)
 - [Agent](#agent)
 - [Chat](#chat)
 - [UI](#ui)
@@ -98,11 +99,37 @@ require("vibing").setup({
 
 ```lua
 adapter = "claude",  -- Global backend adapter
-                     -- "claude":  Claude CLI  (claude -p --output-format stream-json)
-                     -- "codex":   Codex CLI   (codex exec --json)
-                     -- "copilot": Copilot CLI (copilot -p --output-format json)
+                     -- "claude":  Claude CLI      (claude -p --output-format stream-json)
+                     -- "codex":   Codex CLI       (codex exec --json)
+                     -- "copilot": Copilot CLI     (copilot -p --output-format json)
+                     -- "grok":    Grok Build CLI  (grok --single=... --output-format streaming-json)
                      -- Overridable per-chat via the "agent" frontmatter field
 ```
+
+Backends are not feature-equivalent. `AskUserQuestion`'s choice-list UI is Claude-only, and
+`copilot` cannot honour `permissions.mode`, the `ask` list or the Tool Approval UI at all
+(`adapter:supports("dynamic_permissions")` is `false` for it). Grok does honour them, but only
+inside a git repository — see [Grok CLI](#grok-cli).
+
+## Grok CLI
+
+```lua
+grok = {
+  executable = "auto",  -- "auto": detect `grok` on PATH (default)
+                        -- or an explicit path, e.g. "~/.grok/bin/grok"
+}
+```
+
+Only read when `adapter = "grok"` (or a chat's `agent: grok` frontmatter). Unlike
+`node.executable`, a path that does not exist is **not** reset to `"auto"`: having asked for a
+specific binary, silently falling back to whatever `grok` is on PATH would be worse than failing.
+vibing.nvim also refuses a `grok` that is not the official xAI Grok Build CLI, since the name is
+shared with unrelated tools.
+
+**Permission rules need a git repository.** Grok discovers the PreToolUse hook vibing.nvim installs
+(`<cwd>/.grok/hooks/`) only inside a git repo. Outside one the hook is written and never read, so
+`permissions.rules`, the `ask` list and the Tool Approval UI silently do nothing — vibing.nvim
+warns once per working directory when it detects this.
 
 ## Agent
 

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -37,7 +37,7 @@
 ---@class Vibing.Config
 ---vibing.nvimプラグインの設定オブジェクト
 ---アダプター選択、チャットウィンドウ、キーマップ、ツール権限を統合管理
----@field adapter? "claude"|"codex"|"copilot" バックエンドアダプター選択（デフォルト: "claude"）
+---@field adapter? "claude"|"codex"|"copilot"|"grok" バックエンドアダプター選択（デフォルト: "claude"）
 ---@field agent Vibing.AgentConfig エージェント設定（モード、モデル）
 ---@field chat Vibing.ChatConfig チャットウィンドウ設定（位置、サイズ、自動コンテキスト、保存先）
 ---@field ui Vibing.UiConfig UI設定（wrap等）
@@ -45,6 +45,7 @@
 ---@field diff Vibing.DiffConfig diff表示設定（使用ツール、mote設定）
 ---@field permissions Vibing.PermissionsConfig ツール権限設定（許可/拒否リスト）
 ---@field node Vibing.NodeConfig Node.js実行ファイル設定（バイナリパス）
+---@field grok Vibing.GrokConfig Grok Build CLI設定（バイナリパス）
 ---@field mcp Vibing.McpConfig MCP統合設定（RPCポート、自動起動）
 ---@field language? string|Vibing.LanguageConfig AI応答のデフォルト言語（"ja", "en"等、またはLanguageConfig）
 ---@field daily_summary? Vibing.DailySummaryConfig Daily Summary機能設定
@@ -88,6 +89,11 @@
 ---既定では subagent の中身は隠され、ツール結果だけが見える（従来の挙動）
 ---@field enabled boolean? trueでCLIに`--forward-subagent-text`を渡し、subagentの本文をチャットに表示する（デフォルト: false）
 ---@field show_prefix boolean? 各行に`[subagent_type]`のラベルを付けるか（デフォルト: false）
+
+---@class Vibing.GrokConfig
+---Grok Build CLI設定
+---`adapter = "grok"`（またはfrontmatterの`agent: grok`）のときだけ参照される。
+---@field executable string|"auto" grokバイナリのパス（"auto": PATHから自動検出、文字列: 明示的なパス指定）
 
 ---@class Vibing.NodeConfig
 ---Node.js実行ファイル設定
@@ -274,6 +280,9 @@ M.defaults = {
     default_deny_rules = true,
   },
   node = {
+    executable = "auto",
+  },
+  grok = {
     executable = "auto",
   },
   mcp = {
@@ -528,6 +537,28 @@ function M.setup(opts)
         executable
       ))
       M.options.node.executable = "auto"
+    end
+  end
+
+  -- grok_command_builder tells the user to "set config.grok.executable" when the binary is
+  -- missing, so a bad value here has to be caught the same way node.executable's is -- otherwise
+  -- the advice leads to a setting nothing validates. Unlike node this is NOT reset to "auto" on a
+  -- missing binary: `adapter = "grok"` with a wrong path should say so, not quietly fall back to
+  -- whatever `grok` happens to be on PATH.
+  if M.options.grok and M.options.grok.executable then
+    local executable = M.options.grok.executable
+    if type(executable) ~= "string" or executable == "" then
+      notify.warn(
+        string.format(
+          "Invalid grok.executable value '%s'. Must be 'auto' or a path to the grok binary. Resetting to 'auto'.",
+          tostring(executable)
+        )
+      )
+      M.options.grok.executable = "auto"
+    elseif executable ~= "auto" and vim.fn.executable(executable) == 0 then
+      notify.warn(
+        string.format("Grok CLI not found at '%s'. Grok chats will fail until this is corrected.", executable)
+      )
     end
   end
 end

--- a/lua/vibing/core/constants/agents.lua
+++ b/lua/vibing/core/constants/agents.lua
@@ -12,6 +12,8 @@ local M = {}
 ---@class Vibing.AgentDefinition
 ---@field id string エージェント識別子（frontmatter の `agent` フィールドの値）
 ---@field adapter_module string アダプターの require パス
+---@field command_builder_module string argv を組み立てるモジュールの require パス。テストが
+---  バックエンドを一覧するときに使う（列挙を手で並べると新しいバックエンドで更新漏れが起きる）
 ---@field export_name string `infrastructure/init.lua` でのエクスポート名
 ---@field description string frontmatter 補完の agent enum に出す説明
 ---@field models Vibing.AgentModelCandidate[] 補完候補。妥当性検証ではない（自由入力を許す
@@ -22,6 +24,7 @@ M.AGENTS = {
   claude = {
     id = "claude",
     adapter_module = "vibing.infrastructure.adapter.claude_cli",
+    command_builder_module = "vibing.infrastructure.adapter.modules.cli_command_builder",
     export_name = "ClaudeCLIAdapter",
     description = "Claude CLI (Anthropic)",
     models = {
@@ -34,6 +37,7 @@ M.AGENTS = {
   codex = {
     id = "codex",
     adapter_module = "vibing.infrastructure.adapter.codex_cli",
+    command_builder_module = "vibing.infrastructure.adapter.modules.codex_command_builder",
     export_name = "CodexCLIAdapter",
     description = "Codex CLI (OpenAI)",
     models = {
@@ -47,6 +51,7 @@ M.AGENTS = {
   copilot = {
     id = "copilot",
     adapter_module = "vibing.infrastructure.adapter.copilot_cli",
+    command_builder_module = "vibing.infrastructure.adapter.modules.copilot_command_builder",
     export_name = "CopilotCLIAdapter",
     description = "GitHub Copilot CLI",
     -- copilot は30種類以上のモデルを持つため、代表的なものだけを候補に出す。
@@ -63,11 +68,22 @@ M.AGENTS = {
       { value = "gemini-3.1-pro-preview", description = "Gemini 3.1 Pro (preview)" },
     },
   },
+  grok = {
+    id = "grok",
+    adapter_module = "vibing.infrastructure.adapter.grok_cli",
+    command_builder_module = "vibing.infrastructure.adapter.modules.grok_command_builder",
+    export_name = "GrokCLIAdapter",
+    description = "Grok Build CLI (xAI)",
+    models = {
+      { value = "grok-4.5", description = "Grok 4.5" },
+      { value = "grok-composer-2.5-fast", description = "Grok Composer 2.5 Fast" },
+    },
+  },
 }
 
 ---列挙順。`pairs()` の順序は不定なので、ユーザーに見える一覧はすべてこれを経由する。
 ---@type string[]
-M.ORDER = { "claude", "codex", "copilot" }
+M.ORDER = { "claude", "codex", "copilot", "grok" }
 
 ---未知・未指定のエージェントのフォールバック先
 ---@type string

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -238,6 +238,10 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
               error = "Session resume timeout",
               _session_corrupted = true,
               _old_session_id = session_id,
+              -- Without this, send_message's staleness check is skipped entirely: a timeout that
+              -- fires after the user cancelled and sent something new would be treated as the new
+              -- request's result and reset its session id.
+              _handle_id = handle_id,
             })
           end
         end)

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -1,0 +1,313 @@
+--- Grok CLI adapter
+--- Uses `grok -p` (--single) with streaming-json format for communication
+--- @module vibing.infrastructure.adapter.grok_cli
+
+local Base = require("vibing.infrastructure.adapter.base")
+local GrokCommandBuilder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+local GrokEventProcessor = require("vibing.infrastructure.adapter.modules.grok_event_processor")
+local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
+local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
+local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
+local GrokSettingsGenerator = require("vibing.infrastructure.hooks.grok_settings_generator")
+
+---@class Vibing.GrokCLIAdapter : Vibing.Adapter
+---@field _handles table<string, table>
+---@field _session_manager table
+local GrokCLI = setmetatable({}, { __index = Base })
+GrokCLI.__index = GrokCLI
+
+local INITIAL_RESPONSE_TIMEOUT_MS = 120000
+
+local SUPPORTED_FEATURES = {
+  streaming = true,
+  tools = true,
+  model_selection = true,
+  context = true,
+  session = true,
+}
+
+---@param config Vibing.Config
+---@return Vibing.GrokCLIAdapter
+function GrokCLI:new(config)
+  local instance = Base.new(self, config)
+  setmetatable(instance, GrokCLI)
+  instance.name = "grok_cli"
+  instance._handles = {}
+  instance._session_manager = SessionManagerModule.new()
+  -- Fetched once per adapter instance rather than per stream() call — vim.fn.environ()
+  -- marshals the whole process environment from C, which is wasted work to repeat on every
+  -- message when only a handful of keys actually change per call.
+  instance._base_env = vim.fn.environ()
+  math.randomseed(vim.loop.hrtime())
+  return instance
+end
+
+---@param prompt string
+---@param opts Vibing.AdapterOpts
+---@return Vibing.Response
+function GrokCLI:execute(prompt, opts)
+  opts = opts or {}
+  local result = { content = "" }
+  local done = false
+
+  local handle_id = self:stream(prompt, opts, function(chunk)
+    result.content = result.content .. chunk
+  end, function(response)
+    if response.error then
+      result.error = response.error
+    end
+    done = true
+  end)
+
+  vim.wait(INITIAL_RESPONSE_TIMEOUT_MS, function()
+    return done
+  end, 100)
+  if not done then
+    self:cancel(handle_id)
+    result.error = result.error or "Execution timeout"
+  end
+  return result
+end
+
+---@param prompt string
+---@param opts Vibing.AdapterOpts
+---@param on_chunk fun(chunk: string)
+---@param on_done fun(response: Vibing.Response)
+---@return string handle_id
+function GrokCLI:stream(prompt, opts, on_chunk, on_done)
+  opts = opts or {}
+
+  local debug_mode = vim.g.vibing_debug_stream
+  -- hex format avoids LuaJIT's tostring() rendering large hrtime doubles in scientific
+  -- notation (e.g. "2.64e+15"), which pre-tool-use.sh's char-sanitized VIBING_HANDLE_ID
+  -- would then fail to match against this exact registry key
+  local handle_id = string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
+  local session_id = opts._session_id
+
+  if debug_mode then
+    vim.notify(
+      string.format(
+        "[vibing:grok] Starting stream: handle_id=%s, session_id=%s",
+        handle_id,
+        session_id or "new"
+      ),
+      vim.log.levels.INFO
+    )
+  end
+
+  local rpc_server = require("vibing.infrastructure.rpc.server")
+  local rpc_port = rpc_server.get_port()
+
+  local cwd = opts.cwd or vim.fn.getcwd()
+
+  -- Install project PreToolUse hook (reuses bin/hooks/pre-tool-use.sh) unless fully bypassed.
+  -- Grok discovers <cwd>/.grok/hooks/*.json when the folder is trusted.
+  local permission_mode = opts.permission_mode or "default"
+  if permission_mode ~= "bypassPermissions" then
+    local ok_hook, hook_err = pcall(GrokSettingsGenerator.ensure, cwd)
+    if not ok_hook then
+      vim.notify(
+        string.format("[vibing:grok] Failed to install PreToolUse hook: %s", tostring(hook_err)),
+        vim.log.levels.WARN
+      )
+    end
+  end
+
+  -- The builder raises when the grok binary is missing. send_message.lua does not wrap stream()
+  -- in pcall, so without this the chat buffer would show a raw Lua stack trace instead of an
+  -- actionable message. Matches claude_cli.lua and copilot_cli.lua.
+  local build_ok, cmd = pcall(GrokCommandBuilder.build, prompt, opts, session_id, self.config, handle_id, rpc_port)
+  if not build_ok then
+    local message = type(cmd) == "string" and cmd:gsub("^.*:%d+:%s*", "") or tostring(cmd)
+    vim.schedule(function()
+      on_done({ content = "", error = message, _handle_id = handle_id })
+    end)
+    return handle_id
+  end
+
+  local output = {}
+  local error_output = {}
+
+  local received_first_response = false
+  local timeout_timer = nil
+  local completed = false
+
+  local function cancel_timeout()
+    received_first_response = true
+    if timeout_timer then
+      vim.fn.timer_stop(timeout_timer)
+      timeout_timer = nil
+    end
+  end
+
+  local event_context = {
+    sessionManager = self._session_manager,
+    handleId = handle_id,
+    opts = opts,
+    output = output,
+    errorOutput = error_output,
+    onFirstResponse = cancel_timeout,
+    onChunk = function(chunk)
+      cancel_timeout()
+      on_chunk(chunk)
+    end,
+  }
+
+  -- Lets PreToolUse hook identify which chat buffer's stream it belongs to (see ActiveStreamRegistry).
+  local env = vim.tbl_extend("force", self._base_env, { VIBING_HANDLE_ID = handle_id })
+  if rpc_port then
+    local port_str = tostring(rpc_port)
+    env.VIBING_NVIM_RPC_PORT = port_str
+    env.VIBING_RPC_PORT = port_str
+    env.VIBING_NVIM_CONTEXT = "true"
+  end
+
+  ActiveStreamRegistry.register({
+    handle_id = handle_id,
+    adapter = self,
+    on_insert_choices = opts.on_insert_choices,
+    on_approval_required = opts.on_approval_required,
+  })
+
+  -- Only the fields the permission handler actually reads are kept here (rather than the whole
+  -- `opts` table), so closures like on_insert_choices/on_approval_required aren't pinned in
+  -- memory a second time for the stream's lifetime — they're already held by ActiveStreamRegistry
+  -- above.
+  local perm_handler = require("vibing.infrastructure.rpc.handlers.permission")
+  -- The handler stays ignorant of which backend it is serving; it just calls whatever
+  -- vocabulary it was handed (#516).
+  local ToolVocabulary = require("vibing.infrastructure.adapter.modules.grok_tool_vocabulary")
+  perm_handler.set_active_opts(handle_id, vim.tbl_extend("force", opts, { _tool_vocabulary = ToolVocabulary }))
+
+  local wrapped_on_done = function(response)
+    if not completed then
+      completed = true
+      ActiveStreamRegistry.unregister(handle_id)
+      perm_handler.clear_active_opts(handle_id)
+      if timeout_timer then
+        vim.fn.timer_stop(timeout_timer)
+        timeout_timer = nil
+      end
+      on_done(response)
+    end
+  end
+
+  -- vim.system throws synchronously on spawn failure (e.g. invalid cwd) before any process
+  -- exists, so the registry/perm-handler state registered above would otherwise never be
+  -- cleaned up (the exit handler that normally does it never runs).
+  local ok_spawn, handle_or_err = pcall(vim.system, cmd, {
+    text = true,
+    stdin = "",
+    cwd = cwd,
+    env = env,
+    stdout = StreamHandler.create_stdout_handler(GrokEventProcessor, event_context, function()
+      return self._handles[handle_id] == nil
+    end),
+    stderr = StreamHandler.create_stderr_handler(error_output),
+  }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done))
+
+  if not ok_spawn then
+    ActiveStreamRegistry.unregister(handle_id)
+    perm_handler.clear_active_opts(handle_id)
+    on_done({ error = string.format("Failed to spawn grok process: %s", tostring(handle_or_err)) })
+    return handle_id
+  end
+
+  self._handles[handle_id] = handle_or_err
+
+  if debug_mode then
+    local pid = self._handles[handle_id] and self._handles[handle_id].pid or "unknown"
+    vim.notify(string.format("[vibing:grok] Process started: pid=%s", tostring(pid)), vim.log.levels.INFO)
+    vim.notify(
+      string.format("[vibing:grok] Command: %s", table.concat(cmd, " "):sub(1, 200)),
+      vim.log.levels.DEBUG
+    )
+  end
+
+  if session_id then
+    timeout_timer = vim.fn.timer_start(INITIAL_RESPONSE_TIMEOUT_MS, function()
+      if not received_first_response and not completed and self._handles[handle_id] then
+        vim.schedule(function()
+          if not completed then
+            vim.notify(
+              "[vibing] Session resume timeout - killing hung process and resetting session",
+              vim.log.levels.WARN
+            )
+            self:cancel(handle_id)
+            wrapped_on_done({
+              error = "Session resume timeout",
+              _session_corrupted = true,
+              _old_session_id = session_id,
+            })
+          end
+        end)
+      end
+    end)
+  end
+
+  return handle_id
+end
+
+---@param handle_id string?
+function GrokCLI:cancel(handle_id)
+  -- Grok spawns child processes that inherit the stdout pipe (MCP servers, tool shells).
+  -- Kill children first so vim.system's exit handler fires when the pipe closes.
+  local function kill_process(handle)
+    if not handle then
+      return
+    end
+    local pid = handle.pid
+    if not pid or pid <= 0 then
+      return
+    end
+    -- Fire-and-forget: consistent with the rest of this adapter's async design, and avoids
+    -- blocking Neovim's main loop while pkill runs (this can be called from a vim.schedule
+    -- callback on the session-resume timeout path).
+    vim.system({ "sh", "-c", string.format("pkill -9 -P %d 2>/dev/null", pid) }, {}, function() end)
+    pcall(function()
+      handle:kill(9)
+    end)
+  end
+
+  if handle_id then
+    local handle = self._handles[handle_id]
+    if handle then
+      kill_process(handle)
+      self._handles[handle_id] = nil
+    end
+  else
+    for id, handle in pairs(self._handles) do
+      kill_process(handle)
+      self._handles[id] = nil
+    end
+  end
+end
+
+---@param feature string
+---@return boolean
+function GrokCLI:supports(feature)
+  return SUPPORTED_FEATURES[feature] or false
+end
+
+---@param session_id string?
+---@param handle_id string?
+function GrokCLI:set_session_id(session_id, handle_id)
+  SessionManagerModule.set(self._session_manager, session_id, handle_id)
+end
+
+---@param handle_id string?
+---@return string?
+function GrokCLI:get_session_id(handle_id)
+  return SessionManagerModule.get(self._session_manager, handle_id)
+end
+
+---@param handle_id string
+function GrokCLI:cleanup_session(handle_id)
+  SessionManagerModule.cleanup(self._session_manager, handle_id)
+end
+
+function GrokCLI:cleanup_stale_sessions()
+  SessionManagerModule.cleanup_stale(self._session_manager, self._handles)
+end
+
+return GrokCLI

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -80,10 +80,14 @@ local function resolve_grok_path(config)
     resolved = found
   end
 
+  -- Verify before caching. The other order makes the "not the official CLI" error fire exactly
+  -- once: the second call hits the cache above, skips ensure_official_grok, and hands back the
+  -- unofficial binary silently.
+  verified_official = false
+  ensure_official_grok(resolved)
+
   cached_grok_path = resolved
   cached_configured_executable = configured
-  verified_official = false
-  ensure_official_grok(cached_grok_path)
   return cached_grok_path
 end
 
@@ -172,8 +176,10 @@ function M._reset_path_cache()
 end
 
 --- @param config Vibing.Config Plugin config
---- @param handle_id string|nil This turn's stream handle id
---- @param rpc_port number|nil This Neovim instance's RPC server port
+--- @param handle_id string|nil Unused. Kept so every backend's builder takes the same arguments;
+---   grok reaches no vibing-nvim MCP server, so nothing here needs the handle. The value still
+---   travels to the hook, via `VIBING_HANDLE_ID` in the environment `grok_cli` spawns with.
+--- @param rpc_port number|nil Unused, for the same reason: passed through the environment, not argv.
 --- @return string[] Command array for vim.system()
 function M.build(prompt, opts, session_id, config, handle_id, rpc_port)
   opts = opts or {}

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -1,0 +1,226 @@
+--- Grok CLI command builder for `grok -p` / `--single` execution
+--- Builds the command array for the Grok Build CLI with streaming JSON output
+--- @module vibing.infrastructure.adapter.modules.grok_command_builder
+
+local Modes = require("vibing.core.constants.modes")
+local worktree_constants = require("vibing.core.constants.worktree")
+
+local M = {}
+
+-- Grok's --permission-mode only accepts default/dontAsk/acceptEdits/bypassPermissions/plan.
+-- vibing's "auto" mode (Claude's background safety classifier) has no Grok equivalent, so it
+-- falls back to asking for confirmation instead of forwarding an unsupported value.
+local GROK_PERMISSION_MODE_FALLBACK = {
+  auto = "default",
+}
+
+local cached_grok_path = nil
+local cached_configured_executable = nil
+local verified_official = false
+
+--- Detect the official xAI Grok Build CLI (not community grok-dev)
+--- @param path string
+local function ensure_official_grok(path)
+  if verified_official then
+    return
+  end
+  -- Unit tests mock exepath to a non-executable path; skip sniff in that case
+  if vim.fn.executable(path) == 0 then
+    return
+  end
+
+  local version = vim.fn.system({ path, "--version" })
+  -- Official: "grok 0.2.101 (5bc4b5dfadcf) [stable]"
+  if type(version) == "string" and version:match("^grok%s+%d+%.%d+") then
+    verified_official = true
+    return
+  end
+
+  local help = vim.fn.system({ path, "--help" })
+  if type(help) == "string" and help:find("streaming%-json") then
+    verified_official = true
+    return
+  end
+
+  error(
+    "Found a 'grok' binary that does not appear to be the official xAI Grok Build CLI. "
+      .. "Install from https://x.ai/cli or set config.grok.executable to the official binary path."
+  )
+end
+
+--- Resolve path to the grok binary
+--- @param config Vibing.Config
+--- @return string
+local function resolve_grok_path(config)
+  local configured = config and config.grok and config.grok.executable
+
+  if cached_grok_path and cached_configured_executable == configured then
+    return cached_grok_path
+  end
+
+  local resolved
+  if configured and configured ~= "auto" and configured ~= "" then
+    if vim.fn.executable(configured) == 0 then
+      error(
+        string.format(
+          "Grok CLI not found at configured path '%s'. Install the official xAI Grok Build CLI.",
+          configured
+        )
+      )
+    end
+    resolved = configured
+  else
+    local found = vim.fn.exepath("grok")
+    if found == "" then
+      error(
+        "Grok CLI not found in PATH. Install the official xAI Grok Build CLI "
+          .. "(curl -fsSL https://x.ai/cli/install.sh | bash) or set config.grok.executable."
+      )
+    end
+    resolved = found
+  end
+
+  cached_grok_path = resolved
+  cached_configured_executable = configured
+  verified_official = false
+  ensure_official_grok(cached_grok_path)
+  return cached_grok_path
+end
+
+--- Build the `grok -p` (headless single-turn) CLI command array
+--- Uses `--single=<value>` (one argv token) rather than `-p <value>` so hyphen-leading
+--- prompts are not misparsed as flags by clap.
+--- @param prompt string User prompt
+--- @param opts Vibing.AdapterOpts Adapter options
+--- @param session_id string|nil Session ID for resumption
+
+--- Resolve the language to answer in, from opts then config.
+--- @param opts Vibing.AdapterOpts
+--- @param config Vibing.Config
+--- @return string|nil
+local function resolve_language(opts, config)
+  local language = opts.language
+  if not language and config.language then
+    if type(config.language) == "table" then
+      language = config.language.default or config.language.chat
+    else
+      language = config.language
+    end
+  end
+  return type(language) == "string" and language or nil
+end
+
+--- Grok has its own model catalog, so a Claude shortcut name (sonnet/opus/...) left over from a
+--- chat that switched backends must not be forwarded as Grok's `--model`.
+--- @param opts Vibing.AdapterOpts
+--- @param config Vibing.Config
+--- @return string|nil
+local function resolve_model(opts, config)
+  local model = opts.model or (config.agent and config.agent.default_model)
+  if model and Modes.is_valid_model(model) then
+    return nil
+  end
+  return model
+end
+
+--- @param opts Vibing.AdapterOpts
+--- @return string context_prefix Empty string if no context
+local function build_context_prefix(opts)
+  local parts = {}
+  for _, ctx in ipairs(opts.context or {}) do
+    if ctx:match("^@file:") then
+      table.insert(parts, string.format("Context file: %s", ctx:sub(7)))
+    end
+  end
+  if #parts == 0 then
+    return ""
+  end
+  return table.concat(parts, "\n") .. "\n\n"
+end
+
+--- What goes into `--rules`, Grok's equivalent of a system prompt.
+---
+--- Deliberately much smaller than the Claude adapter's block: Grok reaches no vibing-nvim MCP
+--- server, so instructing it to call `nvim_ask_user_question` or `nvim_highlight_range` would
+--- name tools it cannot invoke. Only the backend-agnostic conventions go here.
+--- @param opts Vibing.AdapterOpts
+--- @param config Vibing.Config
+--- @return string
+local function build_rules(opts, config)
+  local lines = {
+    "When creating a git worktree for isolated work, place it under "
+      .. worktree_constants.DIR
+      .. "<branch-name>/ at the repository root.",
+  }
+
+  local language = resolve_language(opts, config)
+  if language and language ~= "en" then
+    local lang_name = require("vibing.core.utils.language").language_names[language]
+    if lang_name then
+      table.insert(lines, 1, string.format("Always respond in %s (%s).", lang_name, language))
+    end
+  end
+
+  return table.concat(lines, "\n")
+end
+
+--- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec that
+--- wants to exercise the "CLI missing" path has to clear what an earlier spec resolved.
+function M._reset_path_cache()
+  cached_grok_path = nil
+  cached_configured_executable = nil
+end
+
+--- @param config Vibing.Config Plugin config
+--- @param handle_id string|nil This turn's stream handle id
+--- @param rpc_port number|nil This Neovim instance's RPC server port
+--- @return string[] Command array for vim.system()
+function M.build(prompt, opts, session_id, config, handle_id, rpc_port)
+  opts = opts or {}
+  config = config or {}
+
+  local grok_path = resolve_grok_path(config)
+
+  local full_prompt = prompt
+  if not session_id then
+    full_prompt = build_context_prefix(opts) .. prompt
+  end
+
+  local cmd = { grok_path }
+
+  table.insert(cmd, "--single=" .. full_prompt)
+  table.insert(cmd, "--output-format")
+  table.insert(cmd, "streaming-json")
+
+  local model = resolve_model(opts, config)
+  if model then
+    table.insert(cmd, "--model")
+    table.insert(cmd, model)
+  end
+
+  if session_id then
+    table.insert(cmd, "--resume")
+    table.insert(cmd, session_id)
+    if opts._is_fork then
+      table.insert(cmd, "--fork-session")
+    end
+  end
+
+  if opts.permission_mode then
+    local mode = GROK_PERMISSION_MODE_FALLBACK[opts.permission_mode] or opts.permission_mode
+    table.insert(cmd, "--permission-mode")
+    table.insert(cmd, mode)
+  end
+
+  if opts.cwd and opts.cwd ~= "" then
+    table.insert(cmd, "--cwd")
+    table.insert(cmd, opts.cwd)
+  end
+
+  table.insert(cmd, "--rules")
+  table.insert(cmd, build_rules(opts, config))
+
+  return cmd
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/grok_event_processor.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_event_processor.lua
@@ -1,0 +1,108 @@
+--- Grok CLI event processor for `grok --output-format streaming-json` output
+--- Processes JSONL events from the Grok Build CLI and dispatches to callbacks
+--- @module vibing.infrastructure.adapter.modules.grok_event_processor
+
+local M = {}
+
+local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
+
+--- Emit formatted text to output and onChunk callback
+--- @param text string
+--- @param context table
+local function emit_chunk(text, context)
+  if text == "" then
+    return
+  end
+  table.insert(context.output, text)
+  if context.onChunk then
+    vim.schedule(function()
+      context.onChunk(text)
+    end)
+  end
+end
+
+--- Handle a "thought" delta (Grok's reasoning stream)
+--- Confirmed via real CLI: "thought" arrives as many small word-by-word deltas.
+--- A "💭 " marker is emitted once when entering thought mode; a blank line closes it on "text".
+--- @param msg table
+--- @param context table
+local function handle_thought(msg, context)
+  if context.onFirstResponse then
+    context.onFirstResponse()
+  end
+  if context._grok_mode ~= "thought" then
+    context._grok_mode = "thought"
+    emit_chunk("\n💭 ", context)
+  end
+  emit_chunk(msg.data or "", context)
+end
+
+--- Handle a "text" delta (Grok's response stream)
+--- @param msg table
+--- @param context table
+local function handle_text(msg, context)
+  if context.onFirstResponse then
+    context.onFirstResponse()
+  end
+  if context._grok_mode == "thought" then
+    emit_chunk("\n\n", context)
+  end
+  context._grok_mode = "text"
+  emit_chunk(msg.data or "", context)
+end
+
+--- Handle the "end" event (turn completion — carries sessionId/usage, not text)
+--- Grok's headless output has no dedicated session-start event; sessionId is only known
+--- once the turn ends. Completion itself is process-exit driven.
+--- @param msg table
+--- @param context table
+local function handle_end(msg, context)
+  if msg.sessionId and context.sessionManager and context.handleId then
+    SessionManagerModule.store(context.sessionManager, context.handleId, msg.sessionId)
+  end
+end
+
+local event_handlers = {
+  thought = function(msg, context)
+    handle_thought(msg, context)
+    return true
+  end,
+  text = function(msg, context)
+    handle_text(msg, context)
+    return true
+  end,
+  ["end"] = function(msg, context)
+    handle_end(msg, context)
+    return true
+  end,
+  error = function(msg, context)
+    if msg.message then
+      table.insert(context.errorOutput, msg.message)
+    end
+    return true
+  end,
+}
+
+--- Process a single JSON line from the Grok CLI output
+--- @param line string JSON string
+--- @param context table Processing context
+--- @return boolean success Whether the line was processed
+function M.processLine(line, context)
+  if line == "" or not context then
+    return false
+  end
+
+  local ok, msg = pcall(vim.json.decode, line)
+  if not ok or not msg or not msg.type then
+    return false
+  end
+
+  local handler = event_handlers[msg.type]
+  if handler then
+    return handler(msg, context)
+  end
+
+  return true
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/grok_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_tool_vocabulary.lua
@@ -39,6 +39,30 @@ function M.to_canonical(native_tool_name)
   return NATIVE_TO_CANONICAL[native_tool_name]
 end
 
+--- Grok's PreToolUse payload is camelCase, where Claude's is snake_case:
+---
+---   {"hookEventName":"pre_tool_use","toolName":"read_file","toolInput":{"target_file":"a.txt"}}
+---
+--- Verified against grok 0.2.101, not inferred. Without this the handler reads a nil `tool_name`,
+--- every granular rule misses, and `to_canonical` below is handed an empty string -- so the whole
+--- vocabulary silently does nothing and the first tool call of every turn stalls the hook until it
+--- fails closed.
+--- @param hook_input table Raw decoded PreToolUse payload
+--- @return table payload with `tool_name`/`tool_input` present. Never mutates the original.
+function M.normalize_payload(hook_input)
+  if type(hook_input) ~= "table" or hook_input.tool_name ~= nil then
+    return hook_input
+  end
+  if hook_input.toolName == nil then
+    return hook_input
+  end
+
+  return vim.tbl_extend("force", hook_input, {
+    tool_name = hook_input.toolName,
+    tool_input = hook_input.toolInput or {},
+  })
+end
+
 --- @param tool_input table
 --- @return table input with `file_path` filled in when Grok named it something else. The original
 ---   is never mutated: the hook payload is also used to render the approval UI.

--- a/lua/vibing/infrastructure/adapter/modules/grok_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_tool_vocabulary.lua
@@ -1,0 +1,59 @@
+--- Grok Build CLI's tool names and input shape, translated to the canonical vocabulary the rest
+--- of vibing.nvim speaks.
+---
+--- Lives beside the adapter rather than in the permission handler so that shared infrastructure
+--- never has to know which backend it is talking to: `grok_cli.lua` hands this module to
+--- `set_active_opts` as a generic `_tool_vocabulary`, and the handler just calls whatever it was
+--- given. See #516.
+--- @module vibing.infrastructure.adapter.modules.grok_tool_vocabulary
+
+local M = {}
+
+--- Confirmed against real PreToolUse payloads and Grok's own Claude-compat matcher aliases, not
+--- inferred from its docs.
+--- @type table<string, string>
+local NATIVE_TO_CANONICAL = {
+  run_terminal_command = "Bash",
+  bash = "Bash",
+  shell = "Bash",
+  read_file = "Read",
+  write_file = "Write",
+  search_replace = "Edit",
+  edit_file = "Edit",
+  apply_patch = "Edit",
+  list_dir = "Glob",
+  grep = "Grep",
+  web_search = "WebSearch",
+  web_fetch = "WebFetch",
+  spawn_subagent = "Task",
+}
+
+--- Where Grok puts the path a tool is about. Granular permission rules read `file_path` (the
+--- Claude convention), so a `paths` rule would silently never match a Grok tool without this.
+--- @type string[]
+local PATH_KEYS = { "path", "target_file", "filePath" }
+
+--- @param native_tool_name string
+--- @return string|nil canonical name, or nil when there is no mapping
+function M.to_canonical(native_tool_name)
+  return NATIVE_TO_CANONICAL[native_tool_name]
+end
+
+--- @param tool_input table
+--- @return table input with `file_path` filled in when Grok named it something else. The original
+---   is never mutated: the hook payload is also used to render the approval UI.
+function M.normalize_input(tool_input)
+  if type(tool_input) ~= "table" or tool_input.file_path then
+    return tool_input
+  end
+
+  for _, key in ipairs(PATH_KEYS) do
+    if tool_input[key] then
+      return vim.tbl_extend("force", tool_input, { file_path = tool_input[key] })
+    end
+  end
+
+  return tool_input
+end
+
+return M

--- a/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
@@ -15,10 +15,28 @@ local HOOK_FILENAME = "vibing-nvim-pre-tool-use.json"
 local trusted_cwds = {}
 
 --- Absolute path to the generated hook JSON for a given cwd
+--- Resolved, so this reports the same path `ensure()` writes -- that one resolves the cwd, and a
+--- symlinked working directory would otherwise make the two disagree.
 --- @param cwd string
 --- @return string
 function M.hook_file_path(cwd)
-  return cwd .. "/.grok/hooks/" .. HOOK_FILENAME
+  return vim.fn.resolve(cwd) .. "/.grok/hooks/" .. HOOK_FILENAME
+end
+
+--- Escape a string for a TOML basic string (the `folders."<path>"` key).
+--- A path is not arbitrary text, but `"` and `\` are both legal in POSIX filenames and either one
+--- would break the file's structure -- and this file is grok's, not ours, so corrupting it takes
+--- out the user's other trusted folders too. Everything else here is written through vim.json.
+--- @param s string
+--- @return string
+function M._toml_escape(s)
+  return (
+    s:gsub("\\", "\\\\")
+      :gsub('"', '\\"')
+      :gsub("\n", "\\n")
+      :gsub("\r", "\\r")
+      :gsub("\t", "\\t")
+  )
 end
 
 --- Grok's config directory. `$GROK_HOME` is Grok's own documented override of `~/.grok`, so
@@ -56,13 +74,15 @@ local function ensure_folder_trust(cwd)
     rf:close()
   end
 
-  local marker = 'folders."' .. real .. '"'
+  local key = M._toml_escape(real)
+  local marker = 'folders."' .. key .. '"'
   if not existing:find(marker, 1, true) then
-    local entry = string.format(
-      '\n[folders."%s"]\ntrusted = true\ndecided_at = %d\n',
-      real,
-      os.time()
-    )
+    local entry = string.format('\n[folders."%s"]\ntrusted = true\ndecided_at = %d\n', key, os.time())
+    -- Appended rather than rewritten on purpose: grok writes this same file itself (`/hooks-trust`),
+    -- and a read-modify-write would clobber whatever it added in between. A small append is atomic
+    -- on POSIX, so the remaining race is two Neovims first touching the *same new* cwd at once and
+    -- both appending the key -- which grok's TOML parser would reject as a duplicate. Narrow enough
+    -- to accept; rewriting the file would trade it for a worse one.
     local wf = io.open(trust_path, "a")
     if wf then
       wf:write(entry)

--- a/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
@@ -1,0 +1,93 @@
+--- Grok Build CLI hook settings generator
+--- Writes a project-scoped PreToolUse hook under <cwd>/.grok/hooks/ so vibing's
+--- pre-tool-use.sh participates in Grok's permission pipeline (Tool Approval UI).
+--- @module vibing.infrastructure.hooks.grok_settings_generator
+
+local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+
+local M = {}
+
+local HOOK_FILENAME = "vibing-nvim-pre-tool-use.json"
+
+--- cwds already confirmed trusted this session — folder trust is idempotent, so once a cwd is
+--- known-trusted there's no need to re-read/re-scan ~/.grok/trusted_folders.toml on every message.
+--- @type table<string, boolean>
+local trusted_cwds = {}
+
+--- Absolute path to the generated hook JSON for a given cwd
+--- @param cwd string
+--- @return string
+function M.hook_file_path(cwd)
+  return cwd .. "/.grok/hooks/" .. HOOK_FILENAME
+end
+
+--- Ensure the session cwd is marked trusted in ~/.grok/trusted_folders.toml
+--- Project hooks are silently skipped without folder trust. Cascades to subdirs.
+--- @param cwd string
+local function ensure_folder_trust(cwd)
+  local real = vim.fn.resolve(cwd)
+  if real == "" or real == "/" or real == vim.fn.expand("~") then
+    return
+  end
+  if trusted_cwds[real] then
+    return
+  end
+
+  local trust_path = vim.fn.expand("~/.grok/trusted_folders.toml")
+  vim.fn.mkdir(vim.fn.fnamemodify(trust_path, ":h"), "p")
+
+  local existing = ""
+  local rf = io.open(trust_path, "r")
+  if rf then
+    existing = rf:read("*a") or ""
+    rf:close()
+  end
+
+  local marker = 'folders."' .. real .. '"'
+  if not existing:find(marker, 1, true) then
+    local entry = string.format(
+      '\n[folders."%s"]\ntrusted = true\ndecided_at = %d\n',
+      real,
+      os.time()
+    )
+    local wf = io.open(trust_path, "a")
+    if wf then
+      wf:write(entry)
+      wf:close()
+    end
+  end
+
+  trusted_cwds[real] = true
+end
+
+--- Ensure project PreToolUse hook file exists for the given cwd
+--- @param cwd? string Working directory (defaults to vim.fn.getcwd())
+--- @return string path Absolute path to the hook JSON file
+function M.ensure(cwd)
+  cwd = cwd or vim.fn.getcwd()
+  local real_cwd = vim.fn.resolve(cwd)
+  local hooks_dir = real_cwd .. "/.grok/hooks"
+  local hook_path = hooks_dir .. "/" .. HOOK_FILENAME
+
+  vim.fn.mkdir(hooks_dir, "p")
+
+  -- Grok resolves relative command paths against the hook JSON file directory
+  -- (.grok/hooks/), not the project root — so a relative plugin path would miss
+  -- bin/hooks/pre-tool-use.sh. Always write an absolute path.
+  local hook_script = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+  local settings = SettingsGenerator.generate(hook_script)
+
+  local json = vim.json.encode(settings)
+  local f, err = io.open(hook_path, "w")
+  if not f then
+    error("Failed to create Grok hook settings file: " .. hook_path .. " (" .. tostring(err) .. ")")
+  end
+  f:write(json)
+  f:close()
+
+  ensure_folder_trust(real_cwd)
+
+  return hook_path
+end
+
+return M

--- a/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
@@ -21,7 +21,20 @@ function M.hook_file_path(cwd)
   return cwd .. "/.grok/hooks/" .. HOOK_FILENAME
 end
 
---- Ensure the session cwd is marked trusted in ~/.grok/trusted_folders.toml
+--- Grok's config directory. `$GROK_HOME` is Grok's own documented override of `~/.grok`, so
+--- honouring it is both correct for users who set it and the seam the specs need: folder trust
+--- cascades to subdirectories and is never expired, so a spec writing throwaway `tempname()`
+--- paths into the real file would keep granting trust that outlives the test run.
+--- @return string
+local function grok_home()
+  local override = vim.env.GROK_HOME
+  if override and override ~= "" then
+    return override
+  end
+  return vim.fn.expand("~/.grok")
+end
+
+--- Ensure the session cwd is marked trusted in <grok home>/trusted_folders.toml
 --- Project hooks are silently skipped without folder trust. Cascades to subdirs.
 --- @param cwd string
 local function ensure_folder_trust(cwd)
@@ -33,7 +46,7 @@ local function ensure_folder_trust(cwd)
     return
   end
 
-  local trust_path = vim.fn.expand("~/.grok/trusted_folders.toml")
+  local trust_path = grok_home() .. "/trusted_folders.toml"
   vim.fn.mkdir(vim.fn.fnamemodify(trust_path, ":h"), "p")
 
   local existing = ""
@@ -60,12 +73,40 @@ local function ensure_folder_trust(cwd)
   trusted_cwds[real] = true
 end
 
+--- cwds already warned about this session, so a non-git worktree does not notify on every message.
+--- @type table<string, boolean>
+local warned_non_git = {}
+
+--- Grok discovers `.grok/hooks/` only inside a git repository -- verified with `grok inspect`,
+--- which lists the project hook under "Hooks" after `git init` and omits it before. Outside one
+--- the hook file is written and then never read, which would silently mean every tool is allowed.
+--- @param cwd string
+local function warn_if_not_git(cwd)
+  if warned_non_git[cwd] then
+    return
+  end
+  if #vim.fs.find(".git", { path = cwd, upward = true }) > 0 then
+    return
+  end
+
+  warned_non_git[cwd] = true
+  vim.notify(
+    string.format(
+      "[vibing:grok] %s is not inside a git repository. Grok ignores .grok/hooks/ there, so "
+        .. "permission rules and the Tool Approval UI will not apply to this session.",
+      cwd
+    ),
+    vim.log.levels.WARN
+  )
+end
+
 --- Ensure project PreToolUse hook file exists for the given cwd
 --- @param cwd? string Working directory (defaults to vim.fn.getcwd())
 --- @return string path Absolute path to the hook JSON file
 function M.ensure(cwd)
   cwd = cwd or vim.fn.getcwd()
   local real_cwd = vim.fn.resolve(cwd)
+  warn_if_not_git(real_cwd)
   local hooks_dir = real_cwd .. "/.grok/hooks"
   local hook_path = hooks_dir .. "/" .. HOOK_FILENAME
 

--- a/lua/vibing/infrastructure/hooks/settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/settings_generator.lua
@@ -26,8 +26,13 @@ function M.get_stop_failure_script_path()
 end
 
 --- Generate settings table with hook configuration
+--- @param hook_script_path? string Override for the PreToolUse script path. Grok resolves a
+---   relative hook command against its own .grok/hooks/ file rather than the project root, so it
+---   has to pass an absolute path it computed itself.
 --- @return table
-function M.generate()
+function M.generate(hook_script_path)
+  local pre_tool_use_script = hook_script_path or M.get_hook_script_path()
+
   return {
     hooks = {
       PreToolUse = {
@@ -36,7 +41,7 @@ function M.generate()
           hooks = {
             {
               type = "command",
-              command = M.get_hook_script_path(),
+              command = pre_tool_use_script,
               timeout = 120,
             },
           },

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -194,6 +194,11 @@ function M.check_tool_permission(params)
   if vocabulary and vocabulary.to_canonical then
     tool_name = vocabulary.to_canonical(tool_name) or tool_name
   end
+  -- Same reasoning for the input: granular `paths` rules read `file_path`, and a backend that
+  -- names it `path`/`target_file` would slip past every one of them.
+  if vocabulary and vocabulary.normalize_input then
+    tool_input = vocabulary.normalize_input(tool_input)
+  end
 
   -- Kill process first, call UI callback, then write deny response. Used by both
   -- AskUserQuestion and "ask" permission paths. The deny response only reaches the model when

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -183,14 +183,23 @@ function M.check_tool_permission(params)
     return { status = "allowed", reason = "invalid request JSON" }
   end
 
-  local tool_name = hook_input.tool_name or ""
-  local tool_input = hook_input.tool_input or {}
   local active_opts = get_active_opts(handle_id)
 
   -- Backends name their tools differently (codex calls an edit "apply_patch"). The adapter
   -- supplies its own translation table as a generic `_tool_vocabulary`, so this handler stays
   -- ignorant of which backend it is serving -- adding a fourth needs no change here (#516).
   local vocabulary = active_opts and active_opts._tool_vocabulary
+
+  -- Backends also disagree on the payload's own key names, not just the tool names inside it
+  -- (grok sends `toolName`/`toolInput`). Normalize before reading, or the two calls below are
+  -- handed nothing to translate.
+  if vocabulary and vocabulary.normalize_payload then
+    hook_input = vocabulary.normalize_payload(hook_input)
+  end
+
+  local tool_name = hook_input.tool_name or ""
+  local tool_input = hook_input.tool_input or {}
+
   if vocabulary and vocabulary.to_canonical then
     tool_name = vocabulary.to_canonical(tool_name) or tool_name
   end
@@ -259,7 +268,10 @@ function M.check_tool_permission(params)
     write_hook_response(request_id, true)
     return { status = "allowed" }
   elseif result.behavior == "deny" then
-    write_hook_response(request_id, false)
+    -- The reason has to go into the response, not just the return value: the hook script reads
+    -- `permissionDecisionReason` and echoes it on stderr, which is the only way a deny rule's
+    -- `message` ever reaches the model. Without it every denial reads as a bare "denied by hook".
+    write_hook_response(request_id, false, result.message)
     return { status = "denied", reason = result.message }
   else
     -- "ask" → kill process first, show approval UI, then write deny

--- a/tests/completion/frontmatter_spec.lua
+++ b/tests/completion/frontmatter_spec.lua
@@ -56,12 +56,14 @@ describe("Frontmatter completion", function()
       assert.are.equal("fable", items[4].word)
     end)
 
-    it("should include copilot in agent enum values", function()
+    it("should offer every registered backend in agent enum values", function()
+      -- Derived from agents.lua, so a new backend appears here without touching the provider.
       local items = frontmatter_provider.get_enum_values("agent")
-      assert.are.equal(3, #items)
+      assert.are.equal(4, #items)
       assert.are.equal("claude", items[1].word)
       assert.are.equal("codex", items[2].word)
       assert.are.equal("copilot", items[3].word)
+      assert.are.equal("grok", items[4].word)
     end)
 
     it("should get copilot model values via get_model_values", function()

--- a/tests/helpers/adapter_stream.lua
+++ b/tests/helpers/adapter_stream.lua
@@ -88,12 +88,10 @@ end
 --- The caches are module-level and therefore process-wide: once one spec has resolved a path, a
 --- later spec stubbing exepath to "" would otherwise never reach the missing-CLI branch.
 function M.reset_path_caches()
-  for _, module in ipairs({
-    "vibing.infrastructure.adapter.modules.cli_command_builder",
-    "vibing.infrastructure.adapter.modules.codex_command_builder",
-    "vibing.infrastructure.adapter.modules.copilot_command_builder",
-  }) do
-    local builder = require(module)
+  -- Derived from the registry, not listed here: a hardcoded list silently skips a new backend,
+  -- and then its "CLI missing" test passes against a stale cached path.
+  for _, def in ipairs(require("vibing.core.constants.agents").list()) do
+    local builder = require(def.command_builder_module)
     if builder._reset_path_cache then
       builder._reset_path_cache()
     end

--- a/tests/lua/core/constants/agents_spec.lua
+++ b/tests/lua/core/constants/agents_spec.lua
@@ -3,7 +3,7 @@ local Agents = require("vibing.core.constants.agents")
 
 describe("agents registry", function()
   it("lists the backends in a fixed order", function()
-    assert.same({ "claude", "codex", "copilot" }, Agents.ORDER)
+    assert.same({ "claude", "codex", "copilot", "grok" }, Agents.ORDER)
   end)
 
   it("has a definition for every id in ORDER, and no strays", function()

--- a/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
@@ -1,0 +1,240 @@
+local grok_command_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+
+describe("grok_command_builder", function()
+  local original_exepath
+  local original_executable
+  local original_system
+
+  before_each(function()
+    original_exepath = vim.fn.exepath
+    original_executable = vim.fn.executable
+    original_system = vim.fn.system
+    vim.fn.exepath = function(name)
+      if name == "grok" then
+        return "/usr/local/bin/grok"
+      end
+      return original_exepath(name)
+    end
+    -- Mock PATH binary as non-executable so official-version sniff is skipped by default
+    vim.fn.executable = function(path)
+      if path == "/usr/local/bin/grok" then
+        return 0
+      end
+      if path == "/opt/custom/grok" then
+        return 1
+      end
+      return original_executable(path)
+    end
+    vim.fn.system = function(cmd)
+      if type(cmd) == "table" and cmd[1] == "/opt/custom/grok" and cmd[2] == "--version" then
+        return "grok 0.2.101 (5bc4b5dfadcf) [stable]\n"
+      end
+      return original_system(cmd)
+    end
+    package.loaded["vibing.infrastructure.adapter.modules.grok_command_builder"] = nil
+    grok_command_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+  end)
+
+  after_each(function()
+    vim.fn.exepath = original_exepath
+    vim.fn.executable = original_executable
+    vim.fn.system = original_system
+  end)
+
+  local function find_flag(cmd, flag)
+    for i, arg in ipairs(cmd) do
+      if arg == flag then
+        return i
+      end
+    end
+    return nil
+  end
+
+  local function find_prefixed(cmd, prefix)
+    for _, arg in ipairs(cmd) do
+      if arg:sub(1, #prefix) == prefix then
+        return arg
+      end
+    end
+    return nil
+  end
+
+  describe("prompt argument", function()
+    it("passes the prompt as a single --single=<value> token, not two argv entries", function()
+      local cmd = grok_command_builder.build("hello world", {}, nil, {})
+      local single_arg = find_prefixed(cmd, "--single=")
+      assert.is_not_nil(single_arg)
+      assert.equals("--single=hello world", single_arg)
+      assert.is_nil(find_flag(cmd, "-p"))
+    end)
+
+    it("keeps a hyphen-leading prompt intact inside the --single= token (clap ambiguity guard)", function()
+      local cmd = grok_command_builder.build("-1 is negative, true or false?", {}, nil, {})
+      local single_arg = find_prefixed(cmd, "--single=")
+      assert.equals("--single=-1 is negative, true or false?", single_arg)
+    end)
+
+    it("prefixes context files only for new sessions, not resume", function()
+      local cmd = grok_command_builder.build("hello", { context = { "@file:init.lua" } }, nil, {})
+      local single_arg = find_prefixed(cmd, "--single=")
+      assert.is_true(single_arg:find("Context file: init.lua", 1, true) ~= nil)
+
+      local resumed_cmd =
+        grok_command_builder.build("hello", { context = { "@file:init.lua" } }, "session-abc", {})
+      local resumed_single_arg = find_prefixed(resumed_cmd, "--single=")
+      assert.is_nil(resumed_single_arg:find("Context file:", 1, true))
+    end)
+  end)
+
+  it("always requests streaming-json output", function()
+    local cmd = grok_command_builder.build("hello", {}, nil, {})
+    local idx = find_flag(cmd, "--output-format")
+    assert.is_not_nil(idx)
+    assert.equals("streaming-json", cmd[idx + 1])
+  end)
+
+  describe("--rules (system prompt additions)", function()
+    it("always appends the worktree directory convention instruction", function()
+      local cmd = grok_command_builder.build("hello", {}, nil, {})
+      local idx = find_flag(cmd, "--rules")
+      assert.is_not_nil(idx)
+      assert.is_true(cmd[idx + 1]:find(".vibing/worktrees/", 1, true) ~= nil)
+    end)
+
+    it("combines the language instruction and worktree instruction into a single flag", function()
+      local config = { language = "ja" }
+      local cmd = grok_command_builder.build("hello", {}, nil, config)
+
+      local count = 0
+      local rules_text = nil
+      for i, arg in ipairs(cmd) do
+        if arg == "--rules" then
+          count = count + 1
+          rules_text = cmd[i + 1]
+        end
+      end
+
+      assert.equals(1, count)
+      assert.is_true(rules_text:find("Japanese", 1, true) ~= nil)
+      assert.is_true(rules_text:find(".vibing/worktrees/", 1, true) ~= nil)
+    end)
+
+    it("names no MCP tool, because Grok cannot reach the vibing-nvim MCP server", function()
+      -- Grok registers no MCP server and no chat_bufnr, so an instruction to call
+      -- nvim_ask_user_question would name a tool it has no way to invoke. Same position as codex.
+      local cmd = grok_command_builder.build("hello", { chat_bufnr = 12 }, nil, {}, "abc123_456", 9878)
+      local rules_text = cmd[find_flag(cmd, "--rules") + 1]
+
+      assert.is_nil(rules_text:find("nvim_ask_user_question", 1, true))
+      assert.is_nil(rules_text:find("mcp__vibing%-nvim__"))
+      assert.is_nil(rules_text:find("Current vibing.nvim chat buffer", 1, true))
+    end)
+
+    it("embeds no handle_id, so the rules stay byte-identical across turns", function()
+      -- A per-turn value here would invalidate the cached prompt prefix on every message (#469).
+      local first = grok_command_builder.build("hello", {}, nil, {}, "handle-1", 9878)
+      local second = grok_command_builder.build("again", {}, "session-1", {}, "handle-2", 9878)
+
+      local a = first[find_flag(first, "--rules") + 1]
+      local b = second[find_flag(second, "--rules") + 1]
+      assert.equals(a, b)
+      assert.is_nil(a:find("handle_id", 1, true))
+    end)
+  end)
+
+  describe("--model", function()
+    it("omits --model for Claude-style model names (grok has its own defaults)", function()
+      local cmd = grok_command_builder.build("hello", { model = "sonnet" }, nil, {})
+      assert.is_nil(find_flag(cmd, "--model"))
+    end)
+
+    it("passes through Grok model names", function()
+      local cmd = grok_command_builder.build("hello", { model = "grok-4.5" }, nil, {})
+      local idx = find_flag(cmd, "--model")
+      assert.is_not_nil(idx)
+      assert.equals("grok-4.5", cmd[idx + 1])
+    end)
+  end)
+
+  describe("--permission-mode", function()
+    it("passes vibing permission modes straight through when Grok supports them natively", function()
+      for _, mode in ipairs({ "default", "acceptEdits", "bypassPermissions", "plan", "dontAsk" }) do
+        local cmd = grok_command_builder.build("hello", { permission_mode = mode }, nil, {})
+        local idx = find_flag(cmd, "--permission-mode")
+        assert.is_not_nil(idx, "missing --permission-mode for " .. mode)
+        assert.equals(mode, cmd[idx + 1])
+      end
+    end)
+
+    it("translates 'auto' to 'default' since Grok has no background-classifier equivalent", function()
+      local cmd = grok_command_builder.build("hello", { permission_mode = "auto" }, nil, {})
+      local idx = find_flag(cmd, "--permission-mode")
+      assert.is_not_nil(idx)
+      assert.equals("default", cmd[idx + 1])
+    end)
+
+    it("omits --permission-mode when not specified", function()
+      local cmd = grok_command_builder.build("hello", {}, nil, {})
+      assert.is_nil(find_flag(cmd, "--permission-mode"))
+    end)
+  end)
+
+  describe("session resume", function()
+    it("adds --resume with the session id", function()
+      local cmd = grok_command_builder.build("hello", {}, "session-abc", {})
+      local idx = find_flag(cmd, "--resume")
+      assert.is_not_nil(idx)
+      assert.equals("session-abc", cmd[idx + 1])
+    end)
+
+    it("adds --fork-session only when resuming a forked chat", function()
+      local cmd = grok_command_builder.build("hello", { _is_fork = true }, "session-abc", {})
+      assert.is_not_nil(find_flag(cmd, "--fork-session"))
+    end)
+
+    it("omits --fork-session for a plain resume", function()
+      local cmd = grok_command_builder.build("hello", {}, "session-abc", {})
+      assert.is_nil(find_flag(cmd, "--fork-session"))
+    end)
+
+    it("omits --resume for a new session", function()
+      local cmd = grok_command_builder.build("hello", {}, nil, {})
+      assert.is_nil(find_flag(cmd, "--resume"))
+    end)
+  end)
+
+  describe("--cwd", function()
+    it("adds --cwd when opts.cwd is set", function()
+      local cmd = grok_command_builder.build("hello", { cwd = "/tmp/worktree" }, nil, {})
+      local idx = find_flag(cmd, "--cwd")
+      assert.is_not_nil(idx)
+      assert.equals("/tmp/worktree", cmd[idx + 1])
+    end)
+
+    it("omits --cwd when not set", function()
+      local cmd = grok_command_builder.build("hello", {}, nil, {})
+      assert.is_nil(find_flag(cmd, "--cwd"))
+    end)
+  end)
+
+  describe("binary resolution", function()
+    it("uses config.grok.executable when set to an explicit path", function()
+      -- Force non-executable so sniff is skipped; path is still used in argv
+      local cmd = grok_command_builder.build("hello", {}, nil, {
+        grok = { executable = "/opt/custom/grok" },
+      })
+      assert.equals("/opt/custom/grok", cmd[1])
+    end)
+
+    it("errors when the grok binary cannot be found", function()
+      vim.fn.exepath = function()
+        return ""
+      end
+      package.loaded["vibing.infrastructure.adapter.modules.grok_command_builder"] = nil
+      local fresh_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+      assert.has_error(function()
+        fresh_builder.build("hello", {}, nil, {})
+      end)
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
@@ -236,5 +236,26 @@ describe("grok_command_builder", function()
         fresh_builder.build("hello", {}, nil, {})
       end)
     end)
+
+    it("keeps rejecting an unofficial binary on every call, not just the first", function()
+      -- The path used to be cached before it was verified, so a second build() hit the cache,
+      -- skipped the check, and handed back the unofficial binary with no error at all.
+      vim.fn.system = function(cmd)
+        if type(cmd) == "table" and cmd[1] == "/opt/custom/grok" then
+          return "grok-dev, a community CLI\n"
+        end
+        return original_system(cmd)
+      end
+      package.loaded["vibing.infrastructure.adapter.modules.grok_command_builder"] = nil
+      local fresh_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+      local config = { grok = { executable = "/opt/custom/grok" } }
+
+      assert.has_error(function()
+        fresh_builder.build("hello", {}, nil, config)
+      end)
+      assert.has_error(function()
+        fresh_builder.build("hello again", {}, nil, config)
+      end)
+    end)
   end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/grok_event_processor_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_event_processor_spec.lua
@@ -1,0 +1,107 @@
+local grok_event_processor = require("vibing.infrastructure.adapter.modules.grok_event_processor")
+local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
+
+describe("grok_event_processor", function()
+  local function make_context()
+    return {
+      sessionManager = SessionManagerModule.new(),
+      handleId = "handle-1",
+      output = {},
+      errorOutput = {},
+      chunks = {},
+      first_response_calls = 0,
+      onFirstResponse = nil,
+      onChunk = nil,
+    }
+  end
+
+  local function new_context()
+    local context = make_context()
+    context.onFirstResponse = function()
+      context.first_response_calls = context.first_response_calls + 1
+    end
+    context.onChunk = function(chunk)
+      table.insert(context.chunks, chunk)
+    end
+    return context
+  end
+
+  local function line(tbl)
+    return vim.json.encode(tbl)
+  end
+
+  local function flush()
+    vim.wait(20)
+  end
+
+  it("emits text deltas as-is and calls onFirstResponse", function()
+    local context = new_context()
+    grok_event_processor.processLine(line({ type = "text", data = "Hello" }), context)
+    flush()
+
+    assert.equals(1, context.first_response_calls)
+    assert.equals("Hello", table.concat(context.chunks, ""))
+  end)
+
+  it("prefixes the first thought delta with a marker but not subsequent ones", function()
+    local context = new_context()
+    grok_event_processor.processLine(line({ type = "thought", data = "The" }), context)
+    grok_event_processor.processLine(line({ type = "thought", data = " user" }), context)
+    flush()
+
+    local combined = table.concat(context.chunks, "")
+    assert.equals("\n💭 The user", combined)
+  end)
+
+  it("inserts a separator when switching from thought to text", function()
+    local context = new_context()
+    grok_event_processor.processLine(line({ type = "thought", data = "thinking" }), context)
+    grok_event_processor.processLine(line({ type = "text", data = "answer" }), context)
+    flush()
+
+    local combined = table.concat(context.chunks, "")
+    assert.equals("\n💭 thinking\n\nanswer", combined)
+  end)
+
+  it("does not re-emit the thought marker after switching back from text", function()
+    local context = new_context()
+    grok_event_processor.processLine(line({ type = "thought", data = "a" }), context)
+    grok_event_processor.processLine(line({ type = "text", data = "b" }), context)
+    grok_event_processor.processLine(line({ type = "thought", data = "c" }), context)
+    flush()
+
+    local combined = table.concat(context.chunks, "")
+    assert.equals("\n💭 a\n\nb\n💭 c", combined)
+  end)
+
+  it("stores the session id from the end event without emitting a chunk", function()
+    local context = new_context()
+    grok_event_processor.processLine(
+      line({ type = "end", stopReason = "EndTurn", sessionId = "session-xyz" }),
+      context
+    )
+    flush()
+
+    assert.equals("session-xyz", SessionManagerModule.get(context.sessionManager, "handle-1"))
+    assert.equals(0, #context.chunks)
+  end)
+
+  it("collects error messages from an error event", function()
+    local context = new_context()
+    grok_event_processor.processLine(line({ type = "error", message = "boom" }), context)
+
+    assert.equals("boom", context.errorOutput[1])
+  end)
+
+  it("ignores unknown event types without erroring", function()
+    local context = new_context()
+    local ok = grok_event_processor.processLine(line({ type = "some_future_event" }), context)
+    assert.is_true(ok)
+  end)
+
+  it("returns false for unparsable lines", function()
+    local context = new_context()
+    assert.is_false(grok_event_processor.processLine("not json", context))
+    assert.is_false(grok_event_processor.processLine("", context))
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/grok_tool_vocabulary_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_tool_vocabulary_spec.lua
@@ -1,0 +1,55 @@
+describe("grok_tool_vocabulary", function()
+  local vocabulary = require("vibing.infrastructure.adapter.modules.grok_tool_vocabulary")
+
+  describe("to_canonical", function()
+    it("translates Grok's names to the ones the permission rules are written in", function()
+      assert.equals("Bash", vocabulary.to_canonical("run_terminal_command"))
+      assert.equals("Read", vocabulary.to_canonical("read_file"))
+      assert.equals("Write", vocabulary.to_canonical("write_file"))
+      assert.equals("Grep", vocabulary.to_canonical("grep"))
+      assert.equals("Task", vocabulary.to_canonical("spawn_subagent"))
+    end)
+
+    it("maps every edit spelling Grok uses onto Edit", function()
+      -- A deny rule on Edit has to catch all three, or one of them silently writes files.
+      assert.equals("Edit", vocabulary.to_canonical("search_replace"))
+      assert.equals("Edit", vocabulary.to_canonical("edit_file"))
+      assert.equals("Edit", vocabulary.to_canonical("apply_patch"))
+    end)
+
+    it("maps every shell spelling onto Bash", function()
+      assert.equals("Bash", vocabulary.to_canonical("bash"))
+      assert.equals("Bash", vocabulary.to_canonical("shell"))
+    end)
+
+    it("returns nil for a name it does not know, so the caller keeps the original", function()
+      assert.is_nil(vocabulary.to_canonical("Bash"))
+      assert.is_nil(vocabulary.to_canonical("something_new"))
+    end)
+  end)
+
+  describe("normalize_input", function()
+    it("fills in file_path from the keys Grok actually uses", function()
+      -- Granular `paths` rules read file_path; without this they match nothing on Grok.
+      assert.equals("a.lua", vocabulary.normalize_input({ path = "a.lua" }).file_path)
+      assert.equals("b.lua", vocabulary.normalize_input({ target_file = "b.lua" }).file_path)
+      assert.equals("c.lua", vocabulary.normalize_input({ filePath = "c.lua" }).file_path)
+    end)
+
+    it("leaves an input that already names file_path alone", function()
+      local input = { file_path = "kept.lua", path = "ignored.lua" }
+      assert.equals("kept.lua", vocabulary.normalize_input(input).file_path)
+    end)
+
+    it("does not mutate the original, which is also what the approval UI renders", function()
+      local input = { path = "a.lua" }
+      vocabulary.normalize_input(input)
+      assert.is_nil(input.file_path)
+    end)
+
+    it("passes through an input with no path at all", function()
+      assert.same({ command = "ls" }, vocabulary.normalize_input({ command = "ls" }))
+      assert.equals("nope", vocabulary.normalize_input("nope"))
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/grok_tool_vocabulary_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_tool_vocabulary_spec.lua
@@ -28,6 +28,50 @@ describe("grok_tool_vocabulary", function()
     end)
   end)
 
+  describe("normalize_payload", function()
+    -- Captured from grok 0.2.101's PreToolUse hook, not hand-written.
+    local GROK_PAYLOAD = {
+      hookEventName = "pre_tool_use",
+      sessionId = "019ff868-db76-7d22-80d1-3530826638aa",
+      toolName = "read_file",
+      toolUseId = "call-c2935dd2-d4e9-4626-81a3-7732aecd6ab8-0",
+      toolInput = { target_file = "README.md" },
+      permissionMode = "auto",
+    }
+
+    it("exposes Grok's camelCase payload under the snake_case keys the handler reads", function()
+      local out = vocabulary.normalize_payload(GROK_PAYLOAD)
+      assert.equals("read_file", out.tool_name)
+      assert.same({ target_file = "README.md" }, out.tool_input)
+    end)
+
+    it("keeps the fields the approval UI still needs", function()
+      local out = vocabulary.normalize_payload(GROK_PAYLOAD)
+      assert.equals("019ff868-db76-7d22-80d1-3530826638aa", out.sessionId)
+      assert.equals("pre_tool_use", out.hookEventName)
+    end)
+
+    it("does not mutate the original", function()
+      local payload = vim.deepcopy(GROK_PAYLOAD)
+      vocabulary.normalize_payload(payload)
+      assert.is_nil(payload.tool_name)
+    end)
+
+    it("leaves a payload that already speaks snake_case alone", function()
+      local payload = { tool_name = "read_file", tool_input = { file_path = "a.lua" }, toolName = "ignored" }
+      assert.equals("read_file", vocabulary.normalize_payload(payload).tool_name)
+    end)
+
+    it("defaults tool_input to a table when Grok sends a tool with no input", function()
+      assert.same({}, vocabulary.normalize_payload({ toolName = "list_dir" }).tool_input)
+    end)
+
+    it("passes through anything that is neither shape", function()
+      assert.same({ other = 1 }, vocabulary.normalize_payload({ other = 1 }))
+      assert.equals("nope", vocabulary.normalize_payload("nope"))
+    end)
+  end)
+
   describe("normalize_input", function()
     it("fills in file_path from the keys Grok actually uses", function()
       -- Granular `paths` rules read file_path; without this they match nothing on Grok.

--- a/tests/lua/infrastructure/adapter/stream_options_spec.lua
+++ b/tests/lua/infrastructure/adapter/stream_options_spec.lua
@@ -139,9 +139,9 @@ for _, backend in ipairs(helper.adapters()) do
 end
 
 describe("adapter stream() options: stdin", function()
-  -- claude reads its prompt from argv; codex and copilot are given an explicit empty stdin so they
-  -- do not sit waiting on a terminal that isn't there.
-  local STDIN_BY_BACKEND = { claude = nil, codex = "", copilot = "" }
+  -- claude reads its prompt from argv; codex, copilot and grok are given an explicit empty stdin
+  -- so they do not sit waiting on a terminal that isn't there.
+  local STDIN_BY_BACKEND = { claude = nil, codex = "", copilot = "", grok = "" }
 
   for _, backend in ipairs(helper.adapters()) do
     it("matches the documented stdin handling for " .. backend.name, function()

--- a/tests/lua/infrastructure/hooks/grok_settings_generator_spec.lua
+++ b/tests/lua/infrastructure/hooks/grok_settings_generator_spec.lua
@@ -1,0 +1,52 @@
+local GrokSettingsGenerator = require("vibing.infrastructure.hooks.grok_settings_generator")
+local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+
+describe("grok_settings_generator", function()
+  local tmp_dir
+
+  before_each(function()
+    tmp_dir = vim.fn.tempname()
+    vim.fn.mkdir(tmp_dir, "p")
+  end)
+
+  after_each(function()
+    if tmp_dir then
+      vim.fn.delete(tmp_dir, "rf")
+    end
+  end)
+
+  it("writes a PreToolUse hook JSON under <cwd>/.grok/hooks/", function()
+    local path = GrokSettingsGenerator.ensure(tmp_dir)
+    assert.is_true(vim.fn.filereadable(path) == 1)
+
+    local f = io.open(path, "r")
+    assert.is_not_nil(f)
+    local content = f:read("*a")
+    f:close()
+
+    local ok, decoded = pcall(vim.json.decode, content)
+    assert.is_true(ok)
+    assert.is_table(decoded.hooks)
+    assert.is_table(decoded.hooks.PreToolUse)
+
+    local entry = decoded.hooks.PreToolUse[1]
+    assert.equals(".*", entry.matcher)
+    assert.equals("command", entry.hooks[1].type)
+    local expected = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+    assert.equals(expected, entry.hooks[1].command)
+    assert.is_true(entry.hooks[1].command:sub(1, 1) == "/", "hook command must be absolute for Grok")
+    assert.equals(120, entry.hooks[1].timeout)
+  end)
+
+  it("rewrites the hook file on subsequent ensure calls (path may change on plugin update)", function()
+    local path1 = GrokSettingsGenerator.ensure(tmp_dir)
+    local path2 = GrokSettingsGenerator.ensure(tmp_dir)
+    assert.equals(path1, path2)
+    assert.is_true(vim.fn.filereadable(path2) == 1)
+  end)
+
+  it("returns hook_file_path for a cwd without writing", function()
+    local expected = tmp_dir .. "/.grok/hooks/vibing-nvim-pre-tool-use.json"
+    assert.equals(expected, GrokSettingsGenerator.hook_file_path(tmp_dir))
+  end)
+end)

--- a/tests/lua/infrastructure/hooks/grok_settings_generator_spec.lua
+++ b/tests/lua/infrastructure/hooks/grok_settings_generator_spec.lua
@@ -71,8 +71,19 @@ describe("grok_settings_generator", function()
     assert.is_true(vim.fn.filereadable(path2) == 1)
   end)
 
+  it("escapes a path before writing it as a TOML key", function()
+    -- The trust file is grok's, not ours: an unescaped quote in a cwd would break its structure
+    -- and take the user's other trusted folders down with it.
+    assert.equals('a\\"b', GrokSettingsGenerator._toml_escape('a"b'))
+    assert.equals("a\\\\b", GrokSettingsGenerator._toml_escape("a\\b"))
+    assert.equals("a\\nb", GrokSettingsGenerator._toml_escape("a\nb"))
+    assert.equals("/plain/path", GrokSettingsGenerator._toml_escape("/plain/path"))
+  end)
+
   it("returns hook_file_path for a cwd without writing", function()
-    local expected = tmp_dir .. "/.grok/hooks/vibing-nvim-pre-tool-use.json"
+    -- Resolved, so it agrees with what ensure() writes for a symlinked cwd.
+    local expected = vim.fn.resolve(tmp_dir) .. "/.grok/hooks/vibing-nvim-pre-tool-use.json"
     assert.equals(expected, GrokSettingsGenerator.hook_file_path(tmp_dir))
+    assert.equals(GrokSettingsGenerator.ensure(tmp_dir), GrokSettingsGenerator.hook_file_path(tmp_dir))
   end)
 end)

--- a/tests/lua/infrastructure/hooks/grok_settings_generator_spec.lua
+++ b/tests/lua/infrastructure/hooks/grok_settings_generator_spec.lua
@@ -3,16 +3,42 @@ local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generato
 
 describe("grok_settings_generator", function()
   local tmp_dir
+  local grok_home
+  local saved_grok_home
 
   before_each(function()
     tmp_dir = vim.fn.tempname()
     vim.fn.mkdir(tmp_dir, "p")
+
+    -- ensure() records folder trust, which without this lands in the developer's real
+    -- ~/.grok/trusted_folders.toml -- trust that cascades to subdirectories and is never expired,
+    -- for a tempname() path this spec is about to delete.
+    saved_grok_home = vim.env.GROK_HOME
+    grok_home = vim.fn.tempname()
+    vim.fn.mkdir(grok_home, "p")
+    vim.env.GROK_HOME = grok_home
   end)
 
   after_each(function()
     if tmp_dir then
       vim.fn.delete(tmp_dir, "rf")
     end
+    if grok_home then
+      vim.fn.delete(grok_home, "rf")
+    end
+    vim.env.GROK_HOME = saved_grok_home
+  end)
+
+  it("records folder trust under $GROK_HOME, never the real ~/.grok", function()
+    GrokSettingsGenerator.ensure(tmp_dir)
+
+    local trust_path = grok_home .. "/trusted_folders.toml"
+    assert.is_true(vim.fn.filereadable(trust_path) == 1, "trust file must be written under GROK_HOME")
+
+    local f = io.open(trust_path, "r")
+    local content = f:read("*a")
+    f:close()
+    assert.is_truthy(content:find(vim.fn.resolve(tmp_dir), 1, true))
   end)
 
   it("writes a PreToolUse hook JSON under <cwd>/.grok/hooks/", function()

--- a/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
@@ -16,6 +16,13 @@ local function write_request(request_id, tool_name, tool_input)
   f:close()
 end
 
+--- Write a payload verbatim, for backends whose hook does not speak Claude's key names.
+local function write_raw_request(request_id, payload)
+  local f = assert(io.open(comm_dir .. "/" .. request_id .. ".req", "w"))
+  f:write(vim.json.encode(payload))
+  f:close()
+end
+
 local function read_response(request_id)
   local f = io.open(comm_dir .. "/" .. request_id .. ".res", "r")
   if not f then
@@ -104,5 +111,49 @@ describe("permission handler tool vocabulary", function()
     local vocabulary = require("vibing.infrastructure.adapter.modules.codex_tool_vocabulary")
     assert.equals("Edit", vocabulary.to_canonical("apply_patch"))
     assert.is_nil(vocabulary.to_canonical("Read"))
+  end)
+
+  it("normalizes a payload whose keys are not Claude's before reading the tool name", function()
+    -- Grok's PreToolUse hook sends camelCase. Read straight through, tool_name is nil, every rule
+    -- misses, and the turn stalls until the hook fails closed. Payload captured from grok 0.2.101.
+    local vocabulary = require("vibing.infrastructure.adapter.modules.grok_tool_vocabulary")
+    permission.set_active_opts(HANDLE_ID, {
+      permissions_deny = { "Read" },
+      _tool_vocabulary = vocabulary,
+    })
+
+    write_raw_request("req-grok", {
+      hookEventName = "pre_tool_use",
+      toolName = "read_file",
+      toolInput = { target_file = "/tmp/vault/secret.txt" },
+    })
+    local result = permission.check_tool_permission({ request_id = "req-grok", handle_id = HANDLE_ID })
+
+    assert.equals("denied", result.status)
+    assert.is_not_nil(read_response("req-grok"), "the hook must get a response, not a 120s stall")
+  end)
+
+  it("sends a deny rule's message to the hook, not just back to its own caller", function()
+    -- pre-tool-use.sh echoes permissionDecisionReason on stderr; that is the only route by which
+    -- a rule's `message` reaches the model. Omitting it renders every denial as "denied by hook".
+    permission.set_active_opts(HANDLE_ID, { permissions_deny = { "Edit" } })
+
+    write_request("req-reason", "Edit", { file_path = "/tmp/x.lua" })
+    local result = permission.check_tool_permission({ request_id = "req-reason", handle_id = HANDLE_ID })
+
+    assert.equals("denied", result.status)
+    assert.is_string(result.reason)
+    local response = read_response("req-reason")
+    assert.equals(result.reason, response.hookSpecificOutput.permissionDecisionReason)
+  end)
+
+  it("normalizes the input of such a payload too, so paths rules have a file_path to match", function()
+    -- The two normalizations are separate steps; this pins that the second still runs after the
+    -- first rewrote the payload's keys.
+    local vocabulary = require("vibing.infrastructure.adapter.modules.grok_tool_vocabulary")
+    local normalized = vocabulary.normalize_input(
+      vocabulary.normalize_payload({ toolName = "read_file", toolInput = { target_file = "a.lua" } }).tool_input
+    )
+    assert.equals("a.lua", normalized.file_path)
   end)
 end)


### PR DESCRIPTION
#463 を現在の main に載せ替えたものです。#463 はクローズしてください。

## 持ってきたもの / 持ってこなかったもの

**持ってきた**: `grok_cli.lua` / `grok_command_builder.lua` / `grok_event_processor.lua` / `grok_settings_generator.lua` とその spec。

**持ってこなかった**: #463 が `modes.lua` / `factory.lua` / `frontmatter.lua` / `infrastructure/init.lua` / `permission.lua` に足していた「grok を知っている」分岐。**`agents.lua` の1エントリからすべて導出されます**（#516）。実際 `VALID_AGENTS`・factory・frontmatter 補完はエントリ追加だけで通りました。

**`command_builder_shared.lua`** も持ってきていません。あれは #515（3アダプタの共通ランタイム抽出）の仕事で、ここに混ぜると「バックエンドを1つ足す」PR ではなくなります。Grok が必要としていた3つの小さなヘルパは、Codex が既にそうしているようにローカルに置きました。

## 単に移動できず、作り直した3点

### 1. system prompt は共有せず、Grok 独自の最小構成に

#463 の `build_system_prompt_lines` は、**今なら回帰**になる2つを含んでいました。

- **`handle_id` をターンごとに埋め込む** — #469 で消したもの。毎メッセージでプロンプトキャッシュの前方一致が壊れます
- **`chat_file_path`** — #489 で `chat_bufnr` に置き換え済み。`:VibingSetFileTitle` のリネームで同じくキャッシュが飛ぶため

そもそも **Grok は `chat_bufnr` を登録せず、vibing-nvim MCP サーバーにも到達しません**。`nvim_ask_user_question` を指示しても呼べないツールを名指しするだけなので、`--rules` は worktree 規約と言語指定だけに絞りました。Codex と同じ立ち位置です。

「MCP ツールを名指ししないこと」「ターン間で `--rules` が byte 一致すること」を回帰テストにしています。

### 2. ツール名対応表は vocabulary モジュールへ

`permission.lua` の grok 分岐は `grok_tool_vocabulary.lua` に移しました。あわせて #463 が同じ場所でやっていた**パス正規化**も、新設の任意メソッド `normalize_input` として一緒に移しています。

これは飾りではなく実バグの修正です。granular な `paths` ルールは `input.file_path` を読みますが、Grok は `path` / `target_file` / `filePath` を送るため、**Grok 上では `paths` ルールが1つも当たりません**でした。

### 3. `grok_cli` に builder の pcall ガードが無かった

`send_message.lua` は `stream()` を pcall しないので、grok バイナリが無いとチャットに Lua のスタックトレースが出ていました。他3アダプタは既にガード済みです。

**これは #547 で入れた共有 spec が見つけました。** spec は `agents.lua` を列挙するので、Grok は存在するだけでテスト対象に加わります。そのとき path キャッシュのリセットだけがビルダー3つの直書きリストのままだったので、**`agents.lua` に `command_builder_module` を追加**して helper が導出するようにしました。同じ取りこぼしが次のバックエンドで起きません。

## その他

- `.grok/` は `.vibing/` と同じくリクエスト時に生成されるので ignore しました（テスト実行でリポジトリに書き出されていました）
- `settings_generator.generate()` に hook スクリプトパスの上書きを追加。Grok は相対パスを自分の `.grok/hooks/` JSON から解決するため絶対パスが要ります

## テスト

`pnpm run test:lua` **1136 passed / 0 failed / 0 errors**。`check` `lint` `format:check` すべて green。

新規: `grok_tool_vocabulary_spec`（対応表とパス正規化、非破壊であること）。`grok_command_builder_spec` は、削除した挙動を検証していた3件を新しい意図の検証に差し替えています。

なお **Grok CLI に対する実動作確認はしていません**（手元に `grok` バイナリがないため）。#463 の時点での動作確認に依存しており、今回変わったのは上記3点です。マージ前に実機で1往復確認してもらえると確実です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grok Build CLI as a supported backend.
  * Added streaming responses, session resume, cancellation, model selection, and permission handling for Grok.
  * Added automatic project hook setup and folder trust configuration.
  * Added Grok executable configuration and validation.

* **Documentation**
  * Updated English and Japanese guides with installation, configuration, usage, and troubleshooting details.

* **Bug Fixes**
  * Improved permission matching across backend payload formats and included clearer denial messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->