### PR TITLE
feat(copilot): support the in-chat Tool Approval UI

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -407,6 +407,13 @@ skipping `ensure` for a lightweight call only skips _rewriting_ it. Any project 
 ordinary grok chat still has the hook on disk, and a utility call is by definition something that
 happens after a chat.
 
+**Copilot does not have grok's problem**, despite also writing its hook into the project tree. The
+generated plugin under `<cwd>/.vibing/copilot-plugin/` is reachable only through `--plugin-dir`,
+which the lightweight branch never emits — copilot auto-discovers hooks from `~/.copilot/hooks/`,
+`.github/hooks/`, its policy dirs and `settings.json`, and vibing.nvim writes none of those. So a
+leftover plugin from an earlier chat is inert, and skipping generation really does leave the run
+hookless, the way it does for claude and codex.
+
 That is why `todo_write` had to be added to `grok_tool_vocabulary`. It is claude's `TodoWrite`
 under another name; unmapped, the raw name reached `can_use_tool`, missed the `INTERNAL_TOOLS`
 always-allow list, matched nothing in the default allow list and resolved to `ask` — which

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -151,7 +151,13 @@ These are the seams that stop backend identity leaking into shared code. The rul
      well above the ~120s that `pre-tool-use.sh` waits before denying.
 
   The payload differs too — `toolName` with `toolArgs` as a JSON _string_ — which
-  `copilot_tool_vocabulary.normalize_payload` handles, the same seam grok uses.
+  `copilot_tool_vocabulary.normalize_payload` handles, the same seam grok uses. Every name in that
+  table except `powershell` and `rg` was read off a real payload; those two come from GitHub's
+  hooks reference and are kept because a missing alias lets a deny rule fall open, while a
+  never-sent one is inert.
+
+  A subagent's own tool calls reach this hook as well, under their own names (`task` fires, then
+  the `bash` the subagent runs) — so the gate covers delegated work, not just the top-level turn.
 
   **Why the backend name is in the shared script**, against the rule above: what varies is not
   only the JSON shape but the deny _signalling convention_ — Claude denies with exit 2 + stderr,

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -86,7 +86,9 @@ path, export name, description, model candidates. `factory.lua`, `modes.lua` (`V
 from it, so adding a backend is a one-file change (grok was added that way). It deliberately requires nothing, which
 is what keeps the dependency one-way.
 
-Two things stop backend identity leaking into shared code:
+These are the seams that stop backend identity leaking into shared code. The rule they encode:
+**a backend name belongs in that backend's own module, and shared code takes what it is handed.**
+`bin/hooks/pre-tool-use.sh` is the one deliberate exception, and the last bullet says why.
 
 - **Tool vocabulary.** Backends name their tools differently (codex calls an edit `apply_patch`,
   copilot uses `bash`/`view`/`create`/`edit`/`web_search`, grok `search_replace`/
@@ -121,10 +123,52 @@ Two things stop backend identity leaking into shared code:
   once per cwd instead. `$GROK_HOME` is grok's own documented override and is honoured — which is
   also the seam the specs use, since folder trust cascades to subdirectories and never expires.
 
-- **`dynamic_permissions` capability.** `adapter:supports("dynamic_permissions")` is `false` for
-  copilot, because its CLI has no per-run hook flag: permissions are fixed at launch with
-  `--allow-all-tools` + `--deny-tool`, so `permission_mode`, the `ask` list and the approval UI do
-  nothing there. Declared rather than left to be discovered by reading the adapter.
+- **Copilot injects its hook as a plugin.** Copilot has no per-run hook flag, and the two places
+  it reads hooks from are both off limits: `~/.copilot/` is the user's own config and
+  `.github/hooks/` is their repository. But `copilot --plugin-dir <dir>` loads a plugin for that
+  run only, and a plugin may contribute hooks — so `copilot_settings_generator.lua` writes a
+  throwaway plugin to `<cwd>/.vibing/copilot-plugin/` and points `--plugin-dir` at it. The hooks
+  are inlined in `plugin.json` (one file, no sibling `hooks.json`), which works only as a bare
+  event map: the `{"version": 1, "hooks": …}` envelope a standalone hooks file requires is
+  silently ignored when inlined — both forms were run against the CLI.
+  That is what makes `dynamic_permissions` true for copilot. Unlike grok's, it does **not** need a
+  git repository (checked by running copilot in a non-git cwd and reading its own log).
+
+  Three things about copilot's hook contract were captured from copilot 1.0.78 rather than read
+  off its docs, and each one silently disables the gate if got wrong:
+
+  1. **Its schema is not Claude's.** The event is lowercase `preToolUse`, the command goes under
+     `bash`, and the timeout is `timeoutSec`. A matcher in a camelCase event is compiled as a
+     regex, so Claude's `*` is rejected — `~/.copilot/logs` reports "Invalid matcher regex … hook
+     will be skipped" and every tool runs unchecked. The generated file omits the matcher.
+  2. **It reads a flat decision.** `{"permissionDecision":…}` on stdout; the
+     `{"hookSpecificOutput":{…}}` wrapper is ignored, and a nested deny let the tool run. Exit 2
+     denies too, but the model is told only "hook exited with code 2" — stderr is dropped, where
+     Claude uses it to carry the reason. So `pre-tool-use.sh` takes a `copilot` argument and
+     unwraps the response instead of re-encoding it (a reason containing a quote survives).
+  3. **A hook timeout fails _open_.** Every non-zero exit fails closed, but a hook that outlives
+     `timeoutSec` is ignored and the tool proceeds. The generated `timeoutSec` therefore stays
+     well above the ~120s that `pre-tool-use.sh` waits before denying.
+
+  The payload differs too — `toolName` with `toolArgs` as a JSON _string_ — which
+  `copilot_tool_vocabulary.normalize_payload` handles, the same seam grok uses.
+
+  **Why the backend name is in the shared script**, against the rule above: what varies is not
+  only the JSON shape but the deny _signalling convention_ — Claude denies with exit 2 + stderr,
+  copilot with exit 0 + stdout. That is shell semantics, so it lives in the shell. The
+  alternatives are worse: a second script would duplicate the ~90 lines that are the security
+  half of this one (comm dir, atomic `.req` rename, `nc` fail-closed, the 120s poll, the timeout
+  deny), and a fail-closed protocol that exists twice is one that drifts into failing open;
+  writing the decision in the backend's own format from `permission.lua` would move process
+  control into Lua and force the handler — which deliberately knows no backend name — to pick an
+  encoder, including on the fallback deny path where no `active_opts` resolve. Passing no
+  argument selects Claude's convention, which is what the other three backends do.
+
+  The gate is skipped in two cases, both by `copilot_cli.lua` rather than the generator:
+  `bypassPermissions` (the mode asked for no gate) and `lightweight` (`core/types.lua` obliges
+  every adapter to register no hooks for utility calls). And installing it is allowed to fail:
+  the generator runs under `pcall`, and a failure warns and falls back to the static
+  `--deny-tool` flags rather than taking the turn down.
 
 ## Module Structure
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -370,13 +370,13 @@ graph TB
 setup の `adapter = "claude"|"codex"|"copilot"` でグローバルに、チャットファイルの frontmatter に
 `agent: claude` / `agent: codex` / `agent: copilot` を書けばチャット単位で切り替えられます。
 
-> **注意:** Copilot バックエンドはチャット内のツール承認 UI に未対応です。`--allow-all-tools` で
-> 実行され、`permissions.deny` は copilot の `--deny-tool` フラグ経由で反映されます。
-> `permissions.ask` を強制しているのは承認 UI なので、Copilot では ask リストは効果がなく、
-> 指定したツールは確認なしで実行されます。実行させたくないものは `permissions.deny` に入れてください。
-> `permissions.deny` が対応するのは `Bash`(`Bash(cmd:*)` 形式を含む)・`Write`・`Edit`・`WebFetch`・
-> `WebSearch` です。それ以外のツール名は Copilot 側に対応する権限パターンが無いため無視され、
-> その際は一度だけ警告を出します。
+> **注意:** Copilot バックエンドでは、`permissions.mode`・`permissions.ask`・チャット内のツール
+> 承認 UI を、vibing.nvim が生成する Copilot プラグイン(`.vibing/copilot-plugin/`)経由で適用
+> します。これは実行ごとに `copilot --plugin-dir` で読み込まれるもので、ユーザーの
+> `~/.copilot/` の設定・ログイン情報には一切触れません。Copilot の静的な `--deny-tool` フラグも
+> 引き続きバックストップとして渡します。対応するのは `Bash`(`Bash(cmd:*)` 形式を含む)・
+> `Write`・`Edit`・`WebFetch`・`WebSearch` で、Copilot 側に権限パターンが無いツール名を落とす
+> 際は一度だけ警告を出します。
 
 ### なぜ Node.js が必要なのですか?
 

--- a/README.md
+++ b/README.md
@@ -381,13 +381,12 @@ graph TB
 Switch globally with `adapter = "claude"|"codex"|"copilot"|"grok"` in setup, or per-chat by adding
 `agent: claude`, `agent: codex`, or `agent: copilot` to a chat file's YAML frontmatter.
 
-> **Note:** the Copilot backend does not yet support the in-chat Tool Approval UI. It runs with
-> `--allow-all-tools` and honors the `permissions.deny` list via copilot's `--deny-tool` flag.
-> Because the approval UI is what enforces `permissions.ask`, that list has no effect on Copilot —
-> tools listed there run without prompting. Use `permissions.deny` for anything that must not run.
-> `permissions.deny` covers `Bash` (including `Bash(cmd:*)` patterns), `Write`, `Edit`, `WebFetch`,
-> and `WebSearch`; Copilot has no permission pattern for the other tool names, and vibing.nvim
-> warns once when it drops one.
+> **Note:** on the Copilot backend, `permissions.mode`, `permissions.ask` and the in-chat Tool
+> Approval UI are enforced through a generated Copilot plugin (`.vibing/copilot-plugin/`) that
+> vibing.nvim loads per run with `copilot --plugin-dir`. Your own `~/.copilot/` configuration and
+> login are never touched. Copilot's static `--deny-tool` flags are still passed as a backstop;
+> they cover `Bash` (including `Bash(cmd:*)` patterns), `Write`, `Edit`, `WebFetch` and
+> `WebSearch`, and vibing.nvim warns once when it drops a tool name Copilot cannot express.
 
 ### Why does it require Node.js?
 

--- a/bin/hooks/pre-tool-use.sh
+++ b/bin/hooks/pre-tool-use.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 # vibing.nvim pre-tool-use hook
 # Communicates with Neovim RPC server to check tool permissions
+#
+# Usage: pre-tool-use.sh [claude|copilot]
+#
+# The RPC protocol is identical for every backend; only the way a decision is handed back to the
+# CLI differs, hence the argument. Claude (and the CLIs that copy its hook schema) read a nested
+# {"hookSpecificOutput":{...}} object and take the deny reason from stderr. Copilot reads a FLAT
+# {"permissionDecision":...} object and ignores both the wrapper and stderr -- verified against
+# copilot 1.0.78, where a nested deny ran the tool anyway and an exit 2 reported only "hook exited
+# with code 2" to the model.
+FORMAT="${1:-claude}"
 
 debug_log() {
   [ -n "$VIBING_DEBUG" ] && echo "$(date) $1" >> "/tmp/vibing-hook-debug.log"
@@ -49,7 +59,11 @@ if [ "$NC_STATUS" -ne 0 ]; then
   exit 2
 fi
 
-# Poll for response file (max 120 seconds)
+# Poll for response file (max 120 seconds, in 0.1s ticks)
+# Raising this is not local to this script: copilot ignores a hook that outlives its own
+# `timeoutSec` and runs the tool anyway, so HOOK_TIMEOUT_SEC in
+# lua/vibing/infrastructure/hooks/copilot_settings_generator.lua must stay above it. Its spec
+# reads MAX_WAIT back out of this file and fails if the two ever cross.
 ELAPSED=0
 MAX_WAIT=1200
 while [ ! -f "$RES_FILE" ] && [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
@@ -64,10 +78,33 @@ if [ -f "$RES_FILE" ]; then
 
   DECISION=$(echo "$RESPONSE" | grep -o '"permissionDecision":"[^"]*"' | head -1 | cut -d'"' -f4)
 
+  # Copilot's flat form. Produced by unwrapping the response rather than re-encoding the fields,
+  # so a reason containing quotes or backslashes stays escaped exactly as vim.json.encode wrote
+  # it -- rebuilding the JSON from grep/cut output would emit an unparsable object for those, and
+  # a hook whose output does not parse is read as "no decision", i.e. the tool runs.
+  flat_decision() {
+    local body="${RESPONSE#\{\"hookSpecificOutput\":}"
+    # Returns non-zero when the wrapper was not there to strip, i.e. the response has a shape this
+    # script does not recognise. Callers must not print a half-unwrapped object: copilot reads
+    # output it cannot parse as "no decision", which under --allow-all-tools runs the tool.
+    [ "$body" = "$RESPONSE" ] && return 1
+    printf '%s' "${body%\}}"
+  }
+
   case "$DECISION" in
     deny)
       REASON=$(echo "$RESPONSE" | grep -o '"permissionDecisionReason":"[^"]*"' | head -1 | cut -d'"' -f4)
       debug_log "DENY: $REASON"
+      if [ "$FORMAT" = "copilot" ]; then
+        # Exit 0, not 2: both deny, but exit 2 replaces the reason with a generic message, and the
+        # reason is the only way a deny rule's `message` reaches the model. Every *failure* path
+        # below still exits non-zero, which copilot also fails closed on.
+        if flat_decision; then
+          exit 0
+        fi
+        # Unrecognised response shape. Fall through to the exit-2 deny: it loses the reason, but
+        # it still denies, where printing an object copilot cannot parse would let the tool run.
+      fi
       echo "${REASON:-Denied by vibing.nvim}" >&2
       exit 2
       ;;
@@ -76,6 +113,11 @@ if [ -f "$RES_FILE" ]; then
       # printing this is NOT a grant -- a silent exit 0 reads as "no opinion", and in headless
       # `-p` mode the gate it falls back to cannot prompt anyone, so the tool is refused (#564).
       debug_log "ALLOW (explicit grant)"
+      if [ "$FORMAT" = "copilot" ]; then
+        # An unwrap failure falls through to the nested form below, which copilot ignores — and
+        # since copilot runs with --allow-all-tools, no opinion still means the tool runs.
+        flat_decision && exit 0
+      fi
       printf '%s' "$RESPONSE"
       exit 0
       ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,10 +108,11 @@ adapter = "claude",  -- Global backend adapter
                      -- Overridable per-chat via the "agent" frontmatter field
 ```
 
-Backends are not feature-equivalent. `AskUserQuestion`'s choice-list UI is Claude-only, and
-`copilot` cannot honour `permissions.mode`, the `ask` list or the Tool Approval UI at all
-(`adapter:supports("dynamic_permissions")` is `false` for it). Grok does honour them, but only
-inside a git repository — see [Grok CLI](#grok-cli).
+Backends are not feature-equivalent. `AskUserQuestion`'s choice-list UI is Claude-only. Every
+backend honours `permissions.mode`, the `ask` list and the Tool Approval UI, but each one reaches
+them differently: `copilot` through a generated plugin loaded per run with `--plugin-dir` (written
+to `.vibing/copilot-plugin/`; your own `~/.copilot/` is never modified), and `grok` only inside a
+git repository — see [Grok CLI](#grok-cli).
 
 ## Grok CLI
 

--- a/docs/superpowers/specs/2026-08-10-copilot-cli-adapter-design.md
+++ b/docs/superpowers/specs/2026-08-10-copilot-cli-adapter-design.md
@@ -278,3 +278,8 @@ codex の `-c hooks.pre_tool_use=[...]` に相当する実行ごとの注入フ�
 3. `--available-tools` / `--excluded-tools` による静的な絞り込みで代替する
 
 本スコープの実装が動作確認できた後、この調査結果を添えて issue 化する。
+
+**追記 (#512 で解決済み)**: 上の 3 案はいずれも採用しなかった。プラグインが `hooks.json` を
+提供でき、`copilot --plugin-dir <dir>` がその実行限りでプラグインを読み込む — つまり実行ごとの
+フック注入手段は存在した。生成先は `<cwd>/.vibing/copilot-plugin/` で、`~/.copilot/` にも
+リポジトリにも触れない。詳細は `.claude/rules/architecture.md` を参照。

--- a/lua/vibing/infrastructure/adapter/copilot_cli.lua
+++ b/lua/vibing/infrastructure/adapter/copilot_cli.lua
@@ -9,6 +9,8 @@ local CopilotEventProcessor = require("vibing.infrastructure.adapter.modules.cop
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
 local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
 local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
+local CopilotSettingsGenerator = require("vibing.infrastructure.hooks.copilot_settings_generator")
+local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
 
 ---@class Vibing.CopilotCLIAdapter : Vibing.Adapter
 ---@field _handles table<string, table>
@@ -25,8 +27,7 @@ local SUPPORTED_FEATURES = {
   model_selection = true,
   context = true,
   session = true,
-  -- False here, true for the others: see architecture.md. #512 tracks making it real.
-  dynamic_permissions = false,
+  dynamic_permissions = true,
 }
 
 CliRuntime.install(CopilotCLI, SUPPORTED_FEATURES)
@@ -55,10 +56,31 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
   local handle_id = CliRuntime.new_handle_id()
   local session_id = opts._session_id
 
+  local cwd = opts.cwd or vim.fn.getcwd()
+
+  -- Generate the throwaway copilot plugin that registers bin/hooks/pre-tool-use.sh, and load it
+  -- with --plugin-dir. This is what gives copilot `permission_mode`, the `ask` list and the Tool
+  -- Approval UI (#512); a failure here degrades to the static --deny-tool flags rather than
+  -- taking the turn down with it. bypassPermissions asked for no gate at all, so it gets none,
+  -- and a lightweight call registers no hooks by contract (`core/types.lua`) — matching codex.
+  local permission_mode = opts.permission_mode or "default"
+  local plugin_dir
+  if permission_mode ~= "bypassPermissions" and not opts.lightweight then
+    local ok_hook, dir_or_err = pcall(CopilotSettingsGenerator.ensure, cwd)
+    if ok_hook then
+      plugin_dir = dir_or_err
+    else
+      vim.notify(
+        string.format("[vibing:copilot] Failed to install preToolUse hook: %s", tostring(dir_or_err)),
+        vim.log.levels.WARN
+      )
+    end
+  end
+
   -- The builder raises when the copilot binary is missing. The caller in send_message.lua
   -- does not wrap stream() in pcall, so without this the chat buffer would show a raw Lua
   -- stack trace instead of an actionable message.
-  local build_ok, cmd = pcall(CopilotCommandBuilder.build, prompt, opts, session_id, self.config)
+  local build_ok, cmd = pcall(CopilotCommandBuilder.build, prompt, opts, session_id, self.config, plugin_dir)
   if not build_ok then
     CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id
@@ -113,10 +135,16 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
     on_approval_required = opts.on_approval_required,
   })
 
+  -- Hands the permission handler this chat's frontmatter permissions plus copilot's tool
+  -- vocabulary, so the handler stays ignorant of which backend it is serving (#516).
+  local perm_handler = require("vibing.infrastructure.rpc.handlers.permission")
+  perm_handler.set_active_opts(handle_id, vim.tbl_extend("force", opts, { _tool_vocabulary = ToolVocabulary }))
+
   local wrapped_on_done = function(response)
     if not completed then
       completed = true
       ActiveStreamRegistry.unregister(handle_id)
+      perm_handler.clear_active_opts(handle_id)
       if timeout_timer then
         vim.fn.timer_stop(timeout_timer)
         timeout_timer = nil
@@ -125,16 +153,29 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
     end
   end
 
-  self._handles[handle_id] = vim.system(cmd, {
+  -- vim.system throws synchronously on spawn failure (e.g. invalid cwd) before any process
+  -- exists, so the registry/perm-handler state registered above would otherwise never be cleaned
+  -- up — and a stale permission entry is not inert: with a single entry left behind, the handler
+  -- falls back to it for hook calls that carry no matching handle_id. Matches grok_cli.lua.
+  local ok_spawn, handle_or_err = pcall(vim.system, cmd, {
     text = true,
     stdin = "",
-    cwd = opts.cwd or vim.fn.getcwd(),
+    cwd = cwd,
     env = env,
     stdout = StreamHandler.create_stdout_handler(CopilotEventProcessor, event_context, function()
       return self._handles[handle_id] == nil
     end),
     stderr = StreamHandler.create_stderr_handler(error_output),
   }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done))
+
+  if not ok_spawn then
+    ActiveStreamRegistry.unregister(handle_id)
+    perm_handler.clear_active_opts(handle_id)
+    on_done({ error = string.format("Failed to spawn copilot process: %s", tostring(handle_or_err)) })
+    return handle_id
+  end
+
+  self._handles[handle_id] = handle_or_err
 
   if debug_mode then
     local pid = self._handles[handle_id] and self._handles[handle_id].pid or "unknown"

--- a/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
@@ -29,11 +29,17 @@ local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_to
 --- no-op grok has for `--tools ""`.
 local NO_TOOLS_SENTINEL = "__vibing_no_tools__"
 
---- Append permission flags. copilot's non-interactive mode requires --allow-all-tools,
---- so denies are expressed with --deny-tool rather than an allow list.
+--- Append permission flags. copilot's non-interactive mode requires --allow-all-tools, so the
+--- real gate is the generated `preToolUse` hook (`--plugin-dir`, see copilot_settings_generator):
+--- it is what carries `permission_mode`, the `ask` list and the Tool Approval UI. The static
+--- `--deny-tool` patterns stay as a backstop that still applies if the plugin fails to load.
+---
+--- A lightweight call never reaches here — it takes the branch below instead, which is what keeps
+--- "registers no hooks" true for copilot no matter what the adapter passes.
 --- @param cmd string[]
 --- @param opts Vibing.AdapterOpts
-local function append_permission_flags(cmd, opts)
+--- @param plugin_dir string|nil Generated hook plugin directory, nil when hooks are not installed
+local function append_permission_flags(cmd, opts, plugin_dir)
   local permission_mode = opts.permission_mode or "default"
 
   if permission_mode == "bypassPermissions" then
@@ -45,6 +51,11 @@ local function append_permission_flags(cmd, opts)
     table.insert(cmd, "--plan")
   end
   table.insert(cmd, "--allow-all-tools")
+
+  if plugin_dir then
+    table.insert(cmd, "--plugin-dir")
+    table.insert(cmd, plugin_dir)
+  end
 
   for _, pattern in ipairs(ToolVocabulary.build_deny_patterns(opts.permissions_deny)) do
     table.insert(cmd, "--deny-tool")
@@ -86,8 +97,9 @@ end
 --- @param opts Vibing.AdapterOpts Adapter options
 --- @param session_id string|nil Session ID for resumption
 --- @param config Vibing.Config Plugin config
+--- @param plugin_dir? string Generated hook plugin directory to load with --plugin-dir
 --- @return string[] Command array for vim.system()
-function M.build(prompt, opts, session_id, config)
+function M.build(prompt, opts, session_id, config, plugin_dir)
   local cmd = { binary_path.resolve(), "--output-format", "json", "--stream", "on", "--no-color" }
 
   if session_id then
@@ -103,7 +115,7 @@ function M.build(prompt, opts, session_id, config)
   if opts.lightweight then
     append_lightweight_flags(cmd)
   else
-    append_permission_flags(cmd, opts)
+    append_permission_flags(cmd, opts, plugin_dir)
   end
 
   local full_prompt = prompt

--- a/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
@@ -10,16 +10,71 @@ local M = {}
 --- @type table<string, string>
 local NATIVE_TO_CANONICAL = {
   bash = "Bash",
+  powershell = "Bash",
   view = "Read",
   create = "Write",
   edit = "Edit",
+  glob = "Glob",
+  grep = "Grep",
+  rg = "Grep",
   web_search = "WebSearch",
+  web_fetch = "WebFetch",
+  task = "Task",
 }
+
+--- Where copilot puts the path a tool is about. Granular permission rules read `file_path` (the
+--- Claude convention), so a `paths` rule would never match a copilot tool without this.
+--- `file_path` itself is deliberately absent: an input that already has it is returned untouched.
+--- @type string[]
+local PATH_KEYS = { "path", "filePath" }
 
 --- @param native_tool_name string
 --- @return string|nil canonical name, or nil when there is no mapping
 function M.to_canonical(native_tool_name)
   return NATIVE_TO_CANONICAL[native_tool_name]
+end
+
+--- Copilot's preToolUse payload is camelCase, and its arguments arrive as a JSON *string* rather
+--- than an object:
+---
+---   {"sessionId":"…","cwd":"…","toolName":"bash","toolArgs":"{\"command\":\"echo hi\"}"}
+---
+--- Captured from copilot 1.0.78, not inferred from its docs. Without this the permission handler
+--- reads a nil tool name, so every rule misses and the turn stalls until the hook fails closed.
+--- @param hook_input table Raw decoded preToolUse payload
+--- @return table payload with `tool_name`/`tool_input` present. Never mutates the original.
+function M.normalize_payload(hook_input)
+  if type(hook_input) ~= "table" or hook_input.tool_name ~= nil or hook_input.toolName == nil then
+    return hook_input
+  end
+
+  local args = hook_input.toolArgs
+  if type(args) == "string" then
+    local ok, decoded = pcall(vim.json.decode, args)
+    args = ok and decoded or nil
+  end
+
+  return vim.tbl_extend("force", hook_input, {
+    tool_name = hook_input.toolName,
+    tool_input = type(args) == "table" and args or {},
+  })
+end
+
+--- @param tool_input table
+--- @return table input with `file_path` filled in when copilot named it something else. The
+---   original is never mutated: the same payload is also used to render the approval UI.
+function M.normalize_input(tool_input)
+  if type(tool_input) ~= "table" or tool_input.file_path then
+    return tool_input
+  end
+
+  for _, key in ipairs(PATH_KEYS) do
+    if tool_input[key] then
+      return vim.tbl_extend("force", tool_input, { file_path = tool_input[key] })
+    end
+  end
+
+  return tool_input
 end
 
 --- Map a vibing permission entry to a copilot permission pattern

--- a/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_tool_vocabulary.lua
@@ -6,20 +6,29 @@
 local M = {}
 
 --- Copilot's native tool names → the canonical vocabulary (`tools.lua`) that `ui.tool_markers`
---- and `permissions_*` are written in.
+--- and `permissions_*` are written in. A name missing from here reaches `can_use_tool` verbatim,
+--- where no `Grep`/`Task`/... rule can match it — so an absent entry silently disables a rule.
+---
+--- Every name below marked "seen" was read off a real preToolUse payload from copilot 1.0.78.
+--- The two marked "unseen" come from GitHub's own hooks reference (the `toolName` enum) and could
+--- not be produced on macOS: `powershell` needs a `pwsh` this machine does not have, and this
+--- install resolves text search to `grep`, never `rg`. They are kept rather than dropped because
+--- the two directions are not symmetric: an alias copilot never sends is dead weight, while a
+--- missing one lets a `Bash`/`Grep` **deny** rule fall open the first time it does send it. Both
+--- are unambiguous by meaning (pwsh is a shell, rg is ripgrep), so neither can be *mis*-mapped.
 --- @type table<string, string>
 local NATIVE_TO_CANONICAL = {
-  bash = "Bash",
-  powershell = "Bash",
-  view = "Read",
-  create = "Write",
-  edit = "Edit",
-  glob = "Glob",
-  grep = "Grep",
-  rg = "Grep",
-  web_search = "WebSearch",
-  web_fetch = "WebFetch",
-  task = "Task",
+  bash = "Bash", -- seen
+  powershell = "Bash", -- unseen (no pwsh on this platform)
+  view = "Read", -- seen
+  create = "Write", -- seen
+  edit = "Edit", -- seen
+  glob = "Glob", -- seen
+  grep = "Grep", -- seen
+  rg = "Grep", -- unseen (this install resolves search to `grep`)
+  web_search = "WebSearch", -- seen
+  web_fetch = "WebFetch", -- seen
+  task = "Task", -- seen; a subagent's own tool calls hit this hook too, under their own names
 }
 
 --- Where copilot puts the path a tool is about. Granular permission rules read `file_path` (the

--- a/lua/vibing/infrastructure/hooks/copilot_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/copilot_settings_generator.lua
@@ -1,0 +1,104 @@
+--- Copilot CLI hook settings generator
+--- Writes a throwaway Copilot *plugin* to <cwd>/.vibing/copilot-plugin/ whose manifest registers
+--- vibing's pre-tool-use.sh as a `preToolUse` hook. `copilot --plugin-dir <dir>` loads it for that
+--- run only, which is what gives the Copilot backend the Tool Approval UI (#512).
+---
+--- Why a plugin rather than the two hook locations Copilot documents: `~/.copilot/hooks/` is the
+--- user's own config (vibing.nvim must not write there) and `.github/hooks/` is the user's
+--- repository. `--plugin-dir` is per-run, needs no global state, and is the only one of the three
+--- that leaves both alone.
+--- @module vibing.infrastructure.hooks.copilot_settings_generator
+
+local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+local Fs = require("vibing.core.utils.fs")
+
+local M = {}
+
+--- Copilot requires a kebab-case plugin name (max 64 chars).
+local PLUGIN_NAME = "vibing-nvim-permissions"
+
+--- Copilot's own hook timeout **fails open** — a hook that runs longer than this is ignored and
+--- the tool proceeds, where every non-zero exit fails closed. pre-tool-use.sh gives up and denies
+--- after ~120s, so this has to stay comfortably above that number or a slow approval would turn
+--- into a silent allow.
+local HOOK_TIMEOUT_SEC = 300
+
+--- Absolute path to the generated plugin directory for a given cwd
+--- Resolved, so this reports the same path `ensure()` writes: that one resolves the cwd, and a
+--- symlinked working directory would otherwise make the two disagree.
+--- @param cwd string
+--- @return string
+function M.plugin_dir(cwd)
+  return vim.fn.resolve(cwd) .. "/.vibing/copilot-plugin"
+end
+
+--- Build the plugin manifest
+---
+--- The hooks are inlined rather than pointed at a sibling `hooks.json`, which keeps the plugin to
+--- a single file. Note the inline object is the bare event map: the `{"version": 1, "hooks": …}`
+--- envelope that a standalone hooks file requires is silently ignored here (both forms were run
+--- against copilot 1.0.78 — only this one reaches the hook registry).
+---
+--- The rest of the schema is Copilot's own, not Claude's: lowercase `preToolUse`, the command
+--- under `bash`, and `timeoutSec` rather than `timeout`. The matcher is omitted on purpose — in
+--- camelCase events it is compiled as a regex (`^(?:PATTERN)$`), so the `*` that means "all tools"
+--- in Claude's PascalCase form is rejected with "Invalid matcher regex … hook will be skipped"
+--- (observed in ~/.copilot/logs). No matcher means every tool.
+--- @param hook_command string Shell command line to run for each tool call
+--- @return table
+local function build_manifest(hook_command)
+  return {
+    name = PLUGIN_NAME,
+    description = "vibing.nvim tool approval bridge (generated; safe to delete)",
+    version = "1.0.0",
+    hooks = {
+      preToolUse = {
+        {
+          type = "command",
+          bash = hook_command,
+          timeoutSec = HOOK_TIMEOUT_SEC,
+        },
+      },
+    },
+  }
+end
+
+--- Ensure the Copilot plugin directory exists for the given cwd
+--- @param cwd? string Working directory (defaults to vim.fn.getcwd())
+--- @return string path Absolute path to the plugin directory, for `--plugin-dir`
+function M.ensure(cwd)
+  local dir = M.plugin_dir(cwd or vim.fn.getcwd())
+  Fs.ensure_dir(dir)
+
+  -- The `copilot` argument switches the script to Copilot's decision format; see the script.
+  -- Shell-escaped because Copilot runs this string through a shell, and a plugin path under a
+  -- checkout with a space in it would otherwise split into two arguments.
+  local script = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+  local hook_command = vim.fn.shellescape(script) .. " copilot"
+
+  -- Always regenerated: the hook script path moves when the plugin is updated or reinstalled.
+  --
+  -- Written through a temp file and renamed, because this path is shared by every chat open on
+  -- this cwd and each one rewrites it just before spawning its own copilot. Truncating in place
+  -- would give a copilot that happens to be reading the manifest at that moment a partial file —
+  -- and an unreadable manifest means no hook, which is the one failure mode that fails *open*.
+  -- rename(2) is atomic within a directory, so a concurrent reader sees either version whole.
+  local path = dir .. "/plugin.json"
+  local tmp_path = string.format("%s.%d.tmp", path, vim.loop.getpid())
+  local f, err = io.open(tmp_path, "w")
+  if not f then
+    error("Failed to create Copilot plugin manifest: " .. tmp_path .. " (" .. tostring(err) .. ")")
+  end
+  f:write(vim.json.encode(build_manifest(hook_command)))
+  f:close()
+
+  local ok, rename_err = os.rename(tmp_path, path)
+  if not ok then
+    os.remove(tmp_path)
+    error("Failed to install Copilot plugin manifest: " .. path .. " (" .. tostring(rename_err) .. ")")
+  end
+
+  return dir
+end
+
+return M

--- a/lua/vibing/infrastructure/hooks/copilot_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/copilot_settings_generator.lua
@@ -83,6 +83,12 @@ function M.ensure(cwd)
   -- would give a copilot that happens to be reading the manifest at that moment a partial file —
   -- and an unreadable manifest means no hook, which is the one failure mode that fails *open*.
   -- rename(2) is atomic within a directory, so a concurrent reader sees either version whole.
+  --
+  -- What makes one shared path safe at all is that the contents are the same for every chat: the
+  -- per-request identity (`VIBING_HANDLE_ID`, the RPC port) travels in copilot's environment, not
+  -- in this file. Anything that has to differ per chat therefore belongs in the environment too —
+  -- putting it here would make concurrent chats overwrite each other's manifest, and this
+  -- directory would have to become per-handle instead.
   local path = dir .. "/plugin.json"
   local tmp_path = string.format("%s.%d.tmp", path, vim.loop.getpid())
   local f, err = io.open(tmp_path, "w")

--- a/tests/copilot_cli_spec.lua
+++ b/tests/copilot_cli_spec.lua
@@ -18,6 +18,9 @@ describe("copilot_cli adapter", function()
     assert.is_true(adapter:supports("model_selection"))
     assert.is_true(adapter:supports("context"))
     assert.is_true(adapter:supports("session"))
+    -- The hook that backs this is generated per run and loaded with `copilot --plugin-dir`; the
+    -- flag is what the rest of the plugin reads to decide whether the approval UI can work here.
+    assert.is_true(adapter:supports("dynamic_permissions"))
     assert.is_false(adapter:supports("nonexistent_feature"))
   end)
 

--- a/tests/copilot_command_builder_spec.lua
+++ b/tests/copilot_command_builder_spec.lua
@@ -107,6 +107,22 @@ describe("copilot_command_builder", function()
       assert.is_true(contains(cmd, "write"))
     end)
 
+    it("loads the generated hook plugin with --plugin-dir", function()
+      local cmd = Builder.build("hi", { permission_mode = "default" }, nil, {}, "/proj/.vibing/copilot-plugin")
+      assert.are.equal("/proj/.vibing/copilot-plugin", value_after(cmd, "--plugin-dir"))
+    end)
+
+    it("omits --plugin-dir when no plugin was generated", function()
+      local cmd = Builder.build("hi", { permission_mode = "default" }, nil, {})
+      assert.is_false(contains(cmd, "--plugin-dir"))
+    end)
+
+    it("omits --plugin-dir under bypassPermissions", function()
+      -- The mode asked for no gate at all, so the hook that implements one is not loaded.
+      local cmd = Builder.build("hi", { permission_mode = "bypassPermissions" }, nil, {}, "/proj/plugin")
+      assert.is_false(contains(cmd, "--plugin-dir"))
+    end)
+
     it("ignores the deny list under bypassPermissions", function()
       local cmd = Builder.build("hi", {
         permission_mode = "bypassPermissions",

--- a/tests/copilot_command_builder_spec.lua
+++ b/tests/copilot_command_builder_spec.lua
@@ -117,6 +117,14 @@ describe("copilot_command_builder", function()
       assert.is_false(contains(cmd, "--plugin-dir"))
     end)
 
+    it("omits --plugin-dir for a lightweight call even when one is passed", function()
+      -- `lightweight` obliges every adapter to register no hooks (core/types.lua). The adapter
+      -- already declines to generate the plugin, so this pins the second half of that: the
+      -- lightweight branch cannot emit the flag no matter what it is handed.
+      local cmd = Builder.build("hi", { lightweight = true }, nil, {}, "/proj/.vibing/copilot-plugin")
+      assert.is_false(contains(cmd, "--plugin-dir"))
+    end)
+
     it("omits --plugin-dir under bypassPermissions", function()
       -- The mode asked for no gate at all, so the hook that implements one is not loaded.
       local cmd = Builder.build("hi", { permission_mode = "bypassPermissions" }, nil, {}, "/proj/plugin")

--- a/tests/copilot_tool_vocabulary_spec.lua
+++ b/tests/copilot_tool_vocabulary_spec.lua
@@ -15,15 +15,23 @@ describe("copilot_tool_vocabulary", function()
       assert.are.equal("WebSearch", Vocabulary.to_canonical("web_search"))
     end)
 
-    it("covers the search and fetch tools, which permission rules name canonically", function()
+    it("covers the search, fetch and subagent tools, which rules name canonically", function()
       -- Unmapped names reach can_use_tool verbatim, so a `Grep` entry in allow/ask/deny would
-      -- never match copilot's `grep` and the rule would silently do nothing.
+      -- never match copilot's `grep` and the rule would silently do nothing. Each name here was
+      -- read off a real preToolUse payload from copilot 1.0.78.
       assert.are.equal("Grep", Vocabulary.to_canonical("grep"))
-      assert.are.equal("Grep", Vocabulary.to_canonical("rg"))
       assert.are.equal("Glob", Vocabulary.to_canonical("glob"))
       assert.are.equal("WebFetch", Vocabulary.to_canonical("web_fetch"))
-      assert.are.equal("Bash", Vocabulary.to_canonical("powershell"))
+      -- `task` launches a subagent, so getting it wrong would quietly un-gate the whole feature.
       assert.are.equal("Task", Vocabulary.to_canonical("task"))
+    end)
+
+    it("keeps the aliases documented but not observed, since a missing one fails open", function()
+      -- Neither could be produced on macOS (no pwsh; this install searches with `grep`, not `rg`).
+      -- They come from GitHub's hooks reference. Dropping them would let a `Bash`/`Grep` deny rule
+      -- miss the first time copilot does send one; keeping them costs a dead table entry.
+      assert.are.equal("Bash", Vocabulary.to_canonical("powershell"))
+      assert.are.equal("Grep", Vocabulary.to_canonical("rg"))
     end)
 
     it("returns nil for a name it has no mapping for", function()

--- a/tests/copilot_tool_vocabulary_spec.lua
+++ b/tests/copilot_tool_vocabulary_spec.lua
@@ -15,6 +15,17 @@ describe("copilot_tool_vocabulary", function()
       assert.are.equal("WebSearch", Vocabulary.to_canonical("web_search"))
     end)
 
+    it("covers the search and fetch tools, which permission rules name canonically", function()
+      -- Unmapped names reach can_use_tool verbatim, so a `Grep` entry in allow/ask/deny would
+      -- never match copilot's `grep` and the rule would silently do nothing.
+      assert.are.equal("Grep", Vocabulary.to_canonical("grep"))
+      assert.are.equal("Grep", Vocabulary.to_canonical("rg"))
+      assert.are.equal("Glob", Vocabulary.to_canonical("glob"))
+      assert.are.equal("WebFetch", Vocabulary.to_canonical("web_fetch"))
+      assert.are.equal("Bash", Vocabulary.to_canonical("powershell"))
+      assert.are.equal("Task", Vocabulary.to_canonical("task"))
+    end)
+
     it("returns nil for a name it has no mapping for", function()
       assert.is_nil(Vocabulary.to_canonical("something_new"))
     end)
@@ -76,4 +87,57 @@ describe("copilot_tool_vocabulary", function()
     end)
   end)
 
+  describe("normalize_payload", function()
+    -- Shape captured from copilot 1.0.78's preToolUse hook, not read off its docs.
+    it("renames toolName/toolArgs and decodes the arguments, which arrive as a JSON string", function()
+      local normalized = Vocabulary.normalize_payload({
+        sessionId = "s-1",
+        cwd = "/proj",
+        toolName = "bash",
+        toolArgs = '{"command":"echo hi","description":"greet"}',
+      })
+
+      assert.are.equal("bash", normalized.tool_name)
+      assert.are.equal("echo hi", normalized.tool_input.command)
+    end)
+
+    it("accepts arguments that already arrived decoded", function()
+      local normalized = Vocabulary.normalize_payload({ toolName = "view", toolArgs = { path = "a.lua" } })
+      assert.are.equal("a.lua", normalized.tool_input.path)
+    end)
+
+    it("yields an empty input rather than failing when toolArgs is not JSON", function()
+      -- A tool whose arguments cannot be read still has to reach a permission decision; the
+      -- alternative is an error inside the handler and a turn that hangs until the hook denies.
+      local normalized = Vocabulary.normalize_payload({ toolName = "bash", toolArgs = "not json" })
+      assert.are.equal("bash", normalized.tool_name)
+      assert.are.same({}, normalized.tool_input)
+    end)
+
+    it("leaves a payload that already speaks the canonical shape alone", function()
+      local input = { tool_name = "Read", tool_input = { file_path = "a.lua" } }
+      assert.are.same(input, Vocabulary.normalize_payload(input))
+    end)
+
+    it("does not mutate the payload it was given", function()
+      local input = { toolName = "bash", toolArgs = '{"command":"ls"}' }
+      Vocabulary.normalize_payload(input)
+      assert.is_nil(input.tool_name)
+    end)
+  end)
+
+  describe("normalize_input", function()
+    it("fills in file_path from copilot's path key, which granular rules read", function()
+      assert.are.equal("a.lua", Vocabulary.normalize_input({ path = "a.lua" }).file_path)
+    end)
+
+    it("keeps an existing file_path", function()
+      local input = Vocabulary.normalize_input({ file_path = "kept.lua", path = "other.lua" })
+      assert.are.equal("kept.lua", input.file_path)
+    end)
+
+    it("leaves an input with no path alone", function()
+      assert.are.same({ command = "ls" }, Vocabulary.normalize_input({ command = "ls" }))
+    end)
+  end)
 end)

--- a/tests/lua/infrastructure/hooks/copilot_settings_generator_spec.lua
+++ b/tests/lua/infrastructure/hooks/copilot_settings_generator_spec.lua
@@ -1,0 +1,133 @@
+local CopilotSettingsGenerator = require("vibing.infrastructure.hooks.copilot_settings_generator")
+local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+
+--- Read the generated manifest for a cwd
+--- @param cwd string
+--- @return table
+local function read_manifest(cwd)
+  local path = CopilotSettingsGenerator.ensure(cwd) .. "/plugin.json"
+  local f = io.open(path, "r")
+  assert.is_not_nil(f, "expected " .. path .. " to exist")
+  local content = f:read("*a")
+  f:close()
+  local ok, decoded = pcall(vim.json.decode, content)
+  assert.is_true(ok, "expected valid JSON in " .. path)
+  return decoded
+end
+
+--- @param manifest table
+--- @return table the single preToolUse hook entry
+local function hook_entry(manifest)
+  return manifest.hooks.preToolUse[1]
+end
+
+describe("copilot_settings_generator", function()
+  local tmp_dir
+
+  before_each(function()
+    tmp_dir = vim.fn.tempname()
+    vim.fn.mkdir(tmp_dir, "p")
+  end)
+
+  after_each(function()
+    if tmp_dir then
+      vim.fn.delete(tmp_dir, "rf")
+    end
+  end)
+
+  it("writes the plugin under <cwd>/.vibing/, never the user's ~/.copilot", function()
+    local dir = CopilotSettingsGenerator.ensure(tmp_dir)
+
+    assert.equals(vim.fn.resolve(tmp_dir) .. "/.vibing/copilot-plugin", dir)
+    assert.equals(1, vim.fn.filereadable(dir .. "/plugin.json"))
+  end)
+
+  it("names the plugin in kebab-case, which copilot requires", function()
+    local manifest = read_manifest(tmp_dir)
+
+    assert.equals("vibing-nvim-permissions", manifest.name)
+    assert.is_truthy(manifest.name:match("^[a-z0-9%-]+$"))
+  end)
+
+  it("inlines the hooks as a bare event map", function()
+    -- Not a path to a sibling hooks.json, and not the {"version":1,"hooks":…} envelope a
+    -- standalone hooks file takes: copilot ignores that envelope when it is inlined here.
+    local manifest = read_manifest(tmp_dir)
+
+    assert.is_table(manifest.hooks)
+    assert.is_table(manifest.hooks.preToolUse)
+    assert.is_nil(manifest.hooks.hooks)
+    assert.is_nil(manifest.hooks.version)
+  end)
+
+  it("registers pre-tool-use.sh as a preToolUse command hook in copilot's own schema", function()
+    local entry = hook_entry(read_manifest(tmp_dir))
+
+    assert.equals("command", entry.type)
+    -- Copilot reads the command from `bash` and the timeout from `timeoutSec` — neither is
+    -- Claude's `command`/`timeout`, so a copy of the Claude settings would load and do nothing.
+    assert.is_string(entry.bash)
+    assert.is_nil(entry.command)
+    assert.is_nil(entry.timeout)
+    local script = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+    assert.is_truthy(entry.bash:find(script, 1, true), "must invoke the bundled hook script")
+    assert.is_truthy(entry.bash:match("%f[%w]copilot$"), "must select the copilot decision format")
+  end)
+
+  it("omits the matcher, which copilot compiles as a regex", function()
+    -- `*` is Claude's "all tools" matcher and an invalid regex here: copilot logs
+    -- "Invalid matcher regex ... hook will be skipped" and every tool runs unchecked.
+    assert.is_nil(hook_entry(read_manifest(tmp_dir)).matcher)
+  end)
+
+  it("allows more time than the hook script waits, because copilot fails open on timeout", function()
+    -- Every non-zero exit denies, but a hook that outlives timeoutSec is ignored and the tool
+    -- proceeds. This invariant spans two languages, so read the script's own budget rather than
+    -- restating it: raising MAX_WAIT for Claude's sake would otherwise silently turn a slow
+    -- copilot approval into an allow, with the suite still green.
+    local script = io.open(vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p"), "r")
+    local source = script:read("*a")
+    script:close()
+
+    local max_wait_ticks = tonumber(source:match("\nMAX_WAIT=(%d+)"))
+    assert.is_not_nil(max_wait_ticks, "could not read MAX_WAIT out of pre-tool-use.sh")
+
+    local script_wait_sec = max_wait_ticks / 10 -- the poll loop sleeps 0.1s per tick
+    assert.is_true(
+      hook_entry(read_manifest(tmp_dir)).timeoutSec > script_wait_sec,
+      "copilot's hook timeout must outlast the script's own wait"
+    )
+  end)
+
+  it("quotes the script path so a directory with a space stays one argument", function()
+    local spaced = tmp_dir .. "/with space"
+    vim.fn.mkdir(spaced, "p")
+
+    local command = hook_entry(read_manifest(spaced)).bash
+    assert.is_truthy(command:match("^['\"]"), "hook command must be shell-quoted: " .. command)
+  end)
+
+  it("rewrites the manifest when it is missing (the hook path moves on plugin update)", function()
+    local dir = CopilotSettingsGenerator.ensure(tmp_dir)
+    assert.equals(0, vim.fn.delete(dir .. "/plugin.json"))
+
+    assert.equals(dir, CopilotSettingsGenerator.ensure(tmp_dir))
+    assert.equals(1, vim.fn.filereadable(dir .. "/plugin.json"))
+  end)
+
+  it("leaves no temp file behind, so copilot never loads a half-written manifest", function()
+    -- The manifest is renamed into place rather than truncated: every chat open on this cwd
+    -- rewrites it just before spawning its own copilot, and an unreadable manifest means no hook
+    -- at all — the one failure mode here that fails open.
+    local dir = CopilotSettingsGenerator.ensure(tmp_dir)
+
+    assert.are.same({}, vim.fn.glob(dir .. "/*.tmp", false, true))
+  end)
+
+  it("reports plugin_dir for a cwd without writing anything", function()
+    local expected = vim.fn.resolve(tmp_dir) .. "/.vibing/copilot-plugin"
+    assert.equals(expected, CopilotSettingsGenerator.plugin_dir(tmp_dir))
+    assert.equals(0, vim.fn.isdirectory(expected))
+    assert.equals(CopilotSettingsGenerator.ensure(tmp_dir), expected)
+  end)
+end)

--- a/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
@@ -133,6 +133,38 @@ describe("permission handler tool vocabulary", function()
     assert.is_not_nil(read_response("req-grok"), "the hook must get a response, not a 120s stall")
   end)
 
+  it("decodes a payload whose arguments arrive as a JSON string", function()
+    -- Copilot's preToolUse payload, captured verbatim from copilot 1.0.78: camelCase like grok's,
+    -- but `toolArgs` is a *string* holding JSON rather than an object. Handed through unparsed,
+    -- every granular rule sees an empty input and the approval UI has nothing to render.
+    local vocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
+    permission.set_active_opts(HANDLE_ID, {
+      permissions_deny = { "Bash" },
+      _tool_vocabulary = vocabulary,
+    })
+
+    write_raw_request("req-copilot", {
+      sessionId = "936ec555-021d-4585-b1d0-8a2ed0a20285",
+      cwd = "/tmp/project",
+      toolName = "bash",
+      toolArgs = '{"command":"echo hello","description":"Print hello"}',
+    })
+    local result = permission.check_tool_permission({ request_id = "req-copilot", handle_id = HANDLE_ID })
+
+    assert.equals("denied", result.status)
+    assert.is_not_nil(read_response("req-copilot"), "the hook must get a response, not a 120s stall")
+  end)
+
+  it("lifts the path out of that decoded string, so paths rules have a file_path to match", function()
+    -- The whole chain in one go: decode toolArgs, then lift `path` to `file_path`. A granular
+    -- `paths` rule reads neither under copilot's own names.
+    local vocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
+    local normalized = vocabulary.normalize_input(
+      vocabulary.normalize_payload({ toolName = "edit", toolArgs = '{"path":"/tmp/project/.env"}' }).tool_input
+    )
+    assert.equals("/tmp/project/.env", normalized.file_path)
+  end)
+
   it("sends a deny rule's message to the hook, not just back to its own caller", function()
     -- pre-tool-use.sh echoes permissionDecisionReason on stderr; that is the only route by which
     -- a rule's `message` reaches the model. Omitting it renders every denial as "denied by hook".

--- a/tests/pre-tool-use-hook.test.mjs
+++ b/tests/pre-tool-use-hook.test.mjs
@@ -24,8 +24,9 @@ const HOOK = join(repoRoot, 'bin/hooks/pre-tool-use.sh');
 /**
  * Run the hook against a fake RPC server that answers with `hookOutput`.
  * @param {object} hookOutput value for hookSpecificOutput in the .res file
+ * @param {string[]} args argv for the hook (selects the CLI's decision format)
  */
-async function runHook(hookOutput) {
+async function runHook(hookOutput, args = []) {
   const commDir = await mkdtemp(join(tmpdir(), 'vibing-hook-test-'));
   const server = createServer((socket) => {
     socket.on('data', async (buf) => {
@@ -41,7 +42,7 @@ async function runHook(hookOutput) {
   try {
     await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
 
-    const child = spawn(HOOK, {
+    const child = spawn(HOOK, args, {
       env: {
         ...process.env,
         VIBING_NVIM_RPC_PORT: String(server.address().port),
@@ -98,4 +99,113 @@ test('deny blocks with the reason on stderr', async () => {
 
   assert.equal(code, 2);
   assert.match(stderr, /Cannot modify sensitive files/);
+});
+
+/*
+ * Copilot reads the same decisions differently, verified against copilot 1.0.78: it parses a FLAT
+ * object and ignores Claude's hookSpecificOutput wrapper (a nested deny ran the tool anyway), and
+ * it drops stderr on exit 2 (the model was told only "hook exited with code 2").
+ */
+
+test('copilot deny is a flat object on stdout, carrying the reason', async () => {
+  const { code, stdout } = await runHook(
+    {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: 'Cannot modify sensitive files',
+    },
+    ['copilot']
+  );
+
+  const decision = JSON.parse(stdout);
+  assert.equal(decision.permissionDecision, 'deny');
+  assert.equal(decision.permissionDecisionReason, 'Cannot modify sensitive files');
+  assert.equal(code, 0, 'exit 2 also denies, but replaces the reason with a generic message');
+});
+
+test('copilot deny stays parsable when the reason contains quotes', async () => {
+  // The flat object is produced by unwrapping the response, not by re-encoding the fields:
+  // rebuilding it from a grep/cut of the JSON truncates at the escaped quote and emits a
+  // trailing backslash, and copilot reads output it cannot parse as "no decision" — i.e. allow.
+  const reason = 'Refused: "rm -rf /" is a \\ destructive command';
+  const { stdout } = await runHook(
+    { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: reason },
+    ['copilot']
+  );
+
+  assert.equal(JSON.parse(stdout).permissionDecisionReason, reason);
+});
+
+test('copilot allow is a flat object too', async () => {
+  const { code, stdout } = await runHook(
+    { hookEventName: 'PreToolUse', permissionDecision: 'allow' },
+    ['copilot']
+  );
+
+  assert.equal(code, 0);
+  assert.equal(JSON.parse(stdout).permissionDecision, 'allow');
+});
+
+test('copilot defer still exits 0 in silence', async () => {
+  const { code, stdout } = await runHook(
+    { hookEventName: 'PreToolUse', permissionDecision: 'defer' },
+    ['copilot']
+  );
+
+  assert.equal(code, 0);
+  assert.equal(stdout, '');
+});
+
+test('copilot deny falls back to exit 2 when the response cannot be unwrapped', async () => {
+  // The unwrap anchors on the exact shape write_hook_response() emits. If that ever grows a
+  // top-level sibling key, the strip stops matching — and printing the untouched nested object
+  // would read as "no decision" on copilot, i.e. the denied tool runs. Deny fails closed instead.
+  const commDir = await mkdtemp(join(tmpdir(), 'vibing-hook-test-'));
+  const server = createServer((socket) => {
+    socket.on('data', async (buf) => {
+      const requestId = JSON.parse(buf.toString()).params.request_id;
+      await writeFile(
+        join(commDir, `${requestId}.res`),
+        JSON.stringify({
+          continue: false,
+          hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: 'nope' },
+        })
+      );
+      socket.end();
+    });
+  });
+
+  try {
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const child = spawn(HOOK, ['copilot'], {
+      env: {
+        ...process.env,
+        VIBING_NVIM_RPC_PORT: String(server.address().port),
+        VIBING_HOOK_COMM_DIR: commDir,
+      },
+    });
+    child.stdin.end(JSON.stringify({ toolName: 'bash', toolArgs: '{"command":"ls"}' }));
+
+    let stdout = '';
+    child.stdout.on('data', (c) => (stdout += c));
+    const code = await new Promise((resolve) => child.on('close', resolve));
+
+    assert.equal(code, 2, 'an unrecognised response shape must still deny');
+    assert.equal(stdout, '', 'and must not print an object copilot would ignore');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(commDir, { recursive: true, force: true });
+  }
+});
+
+test('copilot fails closed when the RPC server is unreachable', async () => {
+  // Non-zero exits deny on copilot as well; only a hook that outlives timeoutSec fails open,
+  // which is why the generated hooks.json allows more time than this script waits.
+  const child = spawn(HOOK, ['copilot'], {
+    env: { ...process.env, VIBING_NVIM_RPC_PORT: '1', VIBING_HOOK_COMM_DIR: tmpdir() },
+  });
+  child.stdin.end(JSON.stringify({ toolName: 'bash', toolArgs: '{"command":"ls"}' }));
+  const code = await new Promise((resolve) => child.on('close', resolve));
+
+  assert.equal(code, 2);
 });


### PR DESCRIPTION
Closes #512

## やったこと

Copilot バックエンドで `permissions.mode` / `permissions.ask` / チャット内のツール承認 UI が効くようになりました。`adapter:supports("dynamic_permissions")` も `true` になります。

### 採った方式: issue の 3 案ではなく `--plugin-dir`

issue に挙がっていた 3 案(案1 `COPILOT_HOME` 差し替え / 案2 `.github/hooks/` / 案3 静的絞り込み)はいずれも採用していません。実機調査の結果、**Copilot プラグインは hooks を提供でき、`copilot --plugin-dir <dir>` はその実行限りでプラグインを読み込む**ことが分かったためです。つまり codex の `-c hooks.pre_tool_use=[...]` に相当する実行ごとの注入手段は存在しました。

- 生成先は `<cwd>/.vibing/copilot-plugin/plugin.json` の 1 ファイルのみ(hooks は manifest にインライン)
- ユーザーの `~/.copilot/`(認証情報・MCP 設定)にもリポジトリにも**一切書き込みません** → 受け入れ条件を満たします
- `.vibing/` は既に gitignore 済みなので追加のルールは不要
- grok と違い **git リポジトリ外でも動作**します(非 git ディレクトリで実行して Copilot 自身のログで確認)

承認フロー自体は既存の `bin/hooks/pre-tool-use.sh` → RPC → `permission.lua` → チャットバッファをそのまま再利用しています。

## 実際に copilot 1.0.78 を叩いて確認したこと

以下はすべて**実機で実行して確認**した挙動です(ドキュメントからの推測ではありません)。どれも間違えるとゲートが黙って無効化されるものです。

| 確認事項 | 結果 |
| --- | --- |
| `--plugin-dir` のフックが実際に発火するか | ✅ 発火。`tool.execution_complete` が `denied` になることを確認 |
| deny 理由がモデルに届くか | ✅ フラットな JSON + exit 0 なら届く。引用符・バックスラッシュ入りの理由もそのまま到達 |
| exit 2 の挙動 | deny にはなるが **stderr は捨てられ**、理由が `hook exited with code 2` に置き換わる |
| Claude 形式のネスト JSON(`hookSpecificOutput`) | ❌ 解釈されず、**ツールがそのまま実行された** |
| defer(無言 exit 0) | ✅ ツールは許可される(通常動作を壊さないことを確認) |
| `matcher: "*"` | ❌ camelCase イベントでは正規表現として不正 → `Invalid matcher regex ... hook will be skipped` がログに出てフックが無効化される。よって matcher は省略 |
| インライン hooks の形式 | `{"version":1,"hooks":{...}}` の封筒付きは**無視される**。イベントマップ直書きのみ有効 |
| 非 git ディレクトリ | ✅ フックは読み込まれる(grok のような git 依存なし) |
| `VIBING_HANDLE_ID` の伝播 | ✅ フック子プロセスに継承され、RPC に正しい handle_id が届く(並行チャットの取り違えが起きない) |
| フックへの payload 形状 | `toolName` + `toolArgs` が**オブジェクトではなく JSON 文字列** |
| フックのタイムアウト | ドキュメント通り **fail open**(非ゼロ終了は fail closed)。よって `timeoutSec=300` をスクリプトの 120 秒待ちより長く設定 |

検証は fake RPC サーバー(Node)を立てて deny / defer の両経路を通しました。`~/.copilot/` への書き込みは行っていません。

## コードから推論しただけで未検証のこと

正直に分けて書きます。

- **実際の Neovim チャットでの承認 UI 表示は未実施**です。フック → RPC → 権限判定 → `.res` 応答までは実 CLI + fake RPC で確認しましたが、`ask` 時にチャットバッファへ `⚠️ Tool approval required` が描画され、ユーザーが選択して再送する部分は**未実行**です。この区間は backend 非依存の共有コード(claude/codex/grok と同一経路)で、`handle_id` ベースのルーティングが届くことは確認済みのため動作するはずですが、実チャットでの目視確認はしていません。`npm run test:e2e` は実トークンを消費するため指示により未実行です。
- **`permissions.ask` 経由でプロセスが kill された後の再開挙動**(`cancel_and_deny` → 再送)も同様に未実行です。
- Windows は未対応のままです(`bash` キーにシェルスクリプトを渡すため。既存の claude/grok フックと同じ制約)。

## 安全側の設計

- フック応答の unwrap は**再エンコードせず**接頭辞を剥がすだけ(引用符入りの理由が壊れない)。剥がせなかった場合、deny は exit 2 にフォールバックして**必ず拒否**します(パースできない出力は Copilot に「判断なし」= 実行、と読まれるため)
- manifest は temp ファイル + rename で**アトミックに**書き込みます。同一 cwd の複数チャットが書き換えるため、読み取り中の Copilot に壊れた manifest を見せると「フックなし」= 全ツール素通りになるので
- `bypassPermissions` と `lightweight`(タイトル生成・`/summarize`)ではフックを仕込みません。後者は `core/types.lua` が全アダプタに課している契約で、codex と揃えました
- 生成失敗時は WARN を出して静的な `--deny-tool` にフォールバックし、ターンは落としません

## テスト

- 新規 `tests/lua/infrastructure/hooks/copilot_settings_generator_spec.lua`(10 件)。うち 1 件は `pre-tool-use.sh` から `MAX_WAIT` を読み出して `timeoutSec` との大小関係を検証します(言語をまたぐ不変条件を、コメントではなくテストで固定するため)
- `tests/pre-tool-use-hook.test.mjs` に copilot 形式の 5 ケースを追加(flat deny / 引用符入り理由 / allow / defer / RPC 到達不可時の fail closed / unwrap 失敗時の exit 2 フォールバック)
- `permission_vocabulary_spec.lua` に**実機で captured した Copilot payload**を流すケースを追加
- `pnpm run check` / `check:doc` / `lint` / `format:check` / `test:lua` / `test:node`(38 件)すべて green。`test:e2e` と `test:eval` は指示により未実行

## ドキュメント

README / README.ja の「承認 UI 未対応」注記を削除し、`.claude/rules/architecture.md` の `dynamic_permissions` の記述を差し替えました(なぜ共有スクリプトに backend 名を置くのが正しいかの根拠つき)。`docs/configuration.md` と #510 の設計ドキュメントの「スコープ外」節も更新しています。

## #585 との rebase(lightweight とフック注入の噛み合わせ)

main の #585(`fix(copilot,grok): restrict lightweight utility calls`)取り込み後、`copilot_command_builder.lua` でコンフリクトしたため rebase して解消しました。**両者の変更はどちらも残しています**(#585 の `--available-tools=<sentinel>` + `--no-custom-instructions` の lightweight 分岐と、本 PR の `--plugin-dir` フック注入)。

「lightweight にフックが注入されてしまわないか」を改めて確認した結果、**噛み合っており修正は不要**でした。二重に担保されています:

1. `copilot_cli.lua` が `permission_mode ~= "bypassPermissions" and not opts.lightweight` の時だけ plugin を生成する(元々本 PR に入れていたガード)
2. rebase 後の builder では lightweight は `append_lightweight_flags` 側の分岐に入るため、**仮に plugin_dir を渡されても `--plugin-dir` は出力されえない**

さらに、#585 が architecture.md に書いた **grok の落とし穴(「フックを登録しない」= 実際にはフックが無い、とは限らない。grok は `<cwd>/.grok/hooks/` をディスクから自動発見するため、生成をスキップしても以前のチャットが書いたフックが残って効いてしまう)は copilot には当てはまりません**。copilot が自動発見するのは `~/.copilot/hooks/` / `.github/hooks/` / policy ディレクトリ / `settings.json` だけで、vibing.nvim はそのいずれにも書きません。生成した plugin は `--plugin-dir` を渡した時のみ読まれるので、**以前のチャットが残した `.vibing/copilot-plugin/` は不活性**です。つまり copilot は claude / codex と同じく lightweight の契約を完全に守れます。この差分は architecture.md に追記し、`omits --plugin-dir for a lightweight call even when one is passed` というテストで固定しました。

## レビューで見送った点(follow-up 候補)

- `copilot_tool_vocabulary.normalize_input` は grok 版とバイト単位で同一です。本 PR のスコープ外なので共通化は見送りました(`PATH_KEYS` だけが異なるため `tool_vocabulary_common.lua` への抽出が候補)
- `copilot_cli.lua` の spawn 失敗ハンドリングは grok 版とほぼ同一で、`cli_runtime` への抽出余地があります
- grok の `lightweight` 時のフック残存は #585 で調査・文書化済みです(ディスク上のフックを消す案は、cwd を共有する並行チャットが必要とするため却下されています)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
