### PR TITLE
refactor: cache copilot's binary lookup like the other builders

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -170,6 +170,14 @@ chat UI frozen. And `execute()` now cancels a run that outlives its timeout inst
 and leaving the process alive; only grok did that. `cli_runtime_spec.lua` runs both over every
 backend.
 
+The pkill is asynchronous (`vim.system`, grok's form) rather than blocking (`vim.fn.system`, what
+codex and copilot used), because `cancel()` can be reached from a `vim.schedule` callback and
+should not stall the main loop there. The cost is that the parent's `kill(9)` is not sequenced
+after the children's: signal delivery is effectively immediate, so an orphan is theoretical rather
+than observed, but it is a real ordering change and not something a test can pin while the call is
+fire-and-forget. Revisit by chaining the parent kill onto the pkill's `on_exit` if orphans ever
+show up.
+
 **Chat (presentation + application):**
 
 - `presentation/chat/buffer.lua`, `view.lua`, `controller.lua` - Chat buffer and window

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -149,6 +149,12 @@ local function add_flag_if_present(cmd, flag, value)
   end
 end
 
+--- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec that
+--- wants to exercise the "CLI missing" path has to clear what an earlier spec resolved.
+function M._reset_path_cache()
+  binary_path.reset()
+end
+
 --- Build the `claude` CLI command array
 --- @param prompt string User prompt
 --- @param opts Vibing.AdapterOpts Adapter options
@@ -161,12 +167,6 @@ end
 ---   and without it the server falls back to the instance registry — which refuses to choose
 ---   once more than one Neovim is live, the normal case with worktrees and concurrent chats.
 --- @return string[] Command array for vim.system()
---- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec that
---- wants to exercise the "CLI missing" path has to clear what an earlier spec resolved.
-function M._reset_path_cache()
-  binary_path.reset()
-end
-
 function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
   local cmd = { binary_path.resolve() }
 

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -25,6 +25,12 @@ local function resolve_sandbox(permission_mode)
   return "workspace-write"
 end
 
+--- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec
+--- exercising the "CLI missing" path has to clear what an earlier spec resolved.
+function M._reset_path_cache()
+  binary_path.reset()
+end
+
 --- Build the `codex exec --json` command array
 --- @param prompt string User prompt
 --- @param opts Vibing.AdapterOpts Adapter options
@@ -32,11 +38,6 @@ end
 --- @param config Vibing.Config Plugin config
 --- @param hook_args string[]|nil Optional -c flag pair for PreToolUse hook injection
 --- @return string[] Command array for vim.system()
---- Forget the resolved binary path. Test seam only, same reason as cli_command_builder.
-function M._reset_path_cache()
-  binary_path.reset()
-end
-
 function M.build(prompt, opts, session_id, config, hook_args)
   local cmd = { binary_path.resolve(), "exec" }
 

--- a/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
@@ -37,19 +37,18 @@ local function append_permission_flags(cmd, opts)
   end
 end
 
+--- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec
+--- exercising the "CLI missing" path has to clear what an earlier spec resolved.
+function M._reset_path_cache()
+  binary_path.reset()
+end
+
 --- Build the `copilot -p --output-format json` command array
 --- @param prompt string User prompt
 --- @param opts Vibing.AdapterOpts Adapter options
 --- @param session_id string|nil Session ID for resumption
 --- @param config Vibing.Config Plugin config
 --- @return string[] Command array for vim.system()
---- Forget the resolved binary path. Test seam only, same reason as the other builders: the
---- cache is process-wide, so a spec exercising the "CLI missing" path has to clear what an
---- earlier spec resolved.
-function M._reset_path_cache()
-  binary_path.reset()
-end
-
 function M.build(prompt, opts, session_id, config)
   local cmd = { binary_path.resolve(), "--output-format", "json", "--stream", "on", "--no-color" }
 

--- a/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
@@ -5,6 +5,11 @@
 local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
 local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
 
+local binary_path = CommonBuilder.binary_resolver(
+  "copilot",
+  "Copilot CLI not found in PATH. Please install GitHub Copilot CLI."
+)
+
 local M = {}
 
 local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
@@ -38,13 +43,15 @@ end
 --- @param session_id string|nil Session ID for resumption
 --- @param config Vibing.Config Plugin config
 --- @return string[] Command array for vim.system()
-function M.build(prompt, opts, session_id, config)
-  local copilot_path = vim.fn.exepath("copilot")
-  if copilot_path == "" then
-    error("Copilot CLI not found in PATH. Please install GitHub Copilot CLI.")
-  end
+--- Forget the resolved binary path. Test seam only, same reason as the other builders: the
+--- cache is process-wide, so a spec exercising the "CLI missing" path has to clear what an
+--- earlier spec resolved.
+function M._reset_path_cache()
+  binary_path.reset()
+end
 
-  local cmd = { copilot_path, "--output-format", "json", "--stream", "on", "--no-color" }
+function M.build(prompt, opts, session_id, config)
+  local cmd = { binary_path.resolve(), "--output-format", "json", "--stream", "on", "--no-color" }
 
   if session_id then
     table.insert(cmd, "--resume=" .. session_id)

--- a/tests/lua/infrastructure/adapter/modules/binary_cache_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/binary_cache_spec.lua
@@ -1,0 +1,62 @@
+local helper = require("tests.helpers.adapter_stream")
+local Agents = require("vibing.core.constants.agents")
+
+--- grok is deliberately absent from the cached set: it resolves a configurable executable name and
+--- sniffs it for executability, which is a different operation from "look this name up on PATH
+--- once". Listing the exceptions here rather than deriving them keeps that a stated decision.
+local UNCACHED = { grok = true }
+
+describe("command builder binary caching", function()
+  local original_exepath
+
+  before_each(function()
+    original_exepath = vim.fn.exepath
+    helper.reset_path_caches()
+  end)
+
+  after_each(function()
+    vim.fn.exepath = original_exepath
+    helper.reset_path_caches()
+  end)
+
+  for _, def in ipairs(Agents.list()) do
+    if not UNCACHED[def.id] then
+      local builder = require(def.command_builder_module)
+
+      it(def.id .. " resolves its binary once, not once per request", function()
+        local lookups = 0
+        vim.fn.exepath = function(name)
+          lookups = lookups + 1
+          return "/usr/local/bin/" .. name
+        end
+
+        builder.build("hi", {}, nil, {}, nil)
+        builder.build("hi", {}, nil, {}, nil)
+        builder.build("hi", {}, nil, {}, nil)
+
+        assert.equals(1, lookups, def.id .. " called exepath " .. lookups .. " times")
+      end)
+
+      it(def.id .. " exposes the reset seam every cached builder needs", function()
+        -- Without it, one spec's resolved path outlives the spec and the next one's "CLI missing"
+        -- case never reaches the missing-CLI branch. helper.reset_path_caches walks the registry.
+        assert.is_function(builder._reset_path_cache)
+      end)
+
+      it(def.id .. " reports a missing binary rather than caching the absence", function()
+        vim.fn.exepath = function()
+          return ""
+        end
+
+        local ok, err = pcall(builder.build, "hi", {}, nil, {}, nil)
+        assert.is_false(ok)
+        assert.is_truthy(tostring(err):lower():find("not found", 1, true))
+
+        vim.fn.exepath = function(name)
+          return "/usr/local/bin/" .. name
+        end
+        assert.is_true(pcall(builder.build, "hi", {}, nil, {}, nil), "a later lookup should succeed")
+      end)
+    end
+  end
+end)


### PR DESCRIPTION
Closes #577

PR #572 のレビューで挙がった2点。

## 1. copilot だけバイナリパスをキャッシュしていなかった

#572 で `binary_resolver` に集約したのは claude と codex だけで、copilot は毎 build ごとに `vim.fn.exepath("copilot")` を呼んでいました。送信のたびに PATH 全体を走査するコストが乗ります。

同じ resolver に載せ替え、テストヘルパー（`helper.reset_path_caches` が agent registry を走査して探す）が要求する `_reset_path_cache` シームも追加しました。

**grok は意図的に対象外のままです。** 設定可能な実行ファイル名を解決し実行可能性を sniff するという、「1つの名前を PATH で一度引く」とは別の操作だからです。この例外は導出ではなく `binary_cache_spec.lua` に明記したので、将来のバックエンドを外すのは判断になります。

## 2. `kill_tree` の非同期化によるタイミング変更（記録）

#572 で `cancel()` を統一した際、pkill が `vim.fn.system`（同期）から `vim.system`（非同期・fire-and-forget）に変わりました。**親の `kill(9)` が子の kill 完了後に順序付けられなくなっています。**

シグナル配送は実質即時なので孤児プロセスは理論上の話であり観測されていませんが、実際の順序変更であることに変わりはなく、呼び出しが待たない以上テストで固定もできません。`architecture.md` に、その事実と「孤児が出たら pkill の `on_exit` に親 kill をチェーンする」という復帰手段を記録しました。

## テスト

`tests/lua/infrastructure/adapter/modules/binary_cache_spec.lua`（9ケース、新規）。キャッシュするビルダー全部（claude / codex / copilot）を3回 driving して:

- `exepath` の呼び出しが**1回だけ**であること（copilot は変更前なら3回で落ちます）
- reset シームが存在すること
- バイナリ不在は「不在をキャッシュ」せず、その後の解決が成功すること

```
pnpm run check         exit 0
pnpm run check:doc     doc: 1 help file(s) OK
pnpm run test:lua      exit 0
pnpm run test:node     23 pass / 0 fail
pnpm run format:check  exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified process cancellation behavior, including asynchronous termination and a potential orphan-process race.

- **Bug Fixes**
  - Improved command-line tool discovery and caching, including recovery when a previously unavailable tool becomes available.
  - Standardized binary resolution across supported agents.

- **Tests**
  - Added coverage for binary path caching, cache resets, repeated lookups, and missing-tool recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->