### PR TITLE
fix: title chats after what the user asked for, not the commands that ran

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -209,7 +209,7 @@ via `/model` slash command.
 CLI applies its own default, which Anthropic tunes over time — pinning a level here would freeze
 it. Set it per chat with `/effort`. Lightweight calls (title generation, `/summarize`, daily
 summary) use `agent.utility_effort` (default `low`) instead. It does **not** pair with a cheap
-model: `utility_model` defaults to `sonnet`, because those calls summarise a noisy chat transcript
+model: `utility_model` defaults to `sonnet`, because those calls summarize a noisy chat transcript
 and haiku measurably picks the wrong subject. Low effort on a capable model is the trade actually
 being made here. An unrecognised level is dropped with a warning rather than passed
 through: the CLI accepts unknown levels silently and then ignores them.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -208,8 +208,10 @@ via `/model` slash command.
 **omitted unless configured**: with no `agent.default_effort` vibing.nvim passes no flag and the
 CLI applies its own default, which Anthropic tunes over time — pinning a level here would freeze
 it. Set it per chat with `/effort`. Lightweight calls (title generation, `/summarize`, daily
-summary) use `agent.utility_effort` (default `low`) instead, pairing with `utility_model` so those
-calls are cheap on both axes. An unrecognised level is dropped with a warning rather than passed
+summary) use `agent.utility_effort` (default `low`) instead. It does **not** pair with a cheap
+model: `utility_model` defaults to `sonnet`, because those calls summarise a noisy chat transcript
+and haiku measurably picks the wrong subject. Low effort on a capable model is the trade actually
+being made here. An unrecognised level is dropped with a warning rather than passed
 through: the CLI accepts unknown levels silently and then ignores them.
 
 Configured permissions are recorded in frontmatter for

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ require("vibing").setup({
   agent = {
     default_mode = "code",
     default_model = "sonnet",
-    utility_model = "haiku",
+    utility_model = "sonnet",
     setting_sources = { "user", "project", "local" },
     subagent = { enabled = false, show_prefix = false },
     auto_resume_on_limit = { enabled = false, max_retries = 1 },
@@ -149,9 +149,11 @@ agent = {
                             -- "haiku": Fastest
                             -- "fable": Claude Fable
 
-  utility_model = "haiku",  -- Model used for lightweight utility calls
+  utility_model = "sonnet", -- Model used for lightweight utility calls
                             -- (AI title generation, chat summaries, daily summaries).
                             -- Takes priority over the chat's model for those calls.
+                            -- Set to "haiku" for the cheapest option: it costs less but
+                            -- picks the wrong subject noticeably more often.
 
   setting_sources = { "user", "project", "local" },
                             -- Passed to the Claude CLI's --setting-sources flag.

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -93,7 +93,7 @@
 ---Claudeのモード（code/plan/explore）とモデル（sonnet/opus/haiku/fable）を指定
 ---@field default_mode "code"|"plan"|"explore" 新規チャットのfrontmatterに記録される`mode`の既定値（意味は core/constants/modes.lua の M.AGENT_MODES 参照）
 ---@field default_model "sonnet"|"opus"|"haiku"|"fable" デフォルトモデル（"sonnet": バランス、"opus": 高性能、"haiku": 高速、"fable": Claude Fable）
----@field utility_model "sonnet"|"opus"|"haiku"|"fable" タイトル生成・要約等の軽量ユーティリティ呼び出し専用モデル（デフォルト: "haiku"）
+---@field utility_model "sonnet"|"opus"|"haiku"|"fable" タイトル生成・要約等の軽量ユーティリティ呼び出し専用モデル（デフォルト: "sonnet"）
 ---@field default_effort ("low"|"medium"|"high"|"xhigh"|"max")? 推論量の既定値（未指定ならCLIの既定に任せる）
 ---@field utility_effort ("low"|"medium"|"high"|"xhigh"|"max")? タイトル生成・要約等の軽量呼び出しの推論量（デフォルト: "low"）
 ---@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）
@@ -223,7 +223,11 @@ M.defaults = {
   agent = {
     default_mode = "code",
     default_model = "sonnet",
-    utility_model = "haiku",
+    -- sonnet, not haiku: the utility calls are all summarisation over a noisy chat transcript,
+    -- and haiku measurably picks the wrong subject (it titles a chat after the last step or the
+    -- commands that ran). The inputs are a few thousand tokens and the calls are on-demand, so
+    -- the extra cost is small. Set it back to "haiku" if you want the cheapest possible.
+    utility_model = "sonnet",
     -- default_effort is deliberately nil: without it vibing.nvim passes no --effort and the CLI
     -- applies its own default, which moves as Anthropic tunes it. Set it to pin a level.
     default_effort = nil,

--- a/lua/vibing/core/utils/chat_excerpt.lua
+++ b/lua/vibing/core/utils/chat_excerpt.lua
@@ -55,13 +55,22 @@ end
 ---`- fix parse(input)` のような markdown 箇条書きがツール行と誤判定され、
 ---ユーザーの依頼そのものが抜粋から消える。ASCII記号のマーカーを使う人は
 ---`config.ui.tool_markers` に載っているので glyphs 側で拾える。
+---
+---`allow_glyph_prefix` は「マーカーで始まるだけ」の緩い判定を使うかどうか。構造マッチと違って
+---行の中身を一切見ないので、user の発言に対しては使ってはいけない: `→ ログインを直して` や
+---`💻 環境構築で詰まってる` のような、記号を箇条書き代わりに使った依頼文がそのまま消え、
+---1行の依頼ならメッセージごと抜粋から落ちる（このPRが直そうとしている症状そのもの）。
 ---@param trimmed string
 ---@param glyphs string[]
+---@param allow_glyph_prefix boolean
 ---@return boolean
-local function is_tool_header(trimmed, glyphs)
+local function is_tool_header(trimmed, glyphs, allow_glyph_prefix)
   local head, name = trimmed:match("^(%S+)%s+([%w_][%w_%.:%-]*)%(")
   if head and name and not head:match("[%w]") and head:match("[\128-\255]") then
     return true
+  end
+  if not allow_glyph_prefix then
+    return false
   end
   for _, g in ipairs(glyphs) do
     if trimmed:sub(1, #g) == g then
@@ -82,8 +91,9 @@ end
 
 ---@param text string
 ---@param glyphs string[]
+---@param allow_glyph_prefix boolean マーカーで始まるだけの行もツール実況として落とすか（assistant のみ）
 ---@return string
-local function clean_with(text, glyphs)
+local function clean_with(text, glyphs, allow_glyph_prefix)
   -- HTMLコメントは複数行にまたがりうるので行分割の前に落とす
   text = text:gsub("<!%-%-.-%-%->", "")
 
@@ -109,7 +119,16 @@ local function clean_with(text, glyphs)
       while i <= #lines and lines[i]:match("^     ") do
         i = i + 1
       end
-    elseif is_tool_header(trimmed, glyphs) then
+    elseif trimmed:match("Tool approval required") then
+      -- 承認UIは1ブロックまるごと落とす。`Tool:` / `Command:` / `File:` 等の行まで含めるため、
+      -- 選択肢行を個別に消すのではなく締めの一行まで読み飛ばす。ユーザーは選択肢を1つ残して
+      -- 送るので、残った `allow_once` もこの範囲に入る。
+      i = i + 1
+      while i <= #lines and not vim.trim(lines[i]):match("^Please select and press") do
+        i = i + 1
+      end
+      i = i + 1
+    elseif is_tool_header(trimmed, glyphs, allow_glyph_prefix) then
       -- ヘッダーの引数は複数行になりうる（Bashの複数行コマンド等）。括弧の釣り合いで終端を探す。
       -- 空行でも打ち切るのは、`case x)` のように釣り合わない括弧を含むコマンドで
       -- 後続の地の文まで丸ごと食べてしまわないため。
@@ -124,7 +143,8 @@ local function clean_with(text, glyphs)
       or trimmed:match("^Context:")
       or trimmed:match("^%*%*Error:%*%*")
       or trimmed:match("^%*Session has been reset")
-      or trimmed:match("Tool approval required")
+      -- 承認ブロックはひとつ上の分岐で丸ごと落とすが、締めの行が消された状態で送られた場合に
+      -- 選択肢だけが残るので、個別のパターンも残しておく
       or trimmed:match("^%d+%.%s+%a+_once%f[%W]")
       or trimmed:match("^%d+%.%s+%a+_for_session%f[%W]")
       or trimmed:match("^Please select and press")
@@ -145,14 +165,26 @@ end
 ---1メッセージ分の描画テキストから、タイトル生成に意味のある地の文だけを残す。
 ---落とすもの: ツール呼び出しヘッダーとその複数行引数、ツール結果ブロック、フェンス済みコードブロック、
 ---HTMLコメント（patch/subagent マーカー等）、`@file:` コンテキスト行、
----レート制限などのシステム通知、ツール承認UIの選択肢。
+---レート制限などのシステム通知、ツール承認UIのブロック。
+---
+---assistant の描画テキスト向け。user の発言には `M.clean_user` を使う。
 ---@param text string?
 ---@return string
 function M.clean(text)
   if not text or text == "" then
     return ""
   end
-  return clean_with(text, marker_glyphs())
+  return clean_with(text, marker_glyphs(), true)
+end
+
+---`M.clean` の user 発言版。マーカーで始まるだけの行は落とさない（理由は `is_tool_header`）。
+---@param text string?
+---@return string
+function M.clean_user(text)
+  if not text or text == "" then
+    return ""
+  end
+  return clean_with(text, marker_glyphs(), false)
 end
 
 ---ツール実況行かどうか。`first_title_line`（モデルの応答側）と抜粋のクリーニングで
@@ -160,7 +192,8 @@ end
 ---@param line string
 ---@return boolean
 function M.is_tool_line(line)
-  return is_tool_header(vim.trim(line), marker_glyphs())
+  -- ここはモデル自身が返したタイトル候補1行が対象なので、緩いマーカー前方一致で構わない。
+  return is_tool_header(vim.trim(line), marker_glyphs(), true)
 end
 
 ---@param s string
@@ -192,7 +225,12 @@ function M.build(conversation)
   local glyphs = marker_glyphs()
 
   for _, msg in ipairs(conversation or {}) do
-    local cleaned = msg.content and msg.content ~= "" and clean_with(msg.content, glyphs) or ""
+    -- マーカー前方一致による除去は assistant 側だけ。user の発言に効かせると、記号を
+    -- 箇条書き代わりに使った依頼文がそのまま消える。
+    local cleaned = msg.content
+        and msg.content ~= ""
+        and clean_with(msg.content, glyphs, msg.role ~= "user")
+      or ""
     if cleaned ~= "" and not BOILERPLATE_MESSAGES[cleaned:lower()] then
       if msg.role == "user" then
         users[#users + 1] = cleaned

--- a/lua/vibing/core/utils/chat_excerpt.lua
+++ b/lua/vibing/core/utils/chat_excerpt.lua
@@ -22,6 +22,25 @@ local BOILERPLATE_MESSAGES = {
   ["deny_for_session"] = true,
 }
 
+---定型メッセージ判定。自動継続プロンプトは設定で差し替えられるので、既定値のハードコードに
+---加えて実際の設定値も見る（差し替えた人だけ「Continue…」が主題として残る、を避ける）。
+---@param cleaned string
+---@return boolean
+local function is_boilerplate(cleaned)
+  local lowered = cleaned:lower()
+  if BOILERPLATE_MESSAGES[lowered] then
+    return true
+  end
+  local ok, config_mod = pcall(require, "vibing.config")
+  if not ok then
+    return false
+  end
+  local ok_get, config = pcall(config_mod.get)
+  local agent = ok_get and config and config.agent
+  local prompt = agent and agent.auto_resume_on_limit and agent.auto_resume_on_limit.prompt
+  return type(prompt) == "string" and vim.trim(prompt):lower() == lowered
+end
+
 ---@return string[]
 local function marker_glyphs()
   local glyphs = {}
@@ -60,6 +79,11 @@ end
 ---行の中身を一切見ないので、user の発言に対しては使ってはいけない: `→ ログインを直して` や
 ---`💻 環境構築で詰まってる` のような、記号を箇条書き代わりに使った依頼文がそのまま消え、
 ---1行の依頼ならメッセージごと抜粋から落ちる（このPRが直そうとしている症状そのもの）。
+---
+---構造マッチのほうは `allow_glyph_prefix` に関わらず user にも効く。これは承知の上で、
+---`⏺ Bash(npm test)` のような描画済みツール行が user セクションに混ざった場合に落とすため。
+---代償として `→ fix(login)`（記号+識別子+`(` がそのまま揃った依頼文）は消える。`→ fix login(x)`
+---のように識別子と `(` の間に何か挟まれば残るので、実際に踏む形はかなり狭い。
 ---@param trimmed string
 ---@param glyphs string[]
 ---@param allow_glyph_prefix boolean
@@ -81,9 +105,17 @@ local function is_tool_header(trimmed, glyphs, allow_glyph_prefix)
 end
 
 ---括弧の釣り合い（開き - 閉じ）。ツールヘッダーの複数行引数の終端検出に使う。
+---
+---引用符の中の括弧は数えない。`💻 Bash(echo ')'` のような行でここが先に0になると、
+---続く `git rebase origin/main)` が地の文として抜粋に残り、そのコマンドがタイトルになる。
+---行をまたぐ引用符までは追わない（そこまで来るとシェルのパーサが要る）が、
+---1行で閉じる引用が実際にはほとんどで、追えなかった場合も次の空行で打ち切られる。
 ---@param s string
 ---@return integer
 local function paren_balance(s)
+  s = s:gsub("\\.", "") -- エスケープされた引用符が対を崩さないよう先に落とす
+  s = s:gsub("'[^']*'", "")
+  s = s:gsub('"[^"]*"', "")
   local _, opens = s:gsub("%(", "")
   local _, closes = s:gsub("%)", "")
   return opens - closes
@@ -231,7 +263,7 @@ function M.build(conversation)
         and msg.content ~= ""
         and clean_with(msg.content, glyphs, msg.role ~= "user")
       or ""
-    if cleaned ~= "" and not BOILERPLATE_MESSAGES[cleaned:lower()] then
+    if cleaned ~= "" and not is_boilerplate(cleaned) then
       if msg.role == "user" then
         users[#users + 1] = cleaned
       elseif msg.role == "assistant" then

--- a/lua/vibing/core/utils/chat_excerpt.lua
+++ b/lua/vibing/core/utils/chat_excerpt.lua
@@ -1,0 +1,246 @@
+---Chat excerpt builder for lightweight utility calls (title generation).
+---@class Vibing.Utils.ChatExcerpt
+---
+---チャットバッファから抽出した会話は「バッファに描画されたテキストそのもの」なので、
+---assistant セクションの大半がツール実況（`💻 Bash(...)`, `⏺ Read(...)`, `⎿ 結果`）で占められる。
+---それをそのままタイトル生成に渡すと、モデルが見るのはシェルコマンドの羅列になり、
+---会話の主題ではなく終盤に実行したコマンドがタイトルになる。
+---このモジュールは描画ノイズを落として「人間が書いた／読んだ文」だけを残す。
+local M = {}
+
+-- Fallback marker glyphs. 実際のマーカーは config.ui.tool_markers でユーザーが差し替えるので、
+-- 構造マッチ（`<記号> ToolName(`）と設定値の両方を併用する。
+local BUILTIN_MARKERS = { "⏺", "📄", "💻", "🔧", "✳", "☒", "☐", "⎿", "→", "▶" }
+
+-- 会話の主題を一切含まない定型メッセージ。抜粋に混ざるとタイトルを乗っ取る。
+local BOILERPLATE_MESSAGES = {
+  ["continue from where you left off."] = true,
+  ["continue from where you left off"] = true,
+  ["allow_once"] = true,
+  ["deny_once"] = true,
+  ["allow_for_session"] = true,
+  ["deny_for_session"] = true,
+}
+
+---@return string[]
+local function marker_glyphs()
+  local glyphs = {}
+  local seen = {}
+  for _, g in ipairs(BUILTIN_MARKERS) do
+    glyphs[#glyphs + 1] = g
+    seen[g] = true
+  end
+  local ok, config_mod = pcall(require, "vibing.config")
+  if ok then
+    local ok_get, config = pcall(config_mod.get)
+    local markers = ok_get and config and config.ui and config.ui.tool_markers
+    if type(markers) == "table" then
+      for _, g in pairs(markers) do
+        if type(g) == "string" and g ~= "" and not seen[g] then
+          glyphs[#glyphs + 1] = g
+          seen[g] = true
+        end
+      end
+    end
+  end
+  return glyphs
+end
+
+---ツール呼び出しヘッダー行かどうか。
+---描画形式は `<marker> <ToolName>(<summary>` （summary は複数行になりうる）。
+---マーカーはユーザー設定で任意の記号になるため、設定済みマーカーによる判定に加えて
+---「非ASCIIの記号1トークン + 識別子 + `(`」という構造でも拾う。
+---
+---非ASCIIを要求するのが肝。ここを「英数字を含まない先頭トークン」まで緩めると、
+---`- fix parse(input)` のような markdown 箇条書きがツール行と誤判定され、
+---ユーザーの依頼そのものが抜粋から消える。ASCII記号のマーカーを使う人は
+---`config.ui.tool_markers` に載っているので glyphs 側で拾える。
+---@param trimmed string
+---@param glyphs string[]
+---@return boolean
+local function is_tool_header(trimmed, glyphs)
+  local head, name = trimmed:match("^(%S+)%s+([%w_][%w_%.:%-]*)%(")
+  if head and name and not head:match("[%w]") and head:match("[\128-\255]") then
+    return true
+  end
+  for _, g in ipairs(glyphs) do
+    if trimmed:sub(1, #g) == g then
+      return true
+    end
+  end
+  return false
+end
+
+---括弧の釣り合い（開き - 閉じ）。ツールヘッダーの複数行引数の終端検出に使う。
+---@param s string
+---@return integer
+local function paren_balance(s)
+  local _, opens = s:gsub("%(", "")
+  local _, closes = s:gsub("%)", "")
+  return opens - closes
+end
+
+---@param text string
+---@param glyphs string[]
+---@return string
+local function clean_with(text, glyphs)
+  -- HTMLコメントは複数行にまたがりうるので行分割の前に落とす
+  text = text:gsub("<!%-%-.-%-%->", "")
+
+  local out = {}
+  local lines = vim.split(text, "\n", { plain = true })
+  local i = 1
+
+  while i <= #lines do
+    local line = lines[i]
+    local trimmed = vim.trim(line)
+
+    if trimmed:match("^```") then
+      -- フェンス済みコードブロックは丸ごと捨てる（閉じていなければ以降すべて）
+      i = i + 1
+      while i <= #lines and not vim.trim(lines[i]):match("^```") do
+        i = i + 1
+      end
+      i = i + 1
+    elseif trimmed:sub(1, #"⎿") == "⎿" then
+      -- ツール結果ブロック: 続く行は5スペース以上のインデントで継続する
+      -- （結果テキスト自身が字下げを持つ場合は5スペースより深くなる）
+      i = i + 1
+      while i <= #lines and lines[i]:match("^     ") do
+        i = i + 1
+      end
+    elseif is_tool_header(trimmed, glyphs) then
+      -- ヘッダーの引数は複数行になりうる（Bashの複数行コマンド等）。括弧の釣り合いで終端を探す。
+      -- 空行でも打ち切るのは、`case x)` のように釣り合わない括弧を含むコマンドで
+      -- 後続の地の文まで丸ごと食べてしまわないため。
+      local balance = paren_balance(line)
+      i = i + 1
+      while i <= #lines and balance > 0 and vim.trim(lines[i]) ~= "" do
+        balance = balance + paren_balance(lines[i])
+        i = i + 1
+      end
+    elseif
+      trimmed:match("^@file:")
+      or trimmed:match("^Context:")
+      or trimmed:match("^%*%*Error:%*%*")
+      or trimmed:match("^%*Session has been reset")
+      or trimmed:match("Tool approval required")
+      or trimmed:match("^%d+%.%s+%a+_once%f[%W]")
+      or trimmed:match("^%d+%.%s+%a+_for_session%f[%W]")
+      or trimmed:match("^Please select and press")
+      or trimmed:match("^Please answer the question and press")
+    then
+      i = i + 1
+    else
+      out[#out + 1] = line
+      i = i + 1
+    end
+  end
+
+  local cleaned = table.concat(out, "\n")
+  cleaned = cleaned:gsub("\n%s*\n%s*\n+", "\n\n")
+  return vim.trim(cleaned)
+end
+
+---1メッセージ分の描画テキストから、タイトル生成に意味のある地の文だけを残す。
+---落とすもの: ツール呼び出しヘッダーとその複数行引数、ツール結果ブロック、フェンス済みコードブロック、
+---HTMLコメント（patch/subagent マーカー等）、`@file:` コンテキスト行、
+---レート制限などのシステム通知、ツール承認UIの選択肢。
+---@param text string?
+---@return string
+function M.clean(text)
+  if not text or text == "" then
+    return ""
+  end
+  return clean_with(text, marker_glyphs())
+end
+
+---ツール実況行かどうか。`first_title_line`（モデルの応答側）と抜粋のクリーニングで
+---同じ判定を使うための公開版。
+---@param line string
+---@return boolean
+function M.is_tool_line(line)
+  return is_tool_header(vim.trim(line), marker_glyphs())
+end
+
+---@param s string
+---@param n integer
+---@return string
+local function truncate(s, n)
+  if vim.fn.strchars(s) > n then
+    return vim.fn.strcharpart(s, 0, n) .. "…"
+  end
+  return s
+end
+
+-- user メッセージは「何をしようとしたか」そのものなので厚く、assistant は文脈補強なので薄く取る。
+local USER_MESSAGE_CHARS = 600
+local ASSISTANT_MESSAGE_CHARS = 400
+local MAX_USER_MESSAGES = 8
+local MAX_ASSISTANT_MESSAGES = 2
+local MAX_TOTAL_CHARS = 6000
+
+---会話からタイトル生成用の抜粋を作る。
+---user メッセージを主情報として全件（多すぎる場合は先頭側と末尾側）取り、
+---assistant は冒頭の応答だけを短く添える。末尾数件だけを取る方式をやめたのは、
+---終盤の雑務（「マージしてcleanup」等）が会話の主題を上書きしてしまうため。
+---@param conversation {role: string, content: string}[]
+---@return string
+function M.build(conversation)
+  local users, assistants = {}, {}
+  -- マーカー一覧は設定を読むので、メッセージごとではなく1会話につき1回だけ組み立てる
+  local glyphs = marker_glyphs()
+
+  for _, msg in ipairs(conversation or {}) do
+    local cleaned = msg.content and msg.content ~= "" and clean_with(msg.content, glyphs) or ""
+    if cleaned ~= "" and not BOILERPLATE_MESSAGES[cleaned:lower()] then
+      if msg.role == "user" then
+        users[#users + 1] = cleaned
+      elseif msg.role == "assistant" then
+        assistants[#assistants + 1] = cleaned
+      end
+    end
+  end
+
+  -- 役割ごとに節を分ける。「主題は user が頼んだこと」という指示を、
+  -- プロンプト文だけでなく抜粋の構造そのものでモデルに伝えるため。
+  -- 見出しに `#` を使わないのは、メッセージ本文中の markdown 見出しと混ざらないようにするため。
+  local parts = { "[USER REQUESTS — this is the subject of the conversation]" }
+
+  local function add_user(text)
+    parts[#parts + 1] = "- " .. truncate(text, USER_MESSAGE_CHARS)
+  end
+
+  if #users == 0 then
+    parts[#parts + 1] = "- (none)"
+  elseif #users <= MAX_USER_MESSAGES then
+    for _, text in ipairs(users) do
+      add_user(text)
+    end
+  else
+    -- 主題を固定する先頭側を残し、直近の文脈も落とさない
+    local head = math.ceil(MAX_USER_MESSAGES / 2)
+    local tail = MAX_USER_MESSAGES - head
+    for j = 1, head do
+      add_user(users[j])
+    end
+    parts[#parts + 1] = "- (…)"
+    for j = #users - tail + 1, #users do
+      add_user(users[j])
+    end
+  end
+
+  -- 冒頭の assistant 応答だけを添える。末尾の応答は「マージと後片付けが完了しました」のような
+  -- 締めの報告になりがちで、それを入れると主題ではなく後始末がタイトルになる。
+  if #assistants > 0 then
+    parts[#parts + 1] = ""
+    parts[#parts + 1] = "[ASSISTANT REPLIES — background only, not the subject]"
+    for j = 1, math.min(MAX_ASSISTANT_MESSAGES, #assistants) do
+      parts[#parts + 1] = "- " .. truncate(assistants[j], ASSISTANT_MESSAGE_CHARS)
+    end
+  end
+
+  return truncate(table.concat(parts, "\n"), MAX_TOTAL_CHARS)
+end
+
+return M

--- a/lua/vibing/core/utils/title_generator.lua
+++ b/lua/vibing/core/utils/title_generator.lua
@@ -6,89 +6,28 @@ local M = {}
 
 local filename_util = require("vibing.core.utils.filename")
 local language_utils = require("vibing.core.utils.language")
-
--- Title generation only needs the gist of the conversation. Sending the whole
--- history (or resuming/forking the full session) makes long chats fail with
--- "Prompt is too long", so we build a bounded excerpt instead.
--- Keep per-message and tail sizes small enough that first + tail comfortably fit
--- under MAX_TOTAL_CHARS, so the final safety-net truncation never drops the most
--- recent message (which matters most for the title).
-local MAX_MESSAGE_CHARS = 800
-local TAIL_MESSAGE_COUNT = 4
-local MAX_TOTAL_CHARS = 6000
-
----@param s string
----@param n integer
----@return string
-local function truncate(s, n)
-  if #s > n then
-    return s:sub(1, n) .. "…"
-  end
-  return s
-end
-
--- チャットバッファ上でツール呼び出しをレンダリングするときの行頭マーカー。
--- 軽量呼び出しでツールを無効化していても（denylist が腐って）モデルが narration や
--- ツール実況を返した場合に、その行をタイトル候補から除外するための防御。
-local TOOL_RENDER_MARKERS = { "⏺", "📄", "💻", "🔧", "✳", "☒", "☐", "⎿", "→" }
+local chat_excerpt = require("vibing.core.utils.chat_excerpt")
 
 ---AI応答から「タイトルとして使える最初の1行」を取り出す。
 ---ツール実況行（⏺ ToolSearch(...) 等）や空行を飛ばし、最初の意味のあるテキスト行を返す。
 ---これによりモデルがタイトル以外を返しても、複数行のゴミがそのままファイル名になるのを防ぐ。
+---軽量呼び出しでツールは無効化しているが、それが破れたときの防御として残している。
+---ツール行の判定は抜粋クリーニングと同じ `chat_excerpt` のものを使う（二重定義を作らないため）。
 ---@param text string
 ---@return string
 local function first_title_line(text)
   for _, line in ipairs(vim.split(text or "", "\n", { plain = true })) do
     local trimmed = vim.trim(line)
-    if trimmed ~= "" then
-      local is_marker = false
-      for _, marker in ipairs(TOOL_RENDER_MARKERS) do
-        if trimmed:sub(1, #marker) == marker then
-          is_marker = true
-          break
-        end
-      end
-      if not is_marker then
-        return trimmed
-      end
+    if trimmed ~= "" and not chat_excerpt.is_tool_line(trimmed) then
+      return trimmed
     end
   end
   return vim.trim((text or ""):match("^([^\n]*)") or "")
 end
 
----会話から「最初のユーザーメッセージ＋末尾数メッセージ」の抜粋を作る。
----各メッセージと全体の両方に上限を設け、長い会話でも context を超えないようにする。
----@param conversation {role: string, content: string}[]
----@return string
-local function build_excerpt(conversation)
-  local selected
-  if #conversation <= TAIL_MESSAGE_COUNT + 1 then
-    selected = conversation
-  else
-    selected = {}
-    -- 最初のユーザーメッセージでトピックを固定
-    for _, msg in ipairs(conversation) do
-      if msg.role == "user" then
-        selected[#selected + 1] = msg
-        break
-      end
-    end
-    -- 直近の文脈
-    for i = #conversation - TAIL_MESSAGE_COUNT + 1, #conversation do
-      selected[#selected + 1] = conversation[i]
-    end
-  end
-
-  local parts = {}
-  for _, msg in ipairs(selected) do
-    parts[#parts + 1] = string.format("[%s]: %s", msg.role, truncate(msg.content or "", MAX_MESSAGE_CHARS))
-  end
-  return truncate(table.concat(parts, "\n\n"), MAX_TOTAL_CHARS)
-end
-
 ---会話履歴からAIにタイトルを生成させる
----会話の抜粋（最初のユーザーメッセージ＋末尾数メッセージ、各上限付き）をアダプタに送り、
----簡潔なファイル名用タイトルを生成する。結果はコールバックで非同期に返される。
+---会話の抜粋（`chat_excerpt` がツール実況を落として user 発言中心に組み立てたもの）を
+---アダプタに送り、簡潔なファイル名用タイトルを生成する。結果はコールバックで非同期に返される。
 ---セッションの resume/fork は行わない（全履歴を読み込んで context を超過し
 ---"Prompt is too long" になるのを避けるため）。抜粋を都度フレッシュに送るだけなので session_id は不要。
 ---@param conversation {role: string, content: string}[] 会話履歴
@@ -111,12 +50,27 @@ function M.generate_from_conversation(conversation, callback, adapter)
 
   local lang_code = language_utils.get_language_code(config.language, "chat")
   local lang_name = lang_code and language_utils.language_names[lang_code]
-  local lang_instruction = lang_name and ("Generate the title in " .. lang_name .. ". ") or ""
 
-  local title_instruction = "Based on the above conversation, generate a concise title (maximum 30 characters) that summarizes the main topic. "
-    .. lang_instruction
-    .. "The title should be suitable for a filename. "
-    .. "Respond with ONLY the title, nothing else."
+  -- 「主題 = ユーザーが達成しようとしたこと」を明示する。これを言わないと、モデルは
+  -- 抜粋の末尾（マージ・クリーンアップ等の後始末）や実行したコマンドをタイトルにしてしまう。
+  local lines = {
+    "The text above is an excerpt of a conversation between a user and an AI coding assistant.",
+    "",
+    "Write a title naming WHAT THE USER WAS TRYING TO ACCOMPLISH across the whole conversation.",
+    "",
+    "Rules:",
+    "- The subject comes from the user's requests, not from the assistant's replies.",
+    "- Do not title it after the last step, the wrap-up work, or the tools and commands that were run.",
+    "- Be specific: name the feature, bug, file, or component involved.",
+    "- 30 characters maximum.",
+    "- No date, no file extension, no quotes, no surrounding punctuation.",
+  }
+  if lang_name then
+    lines[#lines + 1] = "- Write the title in " .. lang_name .. "."
+  end
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "Respond with ONLY the title, nothing else."
+  local title_instruction = table.concat(lines, "\n")
 
   -- Title generation is a lightweight utility call: no tools/CLAUDE.md/MCP needed
   local opts = {
@@ -125,7 +79,7 @@ function M.generate_from_conversation(conversation, callback, adapter)
 
   -- Always send a bounded excerpt as a fresh prompt (no resume/fork), so long
   -- chats never exceed the context window.
-  local prompt = build_excerpt(conversation) .. "\n\n" .. title_instruction
+  local prompt = chat_excerpt.build(conversation) .. "\n\n" .. title_instruction
 
   local collected_response = ""
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -39,7 +39,7 @@ end
 --- @return string|nil
 local function resolve_model(opts, config)
   if opts.lightweight then
-    return (config.agent and config.agent.utility_model) or "haiku"
+    return (config.agent and config.agent.utility_model) or "sonnet"
   end
   return opts.model or (config.agent and config.agent.default_model)
 end

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -45,8 +45,9 @@ local function resolve_model(opts, config)
 end
 
 --- Resolve the reasoning effort level for this call.
---- Lightweight calls (title generation, summarize, daily summary) use config.agent.utility_effort,
---- which pairs with utility_model to make those calls cheap on both axes.
+--- Lightweight calls (title generation, summarize, daily summary) use config.agent.utility_effort.
+--- It is not paired with a cheap model: utility_model defaults to sonnet because those calls
+--- summarise a noisy transcript. Low effort on a capable model is the trade being made.
 --- Returns nil when nothing is configured, so no --effort is passed and the CLI's own default
 --- applies — that default moves as Anthropic tunes it, and pinning it here would freeze it.
 --- Invalid values are dropped with a warning: the CLI accepts an unknown level without complaint

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -47,7 +47,7 @@ end
 --- Resolve the reasoning effort level for this call.
 --- Lightweight calls (title generation, summarize, daily summary) use config.agent.utility_effort.
 --- It is not paired with a cheap model: utility_model defaults to sonnet because those calls
---- summarise a noisy transcript. Low effort on a capable model is the trade being made.
+--- summarize a noisy transcript. Low effort on a capable model is the trade being made.
 --- Returns nil when nothing is configured, so no --effort is passed and the CLI's own default
 --- applies — that default moves as Anthropic tunes it, and pinning it here would freeze it.
 --- Invalid values are dropped with a warning: the CLI accepts an unknown level without complaint

--- a/tests/lua/core/utils/chat_excerpt_spec.lua
+++ b/tests/lua/core/utils/chat_excerpt_spec.lua
@@ -1,0 +1,162 @@
+local chat_excerpt = require("vibing.core.utils.chat_excerpt")
+
+describe("chat_excerpt.clean", function()
+  it("drops tool call headers including multi-line arguments", function()
+    local text = table.concat({
+      "原因が特定できました。",
+      "💻 Bash(cd /repo",
+      "git status --short",
+      "git log --oneline -5)",
+      "修正します。",
+    }, "\n")
+
+    local cleaned = chat_excerpt.clean(text)
+
+    assert.equals("原因が特定できました。\n修正します。", cleaned)
+  end)
+
+  it("drops tool result blocks and their indented continuation lines", function()
+    local text = table.concat({
+      "⏺ Read(/repo/init.lua)",
+      "  ⎿  local M = {}",
+      "     return M",
+      "読みました。",
+    }, "\n")
+
+    assert.equals("読みました。", chat_excerpt.clean(text))
+  end)
+
+  it("drops tool headers whose marker was customised in config", function()
+    -- config.ui.tool_markers is user-configurable, so glyph matching alone is not enough:
+    -- the "<symbol> Name(" shape has to be recognised structurally.
+    assert.equals("done", chat_excerpt.clean("✿ SomeTool(arg)\ndone"))
+  end)
+
+  it("keeps markdown bullets that mention a function call", function()
+    -- "- fix parse(input)" has the same "<symbol> name(" shape as a tool header. Dropping it
+    -- would delete the user's actual request, so the structural match requires a non-ASCII
+    -- marker; ASCII bullets are not tool markers.
+    local text = "- fix parse(input)\n* rename build(x)\n> check run(y)"
+
+    assert.equals(text, chat_excerpt.clean(text))
+  end)
+
+  it("stops swallowing a tool header's arguments at a blank line", function()
+    -- A shell command can contain unbalanced parens (`case x)`), so paren counting alone
+    -- would eat every following line. A blank line ends the header instead.
+    local text = table.concat({
+      "💻 Bash(case $x in",
+      "  a) echo a;;",
+      "",
+      "この後の説明は残す",
+    }, "\n")
+
+    assert.equals("この後の説明は残す", chat_excerpt.clean(text))
+  end)
+
+  it("drops tool result continuation lines indented deeper than five spaces", function()
+    local text = table.concat({
+      "  ⎿  {",
+      '       "key": "value"',
+      "     }",
+      "結果を読みました。",
+    }, "\n")
+
+    assert.equals("結果を読みました。", chat_excerpt.clean(text))
+  end)
+
+  it("drops fenced code blocks, @file: context and HTML comments", function()
+    local text = table.concat({
+      "@file:lua/vibing/init.lua:L10-L20",
+      "```lua",
+      "local x = 1",
+      "```",
+      "<!-- patch: .vibing/patches/abc.patch -->",
+      "この関数を直して",
+    }, "\n")
+
+    assert.equals("この関数を直して", chat_excerpt.clean(text))
+  end)
+
+  it("drops rate-limit notices so they cannot become the topic", function()
+    local text = "**Error:** You've hit your session limit · resets 3:40am\n\n*Session has been reset. Your next message will start a new session.*"
+
+    assert.equals("", chat_excerpt.clean(text))
+  end)
+end)
+
+describe("chat_excerpt.is_tool_line", function()
+  it("recognises rendered tool lines and leaves prose alone", function()
+    assert.is_true(chat_excerpt.is_tool_line("⏺ ToolSearch(select:TaskList)"))
+    assert.is_false(chat_excerpt.is_tool_line("認証まわりのバグ修正"))
+    assert.is_false(chat_excerpt.is_tool_line("- fix parse(input)"))
+  end)
+end)
+
+describe("chat_excerpt.build", function()
+  it("keeps every user request, not just the tail", function()
+    local conversation = {
+      { role = "user", content = "認証まわりのバグを直したい" },
+      { role = "assistant", content = "調べます。" },
+      { role = "user", content = "つづけて" },
+      { role = "assistant", content = "直しました。" },
+      { role = "user", content = "ではマージしてcleanup" },
+      { role = "assistant", content = "マージと後片付けが完了しました。" },
+    }
+
+    local excerpt = chat_excerpt.build(conversation)
+
+    assert.is_not_nil(excerpt:find("認証まわりのバグを直したい", 1, true))
+    assert.is_not_nil(excerpt:find("ではマージしてcleanup", 1, true))
+  end)
+
+  it("excludes the closing assistant report, which describes the wrap-up not the topic", function()
+    local conversation = {
+      { role = "user", content = "認証まわりのバグを直したい" },
+      { role = "assistant", content = "調べます。" },
+      { role = "assistant", content = "直しました。" },
+      { role = "assistant", content = "マージと後片付けが完了しました。" },
+    }
+
+    local excerpt = chat_excerpt.build(conversation)
+
+    assert.is_not_nil(excerpt:find("調べます。", 1, true))
+    assert.is_nil(excerpt:find("マージと後片付けが完了しました。", 1, true))
+  end)
+
+  it("drops auto-resume boilerplate user messages", function()
+    local conversation = {
+      { role = "user", content = "認証まわりのバグを直したい" },
+      { role = "user", content = "Continue from where you left off." },
+    }
+
+    local excerpt = chat_excerpt.build(conversation)
+
+    assert.is_nil(excerpt:find("Continue from where", 1, true))
+  end)
+
+  it("labels user requests as the subject and assistant replies as background", function()
+    local excerpt = chat_excerpt.build({
+      { role = "user", content = "topic" },
+      { role = "assistant", content = "reply" },
+    })
+
+    assert.is_not_nil(excerpt:find("USER REQUESTS", 1, true))
+    assert.is_not_nil(excerpt:find("background only", 1, true))
+  end)
+
+  it("bounds a long conversation", function()
+    local conversation = {}
+    for i = 1, 40 do
+      conversation[#conversation + 1] = { role = "user", content = "request " .. i .. " " .. string.rep("あ", 2000) }
+      conversation[#conversation + 1] = { role = "assistant", content = "reply " .. i .. " " .. string.rep("い", 2000) }
+    end
+
+    local excerpt = chat_excerpt.build(conversation)
+
+    assert.is_not_nil(excerpt:find("request 1 ", 1, true))
+    assert.is_not_nil(excerpt:find("request 40 ", 1, true))
+    assert.is_nil(excerpt:find("request 20 ", 1, true))
+    assert.is_true(vim.fn.strchars(excerpt) <= 6001)
+  end)
+end)

--- a/tests/lua/core/utils/chat_excerpt_spec.lua
+++ b/tests/lua/core/utils/chat_excerpt_spec.lua
@@ -83,6 +83,44 @@ describe("chat_excerpt.clean", function()
 
     assert.equals("", chat_excerpt.clean(text))
   end)
+
+  it("drops the whole approval block, including its Tool/Command lines", function()
+    -- The user answers by deleting all but one option, so what is sent still carries the header
+    -- and the tool details. Leaving those in put the approved command back into the title, which
+    -- is the exact failure this module exists to prevent.
+    local text = table.concat({
+      "⚠️  Tool approval required",
+      "",
+      "Tool: Bash",
+      "Command: npm install",
+      "File: /tmp/x.lua",
+      "",
+      "1. allow_once - Allow this execution only",
+      "",
+      "Please select and press `<CR>` to send.",
+      "",
+      "allow_once",
+    }, "\n")
+
+    assert.equals("allow_once", chat_excerpt.clean(text))
+  end)
+end)
+
+describe("chat_excerpt.clean_user", function()
+  it("keeps a request that opens with a marker glyph", function()
+    -- `→` and `💻` are rendered tool markers, but they are also ordinary punctuation in a
+    -- request. Stripping them here deletes the very thing the excerpt is built from.
+    local text = "認証まわりのバグ修正\n→ ログイン失敗時のエラーメッセージを直して"
+
+    assert.equals(text, chat_excerpt.clean_user(text))
+    assert.equals("💻 環境構築で詰まってるので直して", chat_excerpt.clean_user("💻 環境構築で詰まってるので直して"))
+  end)
+
+  it("still drops structured tool renders and results", function()
+    local text = "⏺ Bash(npm test)\n⎿ 3 passed\n     detail line\nこれで直った？"
+
+    assert.equals("これで直った？", chat_excerpt.clean_user(text))
+  end)
 end)
 
 describe("chat_excerpt.is_tool_line", function()
@@ -133,6 +171,34 @@ describe("chat_excerpt.build", function()
     local excerpt = chat_excerpt.build(conversation)
 
     assert.is_nil(excerpt:find("Continue from where", 1, true))
+  end)
+
+  it("keeps a user request written with marker glyphs, while still cleaning the assistant", function()
+    local conversation = {
+      { role = "user", content = "→ ログイン失敗時のエラーメッセージを直して" },
+      { role = "assistant", content = "⏺ Bash(npm test)\n直しました。" },
+    }
+
+    local excerpt = chat_excerpt.build(conversation)
+
+    assert.is_not_nil(excerpt:find("→ ログイン失敗時のエラーメッセージを直して", 1, true))
+    assert.is_nil(excerpt:find("(none)", 1, true))
+    assert.is_nil(excerpt:find("npm test", 1, true))
+  end)
+
+  it("drops a user message that is nothing but an approval answer", function()
+    local conversation = {
+      { role = "user", content = "認証まわりのバグを直したい" },
+      {
+        role = "user",
+        content = "⚠️  Tool approval required\n\nTool: Bash\nCommand: rm -rf build\n\n1. allow_once - Allow this execution only\n\nPlease select and press `<CR>` to send.\n\nallow_once",
+      },
+    }
+
+    local excerpt = chat_excerpt.build(conversation)
+
+    assert.is_nil(excerpt:find("rm -rf build", 1, true))
+    assert.is_nil(excerpt:find("allow_once", 1, true))
   end)
 
   it("labels user requests as the subject and assistant replies as background", function()

--- a/tests/lua/core/utils/chat_excerpt_spec.lua
+++ b/tests/lua/core/utils/chat_excerpt_spec.lua
@@ -84,6 +84,14 @@ describe("chat_excerpt.clean", function()
     assert.equals("", chat_excerpt.clean(text))
   end)
 
+  it("does not let a quoted paren end a multi-line Bash header early", function()
+    -- `echo ')'` balances the header's own `(` on the first line, so a naive count stops there
+    -- and leaves the rest of the command as prose — putting that command back in the title.
+    local text = "💻 Bash(echo ')'\ngit rebase origin/main)\n直しました。"
+
+    assert.equals("直しました。", chat_excerpt.clean(text))
+  end)
+
   it("drops the whole approval block, including its Tool/Command lines", function()
     -- The user answers by deleting all but one option, so what is sent still carries the header
     -- and the tool details. Leaving those in put the approved command back into the title, which
@@ -120,6 +128,14 @@ describe("chat_excerpt.clean_user", function()
     local text = "⏺ Bash(npm test)\n⎿ 3 passed\n     detail line\nこれで直った？"
 
     assert.equals("これで直った？", chat_excerpt.clean_user(text))
+  end)
+
+  it("keeps a request whose identifier is not immediately followed by a paren", function()
+    -- The known cost of applying the structural match to user text: `→ fix(login)` looks exactly
+    -- like a rendered tool call and is dropped. Anything between the identifier and the `(`
+    -- breaks the resemblance, which is what most prose does.
+    assert.equals("→ fix login(button)", chat_excerpt.clean_user("→ fix login(button)"))
+    assert.equals("", chat_excerpt.clean_user("→ fix(login)"))
   end)
 end)
 

--- a/tests/lua/core/utils/title_generator_spec.lua
+++ b/tests/lua/core/utils/title_generator_spec.lua
@@ -99,8 +99,21 @@ describe("title_generator.generate_from_conversation", function()
     assert.is_not_nil(captured_prompt:find("FIRST_TOPIC_ANCHOR", 1, true))
     assert.is_not_nil(captured_prompt:find("LAST_RECENT_MESSAGE", 1, true))
     -- ...but the whole history is not sent verbatim (a far-middle message is dropped).
-    assert.is_nil(captured_prompt:find("middle message 1 ", 1, true))
+    assert.is_nil(captured_prompt:find("middle message 20 ", 1, true))
     -- And the total prompt stays bounded.
     assert.is_true(#captured_prompt < 20000)
+  end)
+
+  it("strips tool narration from the excerpt it sends", function()
+    -- The chat buffer stores rendered tool calls, so the raw conversation is mostly
+    -- `💻 Bash(...)` lines. Sending those makes the model title the chat after the
+    -- commands that ran instead of what the user asked for.
+    title_generator.generate_from_conversation({
+      { role = "user", content = "認証のバグを直して" },
+      { role = "assistant", content = "調べます。\n💻 Bash(git rebase origin/main)\n直りました。" },
+    }, function() end)
+
+    assert.is_nil(captured_prompt:find("git rebase", 1, true))
+    assert.is_not_nil(captured_prompt:find("認証のバグを直して", 1, true))
   end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -319,11 +319,11 @@ describe("cli_command_builder", function()
       assert.is_nil(find_flag(cmd, "--permission-mode"))
     end)
 
-    it("uses config.agent.utility_model, defaulting to haiku when unset", function()
+    it("uses config.agent.utility_model, defaulting to sonnet when unset", function()
       local cmd = cli_command_builder.build("hello", { lightweight = true }, nil, {}, nil)
       local idx = find_flag(cmd, "--model")
       assert.is_not_nil(idx)
-      assert.equals("haiku", cmd[idx + 1])
+      assert.equals("sonnet", cmd[idx + 1])
     end)
 
     it("prefers config.agent.utility_model over opts.model and config.agent.default_model", function()


### PR DESCRIPTION
## 問題

`:VibingSetFileTitle` が付けるタイトルが、会話の主題ではなく**終盤の後始末や実行したコマンド**になっていました。

| 実際の依頼 | 付いたタイトル |
|---|---|
| fixブランチのworktreeを切ってPR（中身は rate_limit 誤検知の修正） | `fixブランチのworktree作成` |
| openなissueをS/Aから worktree 切って PR | `マージ済みワークツリー削除` |
| VibingPendingResumes ってなに＋バグ報告 | `ペンディングレジューム追加` |

## 原因

`extract_conversation` が返すのは**チャットバッファの描画テキストそのもの**なので、assistant セクションの中身はほぼツール実況です。旧 `build_excerpt` は「最初のuser 1件＋末尾4件、各800字」を切るだけだったため、モデルが実際に見ていたのはこうなっていました。

```
[assistant]: 💻 Bash(gh pr view 510 --json number,title,headRefName,...)
             💻 Bash(git worktree list && git status --short | head -20)
             💻 Bash(cd .vibing/worktrees/... && git status --short ...)
```

複数行の `Bash(...)` ヘッダー1本で800字の枠が埋まり、地の文がほぼ入りません。さらに末尾4件偏重なので主題より終盤の雑務が勝ち、`**Error:** You've hit your session limit` / `Continue from where you left off.` / `@file:` ブロックもそのまま混入していました。

## 変更

- **`lua/vibing/core/utils/chat_excerpt.lua`（新規）**
  ツール呼び出しヘッダー（複数行引数は括弧の釣り合いで終端検出）、`⎿` 結果ブロックとその継続行、コードフェンス、HTMLコメント、`@file:`、レート制限通知、承認UIを除去します。マーカーは `config.ui.tool_markers` で差し替え可能なので、グリフ一覧に加えて `<非ASCII記号> ToolName(` の構造でも判定します（`- fix parse(input)` のような箇条書きを誤って消さないよう、非ASCIIを必須にしています）。
- **抜粋を user 中心に再構成**
  user 発言は全件（8件超なら先頭4＋末尾4）、assistant は冒頭2件のみ400字。締めの報告（「マージと後片付けが完了しました」）は入れません。
- **プロンプト強化**
  「主題は user が達成しようとしたこと。末尾の作業や実行したコマンドではない」を明示。
- **`agent.utility_model` を `haiku` → `sonnet`**
  下の実測に基づく変更です。`utility_effort` は `low` のままなので、「安いモデル×低 effort」から「賢いモデル×低 effort」に振り替えた形になります。`"haiku"` に戻せる旨は docs に記載しました。
- `first_title_line` が持っていたマーカー一覧の二重定義を削除し、`chat_excerpt.is_tool_line` に集約。

## 実測（実チャット15件、判定可能な14件）

| | 主題が合っている |
|---|---|
| 旧（haiku） | 7/14 |
| 新抜粋（haiku） | 11/14 |
| 新抜粋（sonnet） | 13/14 |

同じ3例の改善後:

| 実際の依頼 | 変更後 |
|---|---|
| fixブランチのworktreeを切ってPR | `rate_limit誤検知修正PR作成` |
| openなissueをS/Aから worktree 切って PR | `Issue対応PRの作成とマージ` |
| VibingPendingResumes ってなに＋バグ報告 | `自動再開待ち機能の調査とREADME修正` |

抜粋の修正だけで 7→11、sonnet でさらに +2 です。

## テスト

- `chat_excerpt_spec.lua`（新規14件）— クリーニング各種、箇条書きの誤検知回避、括弧が釣り合わないコマンドの打ち切り、user 全件保持、締めの応答の除外、定型メッセージの除去、長い会話の上限
- `title_generator_spec.lua` — ツール実況が抜粋に混ざらないことを追加
- `pnpm run test:lua` / `test:e2e` / `check` / `format:check` すべて通過

## 影響範囲

`utility_model` の既定変更は `/summarize` と daily summary にも効きます。いずれも入力数千トークンのオンデマンド呼び出しなのでコスト増は小さい想定ですが、最安を優先する場合は `utility_model = "haiku"` で戻せます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic title generation by prioritizing user requests and removing tool output, system messages, and other conversation noise.
  * Added support for clearer, bounded conversation excerpts while preserving meaningful context.

* **Improvements**
  * Lightweight utility operations now default to the more capable Sonnet model, with configurable effort.
  * Updated configuration documentation to reflect the new default and model options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->