### PR TITLE
fix(test): make the E2E specs actually run, and keep them out of test:lua

### DIFF
--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -133,9 +133,13 @@ Which database should we use?
 1. PostgreSQL
 2. MySQL
 3. SQLite
-
-Please answer the question and press `<CR>` to send.
 ```
+
+That is the whole of it — the question text and the options, appended under the unsent `## User`
+header. There is no trailing "press `<CR>` to send" line; only the _approval_ UI has one
+(`renderer.lua`). This example used to include one, and `tests/e2e/ask_user_question_spec.lua` was
+written against the documentation rather than the renderer, so it waited forever for a string
+nothing emits.
 
 Single-select questions render as a numbered list (`1. 2. 3.`); multi-select questions render as a
 bullet list (`- - -`). The user deletes unwanted options with standard Vim commands (`dd`, etc.)

--- a/.claude/rules/self-testing.md
+++ b/.claude/rules/self-testing.md
@@ -8,6 +8,25 @@ For test architecture, the helper API reference (`spawn_nvim_instance`, `send_ke
 and troubleshooting, see the `self-testing` skill (`.claude/skills/self-testing/SKILL.md`).
 Invoke it when writing or debugging E2E tests.
 
+**These specs spend real tokens, and only `test:e2e` runs them.** Some drive a full turn against
+the CLI. `test:lua` sweeps `tests/` including `tests/e2e/`, so every spec self-skips unless
+`VIBING_E2E=1` — which only `test:e2e` sets (`helper.should_run()`). Do not remove that guard to
+"make E2E part of the normal suite": that is a per-run API bill on `pnpm run test`.
+
+Three things the child Neovim needs, each of which silently produced a dead spec before:
+
+- **`--embed`.** `spawn_nvim_instance` starts the child with it, because `jobstart{ rpc = true }`
+  talks msgpack-RPC to its stdio. Without it every `rpcrequest` fails and the spec never gets past
+  its first wait — which is the state all four specs were in.
+- **`tests/e2e_init.lua`, not `tests/minimal_init.lua`.** The latter is the _parent's_ init (it
+  wires up plenary); a child started with it has vibing.nvim on `runtimepath` but never calls
+  `setup()`, so no `:Vibing*` command exists and `:VibingChat` does nothing. `e2e_init.lua` also
+  points `chat.save_dir` at a per-child temp directory, so running the suite stops writing real
+  chat files into the repository.
+- **`wait_for_buffer_name`, not `wait_for_buffer_content`, for a filename.** The latter matches
+  against buffer _text_, so `wait_for_buffer_content(inst, "%.md")` can never match. That one line,
+  repeated at six sites, is what every spec was actually failing on.
+
 ## Agent Behavior Evals
 
 E2E covers the harness; it does not cover whether the **agent** still behaves. `pnpm run test:eval`

--- a/.claude/skills/self-testing/SKILL.md
+++ b/.claude/skills/self-testing/SKILL.md
@@ -31,10 +31,12 @@ unique RPC port in the 9876-9925 range.
 
 ```bash
 npm run test:e2e   # all E2E tests (sets VIBING_E2E=1; spends real tokens)
-npm test           # unit + E2E
+npm test           # unit only (test:lua + test:node) — E2E is deliberately not included
 
-# Specific file
-nvim --headless -c "PlenaryBustedDirectory tests/e2e/ { minimal_init = 'tests/minimal_init.lua' }"
+# Specific file. VIBING_E2E=1 is required: without it every spec self-skips, and the run reports
+# "0 tests" as a pass rather than telling you nothing ran.
+VIBING_E2E=1 nvim --headless -u tests/minimal_init.lua \
+  -c "PlenaryBustedFile tests/e2e/chat_jump_user_spec.lua"
 ```
 
 ## Writing a Test

--- a/.claude/skills/self-testing/SKILL.md
+++ b/.claude/skills/self-testing/SKILL.md
@@ -15,7 +15,8 @@ Test Runner (Current Nvim)
   ├─ lua/vibing/testing/e2e_helper.lua
   │   ├─ spawn_nvim_instance()  - Launch child Nvim via jobstart(rpc=true)
   │   ├─ send_keys()             - Send key input via rpcrequest
-  │   ├─ wait_for_buffer_content() - Poll buffer until pattern matches
+  │   ├─ wait_for_buffer_content() - Poll buffer TEXT until pattern matches
+  │   ├─ wait_for_buffer_name()    - Poll buffer NAME (use this for a filename)
   │   └─ cleanup_instance()      - Stop job
   │
   └─ tests/e2e/*.spec.lua - plenary.nvim test specs
@@ -29,7 +30,7 @@ unique RPC port in the 9876-9925 range.
 ## Running Tests
 
 ```bash
-npm run test:e2e   # all E2E tests
+npm run test:e2e   # all E2E tests (sets VIBING_E2E=1; spends real tokens)
 npm test           # unit + E2E
 
 # Specific file
@@ -49,7 +50,7 @@ describe("E2E: Chat basic flow", function()
   before_each(function()
     nvim_instance = helper.spawn_nvim_instance({
       headless = true,
-      init_script = "tests/minimal_init.lua",
+      init_script = "tests/e2e_init.lua",
     })
   end)
 
@@ -61,7 +62,7 @@ describe("E2E: Chat basic flow", function()
     helper.send_keys(nvim_instance, ":VibingChat<CR>")
     vim.wait(2000)
 
-    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", 5000)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", 5000)
     assert.is_true(ok, "Chat buffer should be created with .md extension")
 
     ok = helper.wait_for_buffer_content(nvim_instance, "created_at:", 2000)
@@ -84,7 +85,9 @@ responses 30000ms, command execution 1000-2000ms.
 Spawn a separate Neovim instance for testing.
 
 - `config.headless` (boolean) - run without UI
-- `config.init_script` (string) - path to init script (e.g. `"tests/minimal_init.lua"`)
+- `config.init_script` (string) - path to the _child's_ init. Use `"tests/e2e_init.lua"`:
+  `minimal_init.lua` is the parent's and leaves the child without `setup()`, so no `:Vibing*`
+  command exists
 - `config.cwd` (string, optional) - working directory
 - Returns: `instance` table with a `job_id` field
 

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -35,8 +35,10 @@ function M.spawn_nvim_instance(config)
   -- parent asking for it afterwards. Asking would mean an rpcrequest during cleanup, and
   -- rpcrequest has no timeout: a child wedged by a failing test would hang after_each, and with
   -- it the whole suite. Owning the path here means cleanup only ever calls jobstop and delete.
+  -- Only the path is decided here; tests/e2e_init.lua does the mkdir in the child. Creating it
+  -- before jobstart would leak the directory on the `error()` below, since the caller never gets
+  -- an instance to hand to cleanup_instance.
   local chat_dir = vim.fn.tempname() .. "/chat"
-  vim.fn.mkdir(chat_dir, "p")
 
   local instance = {
     chat_dir = chat_dir,
@@ -178,7 +180,8 @@ function M.cleanup_instance(instance)
   -- jobstop first, and no RPC anywhere in here: a child wedged by a failing test must not be able
   -- to hang the suite's cleanup. `chat_dir` is the path this process created in
   -- spawn_nvim_instance, so it needs no validation before deletion — nothing the child said is
-  -- involved. Delete the tempname() directory itself, one level above the `chat` subdir.
+  -- involved. Delete the tempname() directory itself, one level above the `chat` subdir; if the
+  -- child never got far enough to create it, this is a no-op.
   vim.fn.jobstop(instance.job_id)
 
   if type(instance.chat_dir) == "string" and instance.chat_dir ~= "" then

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -219,7 +219,9 @@ function M.cleanup_instance(instance)
   -- The base comes from tempname()'s own layout (`<temp>/nvim.<user>/<rand>/<counter>`), a Neovim
   -- implementation detail. If that ever changes the comparison simply stops matching, so the
   -- failure mode is a leftover temp directory rather than a wrong `rf`.
-  local temp_base = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.tempname(), ":h:h"))
+  -- Trailing separator so the prefix test lands on a directory boundary: without it a base of
+  -- `<temp>/nvim.foo` also matches `<temp>/nvim.foobar/...`, a different directory entirely.
+  local temp_base = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.tempname(), ":h:h")) .. "/"
   if vim.fs.normalize(chat_dir):find(temp_base, 1, true) == 1 then
     vim.fn.delete(vim.fn.fnamemodify(chat_dir, ":h"), "rf")
   end

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -15,7 +15,7 @@ end
 
 ---別Neovimインスタンスを起動
 ---@param config? { headless?: boolean, init_script?: string, cwd?: string }
----@return table インスタンスハンドル { job_id: number }
+---@return table インスタンスハンドル { job_id: number, chat_dir: string }
 function M.spawn_nvim_instance(config)
   config = config or {}
 
@@ -31,10 +31,19 @@ function M.spawn_nvim_instance(config)
     table.insert(cmd, config.init_script)
   end
 
+  -- The parent picks where the child writes its chats, rather than the child picking and the
+  -- parent asking for it afterwards. Asking would mean an rpcrequest during cleanup, and
+  -- rpcrequest has no timeout: a child wedged by a failing test would hang after_each, and with
+  -- it the whole suite. Owning the path here means cleanup only ever calls jobstop and delete.
+  local chat_dir = vim.fn.tempname() .. "/chat"
+  vim.fn.mkdir(chat_dir, "p")
+
   local instance = {
+    chat_dir = chat_dir,
     job_id = vim.fn.jobstart(cmd, {
       cwd = config.cwd or vim.fn.getcwd(),
       rpc = true,
+      env = { VIBING_E2E_CHAT_DIR = chat_dir },
       on_exit = function(_, code)
         if code ~= 0 then
           vim.notify("[E2E] Nvim instance exited with code: " .. code, vim.log.levels.WARN)
@@ -159,33 +168,21 @@ function M.wait_for_buffer_name(instance, pattern, timeout)
 end
 
 ---インスタンスをクリーンアップ
----子が書いたチャットファイルの一時ディレクトリも消す（tests/e2e_init.luaが場所を伝えてくる）
+---子が書いたチャットファイルの一時ディレクトリも消す（spawn時にこちらが決めた場所）
 ---@param instance table インスタンスハンドル
 function M.cleanup_instance(instance)
   if not instance or not instance.job_id then
     return
   end
 
-  local ok, chat_dir = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_get_var", "vibing_e2e_chat_dir")
+  -- jobstop first, and no RPC anywhere in here: a child wedged by a failing test must not be able
+  -- to hang the suite's cleanup. `chat_dir` is the path this process created in
+  -- spawn_nvim_instance, so it needs no validation before deletion — nothing the child said is
+  -- involved. Delete the tempname() directory itself, one level above the `chat` subdir.
   vim.fn.jobstop(instance.job_id)
 
-  if not ok or type(chat_dir) ~= "string" or chat_dir == "" then
-    return
-  end
-
-  -- This path arrived over RPC and is about to be handed to `delete(..., "rf")`, so confirm it is
-  -- under the system temp dir first. Normalize both sides with vim.fs.normalize, which collapses
-  -- `..`: a prefix test on raw strings (or on `fnamemodify(:p)`, which leaves `..` in place —
-  -- checked, not assumed) would accept `<temp>/../../etc`.
-  --
-  -- The base comes from tempname()'s own layout (`<temp>/nvim.<user>/<rand>/<counter>`), a Neovim
-  -- implementation detail. If that ever changes the comparison simply stops matching, so the
-  -- failure mode is a leftover temp directory rather than a wrong `rf`.
-  -- Trailing separator so the prefix test lands on a directory boundary: without it a base of
-  -- `<temp>/nvim.foo` also matches `<temp>/nvim.foobar/...`, a different directory entirely.
-  local temp_base = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.tempname(), ":h:h")) .. "/"
-  if vim.fs.normalize(chat_dir):find(temp_base, 1, true) == 1 then
-    vim.fn.delete(vim.fn.fnamemodify(chat_dir, ":h"), "rf")
+  if type(instance.chat_dir) == "string" and instance.chat_dir ~= "" then
+    vim.fn.delete(vim.fn.fnamemodify(instance.chat_dir, ":h"), "rf")
   end
 end
 

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -2,13 +2,27 @@
 ---E2Eテスト用のヘルパー関数集
 local M = {}
 
+---E2E specを実行してよい環境かどうか
+---
+---`test:lua`は`PlenaryBustedDirectory tests/`なので`tests/e2e/`まで巻き込む。E2Eは子Neovimを
+---起動して**実際にCLIへリクエストを投げる**ものがあり、通常のユニットテストのつもりで回すと
+---黙ってトークンを使う。`test:e2e`だけが`VIBING_E2E=1`を立てるので、それ以外では各specが
+---自分でスキップする。
+---@return boolean
+function M.should_run()
+  return vim.env.VIBING_E2E == "1"
+end
+
 ---別Neovimインスタンスを起動
 ---@param config? { headless?: boolean, init_script?: string, cwd?: string }
 ---@return table インスタンスハンドル { job_id: number }
 function M.spawn_nvim_instance(config)
   config = config or {}
 
-  local cmd = { "nvim", "--clean" }
+  -- --embed makes the child's stdio a msgpack-RPC channel, which is what `rpc = true` below is
+  -- talking to. Without it the child starts as an ordinary editor, every rpcrequest fails, and
+  -- the spec never gets past its first wait.
+  local cmd = { "nvim", "--clean", "--embed" }
   if config.headless then
     table.insert(cmd, "--headless")
   end
@@ -124,11 +138,79 @@ function M.wait_for_buffer_content(instance, pattern, timeout)
   return false
 end
 
+---現在のバッファ「名」が条件に一致するまで待機
+---
+---wait_for_buffer_contentと紛らわしいが、見るものが違う。`.md`拡張子やチャットファイル名を
+---待つのはこちら。本文を探しても永久に一致しないため、全specがそこで詰まっていた。
+---@param instance table インスタンスハンドル
+---@param pattern string Luaパターン（バッファ名に対して）
+---@param timeout number タイムアウト（ミリ秒）
+---@return boolean 成功したかどうか
+function M.wait_for_buffer_name(instance, pattern, timeout)
+  if not instance or not instance.job_id then
+    vim.notify("[E2E Helper] Invalid instance: instance or job_id is nil", vim.log.levels.ERROR)
+    return false
+  end
+
+  local start_time = vim.loop.hrtime()
+  local timeout_ns = timeout * 1000000
+  local last_name = ""
+
+  while (vim.loop.hrtime() - start_time) < timeout_ns do
+    local ok, bufnr = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_get_current_buf")
+    if not ok then
+      vim.notify(
+        string.format("[E2E Helper] RPC failed to get buffer: %s", tostring(bufnr)),
+        vim.log.levels.WARN
+      )
+      return false
+    end
+
+    local ok2, name = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_buf_get_name", bufnr)
+    if not ok2 then
+      vim.notify(
+        string.format("[E2E Helper] RPC failed to get buffer name: %s", tostring(name)),
+        vim.log.levels.WARN
+      )
+      return false
+    end
+
+    last_name = name or ""
+    if last_name:match(pattern) then
+      return true
+    end
+
+    vim.loop.sleep(100)
+  end
+
+  vim.notify(
+    string.format(
+      "[E2E Helper] Timeout waiting for buffer name '%s' after %dms\nLast buffer name: %s",
+      pattern,
+      timeout,
+      last_name
+    ),
+    vim.log.levels.DEBUG
+  )
+
+  return false
+end
+
 ---インスタンスをクリーンアップ
+---子が書いたチャットファイルの一時ディレクトリも消す（tests/e2e_init.luaが場所を伝えてくる）
 ---@param instance table インスタンスハンドル
 function M.cleanup_instance(instance)
-  if instance and instance.job_id then
-    vim.fn.jobstop(instance.job_id)
+  if not instance or not instance.job_id then
+    return
+  end
+
+  local ok, chat_dir = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_get_var", "vibing_e2e_chat_dir")
+  vim.fn.jobstop(instance.job_id)
+
+  -- tempname() is always under the system temp dir; refuse anything else rather than trust a
+  -- value read back over RPC.
+  if ok and type(chat_dir) == "string" and chat_dir:find(vim.fn.fnamemodify(vim.fn.tempname(), ":h:h"), 1, true) == 1 then
+    vim.fn.delete(vim.fn.fnamemodify(chat_dir, ":h"), "rf")
   end
 end
 

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -71,82 +71,16 @@ function M.send_keys(instance, keys)
   return true
 end
 
----バッファ内容が条件に一致するまで待機
----@param instance table インスタンスハンドル
----@param pattern string パターン（文字列一致またはLuaパターン）
----@param timeout number タイムアウト（ミリ秒）
----@return boolean 成功したかどうか
-function M.wait_for_buffer_content(instance, pattern, timeout)
-  if not instance or not instance.job_id then
-    vim.notify(
-      "[E2E Helper] Invalid instance: instance or job_id is nil",
-      vim.log.levels.ERROR
-    )
-    return false
-  end
-
-  local start_time = vim.loop.hrtime()
-  local timeout_ns = timeout * 1000000
-  local last_content = ""
-
-  while (vim.loop.hrtime() - start_time) < timeout_ns do
-    local ok, bufnr = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_get_current_buf")
-    if not ok then
-      vim.notify(
-        string.format(
-          "[E2E Helper] RPC failed to get buffer: %s",
-          tostring(bufnr)
-        ),
-        vim.log.levels.WARN
-      )
-      return false
-    end
-
-    local ok2, lines = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_buf_get_lines", bufnr, 0, -1, false)
-    if not ok2 then
-      vim.notify(
-        string.format(
-          "[E2E Helper] RPC failed to get buffer lines: %s",
-          tostring(lines)
-        ),
-        vim.log.levels.WARN
-      )
-      return false
-    end
-
-    local content = table.concat(lines, "\n")
-    last_content = content
-
-    if content:match(pattern) then
-      return true
-    end
-
-    vim.loop.sleep(100)
-  end
-
-  -- Timeout occurred - provide debug information
-  vim.notify(
-    string.format(
-      "[E2E Helper] Timeout waiting for pattern '%s' after %dms\nLast buffer content:\n%s",
-      pattern,
-      timeout,
-      last_content:sub(1, 500) -- First 500 chars to avoid too long message
-    ),
-    vim.log.levels.DEBUG
-  )
-
-  return false
-end
-
----現在のバッファ「名」が条件に一致するまで待機
+---現在のバッファについて、`read` が返す文字列がパターンに一致するまでポーリングする。
 ---
----wait_for_buffer_contentと紛らわしいが、見るものが違う。`.md`拡張子やチャットファイル名を
----待つのはこちら。本文を探しても永久に一致しないため、全specがそこで詰まっていた。
+---wait_for_buffer_content と wait_for_buffer_name はこの1点しか違わない（本文か、名前か）。
 ---@param instance table インスタンスハンドル
----@param pattern string Luaパターン（バッファ名に対して）
+---@param pattern string Luaパターン
 ---@param timeout number タイムアウト（ミリ秒）
+---@param label string タイムアウトメッセージでの呼び名
+---@param read fun(job_id: number, bufnr: number): boolean, string 対象を取り出す
 ---@return boolean 成功したかどうか
-function M.wait_for_buffer_name(instance, pattern, timeout)
+local function wait_for(instance, pattern, timeout, label, read)
   if not instance or not instance.job_id then
     vim.notify("[E2E Helper] Invalid instance: instance or job_id is nil", vim.log.levels.ERROR)
     return false
@@ -154,7 +88,7 @@ function M.wait_for_buffer_name(instance, pattern, timeout)
 
   local start_time = vim.loop.hrtime()
   local timeout_ns = timeout * 1000000
-  local last_name = ""
+  local last_seen = ""
 
   while (vim.loop.hrtime() - start_time) < timeout_ns do
     local ok, bufnr = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_get_current_buf")
@@ -166,17 +100,17 @@ function M.wait_for_buffer_name(instance, pattern, timeout)
       return false
     end
 
-    local ok2, name = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_buf_get_name", bufnr)
+    local ok2, value = read(instance.job_id, bufnr)
     if not ok2 then
       vim.notify(
-        string.format("[E2E Helper] RPC failed to get buffer name: %s", tostring(name)),
+        string.format("[E2E Helper] RPC failed to get buffer %s: %s", label, tostring(value)),
         vim.log.levels.WARN
       )
       return false
     end
 
-    last_name = name or ""
-    if last_name:match(pattern) then
+    last_seen = value or ""
+    if last_seen:match(pattern) then
       return true
     end
 
@@ -185,15 +119,43 @@ function M.wait_for_buffer_name(instance, pattern, timeout)
 
   vim.notify(
     string.format(
-      "[E2E Helper] Timeout waiting for buffer name '%s' after %dms\nLast buffer name: %s",
+      "[E2E Helper] Timeout waiting for buffer %s '%s' after %dms\nLast buffer %s:\n%s",
+      label,
       pattern,
       timeout,
-      last_name
+      label,
+      last_seen:sub(1, 500) -- truncated: a whole chat buffer is too much for one notification
     ),
     vim.log.levels.DEBUG
   )
 
   return false
+end
+
+---バッファ「本文」が条件に一致するまで待機
+---@param instance table インスタンスハンドル
+---@param pattern string パターン（Luaパターン）
+---@param timeout number タイムアウト（ミリ秒）
+---@return boolean 成功したかどうか
+function M.wait_for_buffer_content(instance, pattern, timeout)
+  return wait_for(instance, pattern, timeout, "content", function(job_id, bufnr)
+    local ok, lines = pcall(vim.fn.rpcrequest, job_id, "nvim_buf_get_lines", bufnr, 0, -1, false)
+    return ok, ok and table.concat(lines, "\n") or lines
+  end)
+end
+
+---バッファ「名」が条件に一致するまで待機
+---
+---wait_for_buffer_contentと紛らわしいが、見るものが違う。`.md`拡張子やチャットファイル名を
+---待つのはこちら。本文を探しても永久に一致しないため、全specがそこで詰まっていた。
+---@param instance table インスタンスハンドル
+---@param pattern string Luaパターン（バッファ名に対して）
+---@param timeout number タイムアウト（ミリ秒）
+---@return boolean 成功したかどうか
+function M.wait_for_buffer_name(instance, pattern, timeout)
+  return wait_for(instance, pattern, timeout, "name", function(job_id, bufnr)
+    return pcall(vim.fn.rpcrequest, job_id, "nvim_buf_get_name", bufnr)
+  end)
 end
 
 ---インスタンスをクリーンアップ

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -207,9 +207,20 @@ function M.cleanup_instance(instance)
   local ok, chat_dir = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_get_var", "vibing_e2e_chat_dir")
   vim.fn.jobstop(instance.job_id)
 
-  -- tempname() is always under the system temp dir; refuse anything else rather than trust a
-  -- value read back over RPC.
-  if ok and type(chat_dir) == "string" and chat_dir:find(vim.fn.fnamemodify(vim.fn.tempname(), ":h:h"), 1, true) == 1 then
+  if not ok or type(chat_dir) ~= "string" or chat_dir == "" then
+    return
+  end
+
+  -- This path arrived over RPC and is about to be handed to `delete(..., "rf")`, so confirm it is
+  -- under the system temp dir first. Normalize both sides with vim.fs.normalize, which collapses
+  -- `..`: a prefix test on raw strings (or on `fnamemodify(:p)`, which leaves `..` in place —
+  -- checked, not assumed) would accept `<temp>/../../etc`.
+  --
+  -- The base comes from tempname()'s own layout (`<temp>/nvim.<user>/<rand>/<counter>`), a Neovim
+  -- implementation detail. If that ever changes the comparison simply stops matching, so the
+  -- failure mode is a leftover temp directory rather than a wrong `rf`.
+  local temp_base = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.tempname(), ":h:h"))
+  if vim.fs.normalize(chat_dir):find(temp_base, 1, true) == 1 then
     vim.fn.delete(vim.fn.fnamemodify(chat_dir, ":h"), "rf")
   end
 end

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "npm run test:lua && npm run test:node",
     "test:node": "find tests -name '*.test.mjs' -exec node --test {} +",
     "test:lua": "nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/ { minimal_init = 'tests/minimal_init.lua' }\"",
-    "test:e2e": "nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/e2e/ { minimal_init = 'tests/minimal_init.lua' }\"",
+    "test:e2e": "VIBING_E2E=1 nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/e2e/ { minimal_init = 'tests/minimal_init.lua' }\"",
     "test:eval": "nvim --headless -u tests/minimal_init.lua -l tests/evals/run.lua",
     "check": "find lua -name '*.lua' -exec luac -p {} \\;",
     "check:lua": "luac -p lua/vibing/init.lua",

--- a/tests/e2e/ask_user_question_spec.lua
+++ b/tests/e2e/ask_user_question_spec.lua
@@ -3,6 +3,12 @@
 -- AskUserQuestion and permissions_ask flows inserted UI multiple times.
 local helper = require("vibing.testing.e2e_helper")
 
+-- tests/e2e is swept by `test:lua` too, and some of these specs send a real request to the CLI.
+-- Only `test:e2e` sets VIBING_E2E=1; everything else skips rather than quietly spending tokens.
+if not helper.should_run() then
+  return
+end
+
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,
@@ -30,7 +36,7 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
   before_each(function()
     nvim_instance = helper.spawn_nvim_instance({
       headless = true,
-      init_script = "tests/minimal_init.lua",
+      init_script = "tests/e2e_init.lua",
     })
   end)
 
@@ -42,7 +48,7 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     helper.send_keys(nvim_instance, ":VibingChat<CR>")
     vim.wait(TIMEOUTS.CHAT_CREATION)
 
-    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
     assert.is_true(ok, "Chat buffer should be created")
 
     -- Prompt Claude to use AskUserQuestion tool
@@ -68,7 +74,7 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     helper.send_keys(nvim_instance, ":VibingChat<CR>")
     vim.wait(TIMEOUTS.CHAT_CREATION)
 
-    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
     assert.is_true(ok, "Chat buffer should be created")
 
     -- Prompt Claude to use AskUserQuestion tool

--- a/tests/e2e/ask_user_question_spec.lua
+++ b/tests/e2e/ask_user_question_spec.lua
@@ -9,6 +9,12 @@ if not helper.should_run() then
   return
 end
 
+-- These two specs depend on the model echoing the option labels it was told to use, so the
+-- assertions below match the rendered `1. A` / `1. Red` lines verbatim. That is a deliberate
+-- departure from the eval harness's rule of never reading response prose (see
+-- .claude/rules/self-testing.md): here the rendered list *is* the thing under test, and the
+-- renderer copies `opt.label` straight through. If the model ever paraphrases a label, this goes
+-- flaky — the fix is to loosen the pattern, not to conclude the UI broke.
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,

--- a/tests/e2e/ask_user_question_spec.lua
+++ b/tests/e2e/ask_user_question_spec.lua
@@ -12,6 +12,8 @@ end
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,
+  -- Longer than chat_basic_flow's 30s: those turns answer directly, while these have to find
+  -- the tool through ToolSearch and round-trip through the MCP server first. Measured, not guessed.
   ASSISTANT_RESPONSE = 60000,
 }
 

--- a/tests/e2e/ask_user_question_spec.lua
+++ b/tests/e2e/ask_user_question_spec.lua
@@ -12,7 +12,7 @@ end
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,
-  ASSISTANT_RESPONSE = 30000,
+  ASSISTANT_RESPONSE = 60000,
 }
 
 --- Count how many lines in the current buffer match the given pattern.
@@ -20,7 +20,7 @@ local TIMEOUTS = {
 ---@param pattern string Lua pattern
 ---@return number
 local function count_lines_matching(nvim_instance, pattern)
-  local lines = vim.fn.rpcrequest(nvim_instance.job_id, "nvim_buf_get_lines", { 0, 0, -1, false })
+  local lines = vim.fn.rpcrequest(nvim_instance.job_id, "nvim_buf_get_lines", 0, 0, -1, false)
   local count = 0
   for _, line in ipairs(lines) do
     if line:match(pattern) then
@@ -62,12 +62,12 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     helper.send_keys(nvim_instance, "<CR>")
 
     -- Wait for question prompt
-    ok = helper.wait_for_buffer_content(nvim_instance, "Please answer the question", TIMEOUTS.ASSISTANT_RESPONSE)
-    assert.is_true(ok, "AskUserQuestion prompt should appear")
+    ok = helper.wait_for_buffer_content(nvim_instance, "\n1%. A\n", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, "Choice list should be rendered into the buffer")
 
     -- Verify prompt appears exactly once (regression: was duplicated before the fix)
-    local count = count_lines_matching(nvim_instance, "Please answer the question")
-    assert.equals(1, count, "Question prompt must appear exactly once — no duplicate UI insertion")
+    local count = count_lines_matching(nvim_instance, "^1%. A$")
+    assert.equals(1, count, "The question must be rendered exactly once — no duplicate UI insertion")
   end)
 
   it("should not repeat the question prompt after user answers", function()
@@ -88,8 +88,8 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     helper.send_keys(nvim_instance, "<CR>")
 
     -- Wait for question prompt to appear
-    ok = helper.wait_for_buffer_content(nvim_instance, "Please answer the question", TIMEOUTS.ASSISTANT_RESPONSE)
-    assert.is_true(ok, "AskUserQuestion prompt should appear")
+    ok = helper.wait_for_buffer_content(nvim_instance, "\n1%. Red\n", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, "Choice list should be rendered into the buffer")
 
     -- Send an answer by pressing <CR> (all options remain — Claude understands)
     helper.send_keys(nvim_instance, "<CR>")
@@ -99,7 +99,7 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     assert.is_true(ok, "Claude should respond after the answer is sent")
 
     -- Verify prompt still appears only once (not re-inserted after answering)
-    local count = count_lines_matching(nvim_instance, "Please answer the question")
+    local count = count_lines_matching(nvim_instance, "^1%. Red$")
     assert.equals(1, count, "Question prompt must not be re-inserted after the user answers")
   end)
 end)

--- a/tests/e2e/chat_basic_flow_spec.lua
+++ b/tests/e2e/chat_basic_flow_spec.lua
@@ -1,6 +1,12 @@
 -- E2E Tests for vibing.nvim chat basic flow
 local helper = require("vibing.testing.e2e_helper")
 
+-- tests/e2e is swept by `test:lua` too, and some of these specs send a real request to the CLI.
+-- Only `test:e2e` sets VIBING_E2E=1; everything else skips rather than quietly spending tokens.
+if not helper.should_run() then
+  return
+end
+
 -- Timeout constants
 local TIMEOUTS = {
   CHAT_CREATION = 2000, -- Time for chat buffer creation and rendering
@@ -17,7 +23,7 @@ describe("E2E: Chat basic flow", function()
     -- 別Neovimインスタンスを起動（vibing.nvimロード済み）
     nvim_instance = helper.spawn_nvim_instance({
       headless = true,
-      init_script = "tests/minimal_init.lua",
+      init_script = "tests/e2e_init.lua",
     })
   end)
 
@@ -33,7 +39,7 @@ describe("E2E: Chat basic flow", function()
     vim.wait(TIMEOUTS.CHAT_CREATION)
 
     -- バッファ名確認（.mdファイルが作成される）
-    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
     assert.is_true(ok, "Chat buffer should be created with .md extension")
 
     -- フロントマター確認
@@ -47,7 +53,7 @@ describe("E2E: Chat basic flow", function()
     vim.wait(TIMEOUTS.CHAT_CREATION)
 
     -- バッファ作成確認
-    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
     assert.is_true(ok, "Chat buffer should be created")
 
     -- メッセージ送信（簡単なプロンプト）

--- a/tests/e2e/chat_jump_user_spec.lua
+++ b/tests/e2e/chat_jump_user_spec.lua
@@ -1,6 +1,12 @@
 -- E2E Tests for :VibingChatJumpNextUser / :VibingChatJumpPrevUser
 local helper = require("vibing.testing.e2e_helper")
 
+-- tests/e2e is swept by `test:lua` too, and some of these specs send a real request to the CLI.
+-- Only `test:e2e` sets VIBING_E2E=1; everything else skips rather than quietly spending tokens.
+if not helper.should_run() then
+  return
+end
+
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,
@@ -43,12 +49,12 @@ describe("E2E: Jump to User section", function()
   before_each(function()
     nvim_instance = helper.spawn_nvim_instance({
       headless = true,
-      init_script = "tests/minimal_init.lua",
+      init_script = "tests/e2e_init.lua",
     })
 
     helper.send_keys(nvim_instance, ":VibingChat<CR>")
     vim.wait(TIMEOUTS.CHAT_CREATION)
-    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
     assert.is_true(ok, "Chat buffer should be created")
 
     seed_sections(nvim_instance)

--- a/tests/e2e/nvim_ask_user_question_spec.lua
+++ b/tests/e2e/nvim_ask_user_question_spec.lua
@@ -13,7 +13,7 @@ end
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,
-  ASSISTANT_RESPONSE = 30000,
+  ASSISTANT_RESPONSE = 60000,
 }
 
 --- Count how many lines in the current buffer match the given pattern.
@@ -21,7 +21,7 @@ local TIMEOUTS = {
 ---@param pattern string Lua pattern
 ---@return number
 local function count_lines_matching(nvim_instance, pattern)
-  local lines = vim.fn.rpcrequest(nvim_instance.job_id, "nvim_buf_get_lines", { 0, 0, -1, false })
+  local lines = vim.fn.rpcrequest(nvim_instance.job_id, "nvim_buf_get_lines", 0, 0, -1, false)
   local count = 0
   for _, line in ipairs(lines) do
     if line:match(pattern) then
@@ -63,10 +63,10 @@ describe("E2E: nvim_ask_user_question MCP tool", function()
     helper.send_keys(nvim_instance, "<CR>")
 
     -- Wait for question prompt (same UI as AskUserQuestion)
-    ok = helper.wait_for_buffer_content(nvim_instance, "Please answer the question", TIMEOUTS.ASSISTANT_RESPONSE)
+    ok = helper.wait_for_buffer_content(nvim_instance, "\n1%. A\n", TIMEOUTS.ASSISTANT_RESPONSE)
     assert.is_true(ok, "Choice-list prompt should appear")
 
-    local count = count_lines_matching(nvim_instance, "Please answer the question")
-    assert.equals(1, count, "Question prompt must appear exactly once — no duplicate UI insertion")
+    local count = count_lines_matching(nvim_instance, "^1%. A$")
+    assert.equals(1, count, "The question must be rendered exactly once — no duplicate UI insertion")
   end)
 end)

--- a/tests/e2e/nvim_ask_user_question_spec.lua
+++ b/tests/e2e/nvim_ask_user_question_spec.lua
@@ -4,6 +4,12 @@
 -- because native AskUserQuestion is unavailable in headless `claude -p` mode.
 local helper = require("vibing.testing.e2e_helper")
 
+-- tests/e2e is swept by `test:lua` too, and some of these specs send a real request to the CLI.
+-- Only `test:e2e` sets VIBING_E2E=1; everything else skips rather than quietly spending tokens.
+if not helper.should_run() then
+  return
+end
+
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,
@@ -31,7 +37,7 @@ describe("E2E: nvim_ask_user_question MCP tool", function()
   before_each(function()
     nvim_instance = helper.spawn_nvim_instance({
       headless = true,
-      init_script = "tests/minimal_init.lua",
+      init_script = "tests/e2e_init.lua",
     })
   end)
 
@@ -43,7 +49,7 @@ describe("E2E: nvim_ask_user_question MCP tool", function()
     helper.send_keys(nvim_instance, ":VibingChat<CR>")
     vim.wait(TIMEOUTS.CHAT_CREATION)
 
-    local ok = helper.wait_for_buffer_content(nvim_instance, "%.md", TIMEOUTS.BUFFER_READY)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
     assert.is_true(ok, "Chat buffer should be created")
 
     -- Prompt Claude to use the vibing.nvim-dedicated question tool

--- a/tests/e2e/nvim_ask_user_question_spec.lua
+++ b/tests/e2e/nvim_ask_user_question_spec.lua
@@ -13,6 +13,8 @@ end
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,
+  -- Longer than chat_basic_flow's 30s: those turns answer directly, while these have to find
+  -- the tool through ToolSearch and round-trip through the MCP server first. Measured, not guessed.
   ASSISTANT_RESPONSE = 60000,
 }
 

--- a/tests/e2e/nvim_ask_user_question_spec.lua
+++ b/tests/e2e/nvim_ask_user_question_spec.lua
@@ -10,6 +10,12 @@ if not helper.should_run() then
   return
 end
 
+-- These two specs depend on the model echoing the option labels it was told to use, so the
+-- assertions below match the rendered `1. A` / `1. Red` lines verbatim. That is a deliberate
+-- departure from the eval harness's rule of never reading response prose (see
+-- .claude/rules/self-testing.md): here the rendered list *is* the thing under test, and the
+-- renderer copies `opt.label` straight through. If the model ever paraphrases a label, this goes
+-- flaky — the fix is to loosen the pattern, not to conclude the UI broke.
 local TIMEOUTS = {
   CHAT_CREATION = 2000,
   BUFFER_READY = 5000,

--- a/tests/e2e_init.lua
+++ b/tests/e2e_init.lua
@@ -13,7 +13,14 @@ vim.opt.backup = false
 -- Chats go to a per-child temp directory. The default ("project") writes into the repository's
 -- own .vibing/chat/, so running the suite used to leave real chat files behind — in CI, in a
 -- checkout, every time.
-local chat_dir = vim.fn.tempname() .. "/chat"
+--
+-- The path comes from the parent (spawn_nvim_instance sets $VIBING_E2E_CHAT_DIR) so that cleanup
+-- never has to ask this process where it wrote; rpcrequest has no timeout, and a wedged child
+-- would otherwise hang the suite. The fallback keeps this init usable when run by hand.
+local chat_dir = vim.env.VIBING_E2E_CHAT_DIR
+if not chat_dir or chat_dir == "" then
+  chat_dir = vim.fn.tempname() .. "/chat"
+end
 vim.fn.mkdir(chat_dir, "p")
 
 require("vibing").setup({
@@ -33,6 +40,3 @@ require("vibing").setup({
   -- allows it; the CLI's gate is what refuses, and this is the only lever that clears it.
   permissions = { mode = "bypassPermissions" },
 })
-
--- Read back by cleanup_instance so the parent can delete what this child wrote.
-vim.g.vibing_e2e_chat_dir = chat_dir

--- a/tests/e2e_init.lua
+++ b/tests/e2e_init.lua
@@ -1,0 +1,31 @@
+-- init.lua for the *child* Neovim an E2E spec drives over RPC.
+--
+-- tests/minimal_init.lua is the parent's init: it wires up plenary so the specs can run. The
+-- child needs something different — vibing.nvim actually set up, so `:Vibing*` commands exist at
+-- all. Pointing the child at minimal_init left it with no commands, which is why every spec's
+-- first `:VibingChat` did nothing.
+
+vim.opt.runtimepath:append(vim.fn.getcwd())
+
+vim.opt.swapfile = false
+vim.opt.backup = false
+
+-- Chats go to a per-child temp directory. The default ("project") writes into the repository's
+-- own .vibing/chat/, so running the suite used to leave real chat files behind — in CI, in a
+-- checkout, every time.
+local chat_dir = vim.fn.tempname() .. "/chat"
+vim.fn.mkdir(chat_dir, "p")
+
+require("vibing").setup({
+  chat = {
+    save_location_type = "custom",
+    save_dir = chat_dir,
+  },
+  -- MCP stays on: nvim_ask_user_question_spec exists to drive that tool, so a child without the
+  -- RPC server could never pass it. Concurrent children do not collide — the server walks to the
+  -- next free port when 9876 is taken.
+  mcp = { enabled = true },
+})
+
+-- Read back by cleanup_instance so the parent can delete what this child wrote.
+vim.g.vibing_e2e_chat_dir = chat_dir

--- a/tests/e2e_init.lua
+++ b/tests/e2e_init.lua
@@ -25,6 +25,13 @@ require("vibing").setup({
   -- RPC server could never pass it. Concurrent children do not collide — the server walks to the
   -- next free port when 9876 is taken.
   mcp = { enabled = true },
+  -- The child is a throwaway editor in a temp directory, and these specs are about UI plumbing,
+  -- not about permissions. It also has to be bypassPermissions to work at all: under acceptEdits
+  -- the CLI refuses the vibing-nvim MCP tool ("Claude requested permissions to use ..."), and
+  -- listing it in --allowedTools does not change that — verified with the exact tool name, the
+  -- `mcp__<server>__*` form and the bare `mcp__<server>` form. vibing's own PreToolUse hook
+  -- allows it; the CLI's gate is what refuses, and this is the only lever that clears it.
+  permissions = { mode = "bypassPermissions" },
 })
 
 -- Read back by cleanup_instance so the parent can delete what this child wrote.

--- a/tests/e2e_init.lua
+++ b/tests/e2e_init.lua
@@ -21,9 +21,9 @@ require("vibing").setup({
     save_location_type = "custom",
     save_dir = chat_dir,
   },
-  -- MCP stays on: nvim_ask_user_question_spec exists to drive that tool, so a child without the
-  -- RPC server could never pass it. Concurrent children do not collide — the server walks to the
-  -- next free port when 9876 is taken.
+  -- Already the default; stated because nvim_ask_user_question_spec exists to drive that tool and
+  -- a child without the RPC server could never pass it, so this is not safe to "tidy away".
+  -- Concurrent children do not collide — the server walks to the next free port when 9876 is taken.
   mcp = { enabled = true },
   -- The child is a throwaway editor in a temp directory, and these specs are about UI plumbing,
   -- not about permissions. It also has to be bypassPermissions to work at all: under acceptEdits


### PR DESCRIPTION
## 何が起きていたか

main で `pnpm run test:e2e` を実行すると、こうなります。

```
Test environment initialized
Starting...Scheduling: tests/e2e/chat_basic_flow_spec.lua
Scheduling: tests/e2e/nvim_ask_user_question_spec.lua
Scheduling: tests/e2e/chat_jump_user_spec.lua
Scheduling: tests/e2e/ask_user_question_spec.lua
```

出力はこれで全部で、exit 1 です。**1本も実行されていません。** #560 のレビューで報告した「落ちる E2E」を追っていて分かりました。

実行に到達するには条件が揃う必要があり、そのどれも満たされていませんでした。前の層を直すたびに次の層が出てくる構造だったので、順に並べます。

### 1. 子 Neovim に `--embed` が無い

`jobstart{ rpc = true }` は子の stdio と msgpack-RPC で話しますが、`--embed` が無いと子は普通のエディタとして起動します。`rpcrequest` が全滅し、spec は最初の待機から先へ進みません。

### 2. 子が親の init を使っていた

`init_script = "tests/minimal_init.lua"` を渡していましたが、これは**親の** init です（plenary を通すためのもの）。子は vibing.nvim を `runtimepath` に持つものの `setup()` を呼ばないので、**`:VibingChat` というコマンドが存在せず**、送っても何も起きません。

新規 `tests/e2e_init.lua` が `setup()` を担います。あわせて `chat.save_dir` を子ごとの一時ディレクトリに向けました。既定の `"project"` はリポジトリの `.vibing/chat/` に書くので、**スイートを回すたびに実チャットファイルが残っていました**。`cleanup_instance` がその一時ディレクトリごと消します。

### 3. ファイル名をバッファ本文から探していた

6箇所が `wait_for_buffer_content(inst, "%.md")` でした。この関数は `nvim_buf_get_lines` の**本文**にパターンを当てるので、ファイル名は永久に一致しません。バッファ**名**を待つ `wait_for_buffer_name` を追加して差し替えました。

### 4. 存在しない文字列を待っていた（AskUserQuestion 2本）

spec は `"Please answer the question"` を待っていましたが、これは**コードベースのどこにもありません**。描画されるのは質問文と選択肢だけで、`press <CR> to send` を持つのは*承認 UI* のほうです。`features.md` の例文にその行が書かれており、spec は実装ではなくドキュメントに対して書かれていました。ドキュメント側も実装に合わせて修正しています。

判定は、ユーザーの発言には現れない**描画された選択肢行**に変えました（質問文はユーザーの指示文にも含まれるため素通りします）。

### 5. `count_lines_matching` の RPC 引数

`nvim_buf_get_lines` の引数をテーブル1個で渡しており、到達した瞬間に落ちます。4で永久に待っていたため一度も到達していませんでした。

### 6. 子の権限モード

`acceptEdits` では CLI が vibing-nvim の MCP ツールを拒否します。`--allowedTools` に完全修飾のツール名を入れても（子の実 argv に入っていることを確認した上で）通りません。vibing 自身の PreToolUse フックは allow を返しており、拒否しているのは CLI のゲートです。

子は使い捨ての一時ディレクトリで UI の配管を見るだけなので `bypassPermissions` で回します。ただし**このゲート自体は E2E に隠して済ませる話ではない**ので、切り分け結果を #564 に切り出しました。

## test:lua から E2E を切り離した

E2E の一部は**実際に CLI へリクエストを投げます**（`chat_basic_flow` の "should send message and receive response" は本物の1往復です）。`test:lua` は `PlenaryBustedDirectory tests/` なので `tests/e2e/` まで巻き込みます。つまり動くようにした瞬間、通常のユニットテストがトークンを使うことになります。

各 spec が `VIBING_E2E=1` でなければ自分でスキップするようにし、`test:e2e` だけがそれを立てます（`helper.should_run()`）。`test:eval` が「実トークンを使うので `test` には含めない」としているのと同じ扱いです。

**副次的な発見:** `pnpm run test:lua` は以前から**失敗0件なのに exit 1** でした。これらの死んだ spec がサマリーを一切出さないためです。今回で exit 0 になります。

## 結果

```
test:lua   1172 pass / 0 fail / exit 0
test:e2e   8 pass / 0 fail / exit 0
           ✓ Chat basic flow (2件、うち1件は実 CLI 往復)
           ✓ Jump to User section (3件)
           ✓ nvim_ask_user_question MCP tool (1件)
           ✓ AskUserQuestion (2件)
```

`check` / `lint` / `format:check` も通っています。

## ドキュメント

`.claude/rules/self-testing.md` と `.claude/skills/self-testing/SKILL.md` に、子 Neovim に必要な3条件と「E2E はトークンを使うので `test:e2e` だけが回す」を明記しました。どれも「間違えると spec が黙って死ぬ」種類のものです。`features.md` の AskUserQuestion の例文も、レンダラーの実出力に合わせました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)