### PR TITLE
fix(codex): block MCP servers for real, and fail closed on a renamed key

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -277,11 +277,41 @@ Claude removes the tools outright with `--tools ""`. Codex cannot: probing its c
 `--strict-config` (which rejects unknown fields) against codex 0.147 shows `tools.shell`,
 `tools.apply_patch`, `tools.view_image`, `tools.plan_tool` and `tools.mcp` are all unknown fields,
 and `tools.web_search` is the only tool toggle that exists. So `codex_command_builder` fences the
-call in instead — `sandbox_mode="read-only"`, `tools.web_search=false`, `approval_policy="never"` —
-plus `mcp_servers={}` and `project_doc_max_bytes=0` — and `codex_cli.lua` skips hook
-registration, matching `claude_cli.lua`. Those last two are codex's answers to claude's
-`--strict-mcp-config`/`--mcp-config` and `--setting-sources ""`: without them a utility call
-still reached the user's MCP servers and still read `AGENTS.md`.
+call in instead — `sandbox_mode="read-only"`, `tools.web_search=false`, `approval_policy="never"`,
+`project_doc_max_bytes=0`, plus the flags `--ignore-user-config --strict-config` — and
+`codex_cli.lua` skips hook registration, matching `claude_cli.lua`. `project_doc_max_bytes=0` and
+`--ignore-user-config` are codex's answers to claude's `--setting-sources ""` and
+`--strict-mcp-config`/`--mcp-config`: without them a utility call still read `AGENTS.md` and still
+reached the user's MCP servers. `--strict-config` is not a fence of its own — it is what keeps the
+others from lapsing unnoticed.
+
+**`-c mcp_servers={}` used to stand in for that and did nothing**, which is what #574 was about.
+`-c` _deep-merges_ into `config.toml`, so an empty table adds no keys and removes none: measured
+against codex 0.147, `codex mcp list -c 'mcp_servers={}'` still lists every configured server, and
+under `codex exec` a server whose command touches a file was still launched and still wrote it.
+That last part makes it a boundary rather than a preference — codex spawns MCP servers itself, so
+the process runs **outside** the read-only sandbox. No narrower switch exists (`mcp.enabled`,
+`tools.mcp`, `features.mcp`, `mcp_enabled`, `disable_mcp` are all unknown fields; `mcp_servers=false`
+is a type error), and per-server `mcp_servers.<name>.enabled=false` works but needs a name list
+that goes stale the moment a server is added — silently, which is the failure mode being fixed.
+`--ignore-user-config` is therefore accepted along with its known cost: it also drops
+`model_provider`, so a user on a custom provider gets utility calls against the default OpenAI
+endpoint. Auth is unaffected; codex reads it from `CODEX_HOME` either way.
+
+`--ignore-user-config` does **not** cover `project_doc_max_bytes`. `AGENTS.md` is discovered from
+the cwd, not from `config.toml`, so dropping the user config only restores the key's 32768-byte
+default. Verified with `codex debug prompt-input`, which renders the model-visible prompt without
+calling the model: a marker line in `AGENTS.md` is present without the override and absent with it.
+
+**`--strict-config` is what stops the rest of that list from lapsing in silence.** Codex ignores
+unknown `-c` keys, so the day it renames or drops one, the fence would come off with no error and
+no warning — and unlike the degradation `rate_limit.lua` tolerates, what is lost here is a safety
+boundary whose absence is unobservable. With the flag, the utility call fails loudly instead. It is
+only safe **paired with `--ignore-user-config`**: on its own it also strictifies the user's
+`config.toml`, so one unrecognised field of their own would break every title generation — which is
+what made #571 reject the flag. With the user config unread it validates our overrides and nothing
+else. Both flags have existed since at least codex 0.140 and are accepted on `codex exec resume`
+too, so unlike `-s` neither is lost on the `/summarize` path.
 
 `read-only` blocks writes **and** network, verified by running commands under `codex sandbox`
 rather than read off the docs: a write reports `Operation not permitted` and `curl` returns
@@ -289,8 +319,8 @@ rather than read off the docs: a write reports `Operation not permitted` and `cu
 tool itself cannot be removed, so the sandbox is the only thing closing the exfiltration path
 a prompt injection in the summarized transcript would otherwise have.
 
-Three details there are not interchangeable. They are `-c` overrides rather than the `-s` flag
-because `/summarize` passes a session id and `codex exec resume` does not accept `-s`. The
+Three details there are not interchangeable. The restrictions are `-c` overrides rather than the
+`-s` flag because `/summarize` passes a session id and `codex exec resume` does not accept `-s`. The
 restriction ignores `permission_mode` entirely, `bypassPermissions` included: the user put the
 _chat_ in that mode, and a title generated behind their back is not the call they made. And
 `utility_model` still goes through the Claude-name filter, so its `sonnet` default becomes no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Breaking Changes
 
+- **The Codex backend now requires codex 0.140+.** Lightweight calls (chat title generation,
+  `/summarize`, daily summary) are run with `--ignore-user-config --strict-config`, so that they
+  cannot reach the user's MCP servers and so that a renamed Codex config key fails the call instead
+  of silently removing a restriction. Both flags were verified present in 0.140.0 and 0.147.0;
+  older releases were not tested. Ordinary chat is unaffected — only lightweight calls would fail,
+  with an unknown-argument error. Note that `--ignore-user-config` also drops `model_provider`, so
+  on a custom provider these utility calls now go to the default OpenAI endpoint.
+
 - **Remove the inline code action feature.** The `:VibingInline` command, its
   action picker/preview UI, and the `language.inline` configuration option have
   been removed. Use the chat interface (`:VibingChat`) for code assistance instead.

--- a/README.ja.md
+++ b/README.ja.md
@@ -78,10 +78,18 @@ vibing.nvim は補完プラグイン(Copilot、Codeium)や他のチャットプ�
 - **Node.js** 18+(MCP サーバー用)
 - AI CLI バックエンドを最低1つ:
   - **Claude CLI**(`claude`)— `npm install -g @anthropic-ai/claude-code`
-  - **Codex CLI**(`codex`)— `npm install -g @openai/codex`
+  - **Codex CLI**(`codex`)— `npm install -g @openai/codex`(**0.140+**。下の注記を参照)
   - **GitHub Copilot CLI**(`copilot`)— `npm install -g @github/copilot`
   - **Grok Build CLI**(`grok`)— [xAI のインストール手順](https://github.com/xai-org/grok-cli)を参照
     (Node.js 22+ が必要。MCP サーバー自体の要件 18+ より高い)
+
+> **Codex のバージョンについて。** vibing.nvim は Codex バックエンドの軽量呼び出し(チャットタイトル
+> 生成・`/summarize`・デイリーサマリー)を `--ignore-user-config --strict-config` 付きで実行します。
+> これによりユーザーの MCP サーバーに到達させず、また Codex 側が設定キーをリネームした際に「気づかない
+> まま制限が外れる」のではなく明示的に失敗するようにしています。両フラグは **0.140.0 と 0.147.0** で、
+> `codex exec` / `codex exec resume` の双方に存在することを確認済みです。それより古いバージョンは未検証
+> で、フラグが無い場合は通常のチャットには影響しませんが、軽量呼び出しが unknown argument エラーで
+> 失敗します。その場合は Codex を更新してください。
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim) を使う場合
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,18 @@ they compose well.
 - **Node.js** 18+ (for the MCP server)
 - At least one AI CLI backend:
   - **Claude CLI** (`claude`) — `npm install -g @anthropic-ai/claude-code`
-  - **Codex CLI** (`codex`) — `npm install -g @openai/codex`
+  - **Codex CLI** (`codex`) — `npm install -g @openai/codex` (**0.140+**; see note below)
   - **GitHub Copilot CLI** (`copilot`) — `npm install -g @github/copilot` (needs Node.js 22+,
     higher than the 18+ the MCP server itself requires)
   - **Grok Build CLI** (`grok`) — see [xAI's install docs](https://github.com/xai-org/grok-cli)
+
+> **Codex version note.** vibing.nvim runs the Codex backend's lightweight calls (chat title
+> generation, `/summarize`, daily summary) with `--ignore-user-config --strict-config`, which keeps
+> those calls out of your MCP servers and makes them fail loudly rather than silently unfenced if
+> Codex renames a config key. Both flags were verified present in **0.140.0 and 0.147.0**, on
+> `codex exec` and `codex exec resume` alike. Older releases were not tested; if they lack the
+> flags, ordinary chat is unaffected but lightweight calls fail with an unknown-argument error.
+> Upgrade Codex if you see that.
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 

--- a/lua/vibing/core/types.lua
+++ b/lua/vibing/core/types.lua
@@ -42,7 +42,7 @@
 ---@field on_tool_use_full fun(tool: string, input: table)? 表示用に間引かない生のツール入力（eval用）
 ---@field _session_id string?
 ---@field _session_id_explicit boolean?
----@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ。各アダプタは「ツールを使わせない・プロジェクト設定を読ませない・フックを登録しない・utility_model を使う」を果たす責務を負う（claude は --tools ""、codex は read-only サンドボックス）
+---@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ。各アダプタは「ツールを使わせない・プロジェクト設定とユーザー MCP サーバーを読ませない・フックを登録しない・utility_model を使う」、かつ「これらが CLI 側のスキーマ変更で黙って外れないこと」を果たす責務を負う（claude は --tools ""、codex は read-only サンドボックス + --ignore-user-config）
 
 ---@class Vibing.AdapterResponse
 ---@field content string?

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -79,6 +79,35 @@ function M.build(prompt, opts, session_id, config, hook_args)
     -- 000 where the same request outside the sandbox returns 200. That closes the exfiltration
     -- path a prompt injection in the summarized transcript would otherwise have, which matters
     -- because the shell tool itself cannot be taken away.
+    --
+    -- `--ignore-user-config` is what actually keeps the user's MCP servers out. It replaced
+    -- `-c mcp_servers={}`, which looked equivalent and did nothing: `-c` *deep-merges* into
+    -- config.toml, so an empty table adds no keys and removes none. Measured against codex
+    -- 0.147, not inferred -- `codex mcp list -c 'mcp_servers={}'` still lists every configured
+    -- server, and under `codex exec` a server whose command touches a file still got launched and
+    -- still wrote it. That last part is why this is a boundary and not a preference: codex spawns
+    -- MCP servers itself, so the process runs *outside* the read-only sandbox above. There is no
+    -- narrower switch -- mcp.enabled, tools.mcp, features.mcp, mcp_enabled and disable_mcp are all
+    -- unknown fields, `mcp_servers=false` is a type error, and per-server
+    -- `mcp_servers.<name>.enabled=false` works but needs a name list that would go stale silently
+    -- the moment the user added a server.
+    --
+    -- The cost is the one #571 named: this also drops model_provider, so a user on a custom
+    -- provider gets utility calls against the default OpenAI endpoint. Accepted now that the
+    -- alternative is known to be a hole rather than an equivalent. Auth is unaffected -- codex
+    -- reads it from CODEX_HOME either way.
+    table.insert(cmd, "--ignore-user-config")
+    -- `--strict-config` makes codex reject unknown config keys, so the day it renames or drops one
+    -- of the overrides below, the utility call fails loudly instead of quietly running unfenced.
+    -- Every restriction here is a safety boundary whose absence is otherwise unobservable, so this
+    -- fails closed on purpose (#574).
+    --
+    -- This is only safe in company with --ignore-user-config: on its own, --strict-config also
+    -- strictifies the user's config.toml, and one unrecognised field of their own would break
+    -- every title generation. With the user config unread, it validates our overrides and nothing
+    -- else. Both flags have existed since at least codex 0.140 and are accepted on
+    -- `codex exec resume` too, so unlike `-s` neither is lost on the /summarize path.
+    table.insert(cmd, "--strict-config")
     table.insert(cmd, "-c")
     table.insert(cmd, 'sandbox_mode="read-only"')
     table.insert(cmd, "-c")
@@ -87,13 +116,12 @@ function M.build(prompt, opts, session_id, config, hook_args)
     -- until the timeout. Verified value: one of untrusted/on-failure/on-request/granular/never.
     table.insert(cmd, "-c")
     table.insert(cmd, 'approval_policy="never"')
-    -- The other two halves of what `lightweight` promises (core/types.lua): no MCP tools and no
-    -- project instructions. These are codex's answers to claude's --strict-mcp-config/--mcp-config
-    -- and --setting-sources "". `--ignore-user-config` would cover both and is deliberately not
-    -- used: unlike claude's flag it also drops model_provider and base URL, so a user on a custom
-    -- provider would lose utility calls entirely.
-    table.insert(cmd, "-c")
-    table.insert(cmd, "mcp_servers={}")
+    -- The last piece of what `lightweight` promises (core/types.lua): no project instructions.
+    -- codex's answer to claude's --setting-sources "". `--ignore-user-config` does *not* cover
+    -- this: AGENTS.md is discovered from the cwd, not from config.toml, so ignoring the user
+    -- config only restores this key's 32768-byte default. Verified with `codex debug prompt-input`
+    -- (which renders the model-visible prompt without calling the model): a marker line in
+    -- AGENTS.md is present without this override and absent with it.
     table.insert(cmd, "-c")
     table.insert(cmd, "project_doc_max_bytes=0")
 

--- a/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
@@ -60,12 +60,20 @@ describe("codex_command_builder", function()
     end)
 
     it("reaches none of the user's MCP servers", function()
-      -- codex's answer to claude's --strict-mcp-config + empty --mcp-config.
+      -- Not `-c mcp_servers={}`: it deep-merged, so it removed nothing. See the builder.
       local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
-      assert.is_true(vim.tbl_contains(config_overrides(cmd), "mcp_servers={}"))
+      assert.is_not_nil(find_flag(cmd, "--ignore-user-config"))
+      assert.is_false(vim.tbl_contains(config_overrides(cmd), "mcp_servers={}"))
+    end)
+
+    it("rejects unknown config keys so a renamed one cannot unfence the call silently", function()
+      -- A key codex renames or drops must fail the call rather than quietly stop applying (#574).
+      local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
+      assert.is_not_nil(find_flag(cmd, "--strict-config"))
     end)
 
     it("reads no AGENTS.md, the way the claude path reads no CLAUDE.md", function()
+      -- Still needed alongside --ignore-user-config: AGENTS.md is found from the cwd.
       local cmd = codex_command_builder.build("hi", { lightweight = true }, nil, {}, nil)
       assert.is_true(vim.tbl_contains(config_overrides(cmd), "project_doc_max_bytes=0"))
     end)
@@ -120,11 +128,13 @@ describe("codex_command_builder", function()
         'sandbox_mode="read-only"',
         "tools.web_search=false",
         'approval_policy="never"',
-        "mcp_servers={}",
         "project_doc_max_bytes=0",
       }) do
         assert.is_false(vim.tbl_contains(overrides, restriction), restriction .. " leaked")
       end
+      -- An ordinary chat is where the user's MCP servers and their own config.toml are the point.
+      assert.is_nil(find_flag(cmd, "--ignore-user-config"))
+      assert.is_nil(find_flag(cmd, "--strict-config"))
       assert.equals("workspace-write", cmd[find_flag(cmd, "-s") + 1])
     end)
 
@@ -144,5 +154,34 @@ describe("codex_command_builder", function()
       local cmd = codex_command_builder.build("hi", {}, nil, config, nil)
       assert.equals("gpt-5-codex", cmd[find_flag(cmd, "-m") + 1])
     end)
+  end)
+
+  -- Checked structurally rather than on one fixture, because the risk is a *future* build that
+  -- sends --strict-config down a path where --ignore-user-config is gated more narrowly. Alone,
+  -- --strict-config also strictifies the user's own config.toml, so one unrecognised field of
+  -- theirs would break the call -- which is exactly why #571 rejected the flag in the first place.
+  describe("--strict-config never travels alone", function()
+    for _, case in ipairs({
+      { name = "lightweight, new session", opts = { lightweight = true }, session = nil },
+      { name = "lightweight, resumed", opts = { lightweight = true }, session = "thread-1" },
+      {
+        name = "lightweight in bypassPermissions",
+        opts = { lightweight = true, permission_mode = "bypassPermissions" },
+        session = nil,
+      },
+      { name = "ordinary call", opts = {}, session = nil },
+      { name = "ordinary plan mode", opts = { permission_mode = "plan" }, session = nil },
+      { name = "ordinary resumed", opts = {}, session = "thread-1" },
+    }) do
+      it("holds for " .. case.name, function()
+        local cmd = codex_command_builder.build("hi", case.opts, case.session, {}, nil)
+        if find_flag(cmd, "--strict-config") then
+          assert.is_not_nil(
+            find_flag(cmd, "--ignore-user-config"),
+            "--strict-config without --ignore-user-config would strictify the user's config.toml"
+          )
+        end
+      end)
+    end
   end)
 end)


### PR DESCRIPTION
## 概要

#571 で入れた lightweight 呼び出しの安全機構のうち、`-c mcp_servers={}` が **実際には何もしていなかった** ことを実機で確認し、修正しました。あわせて #574 本題である「キーが黙って外れる」問題を `--strict-config` で塞いでいます。

検証は npm 経由で codex 0.147.0（#571 と同じバージョン）を一時ディレクトリに入れて実施しました。ユーザーの `~/.codex/config.toml` は一切書き換えず、`CODEX_HOME` を一時ディレクトリに向けています。

## 1. `-c mcp_servers={}` は no-op だった（実測）

codex の `-c` は config.toml に **ディープマージ** します。空テーブルはキーを足しも消しもしません。

| 試行 | 結果 |
| --- | --- |
| `codex mcp list -c 'mcp_servers={}'` | 設定済みサーバーが**全部そのまま並ぶ** |
| `codex mcp list -c 'mcp_servers.foo.command="CHANGED"'` | `foo` だけ書き換わる（= `-c` 自体は効いている） |
| `codex exec -c 'sandbox_mode="read-only"' -c 'mcp_servers={}'` | MCP サーバーが**起動し、ファイルを書き込んだ** |

最後の行が重要です。MCP サーバーは codex 自身が spawn するため、その**プロセスは read-only サンドボックスの外**で動きます。つまり #571 で塞いだつもりの経路は開いたままで、しかもサンドボックスの外側でした。

代替キーは存在しませんでした（`--strict-config` で全部 unknown field）:
`mcp.enabled` / `tools.mcp` / `features.mcp` / `mcp_enabled` / `disable_mcp`、`mcp_servers=false` は型エラー。

サーバー個別の `mcp_servers.<name>.enabled=false` は効きますが、名前一覧が必要で、ユーザーがサーバーを足した瞬間に**黙って**古くなります。それはまさに本 issue が潰そうとしている失敗モードなので採りませんでした。

→ **`--ignore-user-config` を採用**（起動をブロックすることを実測で確認）。

### 代償について

#571 が挙げた懸念（`model_provider` が落ちる）は実測で確認しました。カスタムプロバイダ利用者の lightweight 呼び出しは既定の OpenAI エンドポイントに向きます。

| | provider |
| --- | --- |
| `--ignore-user-config` なし | `myprov`（config.toml 通り） |
| あり | `openai` |

それでも採用したのは、**比較対象が「同等の代替」ではなく「開いた穴」だと判明した**ためです。認証は影響を受けません（codex はどちらでも `CODEX_HOME` から読む）。ここは判断が分かれうる点なので、異論があれば戻せます。

## 2. `--strict-config` で fail-closed（#574 本題）

codex は未知の `-c` キーを黙って無視します。将来リネーム／削除されれば、エラーも警告もなくフェンスだけが外れます。`--strict-config` を付けると、その日に呼び出しが**大きな音を立てて失敗**します。

issue の案1が抱えていた「ユーザーの config.toml の未知フィールドで全部落ちる」問題は、**`--ignore-user-config` と併用することで消滅**します（config.toml を読まないので、厳格化の対象が自分のオーバーライドだけになる）。実測:

| 条件 | 結果 |
| --- | --- |
| `--strict-config` 単独 + config.toml に未知フィールド | ❌ 落ちる（案1の弱点を再現） |
| `--ignore-user-config --strict-config` + 同じ config.toml | ✅ 通る |
| 同上 + オーバーライド側のキーをリネーム | ✅ `unknown configuration field ... in -c/--config override` で落ちる |

つまり案1を、その副作用なしで成立させられました。起動時 probe（案2）や版数検知（案3）は不要になったため入れていません。

この「2つは必ずセット」という不変条件は、fixture 1件ではなく**構造的に**（lightweight/resume/bypassPermissions/通常/plan の6ケースを走査して）spec で固定しています。

## 3. `project_doc_max_bytes=0` は残す

`--ignore-user-config` ではカバーされません。AGENTS.md は config.toml ではなく **cwd から** 探されるため、ユーザー設定を捨てても既定値 32768 に戻るだけです。`codex debug prompt-input`（モデルを呼ばずに model-visible prompt を出す）で確認: オーバーライド無しではマーカー行が入り、有りでは消えます。

## 互換性

`--ignore-user-config` / `--strict-config` はいずれも codex **0.140 以降**に存在し、`codex exec` と `codex exec resume` の**両方**が受け付けます（`-s` と違い `/summarize` 経路でも失われない）。0.140 と 0.147 の両方で確認済み。

## テスト

`pnpm run check` / `check:doc` / `lint` / `format:check` / `test:lua`（exit 0、全 104 spec の Failed/Errors が 0）/ `test:node`（32/32）。`codex_command_builder_spec.lua` は 21 件緑。`test:e2e` と `test:eval` は実トークンを消費するため未実行です。

生成される argv（実機で両経路とも parse 確認済み）:

```
codex exec --json --ignore-user-config --strict-config \
  -c sandbox_mode="read-only" -c tools.web_search=false \
  -c approval_policy="never" -c project_doc_max_bytes=0 <prompt>
```

## 未検証・スコープ外

- **MCP ツール経由の実挙動そのもの**は未検証です。認証が必要でトークンを消費するため、確認したのは「サーバープロセスが起動するか」までです（起動しなければツールにも到達し得ないので、境界としては十分と判断）。
- **copilot / grok は依然 `lightweight` を一切解釈しません**（#571 で明示的にスコープ外とされたまま）。タイトル生成中に任意のツールが動くリスクはこの2バックエンドに残っています。別 issue で追跡する価値があります。
- `--ignore-user-config` は `model_provider` 以外に `shell_environment_policy` や `notify` 等も落とします。lightweight 呼び出しに限られるため実害は小さいと判断しましたが、網羅的には確認していません。

Closes #574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Lightweight Codex operations now reliably use read-only access, disable web search, and restrict automatic approvals.
  - User and project configuration, including MCP servers and project instructions, is excluded from lightweight operations.
  - Configuration overrides are strictly validated for safer behavior.
  - Custom-provider lightweight calls use the default OpenAI endpoint; ordinary chat behavior is unchanged.

- **Documentation**
  - Codex CLI 0.140+ is now required, with upgrade guidance for older versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->