### PR TITLE
ci: verify doc/vibing.txt instead of trusting manual review

### DIFF
--- a/.claude/rules/self-testing.md
+++ b/.claude/rules/self-testing.md
@@ -54,6 +54,23 @@ The one case neither the exit code nor a summary count catches is a spec file th
 tests (a `describe` that stopped being reached): plenary exits 0 without printing a summary, which
 is also how the E2E specs opt out via `should_run()`.
 
+## Vim Help Verification
+
+`npm run check:doc` (`scripts/check-help.lua`, run by the "Verify Vim help files" CI step) is the
+only thing that reads `doc/*.txt`: `npm run check` compiles `lua/` alone, and the prettier / eslint
+/ markdownlint steps do not match `.txt`. It checks three things — that `helptags` generates (a
+duplicate or malformed tag fails only here), that no line exceeds 78 columns, and that CONTENTS and
+the body agree on section numbers and tags.
+
+The width is measured with `strdisplaywidth`, which is why the checker runs inside nvim at all.
+A byte count rejects the `•` and `—` already in `vibing.txt`; a character count would let a CJK
+line run to 156 columns. Only Vim's own measure is right, and it already honours `ambiwidth`.
+
+`:helptags` raises a Vim error instead of setting an exit code, so the checker wraps it in `pcall`
+— nvim otherwise prints `E154` and still exits 0. `tests/help-check.test.mjs` pins each failure the
+gate is supposed to catch, including both width cases above; the CI step gates the document, that
+file gates the checker.
+
 ## 3-Try Auto-Fix Rule
 
 After implementing a feature, run `npm run test:e2e`. If it fails: analyze the failure, apply a

--- a/.claude/rules/self-testing.md
+++ b/.claude/rules/self-testing.md
@@ -67,9 +67,28 @@ A byte count rejects the `•` and `—` already in `vibing.txt`; a character co
 line run to 156 columns. Only Vim's own measure is right, and it already honours `ambiwidth`.
 
 `:helptags` raises a Vim error instead of setting an exit code, so the checker wraps it in `pcall`
-— nvim otherwise prints `E154` and still exits 0. `tests/help-check.test.mjs` pins each failure the
-gate is supposed to catch, including both width cases above; the CI step gates the document, that
-file gates the checker.
+— nvim otherwise prints `E154` and still exits 0.
+
+The CONTENTS check **fails closed**, which is the part worth not undoing. Keying it on "did any
+rows parse" would let one unreadable CONTENTS block switch the check off while the run still
+reported OK — the same shape of dead gate the whole exercise is about. So a file with a `CONTENTS`
+heading and no readable `N. Title |tag|` rows is a failure, and the row pattern deliberately does
+not require a dot leader, because space-aligned CONTENTS is ordinary vimdoc and used to skip the
+check entirely. A file with no CONTENTS heading has nothing to disagree with and passes.
+
+Section headings are matched at column 0 on purpose: that is what keeps a heading-shaped line
+inside an indented `>` code example from being read as a real section.
+
+`tests/help-check.test.mjs` pins each failure the gate is supposed to catch, including both width
+cases and both fail-closed cases. The CI step gates the document; that file gates the checker.
+
+## The Lua Syntax Gate Had the Same Hole
+
+`npm run check` could not fail. `find lua -name '*.lua' -exec luac -p {} \;` reports `find`'s exit
+status, not `luac`'s, so a file that would not compile printed its error and CI went green. It is
+`-exec ... +` now, which propagates, and `tests/lua-syntax-gate.test.mjs` holds it there — reading
+the command out of `package.json` rather than restating it, so the test cannot pass against a
+command the project no longer runs.
 
 ## 3-Try Auto-Fix Rule
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Run Lua syntax check
         run: npm run check
 
+      # doc/*.txt is reachable by no other step: `check` compiles lua/ only, and the
+      # prettier/eslint/markdownlint steps do not match `.txt`. This gates the document;
+      # tests/help-check.test.mjs gates the checker itself, so neither replaces the other.
+      - name: Verify Vim help files
+        run: npm run check:doc
+
       # The exit code is the gate — do not parse the output. PlenaryBustedDirectory runs one
       # child Neovim per spec file and already fails the run on a failing assertion, an error,
       # a file that would not load, or a child that never finished; that is pinned by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@ npm run test:eval
 # Validate Lua syntax
 npm run check
 
+# Verify doc/*.txt (helptags, 78-column limit, CONTENTS/tag agreement)
+npm run check:doc
+
 # Lint TypeScript/JavaScript
 npm run lint
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:eval": "nvim --headless -u tests/minimal_init.lua -l tests/evals/run.lua",
     "check": "find lua -name '*.lua' -exec luac -p {} \\;",
     "check:lua": "luac -p lua/vibing/init.lua",
+    "check:doc": "nvim --headless -l scripts/check-help.lua",
     "validate": "npm run check && echo 'All checks passed'",
     "format": "prettier --write '**/*.{js,mjs,ts,json,md,yml,yaml}'",
     "format:check": "prettier --check '**/*.{js,mjs,ts,json,md,yml,yaml}'",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:lua": "nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/ { minimal_init = 'tests/minimal_init.lua' }\"",
     "test:e2e": "VIBING_E2E=1 nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/e2e/ { minimal_init = 'tests/minimal_init.lua' }\"",
     "test:eval": "nvim --headless -u tests/minimal_init.lua -l tests/evals/run.lua",
-    "check": "find lua -name '*.lua' -exec luac -p {} \\;",
+    "check": "find lua -name '*.lua' -exec luac -p {} +",
     "check:lua": "luac -p lua/vibing/init.lua",
     "check:doc": "nvim --headless -l scripts/check-help.lua",
     "validate": "npm run check && echo 'All checks passed'",

--- a/scripts/check-help.lua
+++ b/scripts/check-help.lua
@@ -24,6 +24,26 @@ local function fail(fmt, ...)
   table.insert(problems, string.format(fmt, ...))
 end
 
+--- The lines inside the CONTENTS section, or nil when the file has no CONTENTS heading.
+---
+--- Scoping matters: CONTENTS_ROW cannot be anchored at column 0 the way SECTION_HEADING is, since
+--- its rows are indented. Run over the whole file it also matches an ordinary body line that ends
+--- in a `|tag|` reference -- `    4. See |vibing-commands|` in a troubleshooting list, say --
+--- which shifts every index after it and reports a section that is present as missing.
+local function contents_block(lines)
+  local first = nil
+  for index, line in ipairs(lines) do
+    if not first then
+      if line:match('^CONTENTS%f[%W]') then
+        first = index
+      end
+    elseif line:match('^=====') then
+      return vim.list_slice(lines, first + 1, index - 1)
+    end
+  end
+  return first and vim.list_slice(lines, first + 1) or nil
+end
+
 --- The `{ number, tag }` of every line matching `pattern`, in the order they appear.
 local function numbered_rows(lines, pattern)
   local rows = {}
@@ -73,18 +93,12 @@ for _, file in ipairs(files) do
   -- CONTENTS block disable the check while still reporting OK, which is the exact failure #542
   -- was filed about -- so a file with a CONTENTS heading and no parseable rows is a problem,
   -- not a pass. A file with no CONTENTS heading at all has nothing to disagree with.
-  local has_contents = false
-  for _, line in ipairs(lines) do
-    if line:match('^CONTENTS%f[%s]') then
-      has_contents = true
-      break
-    end
-  end
+  local block = contents_block(lines)
+  local entries = block and numbered_rows(block, CONTENTS_ROW) or {}
 
-  local entries = numbered_rows(lines, CONTENTS_ROW)
-  if has_contents and #entries == 0 then
+  if block and #entries == 0 then
     fail('%s: CONTENTS block found but no `N. Title |tag|` rows could be read from it', name)
-  elseif has_contents then
+  elseif block then
     local headings = numbered_rows(lines, SECTION_HEADING)
 
     for index = 1, math.max(#entries, #headings) do

--- a/scripts/check-help.lua
+++ b/scripts/check-help.lua
@@ -1,10 +1,5 @@
 -- Verify the Vim help files under doc/ the way Vim itself would read them.
 --
--- Nothing in CI looked at doc/*.txt before this: `npm run check` only compiles lua/, and the
--- prettier/eslint/markdownlint steps do not match `.txt`. The helptags, the 78-column rule and
--- the CONTENTS/tag correspondence were all verified by hand while writing #531, which is why
--- they were about to rot (#542).
---
 -- Usage:
 --   nvim --headless -l scripts/check-help.lua [doc-dir]
 --
@@ -14,6 +9,14 @@
 
 local MAX_WIDTH = 78
 
+-- `    1. Introduction ....... |vibing-introduction|` -- a CONTENTS row. The leader is left
+-- unconstrained: dots and plain spaces are both ordinary vimdoc style, and requiring dots made
+-- the whole CONTENTS check below silently skip a space-aligned file.
+local CONTENTS_ROW = '^%s*(%d+)%.%s+.*|(%S-)|%s*$'
+-- `1. INTRODUCTION            *vibing-introduction*` -- a section heading. Anchored at column 0,
+-- which is what keeps a heading-shaped line inside an indented `>` code example from matching.
+local SECTION_HEADING = '^(%d+)%.%s+%S.-%s+%*([^%*%s]+)%*%s*$'
+
 local doc_dir = (arg and arg[1]) or 'doc'
 local problems = {}
 
@@ -21,40 +24,16 @@ local function fail(fmt, ...)
   table.insert(problems, string.format(fmt, ...))
 end
 
---- Every `*tag*` the file defines. Vim's own definition: an asterisk-delimited run with no
---- whitespace or asterisk inside it.
-local function defined_tags(lines)
-  local tags = {}
+--- The `{ number, tag }` of every line matching `pattern`, in the order they appear.
+local function numbered_rows(lines, pattern)
+  local rows = {}
   for _, line in ipairs(lines) do
-    for tag in line:gmatch('%*([^%*%s]+)%*') do
-      tags[tag] = true
-    end
-  end
-  return tags
-end
-
---- The `N. Title ....... |tag|` rows of the CONTENTS block, in the order they appear.
-local function contents_entries(lines)
-  local entries = {}
-  for _, line in ipairs(lines) do
-    local number, tag = line:match('^%s*(%d+)%.%s+.-%s%.%.+%s*|(%S-)|%s*$')
+    local number, tag = line:match(pattern)
     if number then
-      table.insert(entries, { number = tonumber(number), tag = tag })
+      table.insert(rows, { number = tonumber(number), tag = tag })
     end
   end
-  return entries
-end
-
---- The `N. HEADING                *tag*` section headings, in the order they appear.
-local function section_headings(lines)
-  local headings = {}
-  for _, line in ipairs(lines) do
-    local number, tag = line:match('^(%d+)%.%s+%S.-%s+%*([^%*%s]+)%*%s*$')
-    if number then
-      table.insert(headings, { number = tonumber(number), tag = tag })
-    end
-  end
-  return headings
+  return rows
 end
 
 -- 1. helptags must be generatable. Duplicate or malformed tags fail here, and only here --
@@ -86,22 +65,34 @@ for _, file in ipairs(files) do
     end
   end
 
-  -- 3. CONTENTS must agree with the body: every entry links to a tag that exists, and the
-  -- section headings carry the same numbers and tags in the same order.
-  local entries = contents_entries(lines)
-  if #entries > 0 then
-    local tags = defined_tags(lines)
-    for _, entry in ipairs(entries) do
-      if not tags[entry.tag] then
-        fail('%s: CONTENTS entry %d links to |%s|, which no *%s* defines', name, entry.number, entry.tag, entry.tag)
-      end
+  -- 3. CONTENTS and the body must agree, entry by entry, on both number and tag. Comparing them
+  -- in order covers a mistyped link too: a heading only matches SECTION_HEADING if it defines
+  -- its own tag, so an entry pointing at a tag nothing defines shows up as a mismatch here.
+  --
+  -- This fails closed. Keying it on "did we parse any entries" instead would let one unreadable
+  -- CONTENTS block disable the check while still reporting OK, which is the exact failure #542
+  -- was filed about -- so a file with a CONTENTS heading and no parseable rows is a problem,
+  -- not a pass. A file with no CONTENTS heading at all has nothing to disagree with.
+  local has_contents = false
+  for _, line in ipairs(lines) do
+    if line:match('^CONTENTS%f[%s]') then
+      has_contents = true
+      break
     end
+  end
 
-    local headings = section_headings(lines)
-    for index, entry in ipairs(entries) do
-      local heading = headings[index]
+  local entries = numbered_rows(lines, CONTENTS_ROW)
+  if has_contents and #entries == 0 then
+    fail('%s: CONTENTS block found but no `N. Title |tag|` rows could be read from it', name)
+  elseif has_contents then
+    local headings = numbered_rows(lines, SECTION_HEADING)
+
+    for index = 1, math.max(#entries, #headings) do
+      local entry, heading = entries[index], headings[index]
       if not heading then
         fail('%s: CONTENTS lists %d. |%s| but the body has no matching section', name, entry.number, entry.tag)
+      elseif not entry then
+        fail('%s: section %d. *%s* is missing from CONTENTS', name, heading.number, heading.tag)
       elseif heading.number ~= entry.number or heading.tag ~= entry.tag then
         fail(
           '%s: CONTENTS entry %d. |%s| does not match section %d. *%s*',
@@ -112,10 +103,6 @@ for _, file in ipairs(files) do
           heading.tag
         )
       end
-    end
-    if #headings > #entries then
-      local extra = headings[#entries + 1]
-      fail('%s: section %d. *%s* is missing from CONTENTS', name, extra.number, extra.tag)
     end
   end
 end

--- a/scripts/check-help.lua
+++ b/scripts/check-help.lua
@@ -1,0 +1,131 @@
+-- Verify the Vim help files under doc/ the way Vim itself would read them.
+--
+-- Nothing in CI looked at doc/*.txt before this: `npm run check` only compiles lua/, and the
+-- prettier/eslint/markdownlint steps do not match `.txt`. The helptags, the 78-column rule and
+-- the CONTENTS/tag correspondence were all verified by hand while writing #531, which is why
+-- they were about to rot (#542).
+--
+-- Usage:
+--   nvim --headless -l scripts/check-help.lua [doc-dir]
+--
+-- Exits 0 when everything passes, 1 with one line per problem otherwise. The directory argument
+-- exists so tests/help-check.test.mjs can point it at a deliberately broken fixture -- a gate
+-- nothing can fail is not a gate.
+
+local MAX_WIDTH = 78
+
+local doc_dir = (arg and arg[1]) or 'doc'
+local problems = {}
+
+local function fail(fmt, ...)
+  table.insert(problems, string.format(fmt, ...))
+end
+
+--- Every `*tag*` the file defines. Vim's own definition: an asterisk-delimited run with no
+--- whitespace or asterisk inside it.
+local function defined_tags(lines)
+  local tags = {}
+  for _, line in ipairs(lines) do
+    for tag in line:gmatch('%*([^%*%s]+)%*') do
+      tags[tag] = true
+    end
+  end
+  return tags
+end
+
+--- The `N. Title ....... |tag|` rows of the CONTENTS block, in the order they appear.
+local function contents_entries(lines)
+  local entries = {}
+  for _, line in ipairs(lines) do
+    local number, tag = line:match('^%s*(%d+)%.%s+.-%s%.%.+%s*|(%S-)|%s*$')
+    if number then
+      table.insert(entries, { number = tonumber(number), tag = tag })
+    end
+  end
+  return entries
+end
+
+--- The `N. HEADING                *tag*` section headings, in the order they appear.
+local function section_headings(lines)
+  local headings = {}
+  for _, line in ipairs(lines) do
+    local number, tag = line:match('^(%d+)%.%s+%S.-%s+%*([^%*%s]+)%*%s*$')
+    if number then
+      table.insert(headings, { number = tonumber(number), tag = tag })
+    end
+  end
+  return headings
+end
+
+-- 1. helptags must be generatable. Duplicate or malformed tags fail here, and only here --
+-- a stray `*template*` slipped through manual review during #531 exactly this way.
+--
+-- `:helptags` raises a Vim error rather than setting an exit code, so pcall is what catches it;
+-- nvim would otherwise print the message and still exit 0.
+local ok, err = pcall(vim.cmd, 'helptags ' .. vim.fn.fnameescape(doc_dir))
+if not ok then
+  fail('helptags: %s', (tostring(err):gsub('.*Vim%(helptags%):', '')))
+end
+
+local files = vim.fn.glob(doc_dir .. '/*.txt', false, true)
+if #files == 0 then
+  fail('%s contains no *.txt help file', doc_dir)
+end
+
+for _, file in ipairs(files) do
+  local lines = vim.fn.readfile(file)
+  local name = vim.fn.fnamemodify(file, ':t')
+
+  -- 2. The 78-column convention. Measured with strdisplaywidth, not a byte or character count:
+  -- a byte count reports the • and — already in vibing.txt as overlong, and a character count
+  -- would under-report CJK, which occupies two columns.
+  for lnum, line in ipairs(lines) do
+    local width = vim.fn.strdisplaywidth(line)
+    if width > MAX_WIDTH then
+      fail('%s:%d: %d columns, over the %d-column limit', name, lnum, width, MAX_WIDTH)
+    end
+  end
+
+  -- 3. CONTENTS must agree with the body: every entry links to a tag that exists, and the
+  -- section headings carry the same numbers and tags in the same order.
+  local entries = contents_entries(lines)
+  if #entries > 0 then
+    local tags = defined_tags(lines)
+    for _, entry in ipairs(entries) do
+      if not tags[entry.tag] then
+        fail('%s: CONTENTS entry %d links to |%s|, which no *%s* defines', name, entry.number, entry.tag, entry.tag)
+      end
+    end
+
+    local headings = section_headings(lines)
+    for index, entry in ipairs(entries) do
+      local heading = headings[index]
+      if not heading then
+        fail('%s: CONTENTS lists %d. |%s| but the body has no matching section', name, entry.number, entry.tag)
+      elseif heading.number ~= entry.number or heading.tag ~= entry.tag then
+        fail(
+          '%s: CONTENTS entry %d. |%s| does not match section %d. *%s*',
+          name,
+          entry.number,
+          entry.tag,
+          heading.number,
+          heading.tag
+        )
+      end
+    end
+    if #headings > #entries then
+      local extra = headings[#entries + 1]
+      fail('%s: section %d. *%s* is missing from CONTENTS', name, extra.number, extra.tag)
+    end
+  end
+end
+
+if #problems > 0 then
+  io.stderr:write(('%s: %d problem(s)\n'):format(doc_dir, #problems))
+  for _, problem in ipairs(problems) do
+    io.stderr:write('  ' .. problem .. '\n')
+  end
+  os.exit(1)
+end
+
+print(('%s: %d help file(s) OK'):format(doc_dir, #files))

--- a/tests/help-check.test.mjs
+++ b/tests/help-check.test.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-help.lua is the only thing in CI that reads doc/*.txt, and CI reads nothing but
+ * its exit code. These tests pin that exit code against each failure it is supposed to catch --
+ * a gate that cannot fail is how doc/vibing.txt went unchecked in the first place (#542).
+ *
+ * The two width tests are the point of the exercise. Measuring bytes flags the • and — already
+ * in vibing.txt as overlong; measuring characters lets a CJK line run to 156 columns. Only
+ * Vim's own strdisplaywidth gets both right, which is why the checker runs inside nvim.
+ */
+
+import { strict as assert } from 'assert';
+import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** A minimal but valid help file, used as the base every failure case deviates from. */
+function helpFile({ contents, body }) {
+  return [
+    '*fixture.txt*  fixture',
+    '',
+    '='.repeat(78),
+    'CONTENTS                                                    *fixture-contents*',
+    '',
+    ...contents,
+    '',
+    '='.repeat(78),
+    ...body,
+    '',
+  ].join('\n');
+}
+
+const VALID = helpFile({
+  contents: ['    1. One ..................................... |fixture-one|'],
+  body: [
+    '1. ONE                                                           *fixture-one*',
+    '',
+    'Body.',
+  ],
+});
+
+/** Run the checker over `dir` (or the repository's own doc/) and return its exit code. */
+function check(dir) {
+  const result = spawnSync(
+    'nvim',
+    ['--headless', '-l', 'scripts/check-help.lua', ...(dir ? [dir] : [])],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 60_000,
+    }
+  );
+
+  assert.notEqual(result.status, null, `nvim did not exit: ${result.error ?? 'unknown'}`);
+  return { code: result.status, stderr: result.stderr };
+}
+
+/** Write `text` as the sole help file in a throwaway directory and check it. */
+async function checkText(text) {
+  const dir = await mkdtemp(join(tmpdir(), 'vibing-help-'));
+  try {
+    await writeFile(join(dir, 'fixture.txt'), text);
+    return check(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("the repository's own doc/ passes", () => {
+  const { code, stderr } = check();
+  assert.equal(code, 0, `doc/ must stay valid:\n${stderr}`);
+});
+
+test('a well-formed fixture passes', async () => {
+  const { code, stderr } = await checkText(VALID);
+  assert.equal(code, 0, stderr);
+});
+
+test('a duplicate tag fails, because helptags refuses to generate', async () => {
+  const { code, stderr } = await checkText(`${VALID}\n\nSaid twice *fixture-one*\n`);
+  assert.equal(code, 1);
+  assert.match(stderr, /helptags/);
+});
+
+test('a line wider than 78 columns fails', async () => {
+  const { code, stderr } = await checkText(`${VALID}\n${'x'.repeat(79)}\n`);
+  assert.equal(code, 1);
+  assert.match(stderr, /79 columns/);
+});
+
+test('a 78-column line that exceeds 78 bytes passes', async () => {
+  // 76 ASCII + two 3-byte characters: 78 columns, 82 bytes. A byte count would reject this,
+  // and lines exactly like it already exist in doc/vibing.txt.
+  const line = `${'x'.repeat(76)}•—`;
+  assert.equal(Buffer.byteLength(line), 82);
+
+  const { code, stderr } = await checkText(`${VALID}\n${line}\n`);
+  assert.equal(code, 0, stderr);
+});
+
+test('a 78-character CJK line fails, because it occupies 156 columns', async () => {
+  // A character count would accept this. Vim renders it at double width.
+  const line = '日'.repeat(78);
+  assert.equal([...line].length, 78);
+
+  const { code, stderr } = await checkText(`${VALID}\n${line}\n`);
+  assert.equal(code, 1);
+  assert.match(stderr, /156 columns/);
+});
+
+test('a CONTENTS entry pointing at an undefined tag fails', async () => {
+  const text = helpFile({
+    contents: ['    1. One ..................................... |fixture-nowhere|'],
+    body: [
+      '1. ONE                                                           *fixture-one*',
+      '',
+      'Body.',
+    ],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /fixture-nowhere/);
+});
+
+test('a section numbered out of step with CONTENTS fails', async () => {
+  const text = helpFile({
+    contents: [
+      '    1. One ..................................... |fixture-one|',
+      '    2. Two ..................................... |fixture-two|',
+    ],
+    body: [
+      '1. ONE                                                           *fixture-one*',
+      '',
+      'Body.',
+      '',
+      '='.repeat(78),
+      '3. TWO                                                           *fixture-two*',
+      '',
+      'Body.',
+    ],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /does not match section 3/);
+});
+
+test('a section missing from CONTENTS fails', async () => {
+  const text = helpFile({
+    contents: ['    1. One ..................................... |fixture-one|'],
+    body: [
+      '1. ONE                                                           *fixture-one*',
+      '',
+      'Body.',
+      '',
+      '='.repeat(78),
+      '2. TWO                                                           *fixture-two*',
+      '',
+      'Body.',
+    ],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /missing from CONTENTS/);
+});

--- a/tests/help-check.test.mjs
+++ b/tests/help-check.test.mjs
@@ -181,3 +181,25 @@ test('a help file with no CONTENTS block at all passes', async () => {
   const { code, stderr } = await checkText(text);
   assert.equal(code, 0, stderr);
 });
+
+test('a numbered body line ending in a |tag| is not mistaken for a CONTENTS entry', async () => {
+  // CONTENTS rows are indented, so unlike a section heading their pattern cannot be anchored at
+  // column 0. Scanning the whole file for it also matched a line like the one below, shifting
+  // every index after it and reporting a section that is present as missing.
+  const text = helpFile({
+    contents: [entry(1, 'One', 'fixture-one'), entry(2, 'Two', 'fixture-two')],
+    body: [
+      heading(1, 'One', 'fixture-one'),
+      '',
+      RULE,
+      heading(2, 'Two', 'fixture-two'),
+      '',
+      'Troubleshooting:',
+      '',
+      '    4. See |fixture-one|',
+    ],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 0, stderr);
+});

--- a/tests/help-check.test.mjs
+++ b/tests/help-check.test.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 /**
- * scripts/check-help.lua is the only thing in CI that reads doc/*.txt, and CI reads nothing but
- * its exit code. These tests pin that exit code against each failure it is supposed to catch --
- * a gate that cannot fail is how doc/vibing.txt went unchecked in the first place (#542).
+ * scripts/check-help.lua is what CI runs over doc/*.txt, and CI reads nothing but its exit code.
+ * These tests pin that exit code against each failure it is supposed to catch -- a gate that
+ * cannot fail is how doc/vibing.txt went unchecked in the first place (#542). The CI step gates
+ * the document; this file gates the checker.
  *
- * The two width tests are the point of the exercise. Measuring bytes flags the • and — already
- * in vibing.txt as overlong; measuring characters lets a CJK line run to 156 columns. Only
- * Vim's own strdisplaywidth gets both right, which is why the checker runs inside nvim.
+ * The two width tests are the point of the exercise: only Vim's own strdisplaywidth accepts the
+ * • and — already in vibing.txt while still rejecting a CJK line, which is why the checker runs
+ * inside nvim at all.
  */
 
 import { strict as assert } from 'assert';
@@ -19,64 +20,55 @@ import { fileURLToPath } from 'url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
+/** `    1. One ....... |fixture-one|`, padded the way a CONTENTS row is. */
+const entry = (number, title, tag) => `    ${number}. ${title} ${'.'.repeat(30)} |${tag}|`;
+
+/** `1. ONE                    *fixture-one*`, padded the way a section heading is. */
+const heading = (number, title, tag) => `${number}. ${title.toUpperCase()}`.padEnd(60) + `*${tag}*`;
+
+const RULE = '='.repeat(78);
+
 /** A minimal but valid help file, used as the base every failure case deviates from. */
 function helpFile({ contents, body }) {
   return [
     '*fixture.txt*  fixture',
     '',
-    '='.repeat(78),
-    'CONTENTS                                                    *fixture-contents*',
+    RULE,
+    `CONTENTS${' '.repeat(52)}*fixture-contents*`,
     '',
     ...contents,
     '',
-    '='.repeat(78),
+    RULE,
     ...body,
     '',
   ].join('\n');
 }
 
 const VALID = helpFile({
-  contents: ['    1. One ..................................... |fixture-one|'],
-  body: [
-    '1. ONE                                                           *fixture-one*',
-    '',
-    'Body.',
-  ],
+  contents: [entry(1, 'One', 'fixture-one')],
+  body: [heading(1, 'One', 'fixture-one'), '', 'Body.'],
 });
 
-/** Run the checker over `dir` (or the repository's own doc/) and return its exit code. */
-function check(dir) {
-  const result = spawnSync(
-    'nvim',
-    ['--headless', '-l', 'scripts/check-help.lua', ...(dir ? [dir] : [])],
-    {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      timeout: 60_000,
-    }
-  );
-
-  assert.notEqual(result.status, null, `nvim did not exit: ${result.error ?? 'unknown'}`);
-  return { code: result.status, stderr: result.stderr };
-}
-
-/** Write `text` as the sole help file in a throwaway directory and check it. */
+/** Write `text` as the sole help file in a throwaway directory and run the checker over it. */
 async function checkText(text) {
   const dir = await mkdtemp(join(tmpdir(), 'vibing-help-'));
   try {
     await writeFile(join(dir, 'fixture.txt'), text);
-    return check(dir);
+
+    const result = spawnSync('nvim', ['--headless', '-l', 'scripts/check-help.lua', dir], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+
+    assert.notEqual(result.status, null, `nvim did not exit: ${result.error ?? 'unknown'}`);
+    return { code: result.status, stderr: result.stderr };
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 }
 
-test("the repository's own doc/ passes", () => {
-  const { code, stderr } = check();
-  assert.equal(code, 0, `doc/ must stay valid:\n${stderr}`);
-});
-
-test('a well-formed fixture passes', async () => {
+test('a well-formed help file passes', async () => {
   const { code, stderr } = await checkText(VALID);
   assert.equal(code, 0, stderr);
 });
@@ -113,60 +105,79 @@ test('a 78-character CJK line fails, because it occupies 156 columns', async () 
   assert.match(stderr, /156 columns/);
 });
 
-test('a CONTENTS entry pointing at an undefined tag fails', async () => {
-  const text = helpFile({
-    contents: ['    1. One ..................................... |fixture-nowhere|'],
-    body: [
-      '1. ONE                                                           *fixture-one*',
-      '',
-      'Body.',
-    ],
+const DISAGREEMENTS = [
+  {
+    name: 'a CONTENTS entry linking to a tag no section defines fails',
+    contents: [entry(1, 'One', 'fixture-nowhere')],
+    body: [heading(1, 'One', 'fixture-one')],
+    expect: /fixture-nowhere/,
+  },
+  {
+    name: 'a section numbered out of step with CONTENTS fails',
+    contents: [entry(1, 'One', 'fixture-one'), entry(2, 'Two', 'fixture-two')],
+    body: [heading(1, 'One', 'fixture-one'), '', RULE, heading(3, 'Two', 'fixture-two')],
+    expect: /does not match section 3/,
+  },
+  {
+    name: 'a section missing from CONTENTS fails',
+    contents: [entry(1, 'One', 'fixture-one')],
+    body: [heading(1, 'One', 'fixture-one'), '', RULE, heading(2, 'Two', 'fixture-two')],
+    expect: /missing from CONTENTS/,
+  },
+  {
+    name: 'a CONTENTS entry with no section at all fails',
+    contents: [entry(1, 'One', 'fixture-one'), entry(2, 'Two', 'fixture-two')],
+    body: [heading(1, 'One', 'fixture-one')],
+    expect: /no matching section/,
+  },
+];
+
+for (const { name, contents, body, expect } of DISAGREEMENTS) {
+  test(name, async () => {
+    const { code, stderr } = await checkText(helpFile({ contents, body }));
+    assert.equal(code, 1);
+    assert.match(stderr, expect);
   });
+}
 
-  const { code, stderr } = await checkText(text);
-  assert.equal(code, 1);
-  assert.match(stderr, /fixture-nowhere/);
-});
-
-test('a section numbered out of step with CONTENTS fails', async () => {
+test('a CONTENTS block aligned with spaces is still checked', async () => {
+  // Requiring a dot leader used to make the whole CONTENTS check skip itself on a file like
+  // this, reporting OK while a real mismatch sat in it. Space alignment is ordinary vimdoc.
   const text = helpFile({
     contents: [
-      '    1. One ..................................... |fixture-one|',
-      '    2. Two ..................................... |fixture-two|',
+      `    1. One${' '.repeat(30)}|fixture-one|`,
+      `    2. Two${' '.repeat(30)}|fixture-two|`,
     ],
-    body: [
-      '1. ONE                                                           *fixture-one*',
-      '',
-      'Body.',
-      '',
-      '='.repeat(78),
-      '3. TWO                                                           *fixture-two*',
-      '',
-      'Body.',
-    ],
+    body: [heading(1, 'One', 'fixture-one'), '', RULE, heading(5, 'Two', 'fixture-two')],
   });
 
   const { code, stderr } = await checkText(text);
   assert.equal(code, 1);
-  assert.match(stderr, /does not match section 3/);
+  assert.match(stderr, /does not match section 5/);
 });
 
-test('a section missing from CONTENTS fails', async () => {
+test('a CONTENTS block with no readable rows fails rather than passing', async () => {
   const text = helpFile({
-    contents: ['    1. One ..................................... |fixture-one|'],
-    body: [
-      '1. ONE                                                           *fixture-one*',
-      '',
-      'Body.',
-      '',
-      '='.repeat(78),
-      '2. TWO                                                           *fixture-two*',
-      '',
-      'Body.',
-    ],
+    contents: ['    see the sections below'],
+    body: [heading(1, 'One', 'fixture-one'), '', 'Body.'],
   });
 
   const { code, stderr } = await checkText(text);
   assert.equal(code, 1);
-  assert.match(stderr, /missing from CONTENTS/);
+  assert.match(stderr, /no `N\. Title \|tag\|` rows/);
+});
+
+test('a help file with no CONTENTS block at all passes', async () => {
+  const text = [
+    '*fixture.txt*  fixture',
+    '',
+    RULE,
+    heading(1, 'One', 'fixture-one'),
+    '',
+    'Body.',
+    '',
+  ].join('\n');
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 0, stderr);
 });

--- a/tests/lua-syntax-gate.test.mjs
+++ b/tests/lua-syntax-gate.test.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * CI's "Run Lua syntax check" step is `npm run check`, and it reads nothing but the exit code.
+ *
+ * That step spent its whole life unable to fail. `find ... -exec luac -p {} \;` reports the exit
+ * status of `find`, not of `luac`, so a Lua file that would not compile printed an error and the
+ * job went green -- the same shape of dead gate as #561, found while adding the help-file check
+ * for #542. `-exec ... +` propagates, and these tests hold it to that.
+ *
+ * The command is read out of package.json rather than restated here, so the test cannot pass
+ * against a command the project no longer runs.
+ */
+
+import { strict as assert } from 'assert';
+import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const checkCommand = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8')).scripts
+  .check;
+
+/** Run the project's `check` command over a throwaway tree containing `files`, and return its code. */
+async function runCheck(files) {
+  const dir = await mkdtemp(join(tmpdir(), 'vibing-luac-'));
+  try {
+    await mkdir(join(dir, 'lua'), { recursive: true });
+    for (const [name, body] of Object.entries(files)) {
+      await writeFile(join(dir, 'lua', name), body);
+    }
+
+    const result = spawnSync(checkCommand, {
+      cwd: dir,
+      shell: true,
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    assert.notEqual(result.status, null, `check did not exit: ${result.error ?? 'unknown'}`);
+    return result.status;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('valid Lua exits 0', async () => {
+  assert.equal(await runCheck({ 'a.lua': 'return 1\n', 'b.lua': 'local x = 2\nreturn x\n' }), 0);
+});
+
+test('a file that will not compile fails the run', async () => {
+  const code = await runCheck({ 'a.lua': 'return 1\n', 'b.lua': 'this is not lua((\n' });
+  assert.notEqual(code, 0, 'luac -p rejected the file but the command reported success');
+});
+
+test('a broken file fails even when it sorts before the valid ones', async () => {
+  // `-exec ... +` batches every path into one luac invocation, so this is not a "last one wins"
+  // situation the way a per-file loop would be -- but it is the case a naive fix gets wrong.
+  const code = await runCheck({ 'a_broken.lua': 'function(\n', 'z_ok.lua': 'return 1\n' });
+  assert.notEqual(code, 0);
+});


### PR DESCRIPTION
Closes #542

## 変更

`doc/*.txt` を検証する `scripts/check-help.lua` を追加し、CI に「Verify Vim help files」ステップ（`npm run check:doc`）を足しました。issue が挙げた3項目をすべて実装しています。

1. **helptags が生成できること** — 重複タグや不正な `*tag*` はここでしか落ちません
2. **78カラム以内であること**
3. **CONTENTS の章番号と本文のタグの整合** — issue では任意扱いでしたが実装しました

## なぜ nvim の中で動かすのか

幅の判定を `strdisplaywidth` に任せるためです。issue は「バイト長ではなく文字数で」としていましたが、実測するとどちらも不正確でした。

| 測り方 | `doc/vibing.txt` にある `•` `—` の行 | CJK 78文字の行 |
| --- | --- | --- |
| バイト長 | ❌ 79バイトで誤検知 | — |
| 文字数 | ✅ | ❌ 78文字なので見逃す（実際は156カラム） |
| `strdisplaywidth` | ✅ | ✅ 156カラムとして検出 |

Vim 自身の尺度なので `ambiwidth` の設定にも自動的に追従します。両方のケースをテストで固定しました。

`:helptags` は終了コードを立てずに Vim エラーを投げるため `pcall` で捕捉しています。素の `nvim --headless -c 'helptags doc'` は E154 を表示したうえで exit 0 します。

## レビューで見つかって直した2件

自己レビュー中に、この PR 自体と既存コードの両方に「落ちないゲート」が見つかりました。どちらも再現を確認済みです。

### 1. CONTENTS チェックが fail-open だった（この PR で作り込んだもの）

ドットリーダー前提のパターンにしていたため、スペース揃えの CONTENTS ではマッチ0件になり、チェック全体が黙って無効化されていました。未定義タグへのリンクと章番号のズレを両方仕込んだフィクスチャで、問題0件・exit 0 を確認しています。

リーダーを要求しないパターンに変え、CONTENTS 見出しがあるのに行が読めない場合は「パス」ではなく「失敗」にしました。

### 2. `npm run check` が最初から一度も失敗できなかった（既存の欠陥）

```
find lua -name '*.lua' -exec luac -p {} \;   # 壊れた .lua があっても exit 0
find lua -name '*.lua' -exec luac -p {} +    # exit 1
```

`-exec ... \;` は `find` の終了コードを返すため、コンパイルできない Lua があってもエラーを表示したうえで CI の「Run Lua syntax check」は緑になっていました。#561 と同じ形です。

`+` に変更し、`tests/lua-syntax-gate.test.mjs` で固定しました。このテストはコマンド文字列を `package.json` から読むので、`check` の定義が変わればテストも一緒に動きます。なお `+` に直したうえで現在の `lua/` は exit 0 なので、既存コードに構文エラーはありません。

## テストの役割分担

CI ステップが**ドキュメントを**守り、`tests/help-check.test.mjs` が**チェッカー自体を**守ります（#561 の教訓＝落ちないゲートは無意味）。12ケースで、helptags 重複・78カラム超過・バイト数の偽陽性・CJK の見逃し・CONTENTS の各種不整合・fail-closed の2ケースを固定しています。

## テスト結果

```
pnpm run check           exit 0
pnpm run check:doc       doc: 1 help file(s) OK
pnpm run test:node       22 pass / 0 fail
pnpm run test:lua        exit 0
pnpm run lint            exit 0
pnpm run format:check    exit 0
```

`lint:md` の既存エラーは今回触れていないファイル（`mcp-server/README.md` 他）のみで、当該ステップは `continue-on-error: true` です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
