### PR TITLE
fix(ci): stop losing a mkdir race, which is what flaked view_spec

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -343,6 +343,12 @@ before simplifying it. The component that collided is often an intermediate one,
 that won it has not necessarily reached the leaf yet — so the loser's `fs_stat` on the leaf
 legitimately finds nothing. Catch-and-recheck still failed 3 times in 200; retrying measured 0 in 320.
 
+Only the race is swallowed. Every other way `mkdir` fails — a read-only filesystem, a permission
+denial, a file where the directory should go — raises `E739` as well, and `ensure_dir` re-raises
+those with the original message. Callers were written against `vim.fn.mkdir`'s raising contract,
+so returning a quiet `false` instead would leave eighteen of them continuing as though the
+directory existed.
+
 ## Chat Fork
 
 `:VibingChatFork` creates a branched conversation from the current chat session.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -328,6 +328,21 @@ vibing.nvim supports running multiple chat sessions simultaneously without inter
 
 See `docs/adr/002-concurrent-execution-support.md` for architectural details.
 
+**Directory creation is a shared-state operation here.** `vim.fn.mkdir(path, "p")` is not atomic —
+it walks the path creating each component and raises `E739` when another process creates one
+first. That is routine rather than theoretical: the instance registry is machine-wide, a project's
+`.vibing/` is shared by every chat open on it, and the test suite runs one child Neovim per spec
+file. Measured at 9 failures in 200 concurrent calls, and it is what made `tests/view_spec.lua`
+flake in CI (#576).
+
+Every directory creation therefore goes through `core/utils/fs.lua`'s `ensure_dir`, and
+`fs_spec.lua` fails the build if a direct `vim.fn.mkdir` reappears anywhere in `lua/`.
+
+`ensure_dir` **retries**; catching the error and re-checking is not enough, which is worth knowing
+before simplifying it. The component that collided is often an intermediate one, and the process
+that won it has not necessarily reached the leaf yet — so the loser's `fs_stat` on the leaf
+legitimately finds nothing. Catch-and-recheck still failed 3 times in 200; retrying measured 0 in 320.
+
 ## Chat Fork
 
 `:VibingChatFork` creates a branched conversation from the current chat session.

--- a/lua/vibing/application/chat/handlers/set_file_title.lua
+++ b/lua/vibing/application/chat/handlers/set_file_title.lua
@@ -5,6 +5,7 @@ local FileManager = require("vibing.presentation.chat.modules.file_manager")
 local SyncManager = require("vibing.application.link.sync_manager")
 local DailySummaryScanner = require("vibing.infrastructure.link.daily_summary_scanner")
 local ForkedChatScanner = require("vibing.infrastructure.link.forked_chat_scanner")
+local Fs = require("vibing.core.utils.fs")
 
 ---@param dir string
 ---@return string
@@ -126,9 +127,7 @@ return function(_, chat_buffer)
     local new_filename = filename_util.generate_with_title(title, "chat")
     local normalized_dir = ensure_trailing_slash(save_dir)
 
-    if vim.fn.isdirectory(normalized_dir) == 0 then
-      vim.fn.mkdir(normalized_dir, "p")
-    end
+    Fs.ensure_dir(normalized_dir)
 
     local new_file_path = get_unique_file_path(save_dir, new_filename)
 

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -15,6 +15,7 @@ end
 local BufferReload = require("vibing.core.utils.buffer_reload")
 local GradientAnimation = require("vibing.ui.gradient_animation")
 local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
+local Fs = require("vibing.core.utils.fs")
 
 ---@class Vibing.ChatCallbacks
 ---@field extract_conversation fun(): table 会話履歴を抽出
@@ -624,7 +625,7 @@ function M._finalize_request_diff(callbacks, handle_id, modified_file_paths)
 
   if patch_content then
     local patch_dir = base_dir .. "/.vibing/patches"
-    vim.fn.mkdir(patch_dir, "p")
+    Fs.ensure_dir(patch_dir)
     local suffix = tostring(handle_id or ""):gsub("%W", ""):sub(-6)
     local patch_path = string.format("%s/%s_%s.patch", patch_dir, os.date("%Y%m%d_%H%M%S"), suffix)
     local f = io.open(patch_path, "w")

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -10,6 +10,7 @@ local M = {}
 local ChatSession = require("vibing.domain.chat.session")
 local FileManager = require("vibing.presentation.chat.modules.file_manager")
 local Git = require("vibing.core.utils.git")
+local Fs = require("vibing.core.utils.fs")
 
 ---@deprecated このグローバル状態は複数チャットウィンドウで問題を起こすため廃止予定
 ---セッションはChatBufferインスタンスの.sessionプロパティを使用すること
@@ -54,7 +55,7 @@ function M.create_new()
   })
 
   local save_path = FileManager.get_save_directory(config.chat)
-  vim.fn.mkdir(save_path, "p")
+  Fs.ensure_dir(save_path)
   local filename = FileManager.generate_unique_filename()
   session:set_file_path(save_path .. filename)
 
@@ -86,7 +87,7 @@ function M.create_new_in_directory(directory)
   })
 
   local save_path = normalized_dir .. ".vibing/chat/"
-  vim.fn.mkdir(save_path, "p")
+  Fs.ensure_dir(save_path)
   local filename = FileManager.generate_unique_filename()
   session:set_file_path(save_path .. filename)
 

--- a/lua/vibing/application/chat/use_cases/fork.lua
+++ b/lua/vibing/application/chat/use_cases/fork.lua
@@ -9,6 +9,7 @@ local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
 local Git = require("vibing.core.utils.git")
 local InheritedFrontmatter = require("vibing.application.chat.inherited_frontmatter")
 local SubagentMarker = require("vibing.infrastructure.adapter.modules.subagent_marker")
+local Fs = require("vibing.core.utils.fs")
 
 ---ファイル名から-fork-N.mdを生成
 ---@param source_path string
@@ -102,7 +103,7 @@ function M.execute(chat_buffer)
   })
 
   local save_dir = FileManager.get_save_directory(config.chat)
-  vim.fn.mkdir(save_dir, "p")
+  Fs.ensure_dir(save_dir)
 
   local fork_filename = generate_fork_filename(chat_buffer.file_path, save_dir)
   local fork_path = vim.fs.joinpath(save_dir, fork_filename)

--- a/lua/vibing/application/chat/use_cases/subagent_chat.lua
+++ b/lua/vibing/application/chat/use_cases/subagent_chat.lua
@@ -12,6 +12,7 @@ local ChatSession = require("vibing.domain.chat.session")
 local FileManager = require("vibing.presentation.chat.modules.file_manager")
 local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
 local InheritedFrontmatter = require("vibing.application.chat.inherited_frontmatter")
+local Fs = require("vibing.core.utils.fs")
 
 ---@param save_dir string
 ---@param agent_id string
@@ -77,7 +78,7 @@ function M.execute(chat_buffer, agent_id)
   local config = vibing.get_config()
 
   local save_dir = FileManager.get_save_directory(config.chat)
-  vim.fn.mkdir(save_dir, "p")
+  Fs.ensure_dir(save_dir)
 
   -- 同じsubagentに2つ目のバッファを作ると、同じsession_idを共有するバッファ同士が
   -- 送信を奪い合う。既にあるなら開き直す

--- a/lua/vibing/application/daily_summary/use_case.lua
+++ b/lua/vibing/application/daily_summary/use_case.lua
@@ -4,6 +4,7 @@ local Collector = require("vibing.application.daily_summary.collector")
 local Renderer = require("vibing.application.daily_summary.renderer")
 local FileManager = require("vibing.presentation.chat.modules.file_manager")
 local notify = require("vibing.core.utils.notify")
+local Fs = require("vibing.core.utils.fs")
 
 local M = {}
 
@@ -168,7 +169,7 @@ function M._save_summary(date, content, source_files, total_messages, config, on
   local save_dir = get_save_directory(config)
   -- Expand ~ to full path for all file operations
   save_dir = vim.fn.expand(save_dir)
-  vim.fn.mkdir(save_dir, "p")
+  Fs.ensure_dir(save_dir)
 
   local file_path = save_dir .. date .. ".md"
 

--- a/lua/vibing/core/utils/fs.lua
+++ b/lua/vibing/core/utils/fs.lua
@@ -1,0 +1,58 @@
+--- Filesystem helpers that have to survive concurrent Neovim instances.
+--- @module vibing.core.utils.fs
+
+local uv = vim.loop
+
+local M = {}
+
+--- How many times to re-attempt a directory creation that lost a race. Each retry starts the walk
+--- again from a path that is strictly further along, so this converges in a couple of rounds; the
+--- bound is only there so a genuinely impossible path cannot spin.
+local MAX_ATTEMPTS = 5
+
+--- Whether `path` is a directory right now.
+--- @param path string
+--- @return boolean
+local function is_dir(path)
+  local stat = uv.fs_stat(path)
+  return stat ~= nil and stat.type == "directory"
+end
+
+--- Create a directory, treating "someone else created it first" as success.
+---
+--- `vim.fn.mkdir(path, "p")` is **not atomic**. It walks the path creating each component and
+--- raises `E739: Cannot create directory ...: file already exists` when another process creates
+--- one of them in between. Measured at 9 failures across 200 concurrent calls.
+---
+--- That is a routine race here, not a theoretical one. Several vibing.nvim paths are shared
+--- between processes: the instance registry is machine-wide, a project's `.vibing/` is shared by
+--- every chat open on it, and plenary runs one child Neovim per spec file. It is what made
+--- `tests/view_spec.lua` flake in CI (#576).
+---
+--- **Catching the error and re-checking is not enough**, which is worth stating because it is the
+--- obvious fix and it still failed 3 times out of 200. The component that collided is often an
+--- *intermediate* one, and the process that won that component has not necessarily reached the
+--- leaf yet — so the loser's `fs_stat` on the leaf legitimately finds nothing. Retrying is what
+--- resolves it: the next walk starts past the component that collided.
+---
+--- @param path string
+--- @return boolean success the directory exists now
+function M.ensure_dir(path)
+  for _ = 1, MAX_ATTEMPTS do
+    local ok, created = pcall(vim.fn.mkdir, path, "p")
+    if ok and created == 1 then
+      return true
+    end
+    if is_dir(path) then
+      return true
+    end
+    if ok then
+      -- mkdir declined without raising. Nothing raced us, so another attempt says the same thing.
+      break
+    end
+  end
+
+  return is_dir(path)
+end
+
+return M

--- a/lua/vibing/core/utils/fs.lua
+++ b/lua/vibing/core/utils/fs.lua
@@ -5,9 +5,9 @@ local uv = vim.loop
 
 local M = {}
 
---- How many times to re-attempt a directory creation that lost a race. Each retry starts the walk
---- again from a path that is strictly further along, so this converges in a couple of rounds; the
---- bound is only there so a genuinely impossible path cannot spin.
+--- How many times to re-attempt a directory creation that lost a race. Bounded by the path's
+--- depth in the worst case -- each retry restarts the walk, so a second collision is possible on
+--- a different component -- and by this constant so a degenerate path cannot spin.
 local MAX_ATTEMPTS = 5
 
 --- Whether `path` is a directory right now.
@@ -31,28 +31,37 @@ end
 ---
 --- **Catching the error and re-checking is not enough**, which is worth stating because it is the
 --- obvious fix and it still failed 3 times out of 200. The component that collided is often an
---- *intermediate* one, and the process that won that component has not necessarily reached the
---- leaf yet — so the loser's `fs_stat` on the leaf legitimately finds nothing. Retrying is what
---- resolves it: the next walk starts past the component that collided.
+--- *intermediate* one, and the process that won it has not necessarily reached the leaf yet — so
+--- the loser's `fs_stat` on the leaf legitimately finds nothing. Retrying is what resolves it.
+---
+--- **Only the race is swallowed.** Every other way this fails — a read-only filesystem, a
+--- permission denial, a file sitting where the directory should go — also raises `E739`, and
+--- those are re-raised with their original message. Callers were written against
+--- `vim.fn.mkdir`'s contract, where a genuine failure propagates; turning that into a silent
+--- `false` would leave 18 call sites continuing as if the directory existed.
 ---
 --- @param path string
---- @return boolean success the directory exists now
+--- @return true
 function M.ensure_dir(path)
+  local last_error
+
   for _ = 1, MAX_ATTEMPTS do
-    local ok, created = pcall(vim.fn.mkdir, path, "p")
-    if ok and created == 1 then
+    local ok, result = pcall(vim.fn.mkdir, path, "p")
+    if ok and result == 1 then
       return true
     end
     if is_dir(path) then
       return true
     end
     if ok then
-      -- mkdir declined without raising. Nothing raced us, so another attempt says the same thing.
-      break
+      -- mkdir declined without raising, which only an empty path does. Nothing raced us, so
+      -- another attempt says the same thing.
+      error(string.format("could not create directory %q: mkdir declined", path))
     end
+    last_error = result
   end
 
-  return is_dir(path)
+  error(tostring(last_error))
 end
 
 return M

--- a/lua/vibing/core/utils/mote/moteignore.lua
+++ b/lua/vibing/core/utils/mote/moteignore.lua
@@ -1,5 +1,7 @@
 ---@class Vibing.Utils.Mote.Moteignore
 ---.moteignoreファイルの管理
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 ---デフォルトの.moteignoreルール
@@ -40,7 +42,7 @@ function M.ensure_exists(ignore_file_path)
   end
 
   local parent_dir = vim.fn.fnamemodify(abs_path, ":h")
-  vim.fn.mkdir(parent_dir, "p")
+  Fs.ensure_dir(parent_dir)
 
   vim.fn.writefile(M.DEFAULT_RULES, abs_path)
 end

--- a/lua/vibing/core/utils/mote/operations.lua
+++ b/lua/vibing/core/utils/mote/operations.lua
@@ -1,5 +1,7 @@
 ---@class Vibing.Utils.Mote.Operations
 ---moteの各種操作（diff, snapshot, patch）
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 ---diff出力からファイルパスを抽出
@@ -221,7 +223,7 @@ function M.generate_patch(config, output_path, callback)
   end
 
   local output_dir = vim.fn.fnamemodify(output_path, ":h")
-  vim.fn.mkdir(output_dir, "p")
+  Fs.ensure_dir(output_dir)
 
   local cmd = Command.build_base_args(config)
   table.insert(cmd, "snap")

--- a/lua/vibing/core/utils/project_system_prompt.lua
+++ b/lua/vibing/core/utils/project_system_prompt.lua
@@ -5,6 +5,8 @@
 --- `--append-system-prompt` on every non-lightweight request.
 --- @module vibing.core.utils.project_system_prompt
 
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 --- 8 KiB. Large enough for real instructions, small enough that a stray paste
@@ -22,7 +24,7 @@ end
 function M.ensure(project_root)
   local prompt_file = M.path(project_root)
   if vim.fn.filereadable(prompt_file) == 0 then
-    vim.fn.mkdir(project_root .. "/.vibing", "p")
+    Fs.ensure_dir(project_root .. "/.vibing")
     vim.fn.writefile({}, prompt_file)
   end
 end

--- a/lua/vibing/core/utils/request_diff.lua
+++ b/lua/vibing/core/utils/request_diff.lua
@@ -9,6 +9,8 @@
 ---「そのリクエストで実際に触ったファイル数」にのみ比例する。
 ---バックアップはhandle_id（リクエスト）単位で管理されるので、
 ---並行するチャットバッファ間で差分が混ざることもない。
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 local uv = vim.uv or vim.loop
@@ -121,7 +123,7 @@ function M.capture(handle_id, tool_name, tool_input)
 
   if not s.dir then
     s.dir = vim.fn.tempname() .. ".vibing-reqdiff"
-    vim.fn.mkdir(s.dir, "p")
+    Fs.ensure_dir(s.dir)
   end
   s.count = s.count + 1
   local backup_path = string.format("%s/%d", s.dir, s.count)

--- a/lua/vibing/infrastructure/file/writer.lua
+++ b/lua/vibing/infrastructure/file/writer.lua
@@ -32,13 +32,6 @@ function M.append(path, content)
   return true, nil
 end
 
----ディレクトリを作成
----@param path string
----@return boolean success
-function M.mkdir(path)
-  return vim.fn.mkdir(path, "p") == 1
-end
-
 ---ファイルを削除
 ---@param path string
 ---@return boolean success

--- a/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/grok_settings_generator.lua
@@ -4,6 +4,7 @@
 --- @module vibing.infrastructure.hooks.grok_settings_generator
 
 local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+local Fs = require("vibing.core.utils.fs")
 
 local M = {}
 
@@ -65,7 +66,7 @@ local function ensure_folder_trust(cwd)
   end
 
   local trust_path = grok_home() .. "/trusted_folders.toml"
-  vim.fn.mkdir(vim.fn.fnamemodify(trust_path, ":h"), "p")
+  Fs.ensure_dir(vim.fn.fnamemodify(trust_path, ":h"))
 
   local existing = ""
   local rf = io.open(trust_path, "r")
@@ -130,7 +131,7 @@ function M.ensure(cwd)
   local hooks_dir = real_cwd .. "/.grok/hooks"
   local hook_path = hooks_dir .. "/" .. HOOK_FILENAME
 
-  vim.fn.mkdir(hooks_dir, "p")
+  Fs.ensure_dir(hooks_dir)
 
   -- Grok resolves relative command paths against the hook JSON file directory
   -- (.grok/hooks/), not the project root — so a relative plugin path would miss

--- a/lua/vibing/infrastructure/hooks/settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/settings_generator.lua
@@ -2,6 +2,8 @@
 --- Writes hook settings to .vibing/hook-settings.json for --settings flag
 --- @module vibing.infrastructure.hooks.settings_generator
 
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 --- Resolve a bundled hook script by file name
@@ -75,7 +77,7 @@ function M.ensure(cwd)
   local vibing_dir = cwd .. "/.vibing"
   local settings_path = vibing_dir .. "/hook-settings.json"
 
-  vim.fn.mkdir(vibing_dir, "p")
+  Fs.ensure_dir(vibing_dir)
 
   -- Always regenerate (hook script path may change after plugin update)
   local settings = M.generate()

--- a/lua/vibing/infrastructure/rpc/registry.lua
+++ b/lua/vibing/infrastructure/rpc/registry.lua
@@ -47,11 +47,14 @@ end
 ---@return boolean success Whether directory was created or already exists
 local function ensure_registry_dir()
   local dir = M.get_registry_dir()
-  if Fs.ensure_dir(dir) then
+  local ok, err = pcall(Fs.ensure_dir, dir)
+  if ok then
     return true
   end
 
-  vim.notify(string.format("Failed to create registry directory: %s", dir), vim.log.levels.ERROR)
+  -- The reason matters and used to be thrown away: the old code read a second return value
+  -- `vim.fn.mkdir` does not have, so this always said "unknown error".
+  vim.notify(string.format("Failed to create registry directory %s: %s", dir, err), vim.log.levels.ERROR)
   return false
 end
 

--- a/lua/vibing/infrastructure/rpc/registry.lua
+++ b/lua/vibing/infrastructure/rpc/registry.lua
@@ -1,6 +1,8 @@
 ---@class Vibing.RpcRegistry
 ---Instance registry for managing multiple Neovim instances with vibing.nvim RPC servers
 ---Tracks running instances by PID, port, and working directory
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 local uv = vim.loop
@@ -37,21 +39,20 @@ local function get_instance_file()
 end
 
 ---Ensure registry directory exists
+---
+---This path is machine-wide, so several Neovim instances race to create it on startup and the
+---suite's per-spec children race hardest of all. `Fs.ensure_dir` is what makes losing that race
+---a non-event; the `fs_stat` guard that used to sit here was the check half of the same
+---check-then-act and never prevented anything (#576).
 ---@return boolean success Whether directory was created or already exists
 local function ensure_registry_dir()
   local dir = M.get_registry_dir()
-  local stat = uv.fs_stat(dir)
-  if not stat then
-    local ok, err = vim.fn.mkdir(dir, "p")
-    if ok == 0 then
-      vim.notify(
-        string.format("Failed to create registry directory: %s", err or "unknown error"),
-        vim.log.levels.ERROR
-      )
-      return false
-    end
+  if Fs.ensure_dir(dir) then
+    return true
   end
-  return true
+
+  vim.notify(string.format("Failed to create registry directory: %s", dir), vim.log.levels.ERROR)
+  return false
 end
 
 ---Register current instance

--- a/lua/vibing/infrastructure/storage/limit_state.lua
+++ b/lua/vibing/infrastructure/storage/limit_state.lua
@@ -12,6 +12,7 @@
 --- @module vibing.infrastructure.storage.limit_state
 
 local Git = require("vibing.core.utils.git")
+local Fs = require("vibing.core.utils.fs")
 
 local M = {}
 
@@ -82,7 +83,7 @@ function M.record(info, cwd)
   end
 
   local path = M.get_path(cwd)
-  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+  Fs.ensure_dir(vim.fn.fnamemodify(path, ":h"))
 
   local json = vim.json.encode({
     resets_at = info.resets_at,

--- a/lua/vibing/infrastructure/storage/pending_resume.lua
+++ b/lua/vibing/infrastructure/storage/pending_resume.lua
@@ -8,6 +8,7 @@
 --- @module vibing.infrastructure.storage.pending_resume
 
 local Git = require("vibing.core.utils.git")
+local Fs = require("vibing.core.utils.fs")
 
 local M = {}
 
@@ -100,7 +101,7 @@ end
 --- @return boolean success
 function M.save(entries, cwd)
   local path = M.get_path(cwd)
-  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+  Fs.ensure_dir(vim.fn.fnamemodify(path, ":h"))
 
   -- vim.json.encode turns an empty Lua table into "[]" (an array), which decodes back as a list
   -- and would break every keyed lookup on the next load. Store an explicit empty object instead.

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -6,6 +6,7 @@ local Renderer = require("vibing.presentation.chat.modules.renderer")
 local StreamingHandler = require("vibing.presentation.chat.modules.streaming_handler")
 local ConversationExtractor = require("vibing.presentation.chat.modules.conversation_extractor")
 local KeymapHandler = require("vibing.presentation.chat.modules.keymap_handler")
+local Fs = require("vibing.core.utils.fs")
 
 ---@class Vibing.ChatBuffer
 ---@field buf number?
@@ -154,7 +155,7 @@ function ChatBuffer:_create_buffer()
     vim.api.nvim_buf_set_name(self.buf, self.file_path)
   else
     local save_path = FileManager.get_save_directory(self.config)
-    vim.fn.mkdir(save_path, "p")
+    Fs.ensure_dir(save_path)
     local filename = FileManager.generate_unique_filename()
     self.file_path = save_path .. filename
     vim.api.nvim_buf_set_name(self.buf, self.file_path)

--- a/lua/vibing/presentation/chat/modules/file_manager.lua
+++ b/lua/vibing/presentation/chat/modules/file_manager.lua
@@ -1,3 +1,5 @@
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 ---一意なファイル名を生成
@@ -76,7 +78,7 @@ function M.update_filename_from_message(buf, current_path, message)
   local project_root = vim.fn.getcwd()
   ensure_system_prompt(project_root)
   local chat_dir = project_root .. "/.vibing/chat/"
-  vim.fn.mkdir(chat_dir, "p")
+  Fs.ensure_dir(chat_dir)
 
   local new_filename = base_filename .. ".md"
   local new_file_path = chat_dir .. new_filename

--- a/lua/vibing/testing/eval_harness.lua
+++ b/lua/vibing/testing/eval_harness.lua
@@ -10,6 +10,8 @@
 ---
 ---1タスク＝実CLI呼び出し1回＝実トークン消費。通常のテストスイートには入れず
 ---`pnpm run test:eval`（`tests/evals/run.lua`）からのみ回す。
+local Fs = require("vibing.core.utils.fs")
+
 local M = {}
 
 ---@class Vibing.Eval.Record 1試行の観測結果
@@ -50,7 +52,7 @@ local TIMEOUT_MS = 180000
 ---@return string path
 function M.create_scratch_repo()
   local path = vim.fn.tempname() .. "_eval_repo"
-  vim.fn.mkdir(path, "p")
+  Fs.ensure_dir(path)
   vim.fn.system({ "git", "-C", path, "init", "-q" })
   vim.fn.writefile({ "# eval scratch" }, vim.fs.joinpath(path, "README.md"))
   vim.fn.system({ "git", "-C", path, "add", "." })

--- a/tests/lua/core/utils/fs_spec.lua
+++ b/tests/lua/core/utils/fs_spec.lua
@@ -74,16 +74,16 @@ describe("fs.ensure_dir", function()
       error("Vim:E739: Cannot create directory /nope: file already exists")
     end
 
-    assert.is_false(Fs.ensure_dir(tmp .. "/never-created"))
+    assert.is_false(pcall(Fs.ensure_dir, tmp .. "/never-created"))
     assert.is_true(attempts <= 5, "retries must be bounded, got " .. attempts)
   end)
 
-  it("reports failure when mkdir returns 0 without raising", function()
+  it("raises when mkdir declines without raising", function()
     vim.fn.mkdir = function()
       return 0
     end
 
-    assert.is_false(Fs.ensure_dir(tmp .. "/never-created"))
+    assert.is_false(pcall(Fs.ensure_dir, tmp .. "/never-created"))
   end)
 
   it("reports failure when the path exists but is a file", function()
@@ -92,7 +92,7 @@ describe("fs.ensure_dir", function()
     local file = tmp .. "/afile"
     vim.fn.writefile({}, file)
 
-    assert.is_false(Fs.ensure_dir(file))
+    assert.is_false(pcall(Fs.ensure_dir, file))
   end)
 end)
 
@@ -111,6 +111,9 @@ describe("mkdir call sites", function()
       end
     end
 
+    -- Positive control: fs.lua itself calls it, so an empty result means the grep looked at the
+    -- wrong tree rather than that the tree is clean.
+    assert.is_true(#hits > 0, "grep found nothing at all -- did it run against the right lua/?")
     assert.equals(0, #offenders, "direct vim.fn.mkdir call(s):\n" .. table.concat(offenders, "\n"))
   end)
 end)

--- a/tests/lua/core/utils/fs_spec.lua
+++ b/tests/lua/core/utils/fs_spec.lua
@@ -1,0 +1,116 @@
+local Fs = require("vibing.core.utils.fs")
+
+describe("fs.ensure_dir", function()
+  local tmp, original_mkdir
+
+  before_each(function()
+    tmp = vim.fn.tempname()
+    original_mkdir = vim.fn.mkdir
+  end)
+
+  after_each(function()
+    vim.fn.mkdir = original_mkdir
+    vim.fn.delete(tmp, "rf")
+  end)
+
+  local function is_dir(path)
+    local stat = vim.loop.fs_stat(path)
+    return stat ~= nil and stat.type == "directory"
+  end
+
+  it("creates the directory", function()
+    assert.is_true(Fs.ensure_dir(tmp))
+    assert.is_true(is_dir(tmp))
+  end)
+
+  it("creates intermediate components", function()
+    local nested = tmp .. "/a/b/c"
+    assert.is_true(Fs.ensure_dir(nested))
+    assert.is_true(is_dir(nested))
+  end)
+
+  it("succeeds on a directory that already exists", function()
+    assert.is_true(Fs.ensure_dir(tmp))
+    assert.is_true(Fs.ensure_dir(tmp))
+  end)
+
+  it("succeeds when another process won the race", function()
+    -- The real failure, verbatim: mkdir(..., "p") walks the path and raises when a concurrent
+    -- process creates a component first. 9 occurrences across 200 concurrent calls (#576).
+    original_mkdir(tmp, "p")
+    vim.fn.mkdir = function(path)
+      error(string.format("Vim:E739: Cannot create directory %s: file already exists", path))
+    end
+
+    assert.is_true(Fs.ensure_dir(tmp), "losing the race must not be reported as failure")
+  end)
+
+  it("retries when the collision was on an intermediate component", function()
+    -- The case a plain catch-and-recheck gets wrong, and the reason this helper retries. The
+    -- process that won an intermediate component has not necessarily reached the leaf yet, so
+    -- the loser's fs_stat on the leaf legitimately finds nothing. Re-checking returns false;
+    -- re-attempting succeeds. Measured: catch-and-recheck still failed 3 times in 200.
+    local leaf = tmp .. "/parent/leaf"
+    local attempts = 0
+    vim.fn.mkdir = function(path, flags)
+      attempts = attempts + 1
+      if attempts == 1 then
+        -- Someone else just created `parent`; the leaf does not exist yet.
+        original_mkdir(tmp .. "/parent", "p")
+        error(string.format("Vim:E739: Cannot create directory %s/parent: file already exists", tmp))
+      end
+      return original_mkdir(path, flags)
+    end
+
+    assert.is_true(Fs.ensure_dir(leaf))
+    assert.equals(2, attempts, "should have re-attempted, not just re-checked")
+    assert.is_true(is_dir(leaf))
+  end)
+
+  it("gives up rather than spinning when the path can never be created", function()
+    local attempts = 0
+    vim.fn.mkdir = function()
+      attempts = attempts + 1
+      error("Vim:E739: Cannot create directory /nope: file already exists")
+    end
+
+    assert.is_false(Fs.ensure_dir(tmp .. "/never-created"))
+    assert.is_true(attempts <= 5, "retries must be bounded, got " .. attempts)
+  end)
+
+  it("reports failure when mkdir returns 0 without raising", function()
+    vim.fn.mkdir = function()
+      return 0
+    end
+
+    assert.is_false(Fs.ensure_dir(tmp .. "/never-created"))
+  end)
+
+  it("reports failure when the path exists but is a file", function()
+    -- E739 says "file already exists" for this too, and the caller wants a directory.
+    original_mkdir(tmp, "p")
+    local file = tmp .. "/afile"
+    vim.fn.writefile({}, file)
+
+    assert.is_false(Fs.ensure_dir(file))
+  end)
+end)
+
+describe("mkdir call sites", function()
+  it("all go through fs.ensure_dir", function()
+    -- `vim.fn.mkdir` is not atomic, so a direct call anywhere in lua/ is a latent flake. Keeping
+    -- this as a test rather than a comment is what stops the next one being added silently.
+    local root = vim.fn.getcwd() .. "/lua"
+    local hits = vim.fn.systemlist({ "grep", "-rn", "vim.fn.mkdir(", root })
+
+    local offenders = {}
+    for _, line in ipairs(hits) do
+      -- fs.lua is the one place allowed to call it, in the implementation and its own comment.
+      if not line:match("core/utils/fs%.lua") then
+        table.insert(offenders, (line:gsub("^" .. vim.pesc(root), "lua")))
+      end
+    end
+
+    assert.equals(0, #offenders, "direct vim.fn.mkdir call(s):\n" .. table.concat(offenders, "\n"))
+  end)
+end)


### PR DESCRIPTION
Closes #576

## 原因

issue には `fs_stat` → `mkdir` の TOCTOU と書きましたが、**実際の競合は `vim.fn.mkdir` の内部**でした。まず再現から入っています。

```lua
vim.fn.mkdir(dir, "p")
```

これは非アトミックで、パスの構成要素を順に作っていく途中で他プロセスがどれかを先に作ると `E739: Cannot create directory ...: file already exists` を投げます。**末端だけでなく中間コンポーネントでも起きます。**

nvim を8並列 × 25ラウンド（計200回）で同一パスに走らせた結果:

| 実装 | 200並列での失敗 |
| --- | --- |
| `vim.fn.mkdir(dir, "p")` そのまま | **9回** |

エラーは `/tmp/raceparent/r12`（中間）と `/tmp/raceparent/r18/vibing-instances`（末端）の両方で出ており、`"p"` のウォーク自体が競合源であることが確認できます。

これが `PlenaryBustedDirectory`（spec ファイルごとに子 Neovim を並列起動）と、マシン全体で共有される instance registry の組み合わせで踏まれ、#569 の初回 CI が落ちて再実行で通った件の正体です。

## 単純な修正では足りませんでした

最初に「pcall で捕まえて `fs_stat` で再確認」を実装し、同じ実験を回したところ **200回中3回まだ失敗**しました。

理由は中間コンポーネントの競合です。

1. プロセス B が `/tmp/x/r1/leaf` を作ろうとする
2. `r1` の作成で A に負けて E739
3. B が `leaf` を `fs_stat` → **まだ無い**（A はまだ `leaf` まで到達していない）
4. B は false を返す

**再確認ではなく再試行**が必要でした。次のウォークは衝突したコンポーネントの先から始まるので収束します。

| 実装 | 失敗 |
| --- | --- |
| そのまま | 9 / 200 |
| pcall + `fs_stat` 再確認 | 3 / 200 |
| **pcall + 再試行（本PR）** | **0 / 320** |

## 変更

`lua/vibing/core/utils/fs.lua` に `ensure_dir` を追加し、**`lua/` 内の `vim.fn.mkdir` 呼び出し19箇所すべて**をそこに通しました。`core/` に置いたのは全レイヤーから使えるようにするためです。

同時に片付けたもの:

- **`registry.lua` の `fs_stat` 事前チェックを削除** — 同じ check-then-act の check 側で、何も防いでいませんでした
- **同じ箇所のエラー報告が機能していなかった** — `local ok, err = vim.fn.mkdir(...)` としていましたが `vim.fn.mkdir` の戻り値は1つなので `err` は常に nil、メッセージは常に `unknown error` でした
- **`set_file_title.lua` の `isdirectory` ガードを削除** — これも同型の check-then-act
- **`Writer.mkdir` を削除** — 呼び出し元ゼロの死にコードでした。正しいヘルパーの隣に `mkdir` という名前の非アトミックな1行を残すのは、間違ったほうが選ばれる原因になります

## テスト

`tests/lua/core/utils/fs_spec.lua`（9ケース、全通過）。実際に観測した E739 メッセージをそのまま注入する形で、決定的に検証しています。

- 作成 / 中間ディレクトリ作成 / 既存ディレクトリで成功
- **競合に負けても成功**
- **中間コンポーネントでの衝突は再試行で解決**（`attempts == 2` を assert。再確認だけの実装では落ちます）
- 再試行が有界であること
- `mkdir` が raise せず 0 を返した場合は失敗
- パスがファイルだった場合は失敗

加えて **`lua/` 内に直接の `vim.fn.mkdir` が再登場したらビルドを落とすテスト**を入れました。次の1件が黙って追加されるのを防ぐためです。

```
pnpm run check         exit 0
pnpm run check:doc     doc: 1 help file(s) OK
pnpm run test:lua      exit 0
pnpm run test:node     23 pass / 0 fail
pnpm run format:check  exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
