### PR TITLE
feat: jump between User sections in the chat buffer

### DIFF
--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -8,8 +8,8 @@
 | `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                         |
 | `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                         |
 | `:VibingSubagentChat [position]`      | Continue a subagent this chat started, in its own buffer                                            |
-| `:VibingChatJumpNextUser`             | Move the cursor to the next User section in the chat buffer                                          |
-| `:VibingChatJumpPrevUser`             | Move the cursor to the previous User section in the chat buffer                                      |
+| `:VibingChatJumpNextUser [count]`     | Move the cursor to the next User section in the chat buffer                                         |
+| `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                     |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                   |
 | `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                              |
 | `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                          |
@@ -34,6 +34,22 @@ one. Fork's session/frontmatter mechanics (`forked_from`, session inheritance vi
 are documented in `architecture.md` → "Chat Fork" — not duplicated here. `:VibingSubagentChat`
 takes the same position argument; why it shares the parent's `session_id` and never forks is in
 `architecture.md` → "Subagent Chat".
+
+The two jump commands ship without a keymap. They take a count
+(`:3VibingChatJumpNextUser`) and clamp to the last section rather than refusing to move, and they
+push the starting position onto the jumplist so `<C-o>` comes back — `nvim_win_set_cursor` updates
+neither the `'` mark nor the jumplist on its own.
+
+To bind them as `]`/`[` motions and keep the count, forward `v:count1` explicitly. A plain
+`<Cmd>VibingChatJumpNextUser<CR>` mapping works but always moves one section, and the command
+cannot read `v:count` itself: from the command line that variable still holds the count of the
+last Normal-mode command, so `3j` followed by `:VibingChatJumpNextUser` would jump three sections.
+
+```lua
+vim.keymap.set("n", "]u", function()
+  vim.cmd(vim.v.count1 .. "VibingChatJumpNextUser")
+end, { desc = "Next User section" })
+```
 
 ## Slash Commands (in Chat)
 

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -8,6 +8,8 @@
 | `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                         |
 | `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                         |
 | `:VibingSubagentChat [position]`      | Continue a subagent this chat started, in its own buffer                                            |
+| `:VibingChatJumpNextUser`             | Move the cursor to the next User section in the chat buffer                                          |
+| `:VibingChatJumpPrevUser`             | Move the cursor to the previous User section in the chat buffer                                      |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                   |
 | `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                              |
 | `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                          |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ help tags.
 | `:VibingChat [position\|file]`        | Create new chat with optional position (current\|right\|left\|top\|bottom\|back) or open saved file  |
 | `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                          |
 | `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                          |
+| `:VibingChatJumpNextUser`             | Move the cursor to the next User section in the chat buffer                                          |
+| `:VibingChatJumpPrevUser`             | Move the cursor to the previous User section in the chat buffer                                      |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                    |
 | `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                               |
 | `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                           |

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ help tags.
 | `:VibingChat [position\|file]`        | Create new chat with optional position (current\|right\|left\|top\|bottom\|back) or open saved file  |
 | `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                          |
 | `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                          |
-| `:VibingChatJumpNextUser`             | Move the cursor to the next User section in the chat buffer                                          |
-| `:VibingChatJumpPrevUser`             | Move the cursor to the previous User section in the chat buffer                                      |
+| `:VibingChatJumpNextUser [count]`     | Move the cursor to the next User section in the chat buffer                                          |
+| `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                      |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                    |
 | `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                               |
 | `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                           |

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -185,6 +185,14 @@ function M._register_commands()
     end,
   })
 
+  vim.api.nvim_create_user_command("VibingChatJumpNextUser", function()
+    require("vibing.presentation.chat.controller").handle_jump_user("next")
+  end, { desc = "Jump to the next User section in the chat buffer" })
+
+  vim.api.nvim_create_user_command("VibingChatJumpPrevUser", function()
+    require("vibing.presentation.chat.controller").handle_jump_user("prev")
+  end, { desc = "Jump to the previous User section in the chat buffer" })
+
   vim.api.nvim_create_user_command("VibingSlashCommands", function()
     require("vibing.presentation.chat.controller").show_slash_commands()
   end, { desc = "Show slash command picker" })

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -185,13 +185,15 @@ function M._register_commands()
     end,
   })
 
-  vim.api.nvim_create_user_command("VibingChatJumpNextUser", function()
-    require("vibing.presentation.chat.controller").handle_jump_user("next")
-  end, { desc = "Jump to the next User section in the chat buffer" })
+  -- count = 0 で「カウントを取るが既定は無し」になる。`]u` などに割り当てたとき
+  -- 3]u が3セクション先へ飛ぶよう、他の `]`/`[` 系モーションと揃えている。
+  vim.api.nvim_create_user_command("VibingChatJumpNextUser", function(opts)
+    require("vibing.presentation.chat.controller").handle_jump_user("next", opts.count)
+  end, { count = 0, desc = "Jump to the next User section in the chat buffer" })
 
-  vim.api.nvim_create_user_command("VibingChatJumpPrevUser", function()
-    require("vibing.presentation.chat.controller").handle_jump_user("prev")
-  end, { desc = "Jump to the previous User section in the chat buffer" })
+  vim.api.nvim_create_user_command("VibingChatJumpPrevUser", function(opts)
+    require("vibing.presentation.chat.controller").handle_jump_user("prev", opts.count)
+  end, { count = 0, desc = "Jump to the previous User section in the chat buffer" })
 
   vim.api.nvim_create_user_command("VibingSlashCommands", function()
     require("vibing.presentation.chat.controller").show_slash_commands()

--- a/lua/vibing/presentation/chat/controller.lua
+++ b/lua/vibing/presentation/chat/controller.lua
@@ -200,6 +200,8 @@ end
 ---@param count number|nil 何個進むか（省略時は1）
 ---@return number|nil target 移動先の行番号。移動先が無ければnil
 function M._resolve_jump_target(headers, cur, direction, count)
+  -- Both "no count" spellings arrive here: nil from a direct Lua call, and 0 from
+  -- nvim_create_user_command{ count = 0 } when the user typed none. Neither means "stay put".
   count = math.max(count or 1, 1)
 
   local candidates = {}
@@ -228,6 +230,11 @@ end
 ---@param direction "next"|"prev" 移動方向
 ---@param count number|nil いくつ先のセクションへ飛ぶか（省略時は1）
 function M.handle_jump_user(direction, count)
+  if direction ~= "next" and direction ~= "prev" then
+    notify.warn(string.format("Unknown jump direction: %s", tostring(direction)))
+    return
+  end
+
   local view = require("vibing.presentation.chat.view")
   local current_view = view.get_current()
 
@@ -254,7 +261,10 @@ function M.handle_jump_user(direction, count)
   -- これが無いと、このコマンドに ]u などを割り当てたとき <C-o> で戻れず、
   -- 他の `]`/`[` 系モーションと挙動が食い違う。
   vim.cmd("normal! m'")
-  vim.api.nvim_win_set_cursor(0, { target, 0 })
+  -- pcall to match every other nvim_win_set_cursor call site in the codebase (buffer.lua,
+  -- renderer.lua, oil.lua). `target` came from this same buffer a moment ago, but a cursor move
+  -- is not worth an error dialog if the buffer changed underneath us.
+  pcall(vim.api.nvim_win_set_cursor, 0, { target, 0 })
   vim.cmd("normal! zz")
 end
 

--- a/lua/vibing/presentation/chat/controller.lua
+++ b/lua/vibing/presentation/chat/controller.lua
@@ -179,7 +179,7 @@ end
 ---現在のチャットバッファでUserセクションのヘッダー行番号を集める（1-indexed, 昇順）
 ---@param buf number バッファ番号
 ---@return number[] lines
-local function collect_user_header_lines(buf)
+function M._collect_user_header_lines(buf)
   local Timestamp = require("vibing.core.utils.timestamp")
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   local result = {}
@@ -191,10 +191,43 @@ local function collect_user_header_lines(buf)
   return result
 end
 
+---カーソル行から数えてcount個目のUserヘッダー行を返す
+---countが残り個数を超える場合は端のヘッダーを返す。`]`/`[` 系の慣習に合わせ、
+---「行けるところまで行く」ほうが動かないより使いやすい。
+---@param headers number[] Userヘッダーの行番号（1-indexed, 昇順）
+---@param cur number 現在のカーソル行（1-indexed）
+---@param direction "next"|"prev" 移動方向
+---@param count number|nil 何個進むか（省略時は1）
+---@return number|nil target 移動先の行番号。移動先が無ければnil
+function M._resolve_jump_target(headers, cur, direction, count)
+  count = math.max(count or 1, 1)
+
+  local candidates = {}
+  if direction == "next" then
+    for _, lnum in ipairs(headers) do
+      if lnum > cur then
+        table.insert(candidates, lnum)
+      end
+    end
+  else
+    for i = #headers, 1, -1 do
+      if headers[i] < cur then
+        table.insert(candidates, headers[i])
+      end
+    end
+  end
+
+  if #candidates == 0 then
+    return nil
+  end
+  return candidates[math.min(count, #candidates)]
+end
+
 ---次/前のUserセクションへカーソルを移動
 ---コマンド `:VibingChatJumpNextUser` / `:VibingChatJumpPrevUser` から呼ばれる
 ---@param direction "next"|"prev" 移動方向
-function M.handle_jump_user(direction)
+---@param count number|nil いくつ先のセクションへ飛ぶか（省略時は1）
+function M.handle_jump_user(direction, count)
   local view = require("vibing.presentation.chat.view")
   local current_view = view.get_current()
 
@@ -203,35 +236,24 @@ function M.handle_jump_user(direction)
     return
   end
 
-  local headers = collect_user_header_lines(current_view.buf)
+  local headers = M._collect_user_header_lines(current_view.buf)
   if #headers == 0 then
     notify.info("No User section found")
     return
   end
 
   local cur = vim.api.nvim_win_get_cursor(0)[1] -- 1-indexed
-  local target
-  if direction == "next" then
-    for _, lnum in ipairs(headers) do
-      if lnum > cur then
-        target = lnum
-        break
-      end
-    end
-  else
-    for i = #headers, 1, -1 do
-      if headers[i] < cur then
-        target = headers[i]
-        break
-      end
-    end
-  end
+  local target = M._resolve_jump_target(headers, cur, direction, count)
 
   if not target then
     notify.info(direction == "next" and "No next User section" or "No previous User section")
     return
   end
 
+  -- nvim_win_set_cursor は ' マークも jumplist も更新しないので明示的に積む。
+  -- これが無いと、このコマンドに ]u などを割り当てたとき <C-o> で戻れず、
+  -- 他の `]`/`[` 系モーションと挙動が食い違う。
+  vim.cmd("normal! m'")
   vim.api.nvim_win_set_cursor(0, { target, 0 })
   vim.cmd("normal! zz")
 end

--- a/lua/vibing/presentation/chat/controller.lua
+++ b/lua/vibing/presentation/chat/controller.lua
@@ -176,4 +176,64 @@ function M.handle_subagent_chat(args)
   end)
 end
 
+---現在のチャットバッファでUserセクションのヘッダー行番号を集める（1-indexed, 昇順）
+---@param buf number バッファ番号
+---@return number[] lines
+local function collect_user_header_lines(buf)
+  local Timestamp = require("vibing.core.utils.timestamp")
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local result = {}
+  for i, line in ipairs(lines) do
+    if Timestamp.extract_role(line) == "user" then
+      table.insert(result, i)
+    end
+  end
+  return result
+end
+
+---次/前のUserセクションへカーソルを移動
+---コマンド `:VibingChatJumpNextUser` / `:VibingChatJumpPrevUser` から呼ばれる
+---@param direction "next"|"prev" 移動方向
+function M.handle_jump_user(direction)
+  local view = require("vibing.presentation.chat.view")
+  local current_view = view.get_current()
+
+  if not current_view then
+    notify.warn("Not in a vibing chat buffer")
+    return
+  end
+
+  local headers = collect_user_header_lines(current_view.buf)
+  if #headers == 0 then
+    notify.info("No User section found")
+    return
+  end
+
+  local cur = vim.api.nvim_win_get_cursor(0)[1] -- 1-indexed
+  local target
+  if direction == "next" then
+    for _, lnum in ipairs(headers) do
+      if lnum > cur then
+        target = lnum
+        break
+      end
+    end
+  else
+    for i = #headers, 1, -1 do
+      if headers[i] < cur then
+        target = headers[i]
+        break
+      end
+    end
+  end
+
+  if not target then
+    notify.info(direction == "next" and "No next User section" or "No previous User section")
+    return
+  end
+
+  vim.api.nvim_win_set_cursor(0, { target, 0 })
+  vim.cmd("normal! zz")
+end
+
 return M

--- a/tests/e2e/chat_jump_user_spec.lua
+++ b/tests/e2e/chat_jump_user_spec.lua
@@ -1,0 +1,88 @@
+-- E2E Tests for :VibingChatJumpNextUser / :VibingChatJumpPrevUser
+local helper = require("vibing.testing.e2e_helper")
+
+local TIMEOUTS = {
+  CHAT_CREATION = 2000,
+  BUFFER_READY = 5000,
+  COMMAND = 300,
+}
+
+-- 別インスタンスへの同期RPC呼び出し（失敗時はテストを落とす）
+local function rpc(instance, method, ...)
+  local ok, res = pcall(vim.fn.rpcrequest, instance.job_id, method, ...)
+  assert.is_true(ok, string.format("RPC %s failed: %s", method, tostring(res)))
+  return res
+end
+
+-- チャットバッファに既知のUser/Assistantセクションを流し込む。
+-- User見出しは1行目と5行目に来る（下のレイアウト参照）。
+local function seed_sections(instance)
+  local bufnr = rpc(instance, "nvim_get_current_buf")
+  rpc(instance, "nvim_buf_set_option", bufnr, "modifiable", true)
+  rpc(instance, "nvim_buf_set_lines", bufnr, 0, -1, false, {
+    "## User", -- line 1
+    "first question",
+    "## Assistant",
+    "first answer",
+    "## User", -- line 5
+    "second question",
+    "## Assistant",
+    "second answer",
+  })
+  return bufnr
+end
+
+local function cursor_line(instance)
+  local pos = rpc(instance, "nvim_win_get_cursor", 0)
+  return pos[1]
+end
+
+describe("E2E: Jump to User section", function()
+  local nvim_instance
+
+  before_each(function()
+    nvim_instance = helper.spawn_nvim_instance({
+      headless = true,
+      init_script = "tests/minimal_init.lua",
+    })
+
+    helper.send_keys(nvim_instance, ":VibingChat<CR>")
+    vim.wait(TIMEOUTS.CHAT_CREATION)
+    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    assert.is_true(ok, "Chat buffer should be created")
+
+    seed_sections(nvim_instance)
+  end)
+
+  after_each(function()
+    helper.cleanup_instance(nvim_instance)
+  end)
+
+  it("jumps forward to the next User section", function()
+    rpc(nvim_instance, "nvim_win_set_cursor", 0, { 1, 0 })
+
+    helper.send_keys(nvim_instance, ":VibingChatJumpNextUser<CR>")
+    vim.wait(TIMEOUTS.COMMAND)
+
+    assert.are.equal(5, cursor_line(nvim_instance), "Cursor should move to the second User header")
+  end)
+
+  it("jumps backward to the previous User section", function()
+    -- 5行目のUser見出しから後方ジャンプ → 1行目の最初のUser見出しへ
+    rpc(nvim_instance, "nvim_win_set_cursor", 0, { 5, 0 })
+
+    helper.send_keys(nvim_instance, ":VibingChatJumpPrevUser<CR>")
+    vim.wait(TIMEOUTS.COMMAND)
+
+    assert.are.equal(1, cursor_line(nvim_instance), "Cursor should move to the first User header")
+  end)
+
+  it("stays put when there is no next User section", function()
+    rpc(nvim_instance, "nvim_win_set_cursor", 0, { 5, 0 })
+
+    helper.send_keys(nvim_instance, ":VibingChatJumpNextUser<CR>")
+    vim.wait(TIMEOUTS.COMMAND)
+
+    assert.are.equal(5, cursor_line(nvim_instance), "Cursor should not move past the last User header")
+  end)
+end)

--- a/tests/lua/presentation/chat/controller_jump_user_spec.lua
+++ b/tests/lua/presentation/chat/controller_jump_user_spec.lua
@@ -1,0 +1,95 @@
+--- Unit coverage for the arithmetic behind :VibingChatJumpNextUser / :VibingChatJumpPrevUser.
+--- tests/e2e/chat_jump_user_spec.lua drives the commands for real; this pins the edge cases that
+--- would need one spawned Neovim instance each to reach through the command.
+local Controller = require("vibing.presentation.chat.controller")
+
+describe("controller User section jump", function()
+  local buffers = {}
+
+  local function scratch(lines)
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    table.insert(buffers, buf)
+    return buf
+  end
+
+  after_each(function()
+    for _, buf in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end
+    buffers = {}
+  end)
+
+  describe("_collect_user_header_lines", function()
+    it("finds every spelling of a User header a chat file can contain", function()
+      -- Timestamped, legacy and unsent headers all have to count, or the jump silently skips
+      -- whichever form the file happens to use.
+      local buf = scratch({
+        "---",
+        "vibing.nvim: true",
+        "---",
+        "## User <!-- 2026-08-13 09:00:00 -->", -- 4
+        "hello",
+        "## Assistant <!-- 2026-08-13 09:00:01 -->",
+        "hi",
+        "## User", -- 8, legacy
+        "again",
+        "## Assistant",
+        "sure",
+        "## User <!-- unsent -->", -- 12
+      })
+
+      assert.same({ 4, 8, 12 }, Controller._collect_user_header_lines(buf))
+    end)
+
+    it("returns an empty list for a buffer with no User header", function()
+      local buf = scratch({ "# Notes", "## Assistant", "nothing here" })
+      assert.same({}, Controller._collect_user_header_lines(buf))
+    end)
+  end)
+
+  describe("_resolve_jump_target", function()
+    local headers = { 4, 8, 12 }
+
+    it("moves to the header strictly after the cursor", function()
+      assert.equals(4, Controller._resolve_jump_target(headers, 1, "next"))
+      assert.equals(8, Controller._resolve_jump_target(headers, 4, "next"))
+    end)
+
+    it("moves to the header strictly before the cursor", function()
+      assert.equals(8, Controller._resolve_jump_target(headers, 12, "prev"))
+      assert.equals(4, Controller._resolve_jump_target(headers, 8, "prev"))
+    end)
+
+    it("does not offer the header the cursor already sits on", function()
+      -- Otherwise the command is a no-op when invoked from a header and looks broken.
+      assert.equals(8, Controller._resolve_jump_target(headers, 4, "next"))
+      assert.equals(4, Controller._resolve_jump_target(headers, 8, "prev"))
+    end)
+
+    it("honours a count", function()
+      assert.equals(12, Controller._resolve_jump_target(headers, 1, "next", 3))
+      assert.equals(4, Controller._resolve_jump_target(headers, 12, "prev", 2))
+    end)
+
+    it("treats the command's countless default of 0 as 1", function()
+      -- nvim_create_user_command{ count = 0 } passes 0 when the user typed no count.
+      assert.equals(4, Controller._resolve_jump_target(headers, 1, "next", 0))
+      assert.equals(8, Controller._resolve_jump_target(headers, 12, "prev", 0))
+    end)
+
+    it("stops at the last header when the count overshoots", function()
+      -- Refusing to move would be worse: 5]u near the end should still reach the end.
+      assert.equals(12, Controller._resolve_jump_target(headers, 1, "next", 99))
+      assert.equals(4, Controller._resolve_jump_target(headers, 12, "prev", 99))
+    end)
+
+    it("returns nil past the last and before the first header", function()
+      assert.is_nil(Controller._resolve_jump_target(headers, 12, "next"))
+      assert.is_nil(Controller._resolve_jump_target(headers, 4, "prev"))
+      assert.is_nil(Controller._resolve_jump_target({}, 1, "next"))
+    end)
+  end)
+end)

--- a/tests/lua/presentation/chat/controller_jump_user_spec.lua
+++ b/tests/lua/presentation/chat/controller_jump_user_spec.lua
@@ -2,6 +2,8 @@
 --- tests/e2e/chat_jump_user_spec.lua drives the commands for real; this pins the edge cases that
 --- would need one spawned Neovim instance each to reach through the command.
 local Controller = require("vibing.presentation.chat.controller")
+local view = require("vibing.presentation.chat.view")
+local notify = require("vibing.core.utils.notify")
 
 describe("controller User section jump", function()
   local buffers = {}
@@ -90,6 +92,67 @@ describe("controller User section jump", function()
       assert.is_nil(Controller._resolve_jump_target(headers, 12, "next"))
       assert.is_nil(Controller._resolve_jump_target(headers, 4, "prev"))
       assert.is_nil(Controller._resolve_jump_target({}, 1, "next"))
+    end)
+  end)
+
+  describe("handle_jump_user guard branches", function()
+    -- The E2E spec can only reach these by spawning an instance per case, which is why they were
+    -- uncovered: each is a one-line early return that decides which message the user sees.
+    local original_get_current, original_warn, original_info
+    local messages
+
+    before_each(function()
+      messages = {}
+      original_get_current, original_warn, original_info = view.get_current, notify.warn, notify.info
+      notify.warn = function(msg)
+        table.insert(messages, { level = "warn", msg = msg })
+      end
+      notify.info = function(msg)
+        table.insert(messages, { level = "info", msg = msg })
+      end
+    end)
+
+    after_each(function()
+      view.get_current, notify.warn, notify.info = original_get_current, original_warn, original_info
+    end)
+
+    it("warns when the current buffer is not a chat", function()
+      view.get_current = function()
+        return nil
+      end
+
+      Controller.handle_jump_user("next")
+
+      assert.equals(1, #messages)
+      assert.equals("warn", messages[1].level)
+      assert.equals("Not in a vibing chat buffer", messages[1].msg)
+    end)
+
+    it("says so for a chat with no User section at all", function()
+      -- A brand-new chat, before the first message is committed.
+      local buf = scratch({ "---", "vibing.nvim: true", "---", "" })
+      view.get_current = function()
+        return { buf = buf }
+      end
+
+      Controller.handle_jump_user("next")
+
+      assert.equals(1, #messages)
+      assert.equals("info", messages[1].level)
+      assert.equals("No User section found", messages[1].msg)
+    end)
+
+    it("rejects a direction it does not know instead of silently jumping backwards", function()
+      -- The two commands hardcode next/prev, but the function is exported and reachable.
+      view.get_current = function()
+        error("must not be reached: direction is validated first")
+      end
+
+      Controller.handle_jump_user("sideways")
+
+      assert.equals(1, #messages)
+      assert.equals("warn", messages[1].level)
+      assert.is_truthy(messages[1].msg:find("sideways", 1, true))
     end)
   end)
 end)


### PR DESCRIPTION
## 概要

チャットバッファ内で User セクション（`## User ...` ヘッダー）へ前後ジャンプする **コマンド** を追加します。固定キーマップではなくコマンドとして提供するため、ユーザーが好きなキーに割り当てられます。

| コマンド | 動作 |
| --- | --- |
| `:VibingChatJumpNextUser` | 次の User セクションへジャンプ |
| `:VibingChatJumpPrevUser` | 前の User セクションへジャンプ |

- ジャンプ後は `zz` で画面中央に寄せます
- User セクションが無い／これ以上先が無い場合は通知します
- ヘッダー判定は既存の `Timestamp.extract_role` を再利用（`## User`・タイムスタンプ付き・未送信ヘッダーすべて対応）
- チャットバッファ外で実行した場合は警告します

### キー割り当て例

```lua
vim.api.nvim_create_autocmd("FileType", {
  pattern = "markdown", -- チャットバッファに合わせて調整
  callback = function()
    vim.keymap.set("n", "]u", "<Cmd>VibingChatJumpNextUser<CR>", { buffer = true })
    vim.keymap.set("n", "[u", "<Cmd>VibingChatJumpPrevUser<CR>", { buffer = true })
  end,
})
```

## 変更ファイル

- `lua/vibing/presentation/chat/controller.lua` — `handle_jump_user(direction)` とヘッダー収集ロジック
- `lua/vibing/init.lua` — 2つのユーザーコマンドを登録
- `README.md` / `.claude/rules/commands-reference.md` — コマンド一覧に追記

## 動作確認

- Lua 構文チェック（`loadfile`）済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)