### PR TITLE
fix(permissions): actually grant vibing-nvim MCP tools in the PreToolUse hook

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -42,6 +42,27 @@ listening port it falls back to a PID-suffixed path rather than a single shared 
 The instance registry has the same treatment via `$VIBING_INSTANCES_DIR` (honoured by both
 `rpc/registry.lua` and `mcp-server/src/handlers/instances.ts`).
 
+The `.res` file carries **three** decisions, not two, and the difference is the whole permission
+contract with the CLI:
+
+- **`deny`** — the hook exits 2 with the reason on stderr, which is how a deny rule's `message`
+  reaches the model.
+- **`allow`** — the hook prints the JSON verbatim on stdout, and the CLI skips its own permission
+  gate. Note that exiting 0 in silence is **not** an approval: the CLI reads it as "no opinion".
+- **`defer`** — vibing.nvim permits the call but leaves the CLI's gate, and with it the user's own
+  `settings.json` rules, in charge. The hook exits 0 silently.
+
+Only vibing-nvim's own MCP tools get `allow`; everything else vibing.nvim permits gets `defer`.
+Granting everything would override the user's `settings.json` deny rules, which
+`--setting-sources user,project,local` still pulls in.
+
+Those MCP tools are the exception because `--allowedTools` cannot express them reliably: it takes
+literal prefixes, and the plugin-scoped one is `mcp__plugin_<marketplace>_vibing-nvim__`, a name
+fixed when `claude plugin marketplace add` ran. `can_use_tool.is_vibing_nvim_mcp_tool` matches on
+the suffix instead, so the grant survives a rename that `VIBING_NVIM_MCP_TOOL_PATTERNS` would not.
+Before #564 every allowed call took the silent path, so under any mode but `bypassPermissions` the
+CLI refused those tools while vibing.nvim's own log said "allow".
+
 `hook_cleanup.cleanup_stale_dirs()` (run at startup) treats a comm directory as stale only when
 its owning Neovim is gone: it cross-checks `registry.list()`, which already filters to live PIDs,
 so a concurrent instance's in-flight `.req`/`.res` files are never deleted.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -63,6 +63,14 @@ the suffix instead, so the grant survives a rename that `VIBING_NVIM_MCP_TOOL_PA
 Before #564 every allowed call took the silent path, so under any mode but `bypassPermissions` the
 CLI refused those tools while vibing.nvim's own log said "allow".
 
+The match is on the name and nothing else, and that is worth stating plainly because an `allow`
+skips the user's own `settings.json` rules. It requires the separator both registration styles put
+before the server name (`_vibing-nvim__nvim_<tool>`), so a server merely _ending_ with the name
+(`mcp__my-vibing-nvim__…`) does not match. A third-party server genuinely registered as
+`vibing-nvim` and exposing `nvim_*` tools **would** be granted — nothing in a tool name says who
+registered it. That needs an untrusted MCP server already in the user's own Claude Code config, so
+it is accepted rather than solved.
+
 `hook_cleanup.cleanup_stale_dirs()` (run at startup) treats a comm directory as stale only when
 its owning Neovim is gone: it cross-checks `registry.list()`, which already filters to live PIDs,
 so a concurrent instance's in-flight `.req`/`.res` files are never deleted.

--- a/bin/hooks/pre-tool-use.sh
+++ b/bin/hooks/pre-tool-use.sh
@@ -62,18 +62,30 @@ if [ -f "$RES_FILE" ]; then
   debug_log "got response: $RESPONSE"
   rm -f "$REQ_FILE" "$RES_FILE" 2>/dev/null
 
-  # Check if decision is deny → exit 2 with reason on stderr
   DECISION=$(echo "$RESPONSE" | grep -o '"permissionDecision":"[^"]*"' | head -1 | cut -d'"' -f4)
 
-  if [ "$DECISION" = "deny" ]; then
-    REASON=$(echo "$RESPONSE" | grep -o '"permissionDecisionReason":"[^"]*"' | head -1 | cut -d'"' -f4)
-    debug_log "DENY: $REASON"
-    echo "${REASON:-Denied by vibing.nvim}" >&2
-    exit 2
-  fi
-
-  debug_log "ALLOW"
-  exit 0
+  case "$DECISION" in
+    deny)
+      REASON=$(echo "$RESPONSE" | grep -o '"permissionDecisionReason":"[^"]*"' | head -1 | cut -d'"' -f4)
+      debug_log "DENY: $REASON"
+      echo "${REASON:-Denied by vibing.nvim}" >&2
+      exit 2
+      ;;
+    allow)
+      # An explicit grant, which makes the CLI skip its own permission gate. Exiting 0 without
+      # printing this is NOT a grant -- a silent exit 0 reads as "no opinion", and in headless
+      # `-p` mode the gate it falls back to cannot prompt anyone, so the tool is refused (#564).
+      debug_log "ALLOW (explicit grant)"
+      printf '%s' "$RESPONSE"
+      exit 0
+      ;;
+    *)
+      # "defer" (and any response shape this script does not recognise): vibing.nvim permits the
+      # call but leaves the CLI's own gate, and with it the user's settings.json rules, in charge.
+      debug_log "DEFER to the CLI's own permission flow"
+      exit 0
+      ;;
+  esac
 fi
 
 # Timeout - fail closed (deny)

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -43,15 +43,22 @@ for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
 end
 
 ---vibing-nvim自身が提供するMCPツールの許可パターン。プレーンなユーザーレベルMCPサーバー登録
----（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*、
----このリポジトリが.claude-plugin/marketplace.jsonで出荷する"vibing"マーケットプレイス名前提）の
----両方に対応する。can_use_tool.M.is_vibing_nvim_mcp_tool側はサフィックスマッチでマーケットプレイス名
----に依存しないが、Claude Code CLIの--allowedToolsゲート自体は具体的なプレフィックスを要求するため、
----こちらは定数化のみで対応している。マーケットプレイス名を変更した場合はここを更新すること。
+---（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*）の
+---両方に対応する。
+---
+---プラグイン側の接頭辞は`mcp__plugin_vibing-nvim_vibing-nvim__`。マーケットプレイス名は
+---.claude-plugin/marketplace.jsonの`name`（"vibing"）ではなく`claude plugin marketplace add`が
+---実際に登録した名前で決まり、build.shが入れるのは`vibing-nvim@vibing-nvim`である（`claude plugin
+---list --json`のidと、実際に配られるツール名の両方で確認済み）。
+---
+---ただしこのリストにマーケットプレイス名の追従を頼ってはいけない。--allowedToolsは具体的な
+---プレフィックスしか受け付けず、ここがずれると当該ツールはCLI自身のゲートで止まる（#564）。
+---最終的な担保はPreToolUseフックが返す明示的なallow決定のほうで、そちらは
+---can_use_tool.M.is_vibing_nvim_mcp_toolのサフィックスマッチなのでマーケットプレイス名に依存しない。
 ---@type string[]
 M.VIBING_NVIM_MCP_TOOL_PATTERNS = {
   "mcp__vibing-nvim__*",
-  "mcp__plugin_vibing_vibing-nvim__*",
+  "mcp__plugin_vibing-nvim_vibing-nvim__*",
 }
 
 ---`permissions.allow`の既定値。`config.lua`はこのリストを参照するだけで、値を再列挙しない。

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -65,11 +65,19 @@ local INTERNAL_TOOLS = {
 
 --- Check whether a tool name is a vibing-nvim MCP tool, regardless of how the MCP server was
 --- registered (plain user-level server vs. Claude Code plugin — see the call site for details).
+---
+--- The leading `_` is the whole reason this is not a bare suffix match. Both registration styles
+--- put a separator directly before the server name — `mcp__vibing-nvim__` and
+--- `mcp__plugin_<marketplace>_vibing-nvim__` — so requiring one rejects a server whose name merely
+--- *ends* with it (`mcp__my-vibing-nvim__nvim_get_buffer`). What it cannot reject is a third-party
+--- server actually named `vibing-nvim` exposing `nvim_*` tools: nothing in the tool name says who
+--- registered it. That call is granted, which matters because this decision bypasses the CLI's own
+--- gate — see the call site in `rpc/handlers/permission.lua`.
 --- @param tool_name string
 --- @param specific_tool? string Match only this vibing-nvim tool (e.g. "nvim_ask_user_question"); omit to match any vibing-nvim MCP tool
 --- @return boolean
 function M.is_vibing_nvim_mcp_tool(tool_name, specific_tool)
-  local pattern = specific_tool and ("vibing%-nvim__" .. specific_tool .. "$") or "vibing%-nvim__nvim_[%w_]+$"
+  local pattern = specific_tool and ("_vibing%-nvim__" .. specific_tool .. "$") or "_vibing%-nvim__nvim_[%w_]+$"
   return tool_name:match(pattern) ~= nil
 end
 

--- a/lua/vibing/infrastructure/rpc/handlers/permission.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/permission.lua
@@ -101,19 +101,30 @@ local function get_comm_dir()
 end
 
 --- Write response file for hook script
+---
+--- The file is a private protocol between this handler and `bin/hooks/pre-tool-use.sh`, so it
+--- carries three decisions where the CLI's own hook schema has two:
+---
+---   "allow"  — an explicit grant. The hook prints this JSON verbatim on stdout, which makes the
+---              CLI skip its own permission gate. Anything less is not a grant: a hook that just
+---              exits 0 reads as "no opinion", and in headless `-p` mode the gate it falls
+---              through to has no way to prompt, so the tool is refused (#564).
+---   "deny"   — the hook exits 2 with the reason on stderr.
+---   "defer"  — vibing.nvim permits the call but leaves the CLI's own gate (and with it the
+---              user's own settings.json rules) in charge. The hook exits 0 silently.
+---
 --- @param request_id string
---- @param allow boolean
+--- @param decision "allow"|"deny"|"defer"
 --- @param reason? string Surfaced to the model as the tool_result when the underlying process
 ---   was NOT successfully cancelled (e.g. cancel_and_deny's fallback path). When cancellation
 ---   does succeed, the process is killed before this response can ever reach the model, so the
 ---   reason is moot in that case — it only matters for the failure path.
-local function write_hook_response(request_id, allow, reason)
+local function write_hook_response(request_id, decision, reason)
   local comm_dir = get_comm_dir()
   local res_file = comm_dir .. "/" .. request_id .. ".res"
   local tmp_file = res_file .. ".tmp"
 
-  local decision = allow and "allow" or "deny"
-  local output = { permissionDecision = decision }
+  local output = { hookEventName = "PreToolUse", permissionDecision = decision }
   if reason then
     output.permissionDecisionReason = reason
   end
@@ -136,7 +147,7 @@ local function write_hook_response(request_id, allow, reason)
     local fallback_f, fallback_err = io.open(res_file, "w")
     if fallback_f then
       local deny_json = vim.json.encode({
-        hookSpecificOutput = { permissionDecision = "deny" },
+        hookSpecificOutput = { hookEventName = "PreToolUse", permissionDecision = "deny" },
       })
       fallback_f:write(deny_json)
       fallback_f:close()
@@ -170,7 +181,7 @@ function M.check_tool_permission(params)
 
   local f = io.open(req_file, "r")
   if not f then
-    write_hook_response(request_id, true)
+    write_hook_response(request_id, "defer")
     return { status = "allowed", reason = "request file not found" }
   end
 
@@ -179,7 +190,7 @@ function M.check_tool_permission(params)
 
   local ok, hook_input = pcall(vim.json.decode, content)
   if not ok or not hook_input then
-    write_hook_response(request_id, true)
+    write_hook_response(request_id, "defer")
     return { status = "allowed", reason = "invalid request JSON" }
   end
 
@@ -227,7 +238,7 @@ function M.check_tool_permission(params)
         vim.notify("[vibing] cancel_and_deny: no active stream found", vim.log.levels.WARN)
         reason = fallback_reason
       end
-      write_hook_response(request_id, false, reason)
+      write_hook_response(request_id, "deny", reason)
     end)
   end
 
@@ -265,13 +276,20 @@ function M.check_tool_permission(params)
       end
       require("vibing.core.utils.request_diff").capture(effective_handle, tool_name, tool_input)
     end)
-    write_hook_response(request_id, true)
+    -- Only vibing-nvim's own MCP tools are granted outright; everything else defers to the CLI's
+    -- gate, which is still where the user's own settings.json rules are enforced. The distinction
+    -- is not cosmetic: --allowedTools needs a literal prefix, and the plugin's is
+    -- mcp__plugin_<marketplace>_vibing-nvim__ — a name decided at install time that this process
+    -- cannot know. is_vibing_nvim_mcp_tool matches on the suffix instead, so granting here is the
+    -- only form of the answer that survives the marketplace being renamed (#564).
+    local decision = can_use_tool_mod.is_vibing_nvim_mcp_tool(tool_name) and "allow" or "defer"
+    write_hook_response(request_id, decision)
     return { status = "allowed" }
   elseif result.behavior == "deny" then
     -- The reason has to go into the response, not just the return value: the hook script reads
     -- `permissionDecisionReason` and echoes it on stderr, which is the only way a deny rule's
     -- `message` ever reaches the model. Without it every denial reads as a bare "denied by hook".
-    write_hook_response(request_id, false, result.message)
+    write_hook_response(request_id, "deny", result.message)
     return { status = "denied", reason = result.message }
   else
     -- "ask" → kill process first, show approval UI, then write deny

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -276,7 +276,10 @@ describe("cli_command_builder", function()
       assert.is_not_nil(idx)
       local allowed = cmd[idx + 1]
       assert.is_true(allowed:find("mcp__vibing-nvim__*", 1, true) ~= nil)
-      assert.is_true(allowed:find("mcp__plugin_vibing_vibing-nvim__*", 1, true) ~= nil)
+      -- The plugin-scoped prefix has to be the one build.sh actually installs
+      -- (`vibing-nvim@vibing-nvim`); --allowedTools takes literal prefixes, so a stale
+      -- marketplace name here silently matches nothing at all (#564).
+      assert.is_true(allowed:find("mcp__plugin_vibing-nvim_vibing-nvim__*", 1, true) ~= nil)
     end)
   end)
 

--- a/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
+++ b/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
@@ -145,5 +145,18 @@ describe("can_use_tool", function()
     it("does not match native AskUserQuestion", function()
       assert.is_false(can_use_tool.is_vibing_nvim_mcp_tool("AskUserQuestion", "nvim_ask_user_question"))
     end)
+
+    it("does not match a server whose name merely ends with vibing-nvim", function()
+      -- Matching here would grant an unrelated server the CLI-gate bypass. Both real registration
+      -- styles put a separator right before the name, so requiring one costs nothing.
+      assert.is_false(can_use_tool.is_vibing_nvim_mcp_tool("mcp__my-vibing-nvim__nvim_get_buffer"))
+      assert.is_false(
+        can_use_tool.is_vibing_nvim_mcp_tool("mcp__my-vibing-nvim__nvim_ask_user_question", "nvim_ask_user_question")
+      )
+    end)
+
+    it("does not match a non-nvim_ tool on the vibing-nvim server", function()
+      assert.is_false(can_use_tool.is_vibing_nvim_mcp_tool("mcp__vibing-nvim__something_else"))
+    end)
   end)
 end)

--- a/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
@@ -1,0 +1,80 @@
+---@diagnostic disable: undefined-field
+--- What the handler writes into the .res file is the whole permission contract with the CLI, and
+--- it is three-valued rather than two: an allowed call is either granted outright or handed back
+--- to the CLI's own gate. Before #564 every allowed call took the second path, which in headless
+--- `-p` mode simply refuses vibing-nvim's own MCP tools.
+local permission = require("vibing.infrastructure.rpc.handlers.permission")
+
+local HANDLE_ID = "decision-spec-handle"
+
+local comm_dir
+
+local function write_request(request_id, tool_name, tool_input)
+  local f = assert(io.open(comm_dir .. "/" .. request_id .. ".req", "w"))
+  f:write(vim.json.encode({ tool_name = tool_name, tool_input = tool_input or {} }))
+  f:close()
+end
+
+--- @return table hookSpecificOutput
+local function decide(request_id, tool_name, tool_input)
+  write_request(request_id, tool_name, tool_input)
+  permission.check_tool_permission({ request_id = request_id, handle_id = HANDLE_ID })
+
+  local f = assert(io.open(comm_dir .. "/" .. request_id .. ".res", "r"))
+  local content = f:read("*a")
+  f:close()
+  return vim.json.decode(content).hookSpecificOutput
+end
+
+describe("permission handler hook decision", function()
+  local original_comm_dir
+
+  before_each(function()
+    original_comm_dir = vim.env.VIBING_HOOK_COMM_DIR
+    comm_dir = vim.fn.tempname()
+    vim.fn.mkdir(comm_dir, "p")
+    vim.env.VIBING_HOOK_COMM_DIR = comm_dir
+    permission.set_active_opts(HANDLE_ID, {
+      permissions_allow = { "Read" },
+      permissions_deny = { "Bash" },
+      permission_mode = "acceptEdits",
+    })
+  end)
+
+  after_each(function()
+    permission.clear_active_opts(HANDLE_ID)
+    vim.env.VIBING_HOOK_COMM_DIR = original_comm_dir
+    vim.fn.delete(comm_dir, "rf")
+  end)
+
+  it("grants vibing-nvim's own MCP tools outright", function()
+    local output = decide("req-mcp", "mcp__plugin_vibing-nvim_vibing-nvim__nvim_list_windows", {})
+
+    assert.equals("allow", output.permissionDecision)
+    -- Without hookEventName the CLI does not read the object as a PreToolUse decision at all.
+    assert.equals("PreToolUse", output.hookEventName)
+  end)
+
+  it("grants them whatever marketplace the plugin was installed from", function()
+    -- The prefix is decided at install time and cannot be known here, which is exactly why the
+    -- grant has to come from this suffix match rather than from --allowedTools.
+    local output = decide("req-mcp-alt", "mcp__plugin_some-other-name_vibing-nvim__nvim_get_buffer", {})
+
+    assert.equals("allow", output.permissionDecision)
+  end)
+
+  it("defers an ordinary allowed tool to the CLI's own gate", function()
+    -- Not "allow": granting every permitted tool would also override the deny rules in the user's
+    -- own settings.json, which --setting-sources still pulls in.
+    local output = decide("req-read", "Read", { file_path = "/tmp/x.lua" })
+
+    assert.equals("defer", output.permissionDecision)
+  end)
+
+  it("denies with the reason attached", function()
+    local output = decide("req-bash", "Bash", { command = "echo hi" })
+
+    assert.equals("deny", output.permissionDecision)
+    assert.is_truthy(output.permissionDecisionReason)
+  end)
+end)

--- a/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
@@ -63,6 +63,21 @@ describe("permission handler hook decision", function()
     assert.equals("allow", output.permissionDecision)
   end)
 
+  it("defers a server whose name merely ends with vibing-nvim", function()
+    -- Permitted by the allow list, so the only question left is which of the two "yes" answers it
+    -- gets. "allow" would hand an unrelated MCP server the same bypass of the user's own
+    -- settings.json that vibing-nvim's own tools get.
+    local LOOKALIKE = "mcp__my-vibing-nvim__nvim_get_buffer"
+    permission.set_active_opts(HANDLE_ID, {
+      permissions_allow = { LOOKALIKE },
+      permission_mode = "acceptEdits",
+    })
+
+    local output = decide("req-lookalike", LOOKALIKE, {})
+
+    assert.equals("defer", output.permissionDecision)
+  end)
+
   it("defers an ordinary allowed tool to the CLI's own gate", function()
     -- Not "allow": granting every permitted tool would also override the deny rules in the user's
     -- own settings.json, which --setting-sources still pulls in.

--- a/tests/pre-tool-use-hook.test.mjs
+++ b/tests/pre-tool-use-hook.test.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * The hook script is the half of the permission contract that talks to the CLI, and the CLI reads
+ * it entirely through the exit code and stdout. Exiting 0 in silence is not an approval — it means
+ * "no opinion", and the gate it falls through to cannot prompt anyone in headless `-p` mode, so
+ * vibing-nvim's own MCP tools were refused under acceptEdits (issue #564).
+ *
+ * These tests stand in for the Neovim RPC server: a TCP listener that writes the .res file the
+ * handler would write, so the real script runs its real polling path.
+ */
+
+import { strict as assert } from 'assert';
+import { test } from 'node:test';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const HOOK = join(repoRoot, 'bin/hooks/pre-tool-use.sh');
+
+/**
+ * Run the hook against a fake RPC server that answers with `hookOutput`.
+ * @param {object} hookOutput value for hookSpecificOutput in the .res file
+ */
+async function runHook(hookOutput) {
+  const commDir = await mkdtemp(join(tmpdir(), 'vibing-hook-test-'));
+  const server = createServer((socket) => {
+    socket.on('data', async (buf) => {
+      const requestId = JSON.parse(buf.toString()).params.request_id;
+      await writeFile(
+        join(commDir, `${requestId}.res`),
+        JSON.stringify({ hookSpecificOutput: hookOutput })
+      );
+      socket.end();
+    });
+  });
+
+  try {
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    const child = spawn(HOOK, {
+      env: {
+        ...process.env,
+        VIBING_NVIM_RPC_PORT: String(server.address().port),
+        VIBING_HOOK_COMM_DIR: commDir,
+      },
+    });
+    child.stdin.end(JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/tmp/x' } }));
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => (stdout += c));
+    child.stderr.on('data', (c) => (stderr += c));
+    const code = await new Promise((resolve) => child.on('close', resolve));
+
+    return { code, stdout, stderr };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(commDir, { recursive: true, force: true });
+  }
+}
+
+test('allow is forwarded to the CLI verbatim, not swallowed', async () => {
+  const output = {
+    hookEventName: 'PreToolUse',
+    permissionDecision: 'allow',
+    permissionDecisionReason: 'allowed by vibing.nvim',
+  };
+  const { code, stdout } = await runHook(output);
+
+  assert.equal(code, 0);
+  assert.deepEqual(
+    JSON.parse(stdout),
+    { hookSpecificOutput: output },
+    'a silent exit 0 is not a grant — the decision has to reach the CLI on stdout'
+  );
+});
+
+test('defer exits 0 without claiming a decision', async () => {
+  const { code, stdout } = await runHook({
+    hookEventName: 'PreToolUse',
+    permissionDecision: 'defer',
+  });
+
+  assert.equal(code, 0);
+  assert.equal(stdout, '', 'defer must leave the CLI’s own permission flow in charge');
+});
+
+test('deny blocks with the reason on stderr', async () => {
+  const { code, stderr } = await runHook({
+    hookEventName: 'PreToolUse',
+    permissionDecision: 'deny',
+    permissionDecisionReason: 'Cannot modify sensitive files',
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr, /Cannot modify sensitive files/);
+});


### PR DESCRIPTION
Closes #564

## 原因

イシューに書かれていた「フックは allow を返しているのに CLI が拒否する」の答えは、イシュー本文の推測どおりでした。**`bin/hooks/pre-tool-use.sh` は allow のとき stdout に何も書かず `exit 0` するだけで、これは Claude Code のフック契約では「許可」ではなく「判断なし」**です。判断がなければ CLI は自分の権限ゲートに落ち、headless `-p` では誰にも聞けないので拒否になります。だから `bypassPermissions` だけが通りました。

実測（最小の MCP サーバーを立て、`--permission-mode acceptEdits` で再現）:

| フックの stdout | 結果 |
| --- | --- |
| なし（`exit 0` のみ = 現状） | `Claude requested permissions to use mcp__probe__probe_touch, but you haven't granted it yet.`（2/2 再現） |
| `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow",...}}` | ツールが実行される |

## `--allowedTools` が効かなかった理由

イシューの表では「完全修飾名でも効かない」となっていましたが、**同じ最小構成で測ると `--allowedTools` は効きます**（`mcp__probe__probe_touch` も `mcp__probe__*` も、カンマ結合リストの一部でも通りました）。効かなかったのは接頭辞がずれていたためです。

`lua/vibing/core/constants/tools.lua` は `mcp__plugin_vibing_vibing-nvim__*` を持っていましたが、実際に配られる接頭辞は `mcp__plugin_vibing-nvim_vibing-nvim__` です。マーケットプレイス名は `.claude-plugin/marketplace.json` の `name`（`"vibing"`）ではなく `claude plugin marketplace add` が登録した名前で決まり、`claude plugin marketplace list` は `vibing-nvim`、`claude plugin list --json` の id は `vibing-nvim@vibing-nvim` でした。`--allowedTools` はリテラル接頭辞しか受け付けないので、ずれた名前は何にもマッチしません。

## 修正

**1. フックが実際に許可を返すようにする。** `.res` ファイルの決定を2値から3値にしました。

- `allow` — JSON をそのまま stdout に出す。CLI 自身のゲートを飛ばす
- `deny` — 従来どおり exit 2 + stderr に理由
- `defer` — vibing.nvim としては許可するが、CLI 自身のゲート（＝ユーザーの `settings.json` のルール）に委ねる。従来の無言 `exit 0` と同じ

**`allow` を返すのは vibing-nvim 自身の MCP ツールだけ**にしています。全許可ツールに `allow` を返すと、`--setting-sources user,project,local` で読み込まれるユーザー自身の `settings.json` の deny ルールまで上書きしてしまうためです。

MCP ツールだけを例外にするのは、そこだけ `--allowedTools` で正しく表現できないからです。接頭辞はインストール時に決まる名前を含み、Neovim 側からは知りようがありません。`can_use_tool.is_vibing_nvim_mcp_tool` はサフィックス照合なので、マーケットプレイス名が変わっても壊れません。

**2. 定数を実態に合わせる。** `mcp__plugin_vibing_vibing-nvim__*` → `mcp__plugin_vibing-nvim_vibing-nvim__*`。ただしコメントに書いたとおり、**この定数に追従を頼らない**構造にしたのが1の意味です。

なお codex / grok も同じフックスクリプトを共有しますが、どちらも vibing-nvim の MCP サーバーには到達しないので `is_vibing_nvim_mcp_tool` は決してマッチせず、常に `defer`（＝従来と完全に同じ挙動）になります。

## テスト

- `tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua` — ハンドラが `.res` に書く決定を固定。vibing-nvim の MCP ツールは `allow`（マーケットプレイス名が別物でも `allow`）、通常の許可ツールは `defer`、拒否は理由つき `deny`
- `tests/pre-tool-use-hook.test.mjs` — 偽の RPC サーバーを立てて**実物の** `pre-tool-use.sh` を走らせ、allow が stdout にそのまま出ること・defer が無言 exit 0 であること・deny が exit 2 + stderr であることを固定

## 検証状況（正直なところ）

実測済み:

- 症状の再現と、allow JSON を出すフックで通ること（上の表。最小 MCP サーバー + 実 CLI）
- `--allowedTools` は効くこと、および実インストールの接頭辞
- `pnpm run test:lua` → exit 0、失敗0（`cli_command_builder_spec` の接頭辞アサーションも実態に更新）
- `pnpm run test:node` → 4 tests / 4 pass
- `pnpm run lint` / `format:check` / `check` / `lint:md` → pass

**未実施:** 実物の `pre-tool-use.sh` を実 CLI に通す最終確認は、途中でローカルの `claude` が `Failed to authenticate: OAuth session expired and could not be refreshed` になったため完了できていません。同じ理由で `pnpm run test:e2e` も CLI ターンを回す3本（`ask_user_question` / `nvim_ask_user_question` / `scheduled_request`）がハングします。**これは本 PR の変更とは無関係**で、変更のない `origin/main` のワークツリーで同じコマンドを回しても結果は完全に同一でした（`chat_basic_flow` 2件と `chat_jump_user` 3件のみ pass、残り3本ハング、exit 1）。

鎖の両端は個別に実測済みです — 「allow JSON を出せば CLI は通す」（実 CLI で確認）と「`pre-tool-use.sh` はまさにその JSON を出す」（上記 Node テストで確認）。再認証後に `pnpm run test:e2e` を通していただければ、`nvim_ask_user_question_spec` がこの経路をそのまま踏みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)