### PR TITLE
fix(mcp): repair the open-then-jump path that "show me the code" and code tours run on

### DIFF
--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -52,6 +52,11 @@ performs: each stop is a real file opened at a real line (`nvim_win_open_file` +
 `nvim_set_cursor`), and the whole route is left in the quickfix list so the user can replay it
 with `:cnext`/`:cprev` afterwards.
 
+Both calls take the target window explicitly, and the skill insists on it: `nvim_win_open_file`
+restores focus before returning, so the window showing the file is never the current one. A
+`nvim_set_cursor` without `winnr` moves the chat's cursor instead — and succeeds, so the tour
+looks like it is working while the code window never moves.
+
 The quickfix half is the MCP tool `nvim_set_qflist` (`mcp-server/src/tools/qflist.ts` →
 `infrastructure/rpc/handlers/qflist.lua`). It always pushes a **new** list
 (`vim.fn.setqflist({}, " ", ...)`), so whatever the user had in quickfix stays reachable under

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -52,6 +52,12 @@ pick a window that isn't the chat → `nvim_win_open_file` → `nvim_set_cursor`
 The CLI's system prompt tells the model to do this, so the tools exist to make that instruction
 actionable.
 
+**Carry the `winnr` through the whole sequence.** `nvim_win_open_file` restores focus before it
+returns, so the window it opened is not the current one. `nvim_set_cursor` without a `winnr` moves
+whatever window is active — the chat — and `nvim_highlight_range` wants the `bufnr` the open
+returned, not `0`. Both take the target explicitly for this reason; neither errors when pointed at
+the wrong one, so the failure is silent.
+
 `nvim_highlight_range` puts an extmark range in the `vibing_highlight` namespace using the
 `VibingHighlight` group, which is `default link`ed to `Visual` so `hi VibingHighlight ...` in a
 user's config overrides it. It clears itself after `duration_ms` (default 3000; `0` keeps it), and

--- a/lua/vibing/infrastructure/rpc/handlers/cursor.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/cursor.lua
@@ -12,19 +12,30 @@ function M.get_cursor_position(params)
   }
 end
 
--- Set the window cursor to the specified position.
+-- Set a window's cursor to the specified position.
+--
+-- `winnr` matters more than it looks. Window 0 is the *current* window, which is not the one
+-- `win_open_file` just opened a file in — that handler restores focus before returning. So the
+-- documented open-then-jump sequence ("show me the code", every stop of the code-tour skill)
+-- moved the chat's cursor instead of the opened file's until this took a window.
+--
 -- @param params Table with cursor position fields:
 --   - line (number): 1-based line number to move the cursor to (required).
 --   - col (number): 0-based column number within the line (optional, defaults to 0).
+--   - winnr (number): window to move (optional, defaults to the current window).
 -- @return table A table `{ success = true }` on successful cursor move.
--- @throws error if `params.line` is not provided.
+-- @throws error if `params.line` is not provided, or `params.winnr` is not a valid window.
 function M.set_cursor_position(params)
   local line = params and params.line
   local col = params and params.col or 0
+  local winnr = params and params.winnr
   if not line then
     error("Missing line parameter")
   end
-  vim.api.nvim_win_set_cursor(0, { line, col })
+  if winnr and not vim.api.nvim_win_is_valid(winnr) then
+    error("Invalid window number: " .. tostring(winnr))
+  end
+  vim.api.nvim_win_set_cursor(winnr or 0, { line, col })
   return { success = true }
 end
 

--- a/lua/vibing/infrastructure/rpc/handlers/window.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/window.lua
@@ -240,7 +240,9 @@ function M.win_open_file(params)
   if filepath == "" or filepath:match("^%s*$") then
     error("Invalid filepath: empty or whitespace-only")
   end
-  if filepath:match("\0") then
+  -- Plain find, not match: Lua 5.1 patterns cannot contain an embedded zero, so `match("\0")`
+  -- parses as the *empty* pattern and matches every string -- this guard rejected every path.
+  if filepath:find("\0", 1, true) then
     error("Invalid filepath: contains null character")
   end
   if not vim.api.nvim_win_is_valid(winnr) then

--- a/mcp-server/src/__tests__/cursor-tools.test.ts
+++ b/mcp-server/src/__tests__/cursor-tools.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { allTools } from '../tools/index.js';
+import { handlers } from '../handlers/index.js';
+import * as rpc from '../rpc.js';
+
+vi.mock('../rpc.js', () => ({
+  callNeovim: vi.fn(),
+}));
+
+function call(args: Record<string, unknown>) {
+  return handlers.nvim_set_cursor(args);
+}
+
+describe('nvim_set_cursor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true });
+  });
+
+  describe('registration', () => {
+    it('accepts an optional winnr alongside the required line', () => {
+      const tool = allTools.find((t) => t.name === 'nvim_set_cursor');
+      const inputSchema = tool?.inputSchema as {
+        required?: string[];
+        properties: Record<string, unknown>;
+      };
+
+      expect(inputSchema.properties.winnr).toBeDefined();
+      expect(inputSchema.required).toContain('line');
+      expect(inputSchema.required).not.toContain('winnr');
+    });
+
+    it('tells the model why winnr matters after nvim_win_open_file', () => {
+      // Without this the model has no way to know the open-then-jump sequence needs it: the
+      // tool call succeeds either way, it just moves the wrong window.
+      const tool = allTools.find((t) => t.name === 'nvim_set_cursor');
+      expect(tool?.description).toMatch(/winnr/);
+      expect(tool?.description).toMatch(/nvim_win_open_file/);
+    });
+  });
+
+  describe('forwarding', () => {
+    it('passes winnr through to the Neovim instance', async () => {
+      await call({ line: 12, col: 2, winnr: 1002, rpc_port: 9876 });
+
+      expect(rpc.callNeovim).toHaveBeenCalledWith(
+        'set_cursor_position',
+        { line: 12, col: 2, winnr: 1002 },
+        9876
+      );
+    });
+
+    it('leaves winnr undefined when the caller omits it, so the active window is used', async () => {
+      await call({ line: 3, rpc_port: 9876 });
+
+      expect(rpc.callNeovim).toHaveBeenCalledWith(
+        'set_cursor_position',
+        { line: 3, col: undefined, winnr: undefined },
+        9876
+      );
+    });
+
+    it('names the window it moved, so a wrong-window call is visible in the result', async () => {
+      const withWin = await call({ line: 12, winnr: 1002, rpc_port: 9876 });
+      expect(withWin.content[0].text).toBe('Cursor moved to line 12 in window 1002');
+
+      const withoutWin = await call({ line: 12, rpc_port: 9876 });
+      expect(withoutWin.content[0].text).toBe('Cursor moved to line 12');
+    });
+
+    it('still rejects a call with no line', async () => {
+      await expect(call({ winnr: 1002, rpc_port: 9876 })).rejects.toThrow(
+        'Missing required parameter: line'
+      );
+      expect(rpc.callNeovim).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mcp-server/src/handlers/cursor.ts
+++ b/mcp-server/src/handlers/cursor.ts
@@ -15,7 +15,9 @@ export async function handleGetCursor(args: any) {
 /**
  * Move Neovim's cursor to the specified line and optional column.
  *
- * @param args - Object containing cursor position; must include `line` (number). `col` (number) is optional.
+ * @param args - Object containing cursor position; must include `line` (number). `col` (number) and
+ * `winnr` (number) are optional. Without `winnr` the currently active window is moved, which is
+ * not the one `nvim_win_open_file` just opened a file in — it restores focus before returning.
  * @returns An object with a `content` array containing a single text node confirming the new cursor line.
  * @throws Error if `args` is falsy or `args.line` is undefined with message 'Missing required parameter: line'.
  */
@@ -28,11 +30,13 @@ export async function handleSetCursor(args: any) {
     {
       line: args.line,
       col: args.col,
+      winnr: args.winnr,
     },
     args?.rpc_port
   );
+  const where = args.winnr === undefined ? '' : ` in window ${args.winnr}`;
   return {
-    content: [{ type: 'text', text: `Cursor moved to line ${args.line}` }],
+    content: [{ type: 'text', text: `Cursor moved to line ${args.line}${where}` }],
   };
 }
 

--- a/mcp-server/src/tools/cursor.ts
+++ b/mcp-server/src/tools/cursor.ts
@@ -12,7 +12,10 @@ export const cursorTools = [
   },
   {
     name: 'nvim_set_cursor',
-    description: 'Set cursor position',
+    description:
+      'Set cursor position. Pass winnr when you opened the file with nvim_win_open_file — that ' +
+      'tool leaves focus where it was, so without winnr this moves the cursor of whatever window ' +
+      'is currently active (usually the chat), not the file you just opened.',
     inputSchema: {
       type: 'object' as const,
       properties: withRpcPort({
@@ -23,6 +26,11 @@ export const cursorTools = [
         col: {
           type: 'number' as const,
           description: 'Column number (0-indexed)',
+        },
+        winnr: {
+          type: 'number' as const,
+          description:
+            'Window to move the cursor in, as returned by nvim_list_windows. Defaults to the currently active window.',
         },
       }),
       required: requireRpcPort(['line']),

--- a/skills/vibing-code-tour/SKILL.md
+++ b/skills/vibing-code-tour/SKILL.md
@@ -52,9 +52,15 @@ result.
 For each stop:
 
 1. `nvim_list_windows` to find a window that isn't the chat buffer — never assume `winnr: 0`
-2. `nvim_win_open_file` with that `winnr`, then `nvim_set_cursor` (1-based line, **0-based** col)
+2. `nvim_win_open_file` with that `winnr`, then `nvim_set_cursor` with **the same `winnr`**
+   (1-based line, **0-based** col)
 3. Explain that stop in chat: what this code does, and why the flow moves from here to the next
    stop
+
+Pass `winnr` to `nvim_set_cursor` every time. `nvim_win_open_file` restores focus before it
+returns, so the window holding the file is not the current one; omitting `winnr` moves the chat's
+cursor instead and nothing reports an error. Same for `nvim_highlight_range` — give it the `bufnr`
+the open returned, not `0`.
 
 ### 4. Let the user set the pace
 

--- a/tests/lua/infrastructure/rpc/handlers/cursor_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/cursor_spec.lua
@@ -67,6 +67,16 @@ describe("set_cursor_position", function()
     assert.equals(0, vim.api.nvim_win_get_cursor(other_win)[2])
   end)
 
+  it("treats an explicit winnr of 0 as the active window, the way the nvim API does", function()
+    -- 0 is truthy in Lua, so it reaches the validity check rather than the `or 0` fallback --
+    -- and nvim_win_is_valid(0) is true, since 0 is the API's own name for the current window.
+    -- Same destination by either route, but worth pinning: a reviewer read it as "0 is rejected".
+    cursor.set_cursor_position({ line = 9, winnr = 0 })
+
+    assert.equals(9, vim.api.nvim_win_get_cursor(origin_win)[1])
+    assert.equals(1, vim.api.nvim_win_get_cursor(other_win)[1])
+  end)
+
   it("rejects an invalid window instead of silently moving the active one", function()
     local ok, err = pcall(cursor.set_cursor_position, { line = 3, winnr = 999999 })
 

--- a/tests/lua/infrastructure/rpc/handlers/cursor_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/cursor_spec.lua
@@ -1,0 +1,82 @@
+--- set_cursor_position defaulted to window 0 with no way to name another one, so the documented
+--- "open the file, then jump to the line" sequence moved the *chat's* cursor: win_open_file
+--- restores focus before it returns.
+local cursor = require("vibing.infrastructure.rpc.handlers.cursor")
+
+describe("set_cursor_position", function()
+  local origin_win
+  local other_win
+  local origin_buf
+  local other_buf
+
+  local function fill(buf)
+    local lines = {}
+    for i = 1, 20 do
+      lines[i] = "line " .. i
+    end
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  end
+
+  before_each(function()
+    origin_buf = vim.api.nvim_create_buf(false, true)
+    fill(origin_buf)
+    vim.api.nvim_set_current_buf(origin_buf)
+    origin_win = vim.api.nvim_get_current_win()
+
+    vim.cmd("vsplit")
+    other_win = vim.api.nvim_get_current_win()
+    other_buf = vim.api.nvim_create_buf(false, true)
+    fill(other_buf)
+    vim.api.nvim_win_set_buf(other_win, other_buf)
+
+    vim.api.nvim_set_current_win(origin_win)
+    vim.api.nvim_win_set_cursor(origin_win, { 1, 0 })
+    vim.api.nvim_win_set_cursor(other_win, { 1, 0 })
+  end)
+
+  after_each(function()
+    if other_win and vim.api.nvim_win_is_valid(other_win) and #vim.api.nvim_list_wins() > 1 then
+      vim.api.nvim_win_close(other_win, true)
+    end
+    for _, buf in ipairs({ origin_buf, other_buf }) do
+      if buf and vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end
+  end)
+
+  it("moves the named window, not the active one", function()
+    cursor.set_cursor_position({ line = 12, col = 2, winnr = other_win })
+
+    assert.equals(12, vim.api.nvim_win_get_cursor(other_win)[1])
+    assert.equals(2, vim.api.nvim_win_get_cursor(other_win)[2])
+    assert.equals(1, vim.api.nvim_win_get_cursor(origin_win)[1], "the active window must not move")
+    assert.equals(origin_win, vim.api.nvim_get_current_win(), "focus must stay put")
+  end)
+
+  it("still moves the active window when winnr is omitted", function()
+    -- Every existing caller passes no winnr; that has to keep working.
+    cursor.set_cursor_position({ line = 7 })
+
+    assert.equals(7, vim.api.nvim_win_get_cursor(origin_win)[1])
+    assert.equals(1, vim.api.nvim_win_get_cursor(other_win)[1])
+  end)
+
+  it("defaults col to 0", function()
+    cursor.set_cursor_position({ line = 5, winnr = other_win })
+    assert.equals(0, vim.api.nvim_win_get_cursor(other_win)[2])
+  end)
+
+  it("rejects an invalid window instead of silently moving the active one", function()
+    local ok, err = pcall(cursor.set_cursor_position, { line = 3, winnr = 999999 })
+
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("Invalid window number", 1, true))
+    assert.equals(1, vim.api.nvim_win_get_cursor(origin_win)[1])
+  end)
+
+  it("still requires a line", function()
+    assert.is_false(pcall(cursor.set_cursor_position, { winnr = other_win }))
+    assert.is_false(pcall(cursor.set_cursor_position, {}))
+  end)
+end)

--- a/tests/lua/infrastructure/rpc/handlers/window_open_file_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/window_open_file_spec.lua
@@ -1,0 +1,74 @@
+--- win_open_file is what the "show me the code" instruction and the vibing-code-tour skill both
+--- run on, and it had no test: a NUL guard written as `match("\0")` rejected every path, because
+--- Lua 5.1 patterns cannot contain an embedded zero and the pattern parsed as the empty one.
+local window = require("vibing.infrastructure.rpc.handlers.window")
+
+describe("win_open_file", function()
+  local tmp_file
+  local original_win
+  local target_win
+  local created_bufs = {}
+
+  before_each(function()
+    tmp_file = vim.fn.tempname() .. ".lua"
+    vim.fn.writefile({ "-- opened by the spec", "return {}" }, tmp_file)
+
+    original_win = vim.api.nvim_get_current_win()
+    vim.cmd("vsplit")
+    target_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_current_win(original_win)
+  end)
+
+  after_each(function()
+    if target_win and vim.api.nvim_win_is_valid(target_win) and #vim.api.nvim_list_wins() > 1 then
+      vim.api.nvim_win_close(target_win, true)
+    end
+    for _, buf in ipairs(created_bufs) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end
+    created_bufs = {}
+    if tmp_file then
+      vim.fn.delete(tmp_file)
+    end
+  end)
+
+  it("opens an ordinary path", function()
+    -- The regression: this errored with "contains null character" for every path.
+    local result = window.win_open_file({ winnr = target_win, filepath = tmp_file })
+
+    assert.is_true(result.success)
+    table.insert(created_bufs, result.bufnr)
+    -- resolve() on both sides: tempname() hands back /var/... while the buffer name comes back
+    -- as /private/var/... on macOS.
+    assert.equals(vim.fn.resolve(tmp_file), vim.fn.resolve(vim.api.nvim_buf_get_name(result.bufnr)))
+    assert.equals(result.bufnr, vim.api.nvim_win_get_buf(target_win))
+  end)
+
+  it("leaves focus where it was", function()
+    -- The tour narrates from the chat window; stealing focus would move the user's cursor.
+    local result = window.win_open_file({ winnr = target_win, filepath = tmp_file })
+    table.insert(created_bufs, result.bufnr)
+
+    assert.equals(original_win, vim.api.nvim_get_current_win())
+  end)
+
+  it("still rejects a path that really does contain a NUL", function()
+    local ok, err = pcall(window.win_open_file, { winnr = target_win, filepath = "/tmp/a\0b.lua" })
+
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("null character", 1, true))
+  end)
+
+  it("rejects an empty or whitespace-only path", function()
+    assert.is_false(pcall(window.win_open_file, { winnr = target_win, filepath = "" }))
+    assert.is_false(pcall(window.win_open_file, { winnr = target_win, filepath = "   " }))
+  end)
+
+  it("rejects a missing parameter and an invalid window", function()
+    assert.is_false(pcall(window.win_open_file, { winnr = target_win }))
+    assert.is_false(pcall(window.win_open_file, { filepath = tmp_file }))
+    assert.is_false(pcall(window.win_open_file, { winnr = 999999, filepath = tmp_file }))
+  end)
+end)


### PR DESCRIPTION
「コードを見せて」の指示と `vibing-code-tour` スキルが乗っている経路に、独立した不具合が2つありました。ツアーを実行しようとして両方見つかりました。1つ目は1ストップ目でエラーになり、2つ目はエラーにならないまま**間違ったウィンドウを動かします**。

## 1. `nvim_win_open_file` があらゆるパスを拒否していた

```
Error: window.lua:244: Invalid filepath: contains null character
```

NUL チェックが `filepath:match("\0")` と書かれていました。Lua 5.1 のパターンには埋め込みゼロを書けず（[マニュアル 5.4.1](https://www.lua.org/manual/5.1/manual.html#5.4.1) が明記）、パターン文字列は NUL の手前で終わって**空パターン**として解釈されます。空パターンは任意の文字列にマッチするので、このガードは常に真です。

```
("/tmp/a.lua"):match("\0")  -->  ""     -- 空文字列 = truthy
("/tmp/a.lua"):match("")    -->  ""     -- 同じ
("/tmp/a.lua"):match("%z")  -->  nil    -- 正しい書き方
```

`find("\0", 1, true)` に置き換えました。plain 指定の検索なので NUL は単なる1バイトです。`%z` でも直りますが、リポジトリ内のもう1箇所の NUL チェック（`core/utils/request_diff.lua:174`）が既に `find(..., 1, true)` の形なのでそちらに揃えています。同じ誤りは他にありません。

## 2. `nvim_set_cursor` が対象ウィンドウを指定できなかった

`cursor.lua` は `nvim_win_set_cursor(0, ...)` 固定でした。ウィンドウ0は**現在**のウィンドウですが、`nvim_win_open_file` はフォーカスを元に戻してから返るので、ファイルを開いたウィンドウは決して現在のウィンドウではありません。

つまり `mcp-integration.md` と code-tour スキルが指示している「開く → 飛ぶ」を書いてあるとおりに呼ぶと、**カーソルが動くのはチャットバッファ**です。しかも呼び出しは成功するので、ツアーは動いているように見えて実際にはコードウィンドウが1行も動きません。

省略可能な `winnr` を足しました。

- 省略時は従来どおり現在のウィンドウ（既存の呼び出しはそのまま動きます）
- 不正な `winnr` は「現在のウィンドウに黙ってフォールバック」ではなくエラー
- ツール説明とスキルに「なぜ渡す必要があるか」を明記しました。呼び出しが失敗しない以上、モデルが気づく手段が他にないためです

`nvim_highlight_range` も同様に `bufnr` を明示する必要がある（`0` はチャットになる）ので、その注意もドキュメントに追記しています。

## テスト

どちらのハンドラにも spec が1本もありませんでした。

**`window_open_file_spec.lua`（5本）** — 通常パスが開けること / フォーカスが元のウィンドウに残ること / **本物の NUL を含むパスは引き続き拒否すること** / 空・空白のみのパスを拒否 / パラメータ欠落と不正 `winnr` を拒否。修正前は5本中2本が落ちます。

**`cursor_spec.lua`（5本）** — 指定ウィンドウが動きアクティブ側は動かないこと / `winnr` 省略時は従来どおりアクティブ側が動くこと / `col` 既定0 / 不正 `winnr` を拒否 / `line` は必須のまま。

**`cursor-tools.test.ts`（5本）** — スキーマが `winnr` を任意で公開し `line` は必須のままであること / 説明が `nvim_win_open_file` との関係に触れていること / `winnr` が RPC に転送されること / 省略時に `undefined` のままであること / 結果テキストが動かしたウィンドウを名指しすること。

さらに2つを組み合わせた通しの確認も取りました。

```
opened bufnr      = 3
code win cursor   = 17  (期待 17)
chat win cursor   = 1   (期待 1 / 動かない)
focus is chat     = true
```

`test:lua` 1094 pass / 0 fail、mcp-server 113 pass、`check` / `lint` / `format:check` / `build` も通っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)