### PR TITLE
ci: match CONTENTS by section number, and stop skipping what it cannot read

### DIFF
--- a/.claude/rules/self-testing.md
+++ b/.claude/rules/self-testing.md
@@ -77,7 +77,19 @@ not require a dot leader, because space-aligned CONTENTS is ordinary vimdoc and 
 check entirely. A file with no CONTENTS heading has nothing to disagree with and passes.
 
 Section headings are matched at column 0 on purpose: that is what keeps a heading-shaped line
-inside an indented `>` code example from being read as a real section.
+inside an indented `>` code example from being read as a real section. CONTENTS rows cannot be
+anchored that way — they are indented — so they are read only from inside the CONTENTS block, and
+headings only from outside it. Neither side depends on the two patterns never overlapping.
+
+CONTENTS and the body are matched **by section number**, not by position. Walking the two lists in
+parallel meant one renumbered section shifted everything after it, so a single typo reported as a
+cascade and the first message named a section that was fine. Duplicate numbers on either side are
+reported as such.
+
+Sub-section numbering (`2.1`) is **rejected rather than skipped**. Neither pattern can read it, so
+it used to drop out of the comparison without a word — checked-looking and unchecked, which is the
+failure this checker exists to prevent. Supporting it should be a decision, not something
+discovered from a green run.
 
 `tests/help-check.test.mjs` pins each failure the gate is supposed to catch, including both width
 cases and both fail-closed cases. The CI step gates the document; that file gates the checker.

--- a/scripts/check-help.lua
+++ b/scripts/check-help.lua
@@ -24,11 +24,15 @@ local function fail(fmt, ...)
   table.insert(problems, string.format(fmt, ...))
 end
 
---- `    2.1 Sub-heading ....` -- a sub-section, which neither pattern above can read, because both
---- require whitespace straight after the dot. Detected explicitly so it fails rather than being
---- dropped from the comparison without a word: silently skipping is the failure mode this whole
---- checker exists to prevent.
-local SUBSECTION_ROW = '^%s*%d+%.%d'
+--- A sub-section, which neither pattern above can read because both require whitespace straight
+--- after the dot. Detected explicitly so it fails rather than being dropped from the comparison
+--- without a word: silently skipping is the failure mode this whole checker exists to prevent.
+---
+--- Two forms, scoped the same way as the rows they would otherwise have been: `    2.1 Sub ...`
+--- inside the CONTENTS block, and `2.1 SUB ...` at column 0 in the body. Scanning the whole file
+--- for either would flag ordinary prose and `>` code examples that merely start with `N.M`.
+local CONTENTS_SUBSECTION = '^%s*%d+%.%d'
+local SECTION_SUBSECTION = '^%d+%.%d'
 
 --- Where the CONTENTS section starts and ends, or nil when the file has no CONTENTS heading.
 ---
@@ -77,14 +81,19 @@ end
 --- two lists in parallel meant a single inserted or renumbered section shifted everything after
 --- it, so one typo reported as a cascade and the first message named a section that was fine.
 local function by_number(rows)
-  local map, duplicates = {}, {}
+  local map, seen_duplicate, duplicates = {}, {}, {}
   for _, row in ipairs(rows) do
     if map[row.number] then
-      table.insert(duplicates, row.number)
+      -- Once per number, not once per repeat: three copies of `2.` is one mistake to report.
+      if not seen_duplicate[row.number] then
+        seen_duplicate[row.number] = true
+        table.insert(duplicates, row.number)
+      end
     else
       map[row.number] = row
     end
   end
+  table.sort(duplicates)
   return map, duplicates
 end
 
@@ -153,7 +162,9 @@ for _, file in ipairs(files) do
     -- comparison unannounced. Say so instead; supporting them is a deliberate decision, not
     -- something to discover from a green run.
     for lnum, line in ipairs(lines) do
-      if line:match(SUBSECTION_ROW) then
+      local in_contents = lnum >= from and lnum <= to
+      local pattern = in_contents and CONTENTS_SUBSECTION or SECTION_SUBSECTION
+      if line:match(pattern) then
         fail('%s:%d: sub-section numbering (N.M) is not checked; flatten it or teach the checker', name, lnum)
       end
     end

--- a/scripts/check-help.lua
+++ b/scripts/check-help.lua
@@ -24,36 +24,83 @@ local function fail(fmt, ...)
   table.insert(problems, string.format(fmt, ...))
 end
 
---- The lines inside the CONTENTS section, or nil when the file has no CONTENTS heading.
+--- `    2.1 Sub-heading ....` -- a sub-section, which neither pattern above can read, because both
+--- require whitespace straight after the dot. Detected explicitly so it fails rather than being
+--- dropped from the comparison without a word: silently skipping is the failure mode this whole
+--- checker exists to prevent.
+local SUBSECTION_ROW = '^%s*%d+%.%d'
+
+--- Where the CONTENTS section starts and ends, or nil when the file has no CONTENTS heading.
 ---
---- Scoping matters: CONTENTS_ROW cannot be anchored at column 0 the way SECTION_HEADING is, since
---- its rows are indented. Run over the whole file it also matches an ordinary body line that ends
---- in a `|tag|` reference -- `    4. See |vibing-commands|` in a troubleshooting list, say --
---- which shifts every index after it and reports a section that is present as missing.
-local function contents_block(lines)
+--- Scoping matters in both directions. CONTENTS_ROW cannot be anchored at column 0 the way
+--- SECTION_HEADING is, since its rows are indented; run over the whole file it also matches an
+--- ordinary body line ending in a `|tag|` reference -- `    4. See |vibing-commands|` in a
+--- troubleshooting list, say. And scanning for headings *inside* the CONTENTS block would rely on
+--- the two patterns never overlapping, which is true today only because one ends in `|tag|` and
+--- the other in `*tag*`. Neither side has to depend on that.
+---
+--- @return integer? first line after the CONTENTS heading
+--- @return integer? last line before the rule that closes the section
+local function contents_range(lines)
   local first = nil
   for index, line in ipairs(lines) do
     if not first then
       if line:match('^CONTENTS%f[%W]') then
-        first = index
+        first = index + 1
       end
     elseif line:match('^=====') then
-      return vim.list_slice(lines, first + 1, index - 1)
+      return first, index - 1
     end
   end
-  return first and vim.list_slice(lines, first + 1) or nil
+  return first, first and #lines or nil
 end
 
---- The `{ number, tag }` of every line matching `pattern`, in the order they appear.
-local function numbered_rows(lines, pattern)
+--- The `{ number, tag }` of every line matching `pattern` within `range`, in the order they appear.
+--- @param range table? `{ from, to }` line bounds, or nil for the whole list
+local function numbered_rows(lines, pattern, range)
   local rows = {}
-  for _, line in ipairs(lines) do
-    local number, tag = line:match(pattern)
-    if number then
-      table.insert(rows, { number = tonumber(number), tag = tag })
+  for index, line in ipairs(lines) do
+    local inside = range == nil or (index >= range.from and index <= range.to)
+    if inside then
+      local number, tag = line:match(pattern)
+      if number then
+        table.insert(rows, { number = tonumber(number), tag = tag, lnum = index })
+      end
     end
   end
   return rows
+end
+
+--- Rows keyed by their section number, plus any number that appeared more than once.
+---
+--- Keying by number rather than by position is what keeps one mistake to one message. Walking the
+--- two lists in parallel meant a single inserted or renumbered section shifted everything after
+--- it, so one typo reported as a cascade and the first message named a section that was fine.
+local function by_number(rows)
+  local map, duplicates = {}, {}
+  for _, row in ipairs(rows) do
+    if map[row.number] then
+      table.insert(duplicates, row.number)
+    else
+      map[row.number] = row
+    end
+  end
+  return map, duplicates
+end
+
+--- Every number present in either side, ascending, so diagnostics come out in document order.
+local function all_numbers(a, b)
+  local seen, numbers = {}, {}
+  for _, map in ipairs({ a, b }) do
+    for number in pairs(map) do
+      if not seen[number] then
+        seen[number] = true
+        table.insert(numbers, number)
+      end
+    end
+  end
+  table.sort(numbers)
+  return numbers
 end
 
 -- 1. helptags must be generatable. Duplicate or malformed tags fail here, and only here --
@@ -85,40 +132,67 @@ for _, file in ipairs(files) do
     end
   end
 
-  -- 3. CONTENTS and the body must agree, entry by entry, on both number and tag. Comparing them
-  -- in order covers a mistyped link too: a heading only matches SECTION_HEADING if it defines
-  -- its own tag, so an entry pointing at a tag nothing defines shows up as a mismatch here.
+  -- 3. CONTENTS and the body must agree, section number by section number, on the tag. That also
+  -- covers a mistyped link: a heading only matches SECTION_HEADING if it defines its own tag, so
+  -- an entry pointing at a tag nothing defines has no heading to pair with.
   --
   -- This fails closed. Keying it on "did we parse any entries" instead would let one unreadable
   -- CONTENTS block disable the check while still reporting OK, which is the exact failure #542
   -- was filed about -- so a file with a CONTENTS heading and no parseable rows is a problem,
   -- not a pass. A file with no CONTENTS heading at all has nothing to disagree with.
-  local block = contents_block(lines)
-  local entries = block and numbered_rows(block, CONTENTS_ROW) or {}
+  local from, to = contents_range(lines)
+  if not from then
+    goto continue
+  end
 
-  if block and #entries == 0 then
-    fail('%s: CONTENTS block found but no `N. Title |tag|` rows could be read from it', name)
-  elseif block then
-    local headings = numbered_rows(lines, SECTION_HEADING)
+  do
+    local contents = { from = from, to = to }
+    local entries = numbered_rows(lines, CONTENTS_ROW, contents)
 
-    for index = 1, math.max(#entries, #headings) do
-      local entry, heading = entries[index], headings[index]
+    -- Sub-sections read as neither an entry nor a heading, so they would drop out of the
+    -- comparison unannounced. Say so instead; supporting them is a deliberate decision, not
+    -- something to discover from a green run.
+    for lnum, line in ipairs(lines) do
+      if line:match(SUBSECTION_ROW) then
+        fail('%s:%d: sub-section numbering (N.M) is not checked; flatten it or teach the checker', name, lnum)
+      end
+    end
+
+    if #entries == 0 then
+      fail('%s: CONTENTS block found but no `N. Title |tag|` rows could be read from it', name)
+      goto continue
+    end
+
+    local headings = numbered_rows(lines, SECTION_HEADING, nil)
+    -- Headings inside the CONTENTS block are not sections. Today the two patterns cannot both
+    -- match one line, but nothing enforces that, so the range does the work instead.
+    headings = vim.tbl_filter(function(row)
+      return row.lnum < from or row.lnum > to
+    end, headings)
+
+    local entry_by_number, entry_dupes = by_number(entries)
+    local heading_by_number, heading_dupes = by_number(headings)
+
+    for _, number in ipairs(entry_dupes) do
+      fail('%s: CONTENTS lists section %d more than once', name, number)
+    end
+    for _, number in ipairs(heading_dupes) do
+      fail('%s: the body has more than one section numbered %d', name, number)
+    end
+
+    for _, number in ipairs(all_numbers(entry_by_number, heading_by_number)) do
+      local entry, heading = entry_by_number[number], heading_by_number[number]
       if not heading then
-        fail('%s: CONTENTS lists %d. |%s| but the body has no matching section', name, entry.number, entry.tag)
+        fail('%s: CONTENTS lists %d. |%s| but the body has no section %d', name, number, entry.tag, number)
       elseif not entry then
-        fail('%s: section %d. *%s* is missing from CONTENTS', name, heading.number, heading.tag)
-      elseif heading.number ~= entry.number or heading.tag ~= entry.tag then
-        fail(
-          '%s: CONTENTS entry %d. |%s| does not match section %d. *%s*',
-          name,
-          entry.number,
-          entry.tag,
-          heading.number,
-          heading.tag
-        )
+        fail('%s: section %d. *%s* is missing from CONTENTS', name, number, heading.tag)
+      elseif entry.tag ~= heading.tag then
+        fail('%s: section %d links to |%s| in CONTENTS but defines *%s*', name, number, entry.tag, heading.tag)
       end
     end
   end
+
+  ::continue::
 end
 
 if #problems > 0 then

--- a/tests/help-check.test.mjs
+++ b/tests/help-check.test.mjs
@@ -299,3 +299,54 @@ test('every help file in the directory is checked, not just the first', async ()
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('an indented N.M line in the body is prose, not an unchecked sub-section', async () => {
+  // The subsection scan used to run over the whole file, so a `>` code example or an ordinary
+  // paragraph starting with `2.1` tripped it. Same class of bug as the CONTENTS row scan.
+  const text = helpFile({
+    contents: [entry(1, 'One', 'fixture-one')],
+    body: [
+      heading(1, 'One', 'fixture-one'),
+      '',
+      'Example: >',
+      '    2.1 is a ratio, not a heading',
+      '<',
+      '',
+      '    3.5 mm of travel.',
+    ],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 0, stderr);
+});
+
+test('a real sub-section at column 0 is still caught', async () => {
+  const text = helpFile({
+    contents: [entry(1, 'One', 'fixture-one')],
+    body: [
+      heading(1, 'One', 'fixture-one'),
+      '',
+      RULE,
+      '2.1 SUB' + ' '.repeat(50) + '*fixture-sub*',
+    ],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /sub-section numbering/);
+});
+
+test('a number repeated three times is reported once, not twice', async () => {
+  const text = helpFile({
+    contents: [
+      entry(1, 'One', 'fixture-one'),
+      entry(1, 'Again', 'fixture-again'),
+      entry(1, 'Thrice', 'fixture-thrice'),
+    ],
+    body: [heading(1, 'One', 'fixture-one')],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.equal(stderr.match(/lists section 1 more than once/g).length, 1);
+});

--- a/tests/help-check.test.mjs
+++ b/tests/help-check.test.mjs
@@ -113,10 +113,10 @@ const DISAGREEMENTS = [
     expect: /fixture-nowhere/,
   },
   {
-    name: 'a section numbered out of step with CONTENTS fails',
+    name: 'a renumbered section is reported against its own number, not its neighbour',
     contents: [entry(1, 'One', 'fixture-one'), entry(2, 'Two', 'fixture-two')],
     body: [heading(1, 'One', 'fixture-one'), '', RULE, heading(3, 'Two', 'fixture-two')],
-    expect: /does not match section 3/,
+    expect: /body has no section 2/,
   },
   {
     name: 'a section missing from CONTENTS fails',
@@ -128,7 +128,7 @@ const DISAGREEMENTS = [
     name: 'a CONTENTS entry with no section at all fails',
     contents: [entry(1, 'One', 'fixture-one'), entry(2, 'Two', 'fixture-two')],
     body: [heading(1, 'One', 'fixture-one')],
-    expect: /no matching section/,
+    expect: /body has no section 2/,
   },
 ];
 
@@ -153,7 +153,7 @@ test('a CONTENTS block aligned with spaces is still checked', async () => {
 
   const { code, stderr } = await checkText(text);
   assert.equal(code, 1);
-  assert.match(stderr, /does not match section 5/);
+  assert.match(stderr, /body has no section 2/);
 });
 
 test('a CONTENTS block with no readable rows fails rather than passing', async () => {
@@ -202,4 +202,100 @@ test('a numbered body line ending in a |tag| is not mistaken for a CONTENTS entr
 
   const { code, stderr } = await checkText(text);
   assert.equal(code, 0, stderr);
+});
+
+test('one renumbered section does not cascade into its neighbours', async () => {
+  // Walking the two lists in parallel turned a single mistake into a message per section after
+  // it, and the first one named a section that was fine. Number-keyed matching reports the two
+  // facts about section 3 and says nothing about sections 1 or 2.
+  const text = helpFile({
+    contents: [
+      entry(1, 'One', 'fixture-one'),
+      entry(2, 'Two', 'fixture-two'),
+      entry(3, 'Three', 'fixture-three'),
+    ],
+    body: [
+      heading(1, 'One', 'fixture-one'),
+      '',
+      RULE,
+      heading(2, 'Two', 'fixture-two'),
+      '',
+      RULE,
+      heading(9, 'Three', 'fixture-three'),
+    ],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /2 problem/);
+  assert.doesNotMatch(stderr, /section 1\b/);
+});
+
+test('a duplicated section number in CONTENTS is reported', async () => {
+  const text = helpFile({
+    contents: [entry(1, 'One', 'fixture-one'), entry(1, 'Again', 'fixture-again')],
+    body: [heading(1, 'One', 'fixture-one')],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /lists section 1 more than once/);
+});
+
+test('a duplicated section number in the body is reported', async () => {
+  const text = helpFile({
+    contents: [entry(1, 'One', 'fixture-one')],
+    body: [heading(1, 'One', 'fixture-one'), '', RULE, heading(1, 'Again', 'fixture-again')],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /more than one section numbered 1/);
+});
+
+test('sub-section numbering fails rather than being skipped in silence', async () => {
+  // Neither pattern can read `2.1`, so it used to drop out of the comparison without a word --
+  // checked-looking and unchecked.
+  const text = helpFile({
+    contents: [entry(1, 'One', 'fixture-one'), '    2.1 Sub ......... |fixture-sub|'],
+    body: [heading(1, 'One', 'fixture-one')],
+  });
+
+  const { code, stderr } = await checkText(text);
+  assert.equal(code, 1);
+  assert.match(stderr, /sub-section numbering/);
+});
+
+test('a directory with no help file at all fails', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'vibing-help-'));
+  try {
+    const result = spawnSync('nvim', ['--headless', '-l', 'scripts/check-help.lua', dir], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /no \*\.txt help file/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('every help file in the directory is checked, not just the first', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'vibing-help-'));
+  try {
+    await writeFile(join(dir, 'a.txt'), VALID);
+    // Second file is fine except for one overlong line.
+    await writeFile(join(dir, 'b.txt'), `${VALID}\n${'x'.repeat(90)}\n`);
+
+    const result = spawnSync('nvim', ['--headless', '-l', 'scripts/check-help.lua', dir], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /b\.txt:\d+: 90 columns/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Closes #575

PR #570 のレビューで挙がった4点。いずれも「チェックしているつもりで実はしていない／診断が正確でない」という同じ性質のものです。

## 1. 突き合わせが位置ベースだった → 番号キーに

エントリと見出しを並行に走査していたため、**1箇所の番号ずれが以降すべてをシフト**させ、1件のタイポが連鎖的なメッセージになり、しかも最初のメッセージは無関係なセクションを名指ししていました。

CONTENTS が 1,2 / 本文が 1,3 の場合:

| | 出力 |
| --- | --- |
| 変更前 | `CONTENTS entry 2. \|f-two\| does not match section 3. *f-two*` （2 と 3 を対で責める） |
| 変更後 | `CONTENTS lists 2. \|f-two\| but the body has no section 2`<br>`section 3. *f-two* is missing from CONTENTS` |

セクション番号をキーにしたので、両側の重複番号も検出できるようになりました。

「1件のずれが隣接セクションに波及しない」ことをテストで固定しています（`assert.doesNotMatch(stderr, /section 1\b/)`）。

## 2. 見出し走査が CONTENTS ブロックを含んでいた

`SECTION_HEADING` は全文スキャンでした。今は問題になりませんが、それは **一方が `|tag|` で終わり他方が `*tag*` で終わるという偶然**に依存しているだけで、何も保証していません。

エントリは CONTENTS ブロックの内側から、見出しは外側から読むようにしました。どちらの側もパターンの非重複に依存しません。

## 3. 入れ子番号（`2.1`）が黙ってスキップされていた

両方のパターンがドット直後の空白を要求するため、`2.1 Foo` はエントリとしても見出しとしても読まれず、**一言もなく比較対象から外れていました**。チェックされているように見えて、されていない状態です。

明示的に検出して失敗させます。サポートするかどうかは判断であるべきで、緑のまま気づかないのは本末転倒です。

```
f.txt:6: sub-section numbering (N.M) is not checked; flatten it or teach the checker
```

## 4. テストの穴を2つ埋めた

- `doc/` に `*.txt` が1件も無い場合（分岐は実装済みだったが未検証）
- `doc/` に **複数** の help ファイルがある場合（従来のフィクスチャは常に単一ファイルで、「全ファイルを見る」が未証明だった）

## テスト

`tests/help-check.test.mjs` は 13 → **19ケース**。既存3件は期待値を更新しています（バグではなく、上記1で診断が正確になったことによる文言変更）。

```
pnpm run check         exit 0
pnpm run check:doc     doc: 1 help file(s) OK
pnpm run test:lua      exit 0
pnpm run test:node     29 pass / 0 fail
pnpm run format:check  exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
