### PR TITLE
fix(codex): restrict lightweight calls instead of running them unfenced

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -258,6 +258,14 @@ _chat_ in that mode, and a title generated behind their back is not the call the
 `utility_model` still goes through the Claude-name filter, so its `sonnet` default becomes no
 `-m` at all rather than a model codex would reject.
 
+The model half of that lives in `modules/non_claude_model.lua`, shared by codex, copilot and grok.
+It was three byte-identical private copies before, and #537 was filed against codex alone — so
+teaching one copy about `lightweight` would have left the same bug live on the other two, with
+nothing marking them stale. The restriction half stays per-backend on purpose: claude _removes_
+tools with `--tools ""`, codex can only fence them, and no shared vocabulary spans that.
+`core/types.lua` states the obligation each adapter owes for `lightweight` — no tools, no project
+config, no hooks, `utility_model` — rather than the mechanism any one of them uses.
+
 Configured permissions are recorded in frontmatter for
 transparency and auditability. The optional `language` field ensures consistent AI response language
 across sessions.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -249,7 +249,16 @@ Claude removes the tools outright with `--tools ""`. Codex cannot: probing its c
 `tools.apply_patch`, `tools.view_image`, `tools.plan_tool` and `tools.mcp` are all unknown fields,
 and `tools.web_search` is the only tool toggle that exists. So `codex_command_builder` fences the
 call in instead — `sandbox_mode="read-only"`, `tools.web_search=false`, `approval_policy="never"` —
-and `codex_cli.lua` skips hook registration, matching `claude_cli.lua`.
+plus `mcp_servers={}` and `project_doc_max_bytes=0` — and `codex_cli.lua` skips hook
+registration, matching `claude_cli.lua`. Those last two are codex's answers to claude's
+`--strict-mcp-config`/`--mcp-config` and `--setting-sources ""`: without them a utility call
+still reached the user's MCP servers and still read `AGENTS.md`.
+
+`read-only` blocks writes **and** network, verified by running commands under `codex sandbox`
+rather than read off the docs: a write reports `Operation not permitted` and `curl` returns
+`000` where the same request outside the sandbox returns `200`. That matters because the shell
+tool itself cannot be removed, so the sandbox is the only thing closing the exfiltration path
+a prompt injection in the summarized transcript would otherwise have.
 
 Three details there are not interchangeable. They are `-c` overrides rather than the `-s` flag
 because `/summarize` passes a session id and `codex exec resume` does not accept `-s`. The

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -243,6 +243,21 @@ and haiku measurably picks the wrong subject. Low effort on a capable model is t
 being made here. An unrecognised level is dropped with a warning rather than passed
 through: the CLI accepts unknown levels silently and then ignores them.
 
+**Lightweight calls are restricted differently per backend, because the CLIs differ in kind.**
+Claude removes the tools outright with `--tools ""`. Codex cannot: probing its config schema with
+`--strict-config` (which rejects unknown fields) against codex 0.147 shows `tools.shell`,
+`tools.apply_patch`, `tools.view_image`, `tools.plan_tool` and `tools.mcp` are all unknown fields,
+and `tools.web_search` is the only tool toggle that exists. So `codex_command_builder` fences the
+call in instead — `sandbox_mode="read-only"`, `tools.web_search=false`, `approval_policy="never"` —
+and `codex_cli.lua` skips hook registration, matching `claude_cli.lua`.
+
+Three details there are not interchangeable. They are `-c` overrides rather than the `-s` flag
+because `/summarize` passes a session id and `codex exec resume` does not accept `-s`. The
+restriction ignores `permission_mode` entirely, `bypassPermissions` included: the user put the
+_chat_ in that mode, and a title generated behind their back is not the call they made. And
+`utility_model` still goes through the Claude-name filter, so its `sonnet` default becomes no
+`-m` at all rather than a model codex would reject.
+
 Configured permissions are recorded in frontmatter for
 transparency and auditability. The optional `language` field ensures consistent AI response language
 across sessions.

--- a/lua/vibing/core/types.lua
+++ b/lua/vibing/core/types.lua
@@ -42,7 +42,7 @@
 ---@field on_tool_use_full fun(tool: string, input: table)? 表示用に間引かない生のツール入力（eval用）
 ---@field _session_id string?
 ---@field _session_id_explicit boolean?
----@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ（true時はCLAUDE.md/rules・MCPサーバー・フックを無効化）
+---@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ。各アダプタは「ツールを使わせない・プロジェクト設定を読ませない・フックを登録しない・utility_model を使う」を果たす責務を負う（claude は --tools ""、codex は read-only サンドボックス）
 
 ---@class Vibing.AdapterResponse
 ---@field content string?

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -168,6 +168,11 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   local ToolVocabulary = require("vibing.infrastructure.adapter.modules.codex_tool_vocabulary")
   perm_handler.set_active_opts(handle_id, vim.tbl_extend("force", opts, { _tool_vocabulary = ToolVocabulary }))
 
+  -- Both registrations above run for a lightweight call too, even though it registers no hook.
+  -- They are what `cancel()` and the exit path resolve the handle through, not just permission
+  -- routing, and with no hook to fire nothing consumes the permission entry. Skipping them would
+  -- leave a lightweight stream unreachable by the very cleanup that unregisters it.
+
   local wrapped_on_done = function(response)
     if not completed then
       completed = true

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -90,7 +90,10 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
 
   local permission_mode = opts.permission_mode or "default"
   local hook_args = nil
-  if permission_mode ~= "bypassPermissions" then
+  -- Lightweight calls skip hook registration, matching claude_cli.lua. The builder fences them
+  -- into a read-only sandbox instead, and routing a title-generation tool call into the chat's
+  -- approval UI would prompt the user about a request they never made.
+  if permission_mode ~= "bypassPermissions" and not opts.lightweight then
     hook_args = CodexSettingsGenerator.get_hook_args()
   end
 

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -10,11 +10,20 @@ local cached_codex_path = nil
 
 --- Resolve model name from opts or config
 --- Filters out Claude-specific model names (sonnet/opus/haiku/fable) as codex uses its own models
+--- Lightweight calls (title generation, summarize, daily summary) use config.agent.utility_model,
+--- matching cli_command_builder. Its default is "sonnet", which the filter below turns into nil so
+--- codex falls back to its own default rather than being handed a model it does not have.
 --- @param opts Vibing.AdapterOpts
 --- @param config Vibing.Config
 --- @return string|nil
 local function resolve_model(opts, config)
-  local model = opts.model or (config.agent and config.agent.default_model)
+  local agent = config.agent or {}
+  local model
+  if opts.lightweight then
+    model = agent.utility_model
+  else
+    model = opts.model or agent.default_model
+  end
   if model and Modes.is_valid_model(model) then
     return nil
   end
@@ -118,8 +127,29 @@ function M.build(prompt, opts, session_id, config, hook_args)
     table.insert(cmd, model)
   end
 
+  if opts.lightweight then
+    -- Lightweight calls need no tools, but codex has no way to remove them. Probing the config
+    -- schema with `--strict-config` (which rejects unknown fields) against codex 0.147:
+    -- tools.shell, tools.apply_patch, tools.view_image, tools.plan_tool and tools.mcp are all
+    -- "unknown configuration field", and tools.web_search is the only tool toggle that exists.
+    -- There is no `--tools ""` equivalent, so the tools cannot be taken away -- only fenced in.
+    --
+    -- These are `-c` overrides rather than the `-s`/`--sandbox` flag because /summarize passes a
+    -- session id, and `codex exec resume` does not accept `-s`. sandbox_mode is what `-s` sets.
+    --
+    -- This deliberately ignores permission_mode, including bypassPermissions: the user put the
+    -- *chat* in that mode, and a title generated behind their back is not the call they made.
+    table.insert(cmd, "-c")
+    table.insert(cmd, 'sandbox_mode="read-only"')
+    table.insert(cmd, "-c")
+    table.insert(cmd, "tools.web_search=false")
+    -- With the approval prompt unreachable in headless exec, anything that did ask would stall
+    -- until the timeout. Verified value: one of untrusted/on-failure/on-request/granular/never.
+    table.insert(cmd, "-c")
+    table.insert(cmd, 'approval_policy="never"')
+
   -- Permission mapping (only for new sessions; resume does not accept -s)
-  if not session_id then
+  elseif not session_id then
     local permission_mode = opts.permission_mode
     if permission_mode == "bypassPermissions" then
       table.insert(cmd, "--dangerously-bypass-approvals-and-sandbox")

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -2,33 +2,11 @@
 --- Builds the command array for the Codex CLI with JSONL output
 --- @module vibing.infrastructure.adapter.modules.codex_command_builder
 
-local Modes = require("vibing.core.constants.modes")
+local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
 
 local M = {}
 
 local cached_codex_path = nil
-
---- Resolve model name from opts or config
---- Filters out Claude-specific model names (sonnet/opus/haiku/fable) as codex uses its own models
---- Lightweight calls (title generation, summarize, daily summary) use config.agent.utility_model,
---- matching cli_command_builder. Its default is "sonnet", which the filter below turns into nil so
---- codex falls back to its own default rather than being handed a model it does not have.
---- @param opts Vibing.AdapterOpts
---- @param config Vibing.Config
---- @return string|nil
-local function resolve_model(opts, config)
-  local agent = config.agent or {}
-  local model
-  if opts.lightweight then
-    model = agent.utility_model
-  else
-    model = opts.model or agent.default_model
-  end
-  if model and Modes.is_valid_model(model) then
-    return nil
-  end
-  return model
-end
 
 --- Resolve language setting
 --- @param opts Vibing.AdapterOpts
@@ -121,7 +99,7 @@ function M.build(prompt, opts, session_id, config, hook_args)
   end
 
   -- Model selection
-  local model = resolve_model(opts, config)
+  local model = NonClaudeModel.resolve(opts, config)
   if model then
     table.insert(cmd, "-m")
     table.insert(cmd, model)

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -117,6 +117,11 @@ function M.build(prompt, opts, session_id, config, hook_args)
     --
     -- This deliberately ignores permission_mode, including bypassPermissions: the user put the
     -- *chat* in that mode, and a title generated behind their back is not the call they made.
+    -- read-only blocks writes *and* network, verified by running commands under `codex sandbox`
+    -- rather than read off the docs: a write reports "Operation not permitted" and curl returns
+    -- 000 where the same request outside the sandbox returns 200. That closes the exfiltration
+    -- path a prompt injection in the summarized transcript would otherwise have, which matters
+    -- because the shell tool itself cannot be taken away.
     table.insert(cmd, "-c")
     table.insert(cmd, 'sandbox_mode="read-only"')
     table.insert(cmd, "-c")
@@ -125,6 +130,15 @@ function M.build(prompt, opts, session_id, config, hook_args)
     -- until the timeout. Verified value: one of untrusted/on-failure/on-request/granular/never.
     table.insert(cmd, "-c")
     table.insert(cmd, 'approval_policy="never"')
+    -- The other two halves of what `lightweight` promises (core/types.lua): no MCP tools and no
+    -- project instructions. These are codex's answers to claude's --strict-mcp-config/--mcp-config
+    -- and --setting-sources "". `--ignore-user-config` would cover both and is deliberately not
+    -- used: unlike claude's flag it also drops model_provider and base URL, so a user on a custom
+    -- provider would lose utility calls entirely.
+    table.insert(cmd, "-c")
+    table.insert(cmd, "mcp_servers={}")
+    table.insert(cmd, "-c")
+    table.insert(cmd, "project_doc_max_bytes=0")
 
   -- Permission mapping (only for new sessions; resume does not accept -s)
   elseif not session_id then

--- a/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
@@ -2,25 +2,11 @@
 --- Builds the command array for the GitHub Copilot CLI with JSONL output
 --- @module vibing.infrastructure.adapter.modules.copilot_command_builder
 
-local Modes = require("vibing.core.constants.modes")
+local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
 
 local M = {}
 
 local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
-
---- Resolve model name from opts or config
---- Claude short names (sonnet/opus/haiku/fable) are not valid copilot model ids,
---- so they are dropped and copilot's own default is used instead.
---- @param opts Vibing.AdapterOpts
---- @param config Vibing.Config
---- @return string|nil
-local function resolve_model(opts, config)
-  local model = opts.model or (config.agent and config.agent.default_model)
-  if model and Modes.is_valid_model(model) then
-    return nil
-  end
-  return model
-end
 
 --- Resolve language setting
 --- @param opts Vibing.AdapterOpts
@@ -95,7 +81,7 @@ function M.build(prompt, opts, session_id, config)
     table.insert(cmd, "--resume=" .. session_id)
   end
 
-  local model = resolve_model(opts, config)
+  local model = NonClaudeModel.resolve(opts, config)
   if model then
     table.insert(cmd, "--model")
     table.insert(cmd, model)

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -2,7 +2,7 @@
 --- Builds the command array for the Grok Build CLI with streaming JSON output
 --- @module vibing.infrastructure.adapter.modules.grok_command_builder
 
-local Modes = require("vibing.core.constants.modes")
+local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
 local worktree_constants = require("vibing.core.constants.worktree")
 
 local M = {}
@@ -114,19 +114,6 @@ local function resolve_language(opts, config)
   return type(language) == "string" and language or nil
 end
 
---- Grok has its own model catalog, so a Claude shortcut name (sonnet/opus/...) left over from a
---- chat that switched backends must not be forwarded as Grok's `--model`.
---- @param opts Vibing.AdapterOpts
---- @param config Vibing.Config
---- @return string|nil
-local function resolve_model(opts, config)
-  local model = opts.model or (config.agent and config.agent.default_model)
-  if model and Modes.is_valid_model(model) then
-    return nil
-  end
-  return model
-end
-
 --- @param opts Vibing.AdapterOpts
 --- @return string context_prefix Empty string if no context
 local function build_context_prefix(opts)
@@ -198,7 +185,7 @@ function M.build(prompt, opts, session_id, config, handle_id, rpc_port)
   table.insert(cmd, "--output-format")
   table.insert(cmd, "streaming-json")
 
-  local model = resolve_model(opts, config)
+  local model = NonClaudeModel.resolve(opts, config)
   if model then
     table.insert(cmd, "--model")
     table.insert(cmd, model)

--- a/lua/vibing/infrastructure/adapter/modules/non_claude_model.lua
+++ b/lua/vibing/infrastructure/adapter/modules/non_claude_model.lua
@@ -1,0 +1,39 @@
+--- Model resolution for the backends that do not speak Claude's model names.
+---
+--- codex, copilot and grok each carried a byte-identical copy of this. Only one of them was
+--- updated when #537 taught it about `lightweight`, which is how the same bug stayed live on the
+--- other two: their utility calls kept using `default_model` and never `utility_model`. One copy
+--- means the next backend inherits the behaviour instead of a fourth transcription of it.
+---
+--- @module vibing.infrastructure.adapter.modules.non_claude_model
+
+local Modes = require("vibing.core.constants.modes")
+
+local M = {}
+
+--- Resolve the model to pass on the command line, or nil to let the CLI pick its own.
+---
+--- Claude's short names (sonnet/opus/haiku/fable) are filtered out rather than forwarded: these
+--- backends have their own model catalogues and would reject them. That is also what makes the
+--- lightweight branch safe -- `utility_model` defaults to `sonnet`, so on these backends it
+--- resolves to nil and the CLI's own default applies.
+---
+--- @param opts Vibing.AdapterOpts
+--- @param config Vibing.Config
+--- @return string|nil
+function M.resolve(opts, config)
+  local agent = config.agent or {}
+  local model
+  if opts.lightweight then
+    model = agent.utility_model
+  else
+    model = opts.model or agent.default_model
+  end
+
+  if model and Modes.is_valid_model(model) then
+    return nil
+  end
+  return model
+end
+
+return M

--- a/tests/lua/infrastructure/adapter/codex_cli_spec.lua
+++ b/tests/lua/infrastructure/adapter/codex_cli_spec.lua
@@ -1,0 +1,56 @@
+---@diagnostic disable: undefined-field
+--- Covers the one thing codex_cli decides for itself that the command builder cannot see:
+--- whether the PreToolUse hook gets registered at all.
+---
+--- The builder fences a lightweight call into a read-only sandbox, but the hook flag is assembled
+--- in the adapter, so a spec on the builder alone would pass with the hook still wired up.
+
+local helper = require("tests.helpers.adapter_stream")
+local codex = require("vibing.infrastructure.adapter.codex_cli")
+
+local CONFIG = { agent = { default_model = "sonnet" } }
+
+--- Whether the argv carries a `-c hooks.pre_tool_use=...` pair.
+local function registers_hook(cmd)
+  for index, arg in ipairs(cmd) do
+    if arg == "-c" and type(cmd[index + 1]) == "string" and cmd[index + 1]:find("hooks.pre_tool_use", 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
+describe("codex_cli hook registration", function()
+  local system, adapter
+
+  before_each(function()
+    system = helper.stub_system("/usr/local/bin/codex")
+    adapter = codex:new(CONFIG)
+  end)
+
+  after_each(function()
+    system.restore()
+  end)
+
+  it("registers the PreToolUse hook for an ordinary call", function()
+    helper.run_stream(adapter, { permission_mode = "default" })
+    assert.is_true(registers_hook(system.only_call().cmd))
+  end)
+
+  it("skips it for a lightweight call, matching claude_cli", function()
+    -- Routing a title-generation tool call into the chat's approval UI would prompt the user
+    -- about a request they never made. The read-only sandbox is what constrains it instead.
+    helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
+    assert.is_false(registers_hook(system.only_call().cmd))
+  end)
+
+  it("skips it in bypassPermissions, as before", function()
+    helper.run_stream(adapter, { permission_mode = "bypassPermissions" })
+    assert.is_false(registers_hook(system.only_call().cmd))
+  end)
+
+  it("still fences the lightweight call even with the hook gone", function()
+    helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
+    assert.is_true(vim.tbl_contains(system.only_call().cmd, 'sandbox_mode="read-only"'))
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
@@ -39,10 +39,6 @@ describe("codex_command_builder", function()
     return overrides
   end
 
-  local function contains(list, value)
-    return vim.tbl_contains(list, value)
-  end
-
   describe("lightweight mode", function()
     -- Codex offers no `--tools ""` equivalent: probing the schema with `--strict-config` against
     -- codex 0.147 rejects tools.shell / tools.apply_patch / tools.view_image / tools.plan_tool /
@@ -50,23 +46,23 @@ describe("codex_command_builder", function()
     -- assertions pin a sandbox, not an empty tool set -- fencing the tools in is all there is.
     it("confines the call to a read-only sandbox", function()
       local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
-      assert.is_true(contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
+      assert.is_true(vim.tbl_contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
     end)
 
     it("turns off the one tool codex can actually disable", function()
       local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
-      assert.is_true(contains(config_overrides(cmd), "tools.web_search=false"))
+      assert.is_true(vim.tbl_contains(config_overrides(cmd), "tools.web_search=false"))
     end)
 
     it("never waits on an approval prompt that headless exec cannot show", function()
       local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
-      assert.is_true(contains(config_overrides(cmd), 'approval_policy="never"'))
+      assert.is_true(vim.tbl_contains(config_overrides(cmd), 'approval_policy="never"'))
     end)
 
     it("does not fall back to the workspace-write sandbox", function()
       local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
       assert.is_nil(find_flag(cmd, "-s"))
-      assert.is_false(contains(config_overrides(cmd), 'sandbox_mode="workspace-write"'))
+      assert.is_false(vim.tbl_contains(config_overrides(cmd), 'sandbox_mode="workspace-write"'))
     end)
 
     it("stays read-only even when the chat is in bypassPermissions", function()
@@ -80,14 +76,14 @@ describe("codex_command_builder", function()
         nil
       )
       assert.is_nil(find_flag(cmd, "--dangerously-bypass-approvals-and-sandbox"))
-      assert.is_true(contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
+      assert.is_true(vim.tbl_contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
     end)
 
     it("still restricts a resumed session, where -s is not accepted", function()
       -- /summarize passes the chat's session id, so this is the common case, not the edge one.
       local cmd = codex_command_builder.build("hi", { lightweight = true }, "thread-1", {}, nil)
       assert.is_nil(find_flag(cmd, "-s"))
-      assert.is_true(contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
+      assert.is_true(vim.tbl_contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
     end)
 
     it("uses utility_model rather than default_model", function()
@@ -109,9 +105,9 @@ describe("codex_command_builder", function()
     it("are unaffected by the lightweight restrictions", function()
       local cmd = codex_command_builder.build("hi", {}, nil, {}, nil)
       local overrides = config_overrides(cmd)
-      assert.is_false(contains(overrides, 'sandbox_mode="read-only"'))
-      assert.is_false(contains(overrides, "tools.web_search=false"))
-      assert.is_false(contains(overrides, 'approval_policy="never"'))
+      assert.is_false(vim.tbl_contains(overrides, 'sandbox_mode="read-only"'))
+      assert.is_false(vim.tbl_contains(overrides, "tools.web_search=false"))
+      assert.is_false(vim.tbl_contains(overrides, 'approval_policy="never"'))
       assert.equals("workspace-write", cmd[find_flag(cmd, "-s") + 1])
     end)
 

--- a/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
@@ -1,0 +1,135 @@
+local codex_command_builder = require("vibing.infrastructure.adapter.modules.codex_command_builder")
+
+describe("codex_command_builder", function()
+  local original_exepath
+
+  before_each(function()
+    codex_command_builder._reset_path_cache()
+    original_exepath = vim.fn.exepath
+    vim.fn.exepath = function(name)
+      if name == "codex" then
+        return "/usr/local/bin/codex"
+      end
+      return original_exepath(name)
+    end
+  end)
+
+  after_each(function()
+    vim.fn.exepath = original_exepath
+    codex_command_builder._reset_path_cache()
+  end)
+
+  local function find_flag(cmd, flag)
+    for i, arg in ipairs(cmd) do
+      if arg == flag then
+        return i
+      end
+    end
+    return nil
+  end
+
+  --- Every value passed with `-c`, so a test can assert on the set of config overrides.
+  local function config_overrides(cmd)
+    local overrides = {}
+    for i, arg in ipairs(cmd) do
+      if arg == "-c" and cmd[i + 1] then
+        table.insert(overrides, cmd[i + 1])
+      end
+    end
+    return overrides
+  end
+
+  local function contains(list, value)
+    return vim.tbl_contains(list, value)
+  end
+
+  describe("lightweight mode", function()
+    -- Codex offers no `--tools ""` equivalent: probing the schema with `--strict-config` against
+    -- codex 0.147 rejects tools.shell / tools.apply_patch / tools.view_image / tools.plan_tool /
+    -- tools.mcp as unknown fields, leaving tools.web_search as the only tool toggle. So these
+    -- assertions pin a sandbox, not an empty tool set -- fencing the tools in is all there is.
+    it("confines the call to a read-only sandbox", function()
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
+      assert.is_true(contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
+    end)
+
+    it("turns off the one tool codex can actually disable", function()
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
+      assert.is_true(contains(config_overrides(cmd), "tools.web_search=false"))
+    end)
+
+    it("never waits on an approval prompt that headless exec cannot show", function()
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
+      assert.is_true(contains(config_overrides(cmd), 'approval_policy="never"'))
+    end)
+
+    it("does not fall back to the workspace-write sandbox", function()
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
+      assert.is_nil(find_flag(cmd, "-s"))
+      assert.is_false(contains(config_overrides(cmd), 'sandbox_mode="workspace-write"'))
+    end)
+
+    it("stays read-only even when the chat is in bypassPermissions", function()
+      -- The user put the chat in that mode; a title generated behind their back is not the call
+      -- they made, so the utility call does not inherit it.
+      local cmd = codex_command_builder.build(
+        "hi",
+        { lightweight = true, permission_mode = "bypassPermissions" },
+        nil,
+        {},
+        nil
+      )
+      assert.is_nil(find_flag(cmd, "--dangerously-bypass-approvals-and-sandbox"))
+      assert.is_true(contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
+    end)
+
+    it("still restricts a resumed session, where -s is not accepted", function()
+      -- /summarize passes the chat's session id, so this is the common case, not the edge one.
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, "thread-1", {}, nil)
+      assert.is_nil(find_flag(cmd, "-s"))
+      assert.is_true(contains(config_overrides(cmd), 'sandbox_mode="read-only"'))
+    end)
+
+    it("uses utility_model rather than default_model", function()
+      local config = { agent = { default_model = "gpt-5-codex", utility_model = "gpt-5-mini" } }
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, config, nil)
+      assert.equals("gpt-5-mini", cmd[find_flag(cmd, "-m") + 1])
+    end)
+
+    it("passes no model when utility_model is a Claude name codex does not have", function()
+      -- utility_model defaults to "sonnet"; the existing filter turns it into codex's own default
+      -- instead of a model the CLI would reject.
+      local config = { agent = { default_model = "gpt-5-codex", utility_model = "sonnet" } }
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, config, nil)
+      assert.is_nil(find_flag(cmd, "-m"))
+    end)
+  end)
+
+  describe("ordinary calls", function()
+    it("are unaffected by the lightweight restrictions", function()
+      local cmd = codex_command_builder.build("hi", {}, nil, {}, nil)
+      local overrides = config_overrides(cmd)
+      assert.is_false(contains(overrides, 'sandbox_mode="read-only"'))
+      assert.is_false(contains(overrides, "tools.web_search=false"))
+      assert.is_false(contains(overrides, 'approval_policy="never"'))
+      assert.equals("workspace-write", cmd[find_flag(cmd, "-s") + 1])
+    end)
+
+    it("still map plan mode to a read-only sandbox via -s", function()
+      local cmd = codex_command_builder.build("hi", { permission_mode = "plan" }, nil, {}, nil)
+      assert.equals("read-only", cmd[find_flag(cmd, "-s") + 1])
+    end)
+
+    it("still bypass the sandbox in bypassPermissions", function()
+      local opts = { permission_mode = "bypassPermissions" }
+      local cmd = codex_command_builder.build("hi", opts, nil, {}, nil)
+      assert.is_not_nil(find_flag(cmd, "--dangerously-bypass-approvals-and-sandbox"))
+    end)
+
+    it("use default_model, not utility_model", function()
+      local config = { agent = { default_model = "gpt-5-codex", utility_model = "gpt-5-mini" } }
+      local cmd = codex_command_builder.build("hi", {}, nil, config, nil)
+      assert.equals("gpt-5-codex", cmd[find_flag(cmd, "-m") + 1])
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
@@ -59,6 +59,17 @@ describe("codex_command_builder", function()
       assert.is_true(vim.tbl_contains(config_overrides(cmd), 'approval_policy="never"'))
     end)
 
+    it("reaches none of the user's MCP servers", function()
+      -- codex's answer to claude's --strict-mcp-config + empty --mcp-config.
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
+      assert.is_true(vim.tbl_contains(config_overrides(cmd), "mcp_servers={}"))
+    end)
+
+    it("reads no AGENTS.md, the way the claude path reads no CLAUDE.md", function()
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
+      assert.is_true(vim.tbl_contains(config_overrides(cmd), "project_doc_max_bytes=0"))
+    end)
+
     it("does not fall back to the workspace-write sandbox", function()
       local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
       assert.is_nil(find_flag(cmd, "-s"))
@@ -105,9 +116,15 @@ describe("codex_command_builder", function()
     it("are unaffected by the lightweight restrictions", function()
       local cmd = codex_command_builder.build("hi", {}, nil, {}, nil)
       local overrides = config_overrides(cmd)
-      assert.is_false(vim.tbl_contains(overrides, 'sandbox_mode="read-only"'))
-      assert.is_false(vim.tbl_contains(overrides, "tools.web_search=false"))
-      assert.is_false(vim.tbl_contains(overrides, 'approval_policy="never"'))
+      for _, restriction in ipairs({
+        'sandbox_mode="read-only"',
+        "tools.web_search=false",
+        'approval_policy="never"',
+        "mcp_servers={}",
+        "project_doc_max_bytes=0",
+      }) do
+        assert.is_false(vim.tbl_contains(overrides, restriction), restriction .. " leaked")
+      end
       assert.equals("workspace-write", cmd[find_flag(cmd, "-s") + 1])
     end)
 

--- a/tests/lua/infrastructure/adapter/modules/non_claude_model_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/non_claude_model_spec.lua
@@ -1,0 +1,84 @@
+local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
+
+describe("non_claude_model", function()
+  local CONFIG = { agent = { default_model = "gpt-5-codex", utility_model = "gpt-5-mini" } }
+
+  it("uses default_model for an ordinary call", function()
+    assert.equals("gpt-5-codex", NonClaudeModel.resolve({}, CONFIG))
+  end)
+
+  it("lets opts.model win over default_model", function()
+    assert.equals("grok-4", NonClaudeModel.resolve({ model = "grok-4" }, CONFIG))
+  end)
+
+  it("uses utility_model for a lightweight call", function()
+    assert.equals("gpt-5-mini", NonClaudeModel.resolve({ lightweight = true }, CONFIG))
+  end)
+
+  it("ignores opts.model for a lightweight call", function()
+    -- The chat's own model is not the utility call's model; that is the whole point of the flag.
+    assert.equals("gpt-5-mini", NonClaudeModel.resolve({ lightweight = true, model = "grok-4" }, CONFIG))
+  end)
+
+  it("drops Claude short names so the CLI applies its own default", function()
+    for _, name in ipairs({ "sonnet", "opus", "haiku", "fable" }) do
+      assert.is_nil(NonClaudeModel.resolve({ model = name }, CONFIG), name .. " should not be forwarded")
+    end
+  end)
+
+  it("drops the sonnet default of utility_model rather than forwarding it", function()
+    -- utility_model defaults to "sonnet", which none of these backends has.
+    local config = { agent = { default_model = "gpt-5-codex", utility_model = "sonnet" } }
+    assert.is_nil(NonClaudeModel.resolve({ lightweight = true }, config))
+  end)
+
+  it("returns nil when nothing is configured", function()
+    assert.is_nil(NonClaudeModel.resolve({}, {}))
+    assert.is_nil(NonClaudeModel.resolve({ lightweight = true }, {}))
+  end)
+end)
+
+describe("every non-claude command builder honours utility_model", function()
+  -- #537 was filed against codex, but copilot and grok carried a byte-identical resolve_model and
+  -- the same bug. This pins that the shared helper actually reached all three.
+  local BACKENDS = {
+    { name = "codex", binary = "codex", module = "codex_command_builder" },
+    { name = "copilot", binary = "copilot", module = "copilot_command_builder" },
+    { name = "grok", binary = "grok", module = "grok_command_builder" },
+  }
+
+  local original_exepath
+
+  before_each(function()
+    original_exepath = vim.fn.exepath
+  end)
+
+  after_each(function()
+    vim.fn.exepath = original_exepath
+  end)
+
+  for _, backend in ipairs(BACKENDS) do
+    it(backend.name .. " passes utility_model on a lightweight call", function()
+      local builder = require("vibing.infrastructure.adapter.modules." .. backend.module)
+      if builder._reset_path_cache then
+        builder._reset_path_cache()
+      end
+      vim.fn.exepath = function(name)
+        if name == backend.binary then
+          return "/usr/local/bin/" .. backend.binary
+        end
+        return original_exepath(name)
+      end
+
+      local config = { agent = { default_model = "big-model", utility_model = "small-model" } }
+      local cmd = builder.build("hi", { lightweight = true }, nil, config, nil)
+
+      assert.is_true(vim.tbl_contains(cmd, "small-model"), backend.name .. " did not pass utility_model")
+      assert.is_false(vim.tbl_contains(cmd, "big-model"), backend.name .. " passed default_model instead")
+
+      if builder._reset_path_cache then
+        builder._reset_path_cache()
+      end
+    end)
+  end
+end)


### PR DESCRIPTION
Closes #537

## 問題

`codex_command_builder.lua` が `opts.lightweight` を一切参照していなかったため、`config.adapter = "codex"` の環境ではタイトル生成 / `/summarize` / デイリーサマリーが **ツール制限なし**（`resolve_sandbox(nil)` が返す `workspace-write` のまま）で codex CLI に流れ、`config.agent.utility_model` も無視されていました。Claude 側の #488 は「denylist が古い」問題でしたが、こちらはリストそのものが存在しない状態です。

## 調査結果: codex に `--tools ""` 相当は無い

issue のステップ1として、codex CLI に全ツール無効化の手段があるかを実機で調べました。codex は `--strict-config` を付けると **未知の設定キーをエラーにする** ので、これを使って config スキーマを直接叩いています（codex 0.147）。

```
$ codex exec --strict-config -c tools.shell=false ...
Error loading config.toml: unknown configuration field `tools.shell` in -c/--config override
```

| キー | 結果 |
| --- | --- |
| `tools.web_search` | ✅ 実在 |
| `tools.shell` | ❌ unknown |
| `tools.apply_patch` | ❌ unknown |
| `tools.view_image` | ❌ unknown |
| `tools.plan_tool` | ❌ unknown |
| `tools.mcp` | ❌ unknown |
| `sandbox_mode` | ✅ 実在 |
| `approval_policy` | ✅ 実在（`untrusted` / `on-failure` / `on-request` / `granular` / `never`） |

つまり **ツールを外すことはできず、囲い込むしかありません**。`tools.web_search` が唯一のツールトグルです。

## 対応

lightweight 呼び出しに以下を付与します。

```
-c sandbox_mode="read-only"
-c tools.web_search=false
-c approval_policy="never"
```

加えて `codex_cli.lua` で `CodexSettingsGenerator.get_hook_args()` をスキップします（`claude_cli.lua` が `SettingsGenerator.ensure` をスキップしているのと同じ扱い）。

### 効かせ方で重要な3点

1. **`-s` フラグではなく `-c` オーバーライドにした** — `/summarize` はチャットの session_id を渡すため `codex exec resume` 経路に入り、そこでは `-s` が受け付けられません。フラグにしていたら「最も頻度の高い lightweight 呼び出しだけ無防備」になっていました。
2. **`permission_mode` を一切見ない**（`bypassPermissions` を含む） — その設定をしたのは**チャット**に対してであって、ユーザーの知らないところで走るタイトル生成が全権限を継承するのは筋が違うためです。
3. **`utility_model` も既存の Claude 名フィルタを通す** — 既定値が `sonnet` なので、フィルタによって `-m` 自体が付かず codex 自身の既定モデルになります。存在しないモデル名を渡して弾かれることを避けています。

## テスト

`tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua` を新規作成（12ケース、全通過）。issue が求めていた `cli_command_builder_spec.lua` の `describe("lightweight mode", ...)` 相当です。

lightweight 側:
- read-only サンドボックスに閉じ込める / `tools.web_search=false` / `approval_policy="never"`
- `workspace-write` にフォールバックしない
- `bypassPermissions` でも read-only のまま
- **resume 経路でも制限が効く**（`-s` が使えないケース）
- `utility_model` を使う / それが Claude 名なら `-m` を付けない

通常呼び出し側（デグレ防止）:
- lightweight の制限が一切付かない / `plan` → `-s read-only` / `bypassPermissions` → `--dangerously-bypass-approvals-and-sandbox` / `default_model` を使う

```
pnpm run check         exit 0
pnpm run test:lua      exit 0
pnpm run test:node     7 pass / 0 fail
pnpm run format:check  exit 0
```

## 補足

`--ignore-user-config` も検討しましたが採用していません。Claude の `--setting-sources ""` と違い、codex のそれは `model_provider` やベース URL といった接続設定ごと落とすため、カスタムプロバイダを使っているユーザーの lightweight 呼び出しが丸ごと失敗しかねないためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: copilot / grok にも同じバグがありました

セルフレビューで、`resolve_model` が codex / copilot / grok に **バイト単位で同一のコピー** として存在していることが判明しました。codex のコピーだけ直すと、他の2つで `utility_model` が無視されたまま残り、しかもそれを示す手がかりが何も無い状態になります。

`modules/non_claude_model.lua` に集約し、3バックエンドすべてが呼ぶようにしました。これで **#537 のモデル側の問題は3バックエンドすべてで解消** します。

ツール制限側は意図的にバックエンド固有のままです（claude は `--tools ""` でツールを*外す*、codex は囲い込むしかない、という違いを共通語彙で表現できないため）。copilot / grok のツール制限は本 issue のスコープ外で、従来どおり未対応です。

あわせて `core/types.lua` の `lightweight` の説明が Claude 固有の語彙（「CLAUDE.md/rules・MCPサーバー・フックを無効化」）になっていて codex には既に不正確だったので、各アダプタが負う責務（ツールを使わせない・プロジェクト設定を読ませない・フックを登録しない・`utility_model` を使う）の記述に改めました。未対応のバックエンドが「該当なし」ではなく「未達」として読めるようにするためです。

`non_claude_model_spec.lua` は resolver 自体に加えて、3つのビルダーを実際に driving して修正が届いていることを確認しています（10ケース）。
