### PR TITLE
refactor: extract a shared runtime for the four CLI adapters

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -97,6 +97,7 @@ Two things stop backend identity leaking into shared code:
 
   The three are separate because backends disagree at three different levels, and the order
   matters — each step feeds the next:
+
   1. `normalize_payload` — the hook payload's own key names. Claude sends
      `tool_name`/`tool_input`; grok sends `toolName`/`toolInput`. Read straight through, the
      handler sees a nil tool name, so the two steps below get nothing to work on, every rule

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -97,7 +97,6 @@ Two things stop backend identity leaking into shared code:
 
   The three are separate because backends disagree at three different levels, and the order
   matters — each step feeds the next:
-
   1. `normalize_payload` — the hook payload's own key names. Claude sends
      `tool_name`/`tool_input`; grok sends `toolName`/`toolInput`. Read straight through, the
      handler sees a nil tool name, so the two steps below get nothing to work on, every rule
@@ -142,12 +141,33 @@ The tree is layered (`domain` / `application` / `infrastructure` / `presentation
 **Adapter (`lua/vibing/infrastructure/adapter/`):**
 
 - `base.lua` - Abstract adapter interface
-- `claude_cli.lua` / `codex_cli.lua` / `copilot_cli.lua` - Backend adapters (spawn + stream lifecycle)
+- `claude_cli.lua` / `codex_cli.lua` / `copilot_cli.lua` / `grok_cli.lua` - Backend adapters
+  (`new()` and `stream()`; everything else comes from `cli_runtime`)
+- `modules/cli_runtime.lua` - `execute`/`cancel`/`supports` + session delegations, installed onto
+  each adapter class; plus `new_handle_id`, `kill_tree`, `report_build_failure`
+- `modules/command_builder_common.lua` - Language resolution, the response-language sentence, the
+  `@file:` context prefix, and cached binary lookup — the backend-agnostic half of argv building
 - `modules/cli_command_builder.lua` - Claude CLI argv construction (flags, system prompt)
 - `modules/cli_event_processor.lua` - stream-json → chunk/tool events
 - `modules/codex_command_builder.lua` / `modules/codex_event_processor.lua` - Codex equivalents
+- `modules/non_claude_model.lua` - Model resolution for codex/copilot/grok
 - `modules/<backend>_tool_vocabulary.lua` - Native tool name <-> canonical name, per backend
 - `modules/session_manager.lua`, `modules/active_stream_registry.lua` - Session/handle tracking
+
+**What a new backend still has to write** is `new()` and `stream()`. `stream()` stayed
+per-adapter deliberately: its variation points — which settings generator runs before the build,
+how many arguments the command builder takes, whether a `chat_bufnr` or a tool vocabulary gets
+registered, whether stderr needs filtering — outnumber its shared lines, and the four adapters
+genuinely disagree on the child environment. `cli_runtime` covers the pieces inside it that do
+repeat.
+
+Two behaviours were unified rather than parameterised while extracting them, because the split
+was drift rather than intent. `cancel()` now kills the CLI's children before the parent on every
+backend; claude killed only the parent, so the shells its tools spawned kept the stdout pipe open
+and `vim.system()`'s exit handler — which waits for that pipe to close — never fired, leaving the
+chat UI frozen. And `execute()` now cancels a run that outlives its timeout instead of returning
+and leaving the process alive; only grok did that. `cli_runtime_spec.lua` runs both over every
+backend.
 
 **Chat (presentation + application):**
 

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -3,6 +3,7 @@
 --- @module vibing.infrastructure.adapter.claude_cli
 
 local Base = require("vibing.infrastructure.adapter.base")
+local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local CLICommandBuilder = require("vibing.infrastructure.adapter.modules.cli_command_builder")
 local CLIEventProcessor = require("vibing.infrastructure.adapter.modules.cli_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -27,6 +28,8 @@ local SUPPORTED_FEATURES = {
   dynamic_permissions = true,
 }
 
+CliRuntime.install(ClaudeCLI, SUPPORTED_FEATURES)
+
 ---@param config Vibing.Config
 ---@return Vibing.ClaudeCLIAdapter
 function ClaudeCLI:new(config)
@@ -42,29 +45,6 @@ end
 
 ---@param prompt string
 ---@param opts Vibing.AdapterOpts
----@return Vibing.Response
-function ClaudeCLI:execute(prompt, opts)
-  opts = opts or {}
-  local result = { content = "" }
-  local done = false
-
-  self:stream(prompt, opts, function(chunk)
-    result.content = result.content .. chunk
-  end, function(response)
-    if response.error then
-      result.error = response.error
-    end
-    done = true
-  end)
-
-  vim.wait(120000, function()
-    return done
-  end, 100)
-  return result
-end
-
----@param prompt string
----@param opts Vibing.AdapterOpts
 ---@param on_chunk fun(chunk: string)
 ---@param on_done fun(response: Vibing.Response)
 ---@return string handle_id
@@ -72,10 +52,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   opts = opts or {}
 
   local debug_mode = vim.g.vibing_debug_stream
-  -- hex format avoids LuaJIT's tostring() rendering large hrtime doubles in scientific
-  -- notation (e.g. "2.64e+15"), which pre-tool-use.sh's char-sanitized VIBING_HANDLE_ID
-  -- would then fail to match against this exact registry key
-  local handle_id = string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
+  local handle_id = CliRuntime.new_handle_id()
   local session_id = opts._session_id
 
   if debug_mode then
@@ -111,10 +88,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   -- actionable message. Matches copilot_cli.lua.
   local build_ok, cmd = pcall(CLICommandBuilder.build, prompt, opts, session_id, self.config, settings_path, rpc_port)
   if not build_ok then
-    local message = type(cmd) == "string" and cmd:gsub("^.*:%d+:%s*", "") or tostring(cmd)
-    vim.schedule(function()
-      on_done({ content = "", error = message, _handle_id = handle_id })
-    end)
+    CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id
   end
   local output = {}
@@ -246,57 +220,6 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   end
 
   return handle_id
-end
-
----@param handle_id string?
-function ClaudeCLI:cancel(handle_id)
-  if handle_id then
-    local handle = self._handles[handle_id]
-    if handle then
-      pcall(function()
-        if handle.pid and handle.pid > 0 then
-          handle:kill(9)
-        end
-      end)
-      self._handles[handle_id] = nil
-    end
-  else
-    for id, handle in pairs(self._handles) do
-      pcall(function()
-        if handle.pid and handle.pid > 0 then
-          handle:kill(9)
-        end
-      end)
-      self._handles[id] = nil
-    end
-  end
-end
-
----@param feature string
----@return boolean
-function ClaudeCLI:supports(feature)
-  return SUPPORTED_FEATURES[feature] or false
-end
-
----@param session_id string?
----@param handle_id string?
-function ClaudeCLI:set_session_id(session_id, handle_id)
-  SessionManagerModule.set(self._session_manager, session_id, handle_id)
-end
-
----@param handle_id string?
----@return string?
-function ClaudeCLI:get_session_id(handle_id)
-  return SessionManagerModule.get(self._session_manager, handle_id)
-end
-
----@param handle_id string
-function ClaudeCLI:cleanup_session(handle_id)
-  SessionManagerModule.cleanup(self._session_manager, handle_id)
-end
-
-function ClaudeCLI:cleanup_stale_sessions()
-  SessionManagerModule.cleanup_stale(self._session_manager, self._handles)
 end
 
 return ClaudeCLI

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -17,7 +17,8 @@ local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.acti
 local ClaudeCLI = setmetatable({}, { __index = Base })
 ClaudeCLI.__index = ClaudeCLI
 
-local INITIAL_RESPONSE_TIMEOUT_MS = 120000
+-- Shared with execute()'s own wait, so the two cannot drift apart.
+local INITIAL_RESPONSE_TIMEOUT_MS = CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS
 
 local SUPPORTED_FEATURES = {
   streaming = true,

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -17,7 +17,8 @@ local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.acti
 local CodexCLI = setmetatable({}, { __index = Base })
 CodexCLI.__index = CodexCLI
 
-local INITIAL_RESPONSE_TIMEOUT_MS = 120000
+-- Shared with execute()'s own wait, so the two cannot drift apart.
+local INITIAL_RESPONSE_TIMEOUT_MS = CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS
 
 local SUPPORTED_FEATURES = {
   streaming = true,

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -3,6 +3,7 @@
 --- @module vibing.infrastructure.adapter.codex_cli
 
 local Base = require("vibing.infrastructure.adapter.base")
+local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local CodexCommandBuilder = require("vibing.infrastructure.adapter.modules.codex_command_builder")
 local CodexEventProcessor = require("vibing.infrastructure.adapter.modules.codex_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -27,6 +28,8 @@ local SUPPORTED_FEATURES = {
   dynamic_permissions = true,
 }
 
+CliRuntime.install(CodexCLI, SUPPORTED_FEATURES)
+
 ---@param config Vibing.Config
 ---@return Vibing.CodexCLIAdapter
 function CodexCLI:new(config)
@@ -41,29 +44,6 @@ end
 
 ---@param prompt string
 ---@param opts Vibing.AdapterOpts
----@return Vibing.Response
-function CodexCLI:execute(prompt, opts)
-  opts = opts or {}
-  local result = { content = "" }
-  local done = false
-
-  self:stream(prompt, opts, function(chunk)
-    result.content = result.content .. chunk
-  end, function(response)
-    if response.error then
-      result.error = response.error
-    end
-    done = true
-  end)
-
-  vim.wait(120000, function()
-    return done
-  end, 100)
-  return result
-end
-
----@param prompt string
----@param opts Vibing.AdapterOpts
 ---@param on_chunk fun(chunk: string)
 ---@param on_done fun(response: Vibing.Response)
 ---@return string handle_id
@@ -71,10 +51,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   opts = opts or {}
 
   local debug_mode = vim.g.vibing_debug_stream
-  -- hex format avoids LuaJIT's tostring() rendering large hrtime doubles in scientific
-  -- notation (e.g. "2.64e+15"), which pre-tool-use.sh's char-sanitized VIBING_HANDLE_ID
-  -- would then fail to match against this exact registry key
-  local handle_id = string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
+  local handle_id = CliRuntime.new_handle_id()
   local session_id = opts._session_id
 
   if debug_mode then
@@ -102,10 +79,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   -- actionable message. Matches copilot_cli.lua.
   local build_ok, cmd = pcall(CodexCommandBuilder.build, prompt, opts, session_id, self.config, hook_args)
   if not build_ok then
-    local message = type(cmd) == "string" and cmd:gsub("^.*:%d+:%s*", "") or tostring(cmd)
-    vim.schedule(function()
-      on_done({ content = "", error = message, _handle_id = handle_id })
-    end)
+    CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id
   end
   local output = {}
@@ -243,67 +217,6 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   end
 
   return handle_id
-end
-
----@param handle_id string?
-function CodexCLI:cancel(handle_id)
-  -- codex exec spawns child processes (e.g. shells for tool execution) that
-  -- inherit the stdout pipe. Killing only the codex parent leaves those
-  -- children holding the pipe open, so vim.system()'s exit handler never
-  -- fires (it waits for stdout to close), meaning GradientAnimation.stop()
-  -- and add_user_section() are never called and the UI stays frozen.
-  -- Kill children first via pkill, then the parent.
-  local function kill_process(handle)
-    if not handle then return end
-    local pid = handle.pid
-    if not pid or pid <= 0 then return end
-    -- Kill direct child processes that may be holding stdout/stderr pipes open
-    vim.fn.system(string.format("pkill -9 -P %d 2>/dev/null; true", pid))
-    -- Kill the codex process itself
-    pcall(function()
-      handle:kill(9)
-    end)
-  end
-
-  if handle_id then
-    local handle = self._handles[handle_id]
-    if handle then
-      kill_process(handle)
-      self._handles[handle_id] = nil
-    end
-  else
-    for id, handle in pairs(self._handles) do
-      kill_process(handle)
-      self._handles[id] = nil
-    end
-  end
-end
-
----@param feature string
----@return boolean
-function CodexCLI:supports(feature)
-  return SUPPORTED_FEATURES[feature] or false
-end
-
----@param session_id string?
----@param handle_id string?
-function CodexCLI:set_session_id(session_id, handle_id)
-  SessionManagerModule.set(self._session_manager, session_id, handle_id)
-end
-
----@param handle_id string?
----@return string?
-function CodexCLI:get_session_id(handle_id)
-  return SessionManagerModule.get(self._session_manager, handle_id)
-end
-
----@param handle_id string
-function CodexCLI:cleanup_session(handle_id)
-  SessionManagerModule.cleanup(self._session_manager, handle_id)
-end
-
-function CodexCLI:cleanup_stale_sessions()
-  SessionManagerModule.cleanup_stale(self._session_manager, self._handles)
 end
 
 return CodexCLI

--- a/lua/vibing/infrastructure/adapter/copilot_cli.lua
+++ b/lua/vibing/infrastructure/adapter/copilot_cli.lua
@@ -16,7 +16,8 @@ local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.acti
 local CopilotCLI = setmetatable({}, { __index = Base })
 CopilotCLI.__index = CopilotCLI
 
-local INITIAL_RESPONSE_TIMEOUT_MS = 120000
+-- Shared with execute()'s own wait, so the two cannot drift apart.
+local INITIAL_RESPONSE_TIMEOUT_MS = CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS
 
 local SUPPORTED_FEATURES = {
   streaming = true,

--- a/lua/vibing/infrastructure/adapter/copilot_cli.lua
+++ b/lua/vibing/infrastructure/adapter/copilot_cli.lua
@@ -3,6 +3,7 @@
 --- @module vibing.infrastructure.adapter.copilot_cli
 
 local Base = require("vibing.infrastructure.adapter.base")
+local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local CopilotCommandBuilder = require("vibing.infrastructure.adapter.modules.copilot_command_builder")
 local CopilotEventProcessor = require("vibing.infrastructure.adapter.modules.copilot_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -27,6 +28,8 @@ local SUPPORTED_FEATURES = {
   dynamic_permissions = false,
 }
 
+CliRuntime.install(CopilotCLI, SUPPORTED_FEATURES)
+
 ---@param config Vibing.Config
 ---@return Vibing.CopilotCLIAdapter
 function CopilotCLI:new(config)
@@ -41,29 +44,6 @@ end
 
 ---@param prompt string
 ---@param opts Vibing.AdapterOpts
----@return Vibing.Response
-function CopilotCLI:execute(prompt, opts)
-  opts = opts or {}
-  local result = { content = "" }
-  local done = false
-
-  self:stream(prompt, opts, function(chunk)
-    result.content = result.content .. chunk
-  end, function(response)
-    if response.error then
-      result.error = response.error
-    end
-    done = true
-  end)
-
-  vim.wait(120000, function()
-    return done
-  end, 100)
-  return result
-end
-
----@param prompt string
----@param opts Vibing.AdapterOpts
 ---@param on_chunk fun(chunk: string)
 ---@param on_done fun(response: Vibing.Response)
 ---@return string handle_id
@@ -71,7 +51,7 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
   opts = opts or {}
 
   local debug_mode = vim.g.vibing_debug_stream
-  local handle_id = string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
+  local handle_id = CliRuntime.new_handle_id()
   local session_id = opts._session_id
 
   -- The builder raises when the copilot binary is missing. The caller in send_message.lua
@@ -79,10 +59,7 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
   -- stack trace instead of an actionable message.
   local build_ok, cmd = pcall(CopilotCommandBuilder.build, prompt, opts, session_id, self.config)
   if not build_ok then
-    local message = type(cmd) == "string" and cmd:gsub("^.*:%d+:%s*", "") or tostring(cmd)
-    vim.schedule(function()
-      on_done({ content = "", error = message, _handle_id = handle_id })
-    end)
+    CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id
   end
 
@@ -191,66 +168,6 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
   end
 
   return handle_id
-end
-
----@param handle_id string?
-function CopilotCLI:cancel(handle_id)
-  -- copilot's shell tool spawns children that inherit the stdout pipe. Killing only
-  -- the parent leaves them holding it open, so vim.system()'s exit handler never fires
-  -- and the chat UI stays frozen. Kill children first, then the parent.
-  local function kill_process(handle)
-    if not handle then
-      return
-    end
-    local pid = handle.pid
-    if not pid or pid <= 0 then
-      return
-    end
-    vim.fn.system(string.format("pkill -9 -P %d 2>/dev/null; true", pid))
-    pcall(function()
-      handle:kill(9)
-    end)
-  end
-
-  if handle_id then
-    local handle = self._handles[handle_id]
-    if handle then
-      kill_process(handle)
-      self._handles[handle_id] = nil
-    end
-  else
-    for id, handle in pairs(self._handles) do
-      kill_process(handle)
-      self._handles[id] = nil
-    end
-  end
-end
-
----@param feature string
----@return boolean
-function CopilotCLI:supports(feature)
-  return SUPPORTED_FEATURES[feature] or false
-end
-
----@param session_id string?
----@param handle_id string?
-function CopilotCLI:set_session_id(session_id, handle_id)
-  SessionManagerModule.set(self._session_manager, session_id, handle_id)
-end
-
----@param handle_id string?
----@return string?
-function CopilotCLI:get_session_id(handle_id)
-  return SessionManagerModule.get(self._session_manager, handle_id)
-end
-
----@param handle_id string
-function CopilotCLI:cleanup_session(handle_id)
-  SessionManagerModule.cleanup(self._session_manager, handle_id)
-end
-
-function CopilotCLI:cleanup_stale_sessions()
-  SessionManagerModule.cleanup_stale(self._session_manager, self._handles)
 end
 
 return CopilotCLI

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -3,6 +3,7 @@
 --- @module vibing.infrastructure.adapter.grok_cli
 
 local Base = require("vibing.infrastructure.adapter.base")
+local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local GrokCommandBuilder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
 local GrokEventProcessor = require("vibing.infrastructure.adapter.modules.grok_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -26,6 +27,8 @@ local SUPPORTED_FEATURES = {
   session = true,
 }
 
+CliRuntime.install(GrokCLI, SUPPORTED_FEATURES)
+
 ---@param config Vibing.Config
 ---@return Vibing.GrokCLIAdapter
 function GrokCLI:new(config)
@@ -44,33 +47,6 @@ end
 
 ---@param prompt string
 ---@param opts Vibing.AdapterOpts
----@return Vibing.Response
-function GrokCLI:execute(prompt, opts)
-  opts = opts or {}
-  local result = { content = "" }
-  local done = false
-
-  local handle_id = self:stream(prompt, opts, function(chunk)
-    result.content = result.content .. chunk
-  end, function(response)
-    if response.error then
-      result.error = response.error
-    end
-    done = true
-  end)
-
-  vim.wait(INITIAL_RESPONSE_TIMEOUT_MS, function()
-    return done
-  end, 100)
-  if not done then
-    self:cancel(handle_id)
-    result.error = result.error or "Execution timeout"
-  end
-  return result
-end
-
----@param prompt string
----@param opts Vibing.AdapterOpts
 ---@param on_chunk fun(chunk: string)
 ---@param on_done fun(response: Vibing.Response)
 ---@return string handle_id
@@ -78,10 +54,7 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
   opts = opts or {}
 
   local debug_mode = vim.g.vibing_debug_stream
-  -- hex format avoids LuaJIT's tostring() rendering large hrtime doubles in scientific
-  -- notation (e.g. "2.64e+15"), which pre-tool-use.sh's char-sanitized VIBING_HANDLE_ID
-  -- would then fail to match against this exact registry key
-  local handle_id = string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
+  local handle_id = CliRuntime.new_handle_id()
   local session_id = opts._session_id
 
   if debug_mode then
@@ -118,10 +91,7 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
   -- actionable message. Matches claude_cli.lua and copilot_cli.lua.
   local build_ok, cmd = pcall(GrokCommandBuilder.build, prompt, opts, session_id, self.config, handle_id, rpc_port)
   if not build_ok then
-    local message = type(cmd) == "string" and cmd:gsub("^.*:%d+:%s*", "") or tostring(cmd)
-    vim.schedule(function()
-      on_done({ content = "", error = message, _handle_id = handle_id })
-    end)
+    CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id
   end
 
@@ -250,68 +220,6 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
   end
 
   return handle_id
-end
-
----@param handle_id string?
-function GrokCLI:cancel(handle_id)
-  -- Grok spawns child processes that inherit the stdout pipe (MCP servers, tool shells).
-  -- Kill children first so vim.system's exit handler fires when the pipe closes.
-  local function kill_process(handle)
-    if not handle then
-      return
-    end
-    local pid = handle.pid
-    if not pid or pid <= 0 then
-      return
-    end
-    -- Fire-and-forget: consistent with the rest of this adapter's async design, and avoids
-    -- blocking Neovim's main loop while pkill runs (this can be called from a vim.schedule
-    -- callback on the session-resume timeout path).
-    vim.system({ "sh", "-c", string.format("pkill -9 -P %d 2>/dev/null", pid) }, {}, function() end)
-    pcall(function()
-      handle:kill(9)
-    end)
-  end
-
-  if handle_id then
-    local handle = self._handles[handle_id]
-    if handle then
-      kill_process(handle)
-      self._handles[handle_id] = nil
-    end
-  else
-    for id, handle in pairs(self._handles) do
-      kill_process(handle)
-      self._handles[id] = nil
-    end
-  end
-end
-
----@param feature string
----@return boolean
-function GrokCLI:supports(feature)
-  return SUPPORTED_FEATURES[feature] or false
-end
-
----@param session_id string?
----@param handle_id string?
-function GrokCLI:set_session_id(session_id, handle_id)
-  SessionManagerModule.set(self._session_manager, session_id, handle_id)
-end
-
----@param handle_id string?
----@return string?
-function GrokCLI:get_session_id(handle_id)
-  return SessionManagerModule.get(self._session_manager, handle_id)
-end
-
----@param handle_id string
-function GrokCLI:cleanup_session(handle_id)
-  SessionManagerModule.cleanup(self._session_manager, handle_id)
-end
-
-function GrokCLI:cleanup_stale_sessions()
-  SessionManagerModule.cleanup_stale(self._session_manager, self._handles)
 end
 
 return GrokCLI

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -17,7 +17,8 @@ local GrokSettingsGenerator = require("vibing.infrastructure.hooks.grok_settings
 local GrokCLI = setmetatable({}, { __index = Base })
 GrokCLI.__index = GrokCLI
 
-local INITIAL_RESPONSE_TIMEOUT_MS = 120000
+-- Shared with execute()'s own wait, so the two cannot drift apart.
+local INITIAL_RESPONSE_TIMEOUT_MS = CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS
 
 local SUPPORTED_FEATURES = {
   streaming = true,

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -3,6 +3,7 @@
 --- @module vibing.infrastructure.adapter.modules.cli_command_builder
 
 local tools_constants = require("vibing.core.constants.tools")
+local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
 local worktree_constants = require("vibing.core.constants.worktree")
 
 local M = {}
@@ -10,7 +11,10 @@ local M = {}
 local DEFAULT_SETTING_SOURCES = { "user", "project", "local" }
 local VALID_SETTING_SOURCES = { user = true, project = true, ["local"] = true }
 
-local cached_claude_path = nil
+local binary_path = CommonBuilder.binary_resolver(
+  "claude",
+  "Claude CLI not found in PATH. Please install Claude Code CLI."
+)
 
 --- Resolve the `--setting-sources` list, falling back to the default when config
 --- is missing, malformed, or contains entries outside `user`/`project`/`local`.
@@ -79,22 +83,6 @@ local function resolve_effort(opts, config)
   return effort
 end
 
---- Resolve language setting
---- @param opts Vibing.AdapterOpts
---- @param config Vibing.Config
---- @return string|nil
-local function resolve_language(opts, config)
-  local language = opts.language
-  if not language and config.language then
-    if type(config.language) == "table" then
-      language = config.language.default or config.language.chat
-    else
-      language = config.language
-    end
-  end
-  return type(language) == "string" and language or nil
-end
-
 --- Append tools that are not in the list yet, preserving the user's own ordering
 --- @param allow_tools string[]
 --- @param tools string[]
@@ -150,31 +138,6 @@ local function add_permission_args(cmd, opts)
   end
 end
 
---- Build context prefix for the prompt
---- Reads @file:path entries and formats them as context references
---- @param opts Vibing.AdapterOpts
---- @return string context_prefix Empty string if no context
-local function build_context_prefix(opts)
-  local context_entries = opts.context or {}
-  if #context_entries == 0 then
-    return ""
-  end
-
-  local parts = {}
-  for _, ctx in ipairs(context_entries) do
-    if ctx:match("^@file:") then
-      local file_ref = ctx:sub(7)
-      table.insert(parts, string.format("Context file: %s", file_ref))
-    end
-  end
-
-  if #parts == 0 then
-    return ""
-  end
-
-  return table.concat(parts, "\n") .. "\n\n"
-end
-
 --- Add optional flag if value is present
 --- @param cmd string[]
 --- @param flag string
@@ -201,19 +164,11 @@ end
 --- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec that
 --- wants to exercise the "CLI missing" path has to clear what an earlier spec resolved.
 function M._reset_path_cache()
-  cached_claude_path = nil
+  binary_path.reset()
 end
 
 function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
-  if not cached_claude_path then
-    cached_claude_path = vim.fn.exepath("claude")
-    if cached_claude_path == "" then
-      cached_claude_path = nil
-      error("Claude CLI not found in PATH. Please install Claude Code CLI.")
-    end
-  end
-
-  local cmd = { cached_claude_path }
+  local cmd = { binary_path.resolve() }
 
   table.insert(cmd, "-p")
   table.insert(cmd, "--output-format")
@@ -359,13 +314,9 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     end
   end
 
-  local language = resolve_language(opts, config)
-  if language and language ~= "en" then
-    local language_utils = require("vibing.core.utils.language")
-    local lang_name = language_utils.language_names[language]
-    if lang_name then
-      table.insert(system_prompt_lines, 1, string.format("Always respond in %s (%s).", lang_name, language))
-    end
+  local language_instruction = CommonBuilder.language_instruction(opts, config)
+  if language_instruction then
+    table.insert(system_prompt_lines, 1, language_instruction)
   end
 
   table.insert(cmd, "--append-system-prompt")
@@ -385,7 +336,7 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
   -- Build prompt with context prefix (only for new sessions, not resume)
   local full_prompt = prompt
   if not session_id then
-    local context_prefix = build_context_prefix(opts)
+    local context_prefix = CommonBuilder.context_prefix(opts)
     full_prompt = context_prefix .. prompt
   end
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
@@ -1,0 +1,161 @@
+--- The parts of a CLI adapter that have nothing to do with which CLI is running.
+---
+--- Four adapters each wrote out their own `execute`, `cancel`, `supports` and the four
+--- SessionManager delegations. Normalising the identifiers and diffing them, `supports` and the
+--- session methods were identical in all four; `execute` and `cancel` had drifted into three
+--- variants between them, which is the cost this module exists to stop paying (#515).
+---
+--- `stream()` stays in each adapter. Its differences are real -- which settings generator runs
+--- before the build, how many arguments the command builder takes, whether a `chat_bufnr` or a
+--- tool vocabulary gets registered, whether stderr needs filtering -- and there are more of those
+--- than there are shared lines. The helpers here cover the pieces of it that genuinely repeat.
+---
+--- @module vibing.infrastructure.adapter.modules.cli_runtime
+
+local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
+
+local M = {}
+
+--- How long `execute()` waits for a blocking call to finish.
+M.INITIAL_RESPONSE_TIMEOUT_MS = 120000
+
+--- A handle id unique across concurrent requests.
+---
+--- Hex, not decimal: LuaJIT's tostring() renders large hrtime doubles in scientific notation
+--- ("2.64e+15"), and pre-tool-use.sh's char-sanitized VIBING_HANDLE_ID would then fail to match
+--- this exact registry key.
+---
+--- @return string
+function M.new_handle_id()
+  return string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
+end
+
+--- Kill a spawned CLI along with the children holding its stdout pipe open.
+---
+--- Killing only the parent is not enough: the CLI's tool execution spawns shells (and MCP
+--- servers) that inherit the pipe, so `vim.system()`'s exit handler -- which waits for stdout to
+--- close -- never fires. The animation never stops and the chat UI stays frozen.
+---
+--- The pkill is fire-and-forget rather than `vim.fn.system`, because cancel can be reached from a
+--- `vim.schedule` callback and blocking Neovim's main loop on it is avoidable.
+---
+--- @param handle table? a vim.system handle
+function M.kill_tree(handle)
+  if not handle then
+    return
+  end
+
+  local pid = handle.pid
+  if not pid or pid <= 0 then
+    return
+  end
+
+  vim.system({ "sh", "-c", string.format("pkill -9 -P %d 2>/dev/null", pid) }, {}, function() end)
+  pcall(function()
+    handle:kill(9)
+  end)
+end
+
+--- Report a failure that happened before the process existed, through `on_done`.
+---
+--- The command builders raise when their binary is missing, and `send_message.lua` does not wrap
+--- `stream()` in pcall, so without this the chat buffer would show a raw Lua stack trace. The
+--- `file:line` prefix is stripped for the same reason: the chat should show a message, not a
+--- source location.
+---
+--- @param handle_id string
+--- @param err any whatever pcall returned
+--- @param on_done fun(response: Vibing.Response)
+function M.report_build_failure(handle_id, err, on_done)
+  local message = type(err) == "string" and err:gsub("^.*:%d+:%s*", "") or tostring(err)
+  vim.schedule(function()
+    on_done({ content = "", error = message, _handle_id = handle_id })
+  end)
+end
+
+--- Install every method whose implementation does not depend on the backend.
+---
+--- Defines `execute`, `cancel`, `supports` and the four session delegations on `Class`. The
+--- adapter is left with `new()` and `stream()`.
+---
+--- @param Class table the adapter class
+--- @param features table<string, boolean> what `supports()` should answer
+function M.install(Class, features)
+  --- Run a prompt to completion and return the response, for callers that cannot stream.
+  --- @param prompt string
+  --- @param opts Vibing.AdapterOpts
+  --- @return Vibing.Response
+  function Class:execute(prompt, opts)
+    opts = opts or {}
+    local result = { content = "" }
+    local done = false
+
+    local handle_id = self:stream(prompt, opts, function(chunk)
+      result.content = result.content .. chunk
+    end, function(response)
+      if response.error then
+        result.error = response.error
+      end
+      done = true
+    end)
+
+    vim.wait(M.INITIAL_RESPONSE_TIMEOUT_MS, function()
+      return done
+    end, 100)
+
+    -- Cancelling on timeout is what keeps a hung CLI from outliving the call that started it.
+    -- Three of the four adapters used to return here and leave the process running.
+    if not done then
+      self:cancel(handle_id)
+      result.error = result.error or "Execution timeout"
+    end
+    return result
+  end
+
+  --- Cancel one in-flight request, or every one when `handle_id` is omitted.
+  --- @param handle_id string?
+  function Class:cancel(handle_id)
+    if handle_id then
+      local handle = self._handles[handle_id]
+      if handle then
+        M.kill_tree(handle)
+        self._handles[handle_id] = nil
+      end
+      return
+    end
+
+    for id, handle in pairs(self._handles) do
+      M.kill_tree(handle)
+      self._handles[id] = nil
+    end
+  end
+
+  --- @param feature string
+  --- @return boolean
+  function Class:supports(feature)
+    return features[feature] or false
+  end
+
+  --- @param session_id string?
+  --- @param handle_id string?
+  function Class:set_session_id(session_id, handle_id)
+    SessionManagerModule.set(self._session_manager, session_id, handle_id)
+  end
+
+  --- @param handle_id string?
+  --- @return string?
+  function Class:get_session_id(handle_id)
+    return SessionManagerModule.get(self._session_manager, handle_id)
+  end
+
+  --- @param handle_id string
+  function Class:cleanup_session(handle_id)
+    SessionManagerModule.cleanup(self._session_manager, handle_id)
+  end
+
+  function Class:cleanup_stale_sessions()
+    SessionManagerModule.cleanup_stale(self._session_manager, self._handles)
+  end
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -3,26 +3,14 @@
 --- @module vibing.infrastructure.adapter.modules.codex_command_builder
 
 local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
+local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
 
 local M = {}
 
-local cached_codex_path = nil
-
---- Resolve language setting
---- @param opts Vibing.AdapterOpts
---- @param config Vibing.Config
---- @return string|nil
-local function resolve_language(opts, config)
-  local language = opts.language
-  if not language and config.language then
-    if type(config.language) == "table" then
-      language = config.language.default or config.language.chat
-    else
-      language = config.language
-    end
-  end
-  return type(language) == "string" and language or nil
-end
+local binary_path = CommonBuilder.binary_resolver(
+  "codex",
+  "Codex CLI not found in PATH. Please install codex-cli."
+)
 
 --- Map vibing permission mode to codex sandbox flag
 --- @param permission_mode string|nil
@@ -37,30 +25,6 @@ local function resolve_sandbox(permission_mode)
   return "workspace-write"
 end
 
---- Build context prefix for the prompt
---- @param opts Vibing.AdapterOpts
---- @return string context_prefix Empty string if no context
-local function build_context_prefix(opts)
-  local context_entries = opts.context or {}
-  if #context_entries == 0 then
-    return ""
-  end
-
-  local parts = {}
-  for _, ctx in ipairs(context_entries) do
-    if ctx:match("^@file:") then
-      local file_ref = ctx:sub(7)
-      table.insert(parts, string.format("Context file: %s", file_ref))
-    end
-  end
-
-  if #parts == 0 then
-    return ""
-  end
-
-  return table.concat(parts, "\n") .. "\n\n"
-end
-
 --- Build the `codex exec --json` command array
 --- @param prompt string User prompt
 --- @param opts Vibing.AdapterOpts Adapter options
@@ -70,19 +34,11 @@ end
 --- @return string[] Command array for vim.system()
 --- Forget the resolved binary path. Test seam only, same reason as cli_command_builder.
 function M._reset_path_cache()
-  cached_codex_path = nil
+  binary_path.reset()
 end
 
 function M.build(prompt, opts, session_id, config, hook_args)
-  if not cached_codex_path then
-    cached_codex_path = vim.fn.exepath("codex")
-    if cached_codex_path == "" then
-      cached_codex_path = nil
-      error("Codex CLI not found in PATH. Please install codex-cli.")
-    end
-  end
-
-  local cmd = { cached_codex_path, "exec" }
+  local cmd = { binary_path.resolve(), "exec" }
 
   if session_id then
     table.insert(cmd, "resume")
@@ -157,17 +113,13 @@ function M.build(prompt, opts, session_id, config, hook_args)
   -- Build prompt with context prefix and language instruction
   local full_prompt = prompt
   if not session_id then
-    local context_prefix = build_context_prefix(opts)
+    local context_prefix = CommonBuilder.context_prefix(opts)
     full_prompt = context_prefix .. prompt
   end
 
-  local language = resolve_language(opts, config)
-  if language and language ~= "en" then
-    local language_utils = require("vibing.core.utils.language")
-    local lang_name = language_utils.language_names[language]
-    if lang_name then
-      full_prompt = string.format("Always respond in %s (%s).\n\n%s", lang_name, language, full_prompt)
-    end
+  local language_instruction = CommonBuilder.language_instruction(opts, config)
+  if language_instruction then
+    full_prompt = language_instruction .. "\n\n" .. full_prompt
   end
 
   table.insert(cmd, full_prompt)

--- a/lua/vibing/infrastructure/adapter/modules/command_builder_common.lua
+++ b/lua/vibing/infrastructure/adapter/modules/command_builder_common.lua
@@ -1,0 +1,111 @@
+--- The parts of argv construction that do not depend on which CLI is being launched.
+---
+--- Four command builders carried their own copy of each of these. They were byte-identical or
+--- trivially reworded, which is the worst kind of duplication: nothing signals when one of them
+--- is fixed and the other three are not. #537 was exactly that -- `resolve_model` was corrected
+--- on one backend and stayed broken on two others.
+---
+--- What stays per-backend is everything that encodes a CLI's own vocabulary: flag names, sandbox
+--- and permission mapping, session/resume syntax, and where in the argv the prompt goes.
+---
+--- @module vibing.infrastructure.adapter.modules.command_builder_common
+
+local M = {}
+
+--- The language the response should be written in, or nil to leave it to the CLI.
+---
+--- `config.language` is accepted both as a plain string and as a table with `default`/`chat`,
+--- which is why this is not a one-line lookup.
+---
+--- @param opts Vibing.AdapterOpts
+--- @param config Vibing.Config
+--- @return string|nil
+function M.resolve_language(opts, config)
+  local language = opts.language
+  if not language and config.language then
+    if type(config.language) == "table" then
+      language = config.language.default or config.language.chat
+    else
+      language = config.language
+    end
+  end
+  return type(language) == "string" and language or nil
+end
+
+--- The one-line instruction that pins the response language, or nil when none applies.
+---
+--- Returns nil for English (the CLIs' own default) and for a code with no display name, so the
+--- caller never has to repeat those two guards. Where the sentence goes is the caller's business:
+--- claude and grok put it at the top of the system prompt, codex and copilot prepend it to the
+--- user prompt, because those two take no system prompt.
+---
+--- @param opts Vibing.AdapterOpts
+--- @param config Vibing.Config
+--- @return string|nil
+function M.language_instruction(opts, config)
+  local language = M.resolve_language(opts, config)
+  if not language or language == "en" then
+    return nil
+  end
+
+  local names = require("vibing.core.utils.language").language_names
+  local name = names[language]
+  if not name then
+    return nil
+  end
+
+  return string.format("Always respond in %s (%s).", name, language)
+end
+
+--- The `@file:` context entries rendered as a prompt prefix, or "" when there are none.
+---
+--- Trailing blank line included, so callers can concatenate unconditionally.
+---
+--- @param opts Vibing.AdapterOpts
+--- @return string
+function M.context_prefix(opts)
+  local parts = {}
+  for _, ctx in ipairs(opts.context or {}) do
+    if ctx:match("^@file:") then
+      table.insert(parts, string.format("Context file: %s", ctx:sub(7)))
+    end
+  end
+
+  if #parts == 0 then
+    return ""
+  end
+  return table.concat(parts, "\n") .. "\n\n"
+end
+
+--- A cached `exepath` lookup for one CLI binary.
+---
+--- The cache is process-wide and deliberately so -- `exepath` is not free and PATH does not move
+--- under a running Neovim. `reset()` is the test seam: a spec that wants the "CLI missing" path
+--- has to clear what an earlier spec resolved.
+---
+--- @param binary string name to look up on PATH
+--- @param missing_message string raised when it is not there
+--- @return table `{ resolve = fun(): string, reset = fun() }`
+function M.binary_resolver(binary, missing_message)
+  local cached = nil
+
+  return {
+    --- @return string path
+    resolve = function()
+      if not cached then
+        local found = vim.fn.exepath(binary)
+        if found == "" then
+          error(missing_message)
+        end
+        cached = found
+      end
+      return cached
+    end,
+
+    reset = function()
+      cached = nil
+    end,
+  }
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
@@ -3,42 +3,11 @@
 --- @module vibing.infrastructure.adapter.modules.copilot_command_builder
 
 local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
+local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
 
 local M = {}
 
 local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
-
---- Resolve language setting
---- @param opts Vibing.AdapterOpts
---- @param config Vibing.Config
---- @return string|nil
-local function resolve_language(opts, config)
-  local language = opts.language
-  if not language and config.language then
-    if type(config.language) == "table" then
-      language = config.language.default or config.language.chat
-    else
-      language = config.language
-    end
-  end
-  return type(language) == "string" and language or nil
-end
-
---- Build context prefix for the prompt
---- @param opts Vibing.AdapterOpts
---- @return string context_prefix Empty string if no context
-local function build_context_prefix(opts)
-  local parts = {}
-  for _, ctx in ipairs(opts.context or {}) do
-    if ctx:match("^@file:") then
-      table.insert(parts, string.format("Context file: %s", ctx:sub(7)))
-    end
-  end
-  if #parts == 0 then
-    return ""
-  end
-  return table.concat(parts, "\n") .. "\n\n"
-end
 
 --- Append permission flags. copilot's non-interactive mode requires --allow-all-tools,
 --- so denies are expressed with --deny-tool rather than an allow list.
@@ -91,16 +60,12 @@ function M.build(prompt, opts, session_id, config)
 
   local full_prompt = prompt
   if not session_id then
-    full_prompt = build_context_prefix(opts) .. prompt
+    full_prompt = CommonBuilder.context_prefix(opts) .. prompt
   end
 
-  local language = resolve_language(opts, config)
-  if language and language ~= "en" then
-    local language_utils = require("vibing.core.utils.language")
-    local lang_name = language_utils.language_names[language]
-    if lang_name then
-      full_prompt = string.format("Always respond in %s (%s).\n\n%s", lang_name, language, full_prompt)
-    end
+  local language_instruction = CommonBuilder.language_instruction(opts, config)
+  if language_instruction then
+    full_prompt = language_instruction .. "\n\n" .. full_prompt
   end
 
   table.insert(cmd, "-p")

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -3,6 +3,7 @@
 --- @module vibing.infrastructure.adapter.modules.grok_command_builder
 
 local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
+local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
 local worktree_constants = require("vibing.core.constants.worktree")
 
 local M = {}
@@ -98,37 +99,6 @@ end
 --- @param opts Vibing.AdapterOpts Adapter options
 --- @param session_id string|nil Session ID for resumption
 
---- Resolve the language to answer in, from opts then config.
---- @param opts Vibing.AdapterOpts
---- @param config Vibing.Config
---- @return string|nil
-local function resolve_language(opts, config)
-  local language = opts.language
-  if not language and config.language then
-    if type(config.language) == "table" then
-      language = config.language.default or config.language.chat
-    else
-      language = config.language
-    end
-  end
-  return type(language) == "string" and language or nil
-end
-
---- @param opts Vibing.AdapterOpts
---- @return string context_prefix Empty string if no context
-local function build_context_prefix(opts)
-  local parts = {}
-  for _, ctx in ipairs(opts.context or {}) do
-    if ctx:match("^@file:") then
-      table.insert(parts, string.format("Context file: %s", ctx:sub(7)))
-    end
-  end
-  if #parts == 0 then
-    return ""
-  end
-  return table.concat(parts, "\n") .. "\n\n"
-end
-
 --- What goes into `--rules`, Grok's equivalent of a system prompt.
 ---
 --- Deliberately much smaller than the Claude adapter's block: Grok reaches no vibing-nvim MCP
@@ -144,12 +114,9 @@ local function build_rules(opts, config)
       .. "<branch-name>/ at the repository root.",
   }
 
-  local language = resolve_language(opts, config)
-  if language and language ~= "en" then
-    local lang_name = require("vibing.core.utils.language").language_names[language]
-    if lang_name then
-      table.insert(lines, 1, string.format("Always respond in %s (%s).", lang_name, language))
-    end
+  local language_instruction = CommonBuilder.language_instruction(opts, config)
+  if language_instruction then
+    table.insert(lines, 1, language_instruction)
   end
 
   return table.concat(lines, "\n")
@@ -176,7 +143,7 @@ function M.build(prompt, opts, session_id, config, handle_id, rpc_port)
 
   local full_prompt = prompt
   if not session_id then
-    full_prompt = build_context_prefix(opts) .. prompt
+    full_prompt = CommonBuilder.context_prefix(opts) .. prompt
   end
 
   local cmd = { grok_path }

--- a/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
@@ -1,0 +1,195 @@
+local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
+local helper = require("tests.helpers.adapter_stream")
+
+describe("cli_runtime", function()
+  describe("new_handle_id", function()
+    it("is hex, never scientific notation", function()
+      -- LuaJIT renders large hrtime doubles as "2.64e+15", which pre-tool-use.sh's sanitized
+      -- VIBING_HANDLE_ID then fails to match against the registry key.
+      for _ = 1, 20 do
+        local id = CliRuntime.new_handle_id()
+        assert.is_truthy(id:match("^%x+_%x+$"), "not hex: " .. id)
+        assert.is_nil(id:find("e+", 1, true))
+      end
+    end)
+
+    it("does not repeat", function()
+      local seen = {}
+      for _ = 1, 200 do
+        local id = CliRuntime.new_handle_id()
+        assert.is_nil(seen[id], "duplicate handle id")
+        seen[id] = true
+      end
+    end)
+  end)
+
+  describe("kill_tree", function()
+    local original_system, spawned
+
+    before_each(function()
+      spawned = {}
+      original_system = vim.system
+      vim.system = function(cmd)
+        table.insert(spawned, table.concat(cmd, " "))
+        return { pid = 1, kill = function() end }
+      end
+    end)
+
+    after_each(function()
+      vim.system = original_system
+    end)
+
+    it("kills the children before the parent", function()
+      local killed = nil
+      CliRuntime.kill_tree({
+        pid = 4242,
+        kill = function(_, sig)
+          killed = sig
+        end,
+      })
+
+      assert.equals(1, #spawned)
+      assert.is_truthy(spawned[1]:find("pkill -9 -P 4242", 1, true))
+      assert.equals(9, killed)
+    end)
+
+    it("uses vim.system, not vim.fn.system, so the main loop is not blocked", function()
+      -- cancel() can be reached from a vim.schedule callback; a blocking pkill there stalls
+      -- Neovim for as long as it takes.
+      local blocking = false
+      local original_fn_system = vim.fn.system
+      vim.fn.system = function(...)
+        blocking = true
+        return original_fn_system(...)
+      end
+
+      CliRuntime.kill_tree({ pid = 4242, kill = function() end })
+
+      vim.fn.system = original_fn_system
+      assert.is_false(blocking)
+    end)
+
+    it("does nothing without a usable pid", function()
+      CliRuntime.kill_tree(nil)
+      CliRuntime.kill_tree({})
+      CliRuntime.kill_tree({ pid = 0 })
+      CliRuntime.kill_tree({ pid = -1 })
+      assert.equals(0, #spawned)
+    end)
+
+    it("survives a handle whose kill throws", function()
+      assert.has_no.errors(function()
+        CliRuntime.kill_tree({
+          pid = 7,
+          kill = function()
+            error("already gone")
+          end,
+        })
+      end)
+    end)
+  end)
+
+  describe("report_build_failure", function()
+    it("strips the Lua file:line prefix so the chat shows a message", function()
+      local response
+      CliRuntime.report_build_failure("h1", "/path/to/builder.lua:42: codex not found", function(r)
+        response = r
+      end)
+
+      vim.wait(200, function()
+        return response ~= nil
+      end)
+      assert.equals("codex not found", response.error)
+      assert.equals("h1", response._handle_id)
+      assert.equals("", response.content)
+    end)
+
+    it("handles a non-string error object", function()
+      local response
+      CliRuntime.report_build_failure("h1", { code = 1 }, function(r)
+        response = r
+      end)
+
+      vim.wait(200, function()
+        return response ~= nil
+      end)
+      assert.is_truthy(response.error)
+    end)
+  end)
+end)
+
+-- The two behaviours below were not the same on every backend before the extraction: only grok
+-- cancelled a timed-out execute(), and only claude left the child processes alive on cancel().
+-- Running them over every adapter is what stops that drifting apart again.
+for _, backend in ipairs(helper.adapters()) do
+  describe("cli_runtime installed on " .. backend.name, function()
+    local system, adapter
+
+    before_each(function()
+      system = helper.stub_system()
+      adapter = backend.module:new({ agent = { default_model = "sonnet" } })
+    end)
+
+    after_each(function()
+      system.restore()
+    end)
+
+    it("answers supports() from its own feature table", function()
+      assert.is_boolean(adapter:supports("streaming"))
+      assert.is_false(adapter:supports("a feature no backend has"))
+    end)
+
+    it("cancel kills the children that hold the stdout pipe open", function()
+      local killed = false
+      helper.run_stream(adapter)
+      local handle = system.only_call().handle
+      handle.kill = function()
+        killed = true
+      end
+
+      local before = #system.calls
+      adapter:cancel()
+
+      local pkill = nil
+      for i = before + 1, #system.calls do
+        local cmd = table.concat(system.calls[i].cmd, " ")
+        if cmd:find("pkill", 1, true) then
+          pkill = cmd
+        end
+      end
+
+      assert.is_truthy(pkill, "no pkill issued: the exit handler would never fire")
+      assert.is_truthy(pkill:find("-P " .. tostring(handle.pid), 1, true))
+      assert.is_true(killed)
+    end)
+
+    it("cancel forgets the handle so a later cancel is a no-op", function()
+      helper.run_stream(adapter)
+      adapter:cancel()
+      assert.has_no.errors(function()
+        adapter:cancel()
+      end)
+    end)
+
+    it("execute cancels a run that never finishes rather than leaving it alive", function()
+      local original_timeout = CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS
+      CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS = 50
+
+      local cancelled_with = false
+      local original_cancel = adapter.cancel
+      adapter.cancel = function(self, handle_id)
+        cancelled_with = handle_id
+        return original_cancel(self, handle_id)
+      end
+
+      -- stub_system never invokes on_exit, so on_done never fires: the timeout path.
+      local result = adapter:execute("hi", {})
+
+      CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS = original_timeout
+      adapter.cancel = original_cancel
+
+      assert.equals("Execution timeout", result.error)
+      assert.is_string(cancelled_with, "the timed-out handle was not cancelled")
+    end)
+  end)
+end

--- a/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
@@ -172,22 +172,24 @@ for _, backend in ipairs(helper.adapters()) do
     end)
 
     it("execute cancels a run that never finishes rather than leaving it alive", function()
+      -- The timeout is module-level state, so it is restored before the assertions rather than
+      -- after: a failing assertion here would otherwise leave every later spec on a 50ms budget.
       local original_timeout = CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS
-      CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS = 50
+      local original_cancel = adapter.cancel
 
       local cancelled_with = false
-      local original_cancel = adapter.cancel
       adapter.cancel = function(self, handle_id)
         cancelled_with = handle_id
         return original_cancel(self, handle_id)
       end
 
+      CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS = 50
       -- stub_system never invokes on_exit, so on_done never fires: the timeout path.
-      local result = adapter:execute("hi", {})
-
+      local ok, result = pcall(adapter.execute, adapter, "hi", {})
       CliRuntime.INITIAL_RESPONSE_TIMEOUT_MS = original_timeout
       adapter.cancel = original_cancel
 
+      assert.is_true(ok, tostring(result))
       assert.equals("Execution timeout", result.error)
       assert.is_string(cancelled_with, "the timed-out handle was not cancelled")
     end)

--- a/tests/lua/infrastructure/adapter/modules/command_builder_common_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/command_builder_common_spec.lua
@@ -1,0 +1,141 @@
+local Common = require("vibing.infrastructure.adapter.modules.command_builder_common")
+
+describe("command_builder_common", function()
+  describe("resolve_language", function()
+    it("prefers the per-request language", function()
+      assert.equals("ja", Common.resolve_language({ language = "ja" }, { language = "fr" }))
+    end)
+
+    it("accepts config.language as a plain string", function()
+      assert.equals("fr", Common.resolve_language({}, { language = "fr" }))
+    end)
+
+    it("accepts config.language as a table, preferring default over chat", function()
+      assert.equals("de", Common.resolve_language({}, { language = { default = "de", chat = "fr" } }))
+      assert.equals("fr", Common.resolve_language({}, { language = { chat = "fr" } }))
+    end)
+
+    it("returns nil when nothing is set or the value is not a string", function()
+      assert.is_nil(Common.resolve_language({}, {}))
+      assert.is_nil(Common.resolve_language({}, { language = {} }))
+      assert.is_nil(Common.resolve_language({}, { language = 42 }))
+    end)
+  end)
+
+  describe("language_instruction", function()
+    it("names the language and its code", function()
+      assert.equals("Always respond in Japanese (ja).", Common.language_instruction({ language = "ja" }, {}))
+    end)
+
+    it("says nothing for English, which is every CLI's own default", function()
+      assert.is_nil(Common.language_instruction({ language = "en" }, {}))
+    end)
+
+    it("says nothing for a code with no display name", function()
+      assert.is_nil(Common.language_instruction({ language = "zz" }, {}))
+    end)
+
+    it("says nothing when no language is configured", function()
+      assert.is_nil(Common.language_instruction({}, {}))
+    end)
+  end)
+
+  describe("context_prefix", function()
+    it("renders @file: entries with a trailing blank line", function()
+      local prefix = Common.context_prefix({ context = { "@file:a.lua", "@file:b/c.lua" } })
+      assert.equals("Context file: a.lua\nContext file: b/c.lua\n\n", prefix)
+    end)
+
+    it("keeps line ranges, which are part of the reference", function()
+      assert.equals("Context file: a.lua:L10-L25\n\n", Common.context_prefix({ context = { "@file:a.lua:L10-L25" } }))
+    end)
+
+    it("ignores entries that are not file references", function()
+      assert.equals("", Common.context_prefix({ context = { "something else" } }))
+    end)
+
+    it("returns an empty string, not nil, when there is no context", function()
+      assert.equals("", Common.context_prefix({}))
+      assert.equals("", Common.context_prefix({ context = {} }))
+    end)
+  end)
+
+  describe("binary_resolver", function()
+    local original_exepath
+
+    before_each(function()
+      original_exepath = vim.fn.exepath
+    end)
+
+    after_each(function()
+      vim.fn.exepath = original_exepath
+    end)
+
+    it("returns the resolved path", function()
+      vim.fn.exepath = function()
+        return "/usr/local/bin/thing"
+      end
+      assert.equals("/usr/local/bin/thing", Common.binary_resolver("thing", "missing").resolve())
+    end)
+
+    it("looks the binary up once and caches it", function()
+      local lookups = 0
+      vim.fn.exepath = function()
+        lookups = lookups + 1
+        return "/usr/local/bin/thing"
+      end
+
+      local resolver = Common.binary_resolver("thing", "missing")
+      resolver.resolve()
+      resolver.resolve()
+      assert.equals(1, lookups)
+    end)
+
+    it("raises the given message when the binary is absent", function()
+      vim.fn.exepath = function()
+        return ""
+      end
+      local ok, err = pcall(Common.binary_resolver("thing", "thing is not installed").resolve)
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("thing is not installed", 1, true))
+    end)
+
+    it("caches nothing on failure, so a later lookup can still succeed", function()
+      local found = false
+      vim.fn.exepath = function()
+        return found and "/usr/local/bin/thing" or ""
+      end
+
+      local resolver = Common.binary_resolver("thing", "missing")
+      assert.is_false(pcall(resolver.resolve))
+      found = true
+      assert.equals("/usr/local/bin/thing", resolver.resolve())
+    end)
+
+    it("forgets the cached path on reset, which is what the specs need", function()
+      vim.fn.exepath = function()
+        return "/first"
+      end
+      local resolver = Common.binary_resolver("thing", "missing")
+      assert.equals("/first", resolver.resolve())
+
+      vim.fn.exepath = function()
+        return "/second"
+      end
+      assert.equals("/first", resolver.resolve(), "should still be cached")
+
+      resolver.reset()
+      assert.equals("/second", resolver.resolve())
+    end)
+
+    it("gives each caller its own cache", function()
+      vim.fn.exepath = function(name)
+        return "/bin/" .. name
+      end
+      local a = Common.binary_resolver("alpha", "missing")
+      local b = Common.binary_resolver("bravo", "missing")
+      assert.equals("/bin/alpha", a.resolve())
+      assert.equals("/bin/bravo", b.resolve())
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #515

> **スタックド PR です。** ベースは #571（`fix/codex-lightweight-tools`）。#571 が `resolve_model` を `non_claude_model.lua` に切り出しており、本 PR は同じファイル群を触るためです。#571 がマージされれば GitHub が自動で base を main に付け替えます。**本 PR 単体の差分は上の3コミット**（`c792df1`, `7be3bcc`, `fbd24b8`）です。

## 実測した重複と結果

| | before | after |
| --- | --- | --- |
| アダプタ本体 4ファイル | 1176行 | **840行** |
| コマンドビルダー 4ファイル | 1104行 | **729行** |
| 新規共有モジュール | — | `cli_runtime` 161行 + `command_builder_common` 111行 |

## 1. コマンドビルダー（`command_builder_common.lua`）

4ファイルが各々持っていたものを1箇所に集約しました。

- `resolve_language` — **4ファイルでバイト単位に同一**
- `build_context_prefix` — 同一（codex/claude は冗長版、copilot/grok は短縮版で意味は同じ）
- `"Always respond in %s (%s)."` のガード連鎖 — 4箇所。文の**置き場所**だけが違う（claude / grok はシステムプロンプト、codex / copilot はユーザープロンプト前置。後者2つはシステムプロンプトを取れないため）
- `cached_<name>_path` + `exepath` + not-found `error()` — claude / codex で同一。`_reset_path_cache` のテストシームごと `binary_resolver` に移動

バックエンド固有のもの（フラグ名、サンドボックス／権限マッピング、resume 構文、argv 内でのプロンプト位置）は各ビルダーに残しています。

## 2. アダプタ本体（`cli_runtime.lua`）

識別子を正規化して diff した結果:

- `supports` と SessionManager 委譲4つ — **4アダプタで完全一致**
- `execute` — 3つ一致、grok のみ差異
- `cancel` — 3バリアント

`CliRuntime.install(Class, SUPPORTED_FEATURES)` がこの7メソッドを定義します。加えて `new_handle_id` / `kill_tree` / `report_build_failure` を切り出しました。

### ⚠️ 意図的に統一した2つの挙動（レビュー要点）

差異が「設計上の意図」ではなく**drift**であり、修正済みの側にその理由が既にコメントとして書かれていたため、パラメータ化せず統一しました。

**1. `cancel()` が子プロセスを先に殺すようになった（claude の挙動変更）**

claude は親プロセスしか kill していませんでした。ツール実行で生成されたシェルが stdout パイプを保持し続けるため、パイプが閉じるのを待つ `vim.system()` の exit ハンドラが発火せず、**チャット UI が固まったままになります**。これは `codex_cli.lua` が自身の pkill の理由として既に書き残していた内容そのものです。

pkill は grok の非同期版（`vim.system` であって `vim.fn.system` ではない）を採用しました。cancel は `vim.schedule` コールバックから呼ばれ得るため、メインループをブロックしません。

**2. `execute()` がタイムアウト時に cancel するようになった（claude / codex / copilot の挙動変更）**

従来は `vim.wait` が切れてもプロセスを放置して return していました。grok だけが cancel していました。

## `stream()` を共通化しなかった理由

分岐点（どの settings generator を先に走らせるか、コマンドビルダーの引数個数、`chat_bufnr` やツール語彙を登録するか、stderr のフィルタが要るか）が共有行数を上回ります。さらに4アダプタは子プロセスの環境変数で実際に食い違っています — codex / copilot / grok は `VIBING_RPC_PORT` を設定しますが、**フックは `VIBING_NVIM_RPC_PORT` しか読んでおらず、この変数を読むコードはリポジトリ内に存在しません**（`mcp-server/README.md` が記載する MCP サーバ側の設定変数です）。claude は `CLAUDECODE` を消します。

これを揃えるのは「重複除去」とは別の判断なので、本 PR では触っていません。共通化は `stream()` の中で実際に繰り返されている部分（handle_id 生成、ビルド失敗の報告）に留めました。

## テスト

既存の安全網が効いています。`stream_options_spec.lua` は `Agents.list()` から全バックエンドを列挙して同じ 52 ケースを回すので、この抽出はそのまま回帰検出にかかります。

新規:
- `cli_runtime_spec.lua` — 24ケース。統一した2挙動を**4バックエンドすべてに対して**実行（cancel が pkill を出すこと、その pkill が `vim.fn.system` でないこと、timeout 時に cancel されること）
- `command_builder_common_spec.lua` — 18ケース。`config.language` の string/table 両形式、英語で何も出さないこと、表示名のない言語コード、`binary_resolver` のキャッシュ・失敗時に汚さないこと・reset・呼び出し元ごとに独立していること

```
pnpm run check         exit 0
pnpm run test:lua      exit 0
pnpm run test:node     7 pass / 0 fail
pnpm run format:check  exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Grok backend.
  * Standardized CLI streaming, cancellation, timeouts, session handling, and process cleanup across supported backends.
  * Improved command generation with shared language instructions, file context formatting, and executable discovery.

* **Bug Fixes**
  * Improved handling and reporting of command startup failures.
  * Added reliable cancellation when requests time out or are stopped.

* **Tests**
  * Added coverage for runtime behavior, cancellation, timeouts, command generation, executable lookup, and error handling.

* **Documentation**
  * Updated architecture documentation for supported backends and shared CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->