### PR TITLE
fix(permissions): always-allow read-only builtin tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ All `.md` files in `.claude/rules/` are automatically loaded into Claude Code's 
 
 ## Key Constants
 
-`lua/vibing/core/constants/tools.lua` がツール名の唯一の定義元。`lua/vibing/config.lua` は値を
-再列挙せずここを参照する。
+`lua/vibing/core/constants/tools.lua` がツール名の唯一の定義元。`lua/vibing/config.lua` と
+`can_use_tool.lua` は値を再列挙せずここを参照する。
 
 - **`VALID_TOOLS`**: 権限設定に書けるツール名の一覧。権限バリデーション（未知ツール名の警告）に使う
 - **`DEFAULT_ALLOWED_TOOLS`**: `permissions.allow` の既定値。`VALID_TOOLS` からの差集合としては
@@ -94,8 +94,9 @@ All `.md` files in `.claude/rules/` are automatically loaded into Claude Code's 
   下限。`DEFAULT_ALLOWED_TOOLS` から外しても、こちらに残っていれば許可されたままになる。基準は
   「ファイルを作成・更新・削除しない読み取り専用のビルトインツール」（`Read` / `Glob` / `Grep` など）。
   ユーザーが `ask` / `deny` で上書きできる点が下の `INTERNAL_TOOLS` との違い
-- **`INTERNAL_TOOLS`** (`can_use_tool.lua`): `ToolSearch` / `TodoWrite` / `ReportFindings` /
-  `ScheduleWakeup` など、Claude Code ハーネス内部の副作用なし制御ツール。`ask` / `deny` すら通さず
-  常に許可される（評価順で `ALWAYS_ALLOWED_TOOLS` より前）。`VALID_TOOLS` への登録は不要
+- **`INTERNAL_TOOLS`**: `ToolSearch` / `TodoWrite` / `ReportFindings` / `ScheduleWakeup` など、
+  Claude Code ハーネス内部の副作用なし制御ツール。`ask` / `deny` すら通さず常に許可される
+  （`can_use_tool.lua` の評価順で `ALWAYS_ALLOWED_TOOLS` より前）。`VALID_TOOLS` への登録は不要。
+  定義は `tools.lua`（判定は `INTERNAL_TOOLS_MAP` を参照）
 - 新しいツールを追加するとき: 既定で許可するなら `VALID_TOOLS` と `DEFAULT_ALLOWED_TOOLS` の
   両方に、Bash のように既定では許可しないなら `VALID_TOOLS` にのみ足す

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,11 @@ All `.md` files in `.claude/rules/` are automatically loaded into Claude Code's 
 - **`DEFAULT_ALLOWED_TOOLS`**: `permissions.allow` の既定値。`VALID_TOOLS` からの差集合としては
   導出しない（理由は同ファイルのコメント参照）
 - **`ALWAYS_ALLOWED_TOOLS`**: `allow` の内容に関わらず（`ask` / `deny` に無い限り）常に許可される
-  下限。`DEFAULT_ALLOWED_TOOLS` から外しても、こちらに残っていれば許可されたままになる
+  下限。`DEFAULT_ALLOWED_TOOLS` から外しても、こちらに残っていれば許可されたままになる。基準は
+  「ファイルを作成・更新・削除しない読み取り専用のビルトインツール」（`Read` / `Glob` / `Grep` など）。
+  ユーザーが `ask` / `deny` で上書きできる点が下の `INTERNAL_TOOLS` との違い
+- **`INTERNAL_TOOLS`** (`can_use_tool.lua`): `ToolSearch` / `TodoWrite` / `ReportFindings` /
+  `ScheduleWakeup` など、Claude Code ハーネス内部の副作用なし制御ツール。`ask` / `deny` すら通さず
+  常に許可される（評価順で `ALWAYS_ALLOWED_TOOLS` より前）。`VALID_TOOLS` への登録は不要
 - 新しいツールを追加するとき: 既定で許可するなら `VALID_TOOLS` と `DEFAULT_ALLOWED_TOOLS` の
   両方に、Bash のように既定では許可しないなら `VALID_TOOLS` にのみ足す

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -27,10 +27,21 @@ for _, tool in ipairs(M.VALID_TOOLS) do
   M.VALID_TOOLS_MAP[tool] = true
 end
 
----permissions_allowの設定に関わらず、askやdenyに明示的に入っていなければ常に許可されるツール
+---permissions_allowの設定に関わらず、askやdenyに明示的に入っていなければ常に許可されるツール。
+---
+---収録の基準は「ファイルを作成・更新・削除しない読み取り専用のビルトインツール」であること。
+---Edit/Write/Bashは当然対象外。Agent/Workflowはサブエージェント経由でファイルを変更しうるので外す。
+---WebSearch/WebFetch/ShareOnboardingGuideはファイルこそ触らないが外部通信という別軸のリスクがあるので
+---ここには入れない（DEFAULT_ALLOWED_TOOLSのコメントも参照）。
+---
+---ここはあくまで「既定では許可するがユーザーがask/denyで上書きできる」下限。ToolSearchやTodoWriteの
+---ようなハーネス内部の制御ツールは、deny/askすら通さず常に許可すべきなのでcan_use_tool.luaの
+---INTERNAL_TOOLS側に置く（あちらはこの下限より前で評価される）。
 ---@type string[]
 M.ALWAYS_ALLOWED_TOOLS = {
   "Read",
+  "Glob",
+  "Grep",
   "Skill",
   "StructuredOutput",
 }

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -53,6 +53,44 @@ for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
   M.ALWAYS_ALLOWED_TOOLS_MAP[tool] = true
 end
 
+---Claude Codeハーネス内部の副作用なし制御ツール。`ask`/`deny`すら通さず常に許可される
+---（can_use_tool.luaの評価順で`ALWAYS_ALLOWED_TOOLS`より前）。
+---
+---`ALWAYS_ALLOWED_TOOLS`との違いは「ユーザーがask/denyで上書きできるか」。あちらは上書き可・
+---deny/denyルールより後ろで評価されるので、`Read`に対する`paths`限定のdenyルール（.env等）が効く。
+---こちらは上書き不可・denyルールより前で許可を即決するので、止めるとハーネスが機能しなくなる
+---制御ツールだけを収録する。「読み取り専用か」ではなく「ハーネスの制御に必須か」が基準なので、
+---ファイルを変更するもの（NotebookEdit / EnterWorktree / Agent）も含む。`VALID_TOOLS`への登録は不要。
+---@type string[]
+M.INTERNAL_TOOLS = {
+  "ToolSearch",
+  "TodoWrite",
+  "ReportFindings",
+  "Agent",
+  "Task",
+  "TaskCreate",
+  "TaskGet",
+  "TaskList",
+  "TaskOutput",
+  "TaskStop",
+  "TaskUpdate",
+  "SendMessage",
+  "Monitor",
+  "ScheduleWakeup",
+  "EnterPlanMode",
+  "ExitPlanMode",
+  "EnterWorktree",
+  "ExitWorktree",
+  "NotebookEdit",
+}
+
+---INTERNAL_TOOLSの高速検索用マップ
+---@type table<string, boolean>
+M.INTERNAL_TOOLS_MAP = {}
+for _, tool in ipairs(M.INTERNAL_TOOLS) do
+  M.INTERNAL_TOOLS_MAP[tool] = true
+end
+
 ---vibing-nvim自身が提供するMCPツールの許可パターン。プレーンなユーザーレベルMCPサーバー登録
 ---（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*）の
 ---両方に対応する。

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -2,6 +2,17 @@
 ---Claude CLIで利用可能なツールの定数定義
 local M = {}
 
+---ツール名の配列を高速検索用の集合（name -> true）に変換する
+---@param tools string[]
+---@return table<string, boolean>
+local function to_map(tools)
+  local map = {}
+  for _, tool in ipairs(tools) do
+    map[tool] = true
+  end
+  return map
+end
+
 ---有効なツール名の配列
 ---@type string[]
 M.VALID_TOOLS = {
@@ -22,10 +33,7 @@ M.VALID_TOOLS = {
 
 ---有効なツール名のテーブル（高速検索用）
 ---@type table<string, boolean>
-M.VALID_TOOLS_MAP = {}
-for _, tool in ipairs(M.VALID_TOOLS) do
-  M.VALID_TOOLS_MAP[tool] = true
-end
+M.VALID_TOOLS_MAP = to_map(M.VALID_TOOLS)
 
 ---permissions_allowの設定に関わらず、askやdenyに明示的に入っていなければ常に許可されるツール。
 ---
@@ -48,10 +56,7 @@ M.ALWAYS_ALLOWED_TOOLS = {
 
 ---ALWAYS_ALLOWED_TOOLSの高速検索用マップ
 ---@type table<string, boolean>
-M.ALWAYS_ALLOWED_TOOLS_MAP = {}
-for _, tool in ipairs(M.ALWAYS_ALLOWED_TOOLS) do
-  M.ALWAYS_ALLOWED_TOOLS_MAP[tool] = true
-end
+M.ALWAYS_ALLOWED_TOOLS_MAP = to_map(M.ALWAYS_ALLOWED_TOOLS)
 
 ---Claude Codeハーネス内部の副作用なし制御ツール。`ask`/`deny`すら通さず常に許可される
 ---（can_use_tool.luaの評価順で`ALWAYS_ALLOWED_TOOLS`より前）。
@@ -86,10 +91,7 @@ M.INTERNAL_TOOLS = {
 
 ---INTERNAL_TOOLSの高速検索用マップ
 ---@type table<string, boolean>
-M.INTERNAL_TOOLS_MAP = {}
-for _, tool in ipairs(M.INTERNAL_TOOLS) do
-  M.INTERNAL_TOOLS_MAP[tool] = true
-end
+M.INTERNAL_TOOLS_MAP = to_map(M.INTERNAL_TOOLS)
 
 ---vibing-nvim自身が提供するMCPツールの許可パターン。プレーンなユーザーレベルMCPサーバー登録
 ---（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*）の

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -29,6 +29,7 @@ local ONCE_SUFFIX = ":once"
 local INTERNAL_TOOLS = {
   ToolSearch = true,
   TodoWrite = true,
+  ReportFindings = true,
   Agent = true,
   Task = true,
   TaskCreate = true,

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -26,28 +26,6 @@ local M = {}
 
 local ONCE_SUFFIX = ":once"
 
-local INTERNAL_TOOLS = {
-  ToolSearch = true,
-  TodoWrite = true,
-  ReportFindings = true,
-  Agent = true,
-  Task = true,
-  TaskCreate = true,
-  TaskGet = true,
-  TaskList = true,
-  TaskOutput = true,
-  TaskStop = true,
-  TaskUpdate = true,
-  SendMessage = true,
-  Monitor = true,
-  ScheduleWakeup = true,
-  EnterPlanMode = true,
-  ExitPlanMode = true,
-  EnterWorktree = true,
-  ExitWorktree = true,
-  NotebookEdit = true,
-}
-
 
 --- @class CanUseToolResult
 --- @field behavior "allow"|"deny"|"ask"
@@ -205,7 +183,7 @@ function M.can_use_tool(tool_name, input, config)
     end
 
     -- 2. Always allow Claude Code internal tools
-    if INTERNAL_TOOLS[tool_name] then
+    if tools_constants.INTERNAL_TOOLS_MAP[tool_name] then
       return allow(input)
     end
 

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -26,7 +26,6 @@ local M = {}
 
 local ONCE_SUFFIX = ":once"
 
-
 --- @class CanUseToolResult
 --- @field behavior "allow"|"deny"|"ask"
 --- @field message? string

--- a/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
+++ b/tests/lua/infrastructure/permissions/can_use_tool_spec.lua
@@ -18,7 +18,7 @@ end
 
 describe("can_use_tool", function()
   describe("ALWAYS_ALLOWED_TOOLS (UT-PERM-010)", function()
-    local always_allowed = { "Read", "Skill", "StructuredOutput" }
+    local always_allowed = { "Read", "Glob", "Grep", "Skill", "StructuredOutput" }
 
     for _, tool in ipairs(always_allowed) do
       it(string.format("should allow %s even when permissions_allow is empty", tool), function()
@@ -55,6 +55,20 @@ describe("can_use_tool", function()
           asked_tools = { tool },
         }))
         assert.equals("deny", result.behavior)
+      end)
+    end
+  end)
+
+  describe("INTERNAL_TOOLS are allowed even over deny (UT-PERM-012)", function()
+    -- ハーネス内部の副作用なし制御ツール。ALWAYS_ALLOWED_TOOLSと違い、deny/askすら通さず常に許可。
+    local internal = { "ToolSearch", "TodoWrite", "ReportFindings", "ScheduleWakeup" }
+
+    for _, tool in ipairs(internal) do
+      it(string.format("should allow %s even when in the deny list", tool), function()
+        local result = can_use_tool.can_use_tool(tool, {}, make_config({
+          denied_tools = { tool },
+        }))
+        assert.equals("allow", result.behavior)
       end)
     end
   end)


### PR DESCRIPTION
## 背景

読み取り専用のビルトインツールでも権限プロンプトが出る／PreToolUse ゲートに引っかかるケースがあった。特に `ReportFindings` は無害な報告ツールなのに毎回ゲートを叩いていた。

## 調査で分かったこと

権限判定には無条件許可の仕組みが2つあり、**ユーザーが deny/ask で上書きできるか**で意味論が違う（評価順に埋め込まれている）:

- `INTERNAL_TOOLS`: deny/ask すら通さず常に許可（評価順が先）。止めるとハーネスが機能しなくなる制御ツール（`ToolSearch` / `TodoWrite` / `Agent` / `ScheduleWakeup` など）。「読み取り専用か」ではなく「制御に必須か」が基準なので、ファイルを変更するもの（`NotebookEdit` / `EnterWorktree`）も含む。
- `ALWAYS_ALLOWED_TOOLS`: 既定で許可するが `ask` / `deny`・deny ルールで上書き可能な下限。deny ルールより後ろで評価されるため、`Read` に対する `paths` 限定 deny（`.env` 等）が効く。

`ToolSearch` / `ScheduleWakeup` は既に `INTERNAL_TOOLS` にいたが、**`ReportFindings` だけが両リストから漏れていた**ため PreToolUse に引っかかっていた。また `Glob` / `Grep` は読み取り専用なのに `ALWAYS_ALLOWED_TOOLS` に無かった。

## 変更内容

**ツール収録の修正**
- `ALWAYS_ALLOWED_TOOLS` に `Glob` / `Grep` を追加（読み取り専用・ユーザーが deny 可能）
- `INTERNAL_TOOLS` に `ReportFindings` を追加（`TodoWrite` / `ToolSearch` と同類の副作用なし報告ツール）

**定義場所の集約（リファクタ）**
- `INTERNAL_TOOLS` を `can_use_tool.lua` のローカルテーブルから `tools.lua` へ移動。他リストと同じ「配列 + 派生 `_MAP`」スタイルに統一し、`can_use_tool.lua` は `INTERNAL_TOOLS_MAP` を参照するだけに。似た2つの allow リストが1ファイルに揃い、見失いにくくした。
- 両リストの基準・使い分けを `tools.lua` コメントと `CLAUDE.md` に明記

## 検討して見送ったもの

- `Agent` / `Workflow`: サブエージェント経由でファイルを変更しうるため `ALWAYS_ALLOWED` の対象外（`Agent` は制御ツールとして `INTERNAL` には従来どおり在籍）
- `WebSearch` / `WebFetch` / `ShareOnboardingGuide`: ファイルは触らないが外部通信という別軸のリスク

## テスト

`can_use_tool_spec.lua` 43件グリーン。`ALWAYS_ALLOWED_TOOLS` の `Glob`/`Grep` と、`INTERNAL_TOOLS` の deny 上書き耐性（UT-PERM-012）を追加。lint / format:check 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)