### PR TITLE
feat(mcp): add nvim_chat_create so one chat can drive worker chats

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -451,6 +451,71 @@ them would offer a binding the CLI cannot resolve.
 `application/chat/use_cases/subagent_chat.lua` (open, with a dedup check so one agent never gets two
 rival buffers), `presentation/chat/controller.lua` → `handle_subagent_chat`.
 
+## Multi-Agent Orchestration
+
+One chat can create and drive other chats: `nvim_chat_create` (MCP) →
+`infrastructure/rpc/handlers/chat.lua` → `application/chat/use_cases/create_chat.lua` →
+`view.render`. The orchestrator briefs each worker with `nvim_chat_send_message` and polls it with
+`nvim_get_buffer`. The workflow is the bundled `skills/vibing-orchestrate/SKILL.md`; there is no
+command and no scheduler — the whole feature is three MCP calls and a skill.
+
+Nothing new was needed to keep the workers apart. Each chat buffer already owns its own session
+id and handle id (see "Concurrent Execution Support"), so parallel workers are the existing
+concurrency guarantee being used rather than extended.
+
+The use case is the fork/subagent shape: it returns a `ChatSession` and touches no presentation
+code, and the RPC handler is what renders it. That is also why position validation sits in the
+handler — it is an argument the RPC caller supplied, not a property of the session.
+
+Four things it does differently from `:VibingChat`, each for a reason:
+
+- **`position` defaults to `back`.** The chat exists as a listed buffer with no window. A worker
+  the model created is not something the user asked to look at.
+- **The chat file is written immediately** (`save_now` in the handler), matching `fork.lua`.
+  `:VibingChat` leaves the file unwritten until `update_session_id` fires on the first response,
+  so returning the path any earlier would name a file that does not exist.
+- **`working_dir` is validated up front.** It is a git-root-relative path like the frontmatter
+  field, resolved through `Git.resolve_working_dir`. A missing directory is rejected at creation;
+  accepted, it would produce a chat that only fails on its first request, in a buffer the user
+  is not watching.
+- **The chat file still goes to the configured `save_dir`,** not inside `working_dir`. A worker
+  attached to a worktree has to outlive `git worktree remove`, and this matches
+  `vibing-worktree-create`, which only rewrites an existing chat's frontmatter. (The pre-existing
+  and never-called `use_case.create_new_in_directory` does the opposite; `create_new` takes an
+  optional `working_dir` instead.)
+
+`view.render` now returns its `ChatBuffer` and replaces the `window` table before applying a
+one-off `position`. It used to assign straight into `chat_buf.config.window.position`, and
+`ChatBuffer` holds a reference to the live `config.chat` table — so a single `back` render changed
+the user's default position for the rest of the session, right down to `Config.defaults`, which
+survives a later `setup()`. Harmless enough at one `:VibingChat back` a day; not harmless when an
+orchestrator opens three workers that way. Note that `vim.tbl_deep_extend("force", {}, cfg)` does
+**not** fix it: with an empty base nothing collides, so every nested table is assigned by
+reference and `config.window` stays the same table.
+
+**Completion detection is a status field, not a text heuristic.** `nvim_get_buffer` passes
+`include_chat_status` to `buf_get_lines`, which attaches `presentation/chat/modules/chat_status`'s
+verdict: `"responding"` when `ChatBuffer:is_responding()` (either `_is_sending` or a
+`_current_handle_id`), `"idle"` otherwise, and nothing at all for a buffer that is not a chat.
+Both fields are needed — `_current_handle_id` is only set once the adapter spawns the CLI, so the
+gap after `<CR>` would otherwise read as finished. Reading the transcript's shape instead would
+call a turn that died on an error, or one part-way through silent tool calls, complete.
+
+The flag is opt-in rather than a new return shape because the MCP server installs at Claude
+Code's _user_ scope and updates independently of the plugin: without a parameter to key on, a
+newer Neovim answering an older server would hand it an object where it calls `.join()`. Both
+directions of that skew are covered — the Lua side returns the bare array unless asked, and the
+Node side accepts either shape.
+
+`idle` means "no request in flight", not "succeeded": a worker that failed, that is waiting on a
+tool-approval prompt, or that asked a question is idle too. The skill says so, because the
+distinction is not something the status can carry.
+
+**Out of scope, deliberately:** workers cannot message the orchestrator back, there is no
+event-driven completion notification, and the orchestrator does not poll inside its own turn — it
+hands control back to the user and reports when asked. All three would need a channel that does
+not exist yet; the MVP is "distribute, observe, report".
+
 ## Key Patterns
 
 **Adapter Pattern:** All AI backends (`claude_cli`, `codex_cli`) implement the `Adapter` interface

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -77,3 +77,9 @@ requests backed by the `vibing-worktree-{list,create,attach,run,finish}` Claude 
 bundled with this plugin (`skills/`), not by chat slash commands. See
 `skills/vibing-worktree-list/SKILL.md` and its sibling `-create`, `-attach`, `-run`, `-finish`
 skills.
+
+Running several tasks in parallel across worker chats is the same story: ask for it in natural
+language ("並行でやって"), and the bundled `vibing-orchestrate` skill
+(`skills/vibing-orchestrate/SKILL.md`) drives it through the `nvim_chat_create` /
+`nvim_chat_send_message` / `nvim_get_buffer` MCP tools. There is no `:Vibing*` command for it —
+see `architecture.md` → "Multi-Agent Orchestration".

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -29,7 +29,7 @@ Prefix with `mcp__vibing-nvim__`:
 - **Highlighting**: `nvim_highlight_range`, `nvim_clear_highlight` (see "Showing Code" below)
 - **Annotations**: `nvim_annotate`, `nvim_clear_annotations` (see "Inline Review Notes" below)
 - **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
-  `features.md`), `nvim_chat_send_message`
+  `features.md`), `nvim_chat_send_message`, `nvim_chat_create` (see "Orchestration" below)
 - **Instances**: `nvim_list_instances`
 - **Quickfix**: `nvim_set_qflist` (pushes a new list; the previous one survives under `:colder`)
 - **Debugger**: `nvim_dap_get_state`, `nvim_dap_get_stack_trace`, `nvim_dap_get_variables`,
@@ -64,6 +64,17 @@ user's config overrides it. It clears itself after `duration_ms` (default 3000; 
 a second call to the same buffer replaces the first rather than stacking. Out-of-range lines are
 clamped to the buffer rather than rejected — search results go stale by a line or two, and pointing
 at roughly the right place beats refusing to point.
+
+## Orchestration
+
+`nvim_chat_create({ rpc_port, position?, working_dir? })` creates a chat buffer and returns
+`{ bufnr, file_path, working_dir, position, saved }` as JSON, so one chat can spawn worker chats,
+brief each with `nvim_chat_send_message`, and poll them with `nvim_get_buffer` — which reports a
+chat buffer's `responding` / `idle` status as a second content block.
+
+The workflow is the bundled `vibing-orchestrate` skill. Why `position` defaults to `back`, why the
+chat file is written at creation, why the status is a field rather than a text heuristic, and what
+is deliberately out of scope: `architecture.md` → "Multi-Agent Orchestration".
 
 ## Inline Review Notes
 

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -46,7 +46,13 @@ function M.create_new(opts)
   -- チャットファイル自体は working_dir がどこであれ常に設定どおりの保存先に置く。
   -- worktreeの中に置くと `git worktree remove` で会話ごと消えてしまい、
   -- vibing-worktree-create（frontmatterだけ書き換える）とも挙動が食い違う
-  local working_dir = opts and opts.working_dir or Git.get_relative_path(vim.fn.getcwd())
+  --
+  -- 空文字を明示的に弾く: Luaでは `""` がtruthyなので `opts.working_dir or ...` だけだと
+  -- cwd由来の既定値にフォールバックせず `working_dir = ""` のまま進んでしまう。
+  -- 呼び出し元（create_chat.lua）でも弾いているが、既定値の決定はこの関数の責務なので
+  -- 呼び出し元頼みにしない
+  local explicit = opts and opts.working_dir
+  local working_dir = (explicit and explicit ~= "") and explicit or Git.get_relative_path(vim.fn.getcwd())
 
   local frontmatter = create_default_frontmatter(config)
   if working_dir then

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -37,12 +37,16 @@ local function create_default_frontmatter(config)
 end
 
 ---新しいチャットセッションを作成
+---@param opts? {working_dir?: string} working_dirはgitルートからの相対パス（省略時はcwdから算出）
 ---@return Vibing.ChatSession
-function M.create_new()
+function M.create_new(opts)
   local vibing = require("vibing")
   local config = vibing.get_config()
 
-  local working_dir = Git.get_relative_path(vim.fn.getcwd())
+  -- チャットファイル自体は working_dir がどこであれ常に設定どおりの保存先に置く。
+  -- worktreeの中に置くと `git worktree remove` で会話ごと消えてしまい、
+  -- vibing-worktree-create（frontmatterだけ書き換える）とも挙動が食い違う
+  local working_dir = opts and opts.working_dir or Git.get_relative_path(vim.fn.getcwd())
 
   local frontmatter = create_default_frontmatter(config)
   if working_dir then

--- a/lua/vibing/application/chat/use_cases/create_chat.lua
+++ b/lua/vibing/application/chat/use_cases/create_chat.lua
@@ -1,0 +1,36 @@
+---@class Vibing.Application.CreateChatUseCase
+---プログラムからの新規チャット作成（MCPツール `nvim_chat_create` の実体）
+---
+---`:VibingChat` と違うのは `working_dir` を指定できる点だけで、セッション生成そのものは
+---`use_case.create_new` に委譲する。fork/subagent_chat と同じく、ここはPresentation層に
+---依存しない: 呼び出し元が返ってきたsessionをviewに渡す
+local M = {}
+
+local Git = require("vibing.core.utils.git")
+
+---新しいチャットセッションを作成する
+---@param opts? {working_dir?: string} working_dirはgitルートからの相対パス
+---@return Vibing.ChatSession
+---@throws working_dirがgit管理外、または存在しないディレクトリを指している場合
+function M.execute(opts)
+  opts = opts or {}
+  local working_dir = opts.working_dir
+
+  if not working_dir or working_dir == "" then
+    return require("vibing.application.chat.use_case").create_new()
+  end
+
+  -- 存在しないディレクトリを受け入れると、チャットは作れてしまうのに最初のリクエストで
+  -- 初めて失敗する。しかもワーカーのバッファはユーザーが見ていないので、ここで弾く
+  local absolute = Git.resolve_working_dir(working_dir)
+  if not absolute then
+    error("Cannot resolve working_dir '" .. working_dir .. "': not inside a git repository")
+  end
+  if vim.fn.isdirectory(absolute) ~= 1 then
+    error("working_dir does not exist: " .. working_dir .. " (resolved to " .. absolute .. ")")
+  end
+
+  return require("vibing.application.chat.use_case").create_new({ working_dir = working_dir })
+end
+
+return M

--- a/lua/vibing/core/constants/chat.lua
+++ b/lua/vibing/core/constants/chat.lua
@@ -1,0 +1,25 @@
+---@class Vibing.Core.ChatConstants
+---チャットバッファ生成にまつわる定数定義
+---
+---`:VibingChat`/`:VibingChatFork`/`:VibingSubagentChat`（controllerの検証とinit.luaの補完）と、
+---MCPツール`nvim_chat_create`のRPCハンドラが同じ位置指定を受け付ける必要があるため、
+---どこかにlocalで持たせず、ここを参照させる。
+local M = {}
+
+---引数として受け付けるウィンドウ位置
+---`back`はウィンドウを作らずバッファだけを作る（`window_manager.create_window`がnilを返す）
+---
+---`config.chat.window.position` はこれに加えて`float`も取るが、コマンド引数としては元から
+---受け付けていない（`window_manager`のフォールバック分岐でのみ到達する）。ここに足すと
+---`:VibingChat float`の挙動が変わるので、設定専用のままにしてある
+---@type string[]
+M.POSITIONS = { "current", "right", "left", "top", "bottom", "back" }
+
+---ウィンドウ位置が有効かチェック
+---@param position string
+---@return boolean
+function M.is_valid_position(position)
+  return vim.tbl_contains(M.POSITIONS, position)
+end
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/buffer.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/buffer.lua
@@ -5,10 +5,22 @@ local BufferIdentifier = require("vibing.core.utils.buffer_identifier")
 -- Retrieve all lines from the specified buffer.
 -- @param params? Table with optional fields.
 -- @param params.bufnr? number Buffer number to read from; defaults to 0 (current buffer).
--- @return string[] A list of lines from the buffer, in buffer order (each element is a line without trailing newlines).
+-- @param params.include_chat_status? boolean Wrap the result and attach the buffer's chat status.
+-- @return string[]|table Bare line array by default; `{ lines, chat_status }` when
+--   `include_chat_status` is set (`chat_status` is "responding"/"idle", or absent for a buffer
+--   that is not a vibing.nvim chat). The shape stays opt-in because the MCP server and this
+--   plugin are installed separately and can be at different versions: an older MCP server sends
+--   no flag and must keep receiving the array it calls `.join()` on.
 function M.buf_get_lines(params)
   local bufnr = params and params.bufnr or 0
-  return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+  if not (params and params.include_chat_status) then
+    return lines
+  end
+
+  local ChatStatus = require("vibing.presentation.chat.modules.chat_status")
+  return { lines = lines, chat_status = ChatStatus.get(bufnr) }
 end
 
 -- Replace the entire contents of a buffer with the provided lines.

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -1,0 +1,54 @@
+---@class Vibing.Infrastructure.RPC.ChatHandler
+---RPC handler for programmatic chat buffer creation (MCP tool `nvim_chat_create`)
+local M = {}
+
+local ChatConstants = require("vibing.core.constants.chat")
+
+---作成したチャットをその場でディスクに書き出す
+---`:VibingChat`は最初の応答が返るまでファイルを書かない（buffer.lua:update_session_id）。
+---呼び出し元にファイルパスを返す以上、そのパスが存在しないのは嘘なので、forkと同じく
+---作成時点で保存する
+---@param bufnr number
+---@return boolean saved
+local function save_now(bufnr)
+  local ok = pcall(vim.api.nvim_buf_call, bufnr, function()
+    vim.cmd("silent write")
+  end)
+  -- `write`はエラーを黙って飲むことがあるので、pcallの成否だけでなくmodifiedも確認する
+  return ok and not vim.bo[bufnr].modified
+end
+
+---新しいチャットバッファを作成する
+---@param params {position?: string, working_dir?: string}
+---@return {bufnr: number, file_path: string, working_dir: string?, position: string, saved: boolean}
+function M.create_chat(params)
+  params = params or {}
+
+  local position = params.position or "back"
+  if not ChatConstants.is_valid_position(position) then
+    error(
+      string.format(
+        "Invalid position: %s (expected one of: %s)",
+        tostring(position),
+        table.concat(ChatConstants.POSITIONS, ", ")
+      )
+    )
+  end
+
+  local session = require("vibing.application.chat.use_cases.create_chat").execute({
+    working_dir = params.working_dir,
+  })
+  -- background: ワーカーはユーザーが開いたチャットではないので、`view._current_buffer`
+  -- （:VibingCancel などのフォールバック先）を奪わない
+  local chat_buf = require("vibing.presentation.chat.view").render(session, position, { background = true })
+
+  return {
+    bufnr = chat_buf.buf,
+    file_path = chat_buf.file_path,
+    working_dir = session.working_dir,
+    position = position,
+    saved = save_now(chat_buf.buf),
+  }
+end
+
+return M

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -9,6 +9,7 @@ local execute = require("vibing.infrastructure.rpc.handlers.execute")
 local highlight = require("vibing.infrastructure.rpc.handlers.highlight")
 local annotations = require("vibing.infrastructure.rpc.handlers.annotations")
 local message = require("vibing.infrastructure.rpc.handlers.message")
+local chat = require("vibing.infrastructure.rpc.handlers.chat")
 local permission = require("vibing.infrastructure.rpc.handlers.permission")
 local rate_limit = require("vibing.infrastructure.rpc.handlers.rate_limit")
 local qflist = require("vibing.infrastructure.rpc.handlers.qflist")
@@ -53,6 +54,8 @@ M.annotate = annotations.annotate
 M.clear_annotations = annotations.clear_annotations
 
 M.send_message = message.send_message
+
+M.create_chat = chat.create_chat
 
 M.check_tool_permission = permission.check_tool_permission
 M.ask_user_question = permission.ask_user_question

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -119,7 +119,7 @@ end
 ---@return string[]
 local function complete_positions(arg_lead)
   local matches = {}
-  for _, pos in ipairs({ "current", "right", "left", "top", "bottom", "back" }) do
+  for _, pos in ipairs(require("vibing.core.constants.chat").POSITIONS) do
     if pos:find("^" .. vim.pesc(arg_lead)) then
       table.insert(matches, pos)
     end

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -141,6 +141,14 @@ function ChatBuffer:is_sending()
   return self._is_sending == true
 end
 
+---このチャットがリクエストを実行中か（送信開始からCLI終了まで）
+---`_is_sending`は<CR>からCLI起動までの隙間、`_current_handle_id`は起動後の実行中をカバーする。
+---片方だけを見ると送信直後の数十msを「完了」と読んでしまうので、両方を見る必要がある
+---@return boolean
+function ChatBuffer:is_responding()
+  return self:is_sending() or self._current_handle_id ~= nil
+end
+
 ---バッファを作成
 function ChatBuffer:_create_buffer()
   if self.buf and vim.api.nvim_buf_is_valid(self.buf) then

--- a/lua/vibing/presentation/chat/controller.lua
+++ b/lua/vibing/presentation/chat/controller.lua
@@ -6,7 +6,8 @@ local M = {}
 local notify = require("vibing.core.utils.notify")
 
 ---コマンド引数として受け付けるウィンドウ位置
-local VALID_POSITIONS = { current = true, right = true, left = true, top = true, bottom = true, back = true }
+---（MCPツール nvim_chat_create と同じ集合を使う。定義元は core/constants/chat.lua）
+local ChatConstants = require("vibing.core.constants.chat")
 
 ---位置指定のみを取る引数をパースする（不正値は警告してデフォルトに落とす）
 ---@param args string?
@@ -15,7 +16,7 @@ local function parse_position(args)
   if not args or args == "" then
     return nil
   end
-  if VALID_POSITIONS[args] then
+  if ChatConstants.is_valid_position(args) then
     return args
   end
   notify.warn("Invalid position: " .. args .. ". Using default.")
@@ -33,7 +34,7 @@ function M.handle_open(args)
   local file_path = nil
 
   if args and args ~= "" then
-    if VALID_POSITIONS[args] then
+    if ChatConstants.is_valid_position(args) then
       position = args
     else
       -- 位置キーワードでなければファイルパスとして扱う

--- a/lua/vibing/presentation/chat/modules/chat_status.lua
+++ b/lua/vibing/presentation/chat/modules/chat_status.lua
@@ -1,0 +1,28 @@
+---@class Vibing.Presentation.ChatStatus
+---バッファ番号を、そのチャットが今リクエストを実行中かどうかに変換する
+---
+---オーケストレーター（`skills/vibing-orchestrate`）がワーカーの進捗をポーリングするときの
+---唯一の判定材料。本文から「最後のセクションがAssistantか」を推測する方法は、応答がエラーで
+---終わった場合やツール実行だけで無言のまま進んでいる場合に誤判定するため使わない。
+local M = {}
+
+---バッファのチャット実行状態を取得する
+---@param bufnr number バッファ番号（0はカレントバッファ）
+---@return "responding"|"idle"|nil state vibing.nvimのチャットバッファでない場合はnil
+function M.get(bufnr)
+  if not bufnr or bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return nil
+  end
+
+  local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(bufnr)
+  if not chat_buf then
+    return nil
+  end
+
+  return chat_buf:is_responding() and "responding" or "idle"
+end
+
+return M

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -16,14 +16,26 @@ M._attached_buffers = {}
 
 ---セッションをチャットバッファに描画
 ---@param session Vibing.ChatSession
----@param position? string 位置指定（current|right|left）
-function M.render(session, position)
+---@param position? string 位置指定（core/constants/chat.lua の POSITIONS）
+---@param opts? {background?: boolean} backgroundはM._current_bufferを更新しない
+---@return Vibing.ChatBuffer chat_buf 作成したチャットバッファ
+function M.render(session, position, opts)
   local vibing = require("vibing")
   local config = vibing.get_config()
 
   -- 毎回新規バッファを作成（既存バッファを再利用しない）
   local chat_buf = ChatBuffer:new(config.chat)
-  M._current_buffer = chat_buf
+
+  -- M._current_buffer は「ユーザーが最後に開いたチャット」を指すシングルトンで、
+  -- :VibingCancel / :VibingToggleChat / :VibingMoteDir がカーソルがチャット外にあるときの
+  -- フォールバックに使う。nvim_chat_createのワーカーはユーザーが開いたものではないので
+  -- ここを奪ってはいけない。奪うと:VibingCancelがユーザーの実行中リクエストではなくワーカーを
+  -- 止め、backのワーカーにはウィンドウが無いのでis_open()がfalseになり:VibingToggleChatが
+  -- 開いているチャットをトグルせず新しいチャットを作ってしまう。
+  -- 検索は_attached_buffers側で足りる（get_chat_buffer）ので、ワーカーが迷子になることはない
+  if not (opts and opts.background) then
+    M._current_buffer = chat_buf
+  end
 
   -- セッションデータをバッファに反映
   chat_buf.session = session  -- セッション全体を保持（後方互換性のため）
@@ -36,9 +48,16 @@ function M.render(session, position)
   end
   -- NOTE: cwdはfrontmatterのworking_dirから算出されるため、ここでの転送は不要
 
-  -- 位置指定が指定されている場合は一時的にオーバーライド
+  -- 位置指定が指定されている場合はこのバッファに限ってオーバーライドする。
+  -- ChatBuffer:new はグローバル設定テーブルへの参照をそのまま持つので、`window`テーブルまで
+  -- 差し替えないと `:VibingChat back` 1回でユーザーの既定位置が永久にbackになる。
+  -- tbl_deep_extendでは足りない: 空テーブルをベースにすると衝突が起きず、ネストした値は
+  -- 参照のまま代入されるので `config.window` は同じテーブルのままになる（実測でConfig.defaults
+  -- まで書き換わった）。nvim_chat_createはワーカーを常にbackで作るため、この漏れは致命的になる
   if position then
-    chat_buf.config.window.position = position
+    chat_buf.config = vim.tbl_extend("force", {}, chat_buf.config, {
+      window = vim.tbl_extend("force", {}, chat_buf.config.window, { position = position }),
+    })
   end
 
   chat_buf:open()
@@ -58,6 +77,8 @@ function M.render(session, position)
   -- ファイル内容読み込み後にチャットバッファ設定を適用（wrap設定、補完、autocmdなど）
   -- これによりftpluginによる上書きを防ぐ
   M._apply_chat_buffer_settings(chat_buf.buf)
+
+  return chat_buf
 end
 
 ---チャットウィンドウを閉じる

--- a/mcp-server/src/__tests__/buffer-tools.test.ts
+++ b/mcp-server/src/__tests__/buffer-tools.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handlers } from '../handlers/index.js';
+import * as rpc from '../rpc.js';
+
+vi.mock('../rpc.js', () => ({
+  callNeovim: vi.fn(),
+}));
+
+/**
+ * nvim_get_buffer is how an orchestrator polls a worker chat (see the vibing-orchestrate skill),
+ * so it has to say whether the reply it just returned is still being written.
+ */
+describe('nvim_get_buffer chat status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('asks Neovim for the chat status alongside the lines', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ lines: ['a'], chat_status: null });
+
+    await handlers.nvim_get_buffer({ bufnr: 3, rpc_port: 9878 });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'buf_get_lines',
+      { bufnr: 3, include_chat_status: true },
+      9878
+    );
+  });
+
+  it('returns only the buffer text for a non-chat buffer', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ lines: ['line 1', 'line 2'] });
+
+    const result = await handlers.nvim_get_buffer({ bufnr: 3, rpc_port: 9878 });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe('line 1\nline 2');
+  });
+
+  it('adds a status block saying the reply is incomplete while one is streaming', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      lines: ['## Assistant', 'partial'],
+      chat_status: 'responding',
+    });
+
+    const result = await handlers.nvim_get_buffer({ bufnr: 3, rpc_port: 9878 });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].text).toBe('## Assistant\npartial');
+    expect(result.content[1].text).toContain('responding');
+  });
+
+  it('adds a status block saying nothing is in flight when the chat is idle', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      lines: ['## Assistant', 'done'],
+      chat_status: 'idle',
+    });
+
+    const result = await handlers.nvim_get_buffer({ bufnr: 3, rpc_port: 9878 });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1].text).toContain('idle');
+  });
+
+  it('still works against a Neovim old enough to answer with a bare line array', async () => {
+    // The MCP server is installed at Claude Code's user scope and updates independently of the
+    // plugin, so it can outrun the Lua side that knows about include_chat_status.
+    vi.mocked(rpc.callNeovim).mockResolvedValue(['old', 'shape']);
+
+    const result = await handlers.nvim_get_buffer({ bufnr: 3, rpc_port: 9878 });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe('old\nshape');
+  });
+});

--- a/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/mcp-server/src/__tests__/chat-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { allTools } from '../tools/index.js';
+import { CHAT_POSITIONS } from '../tools/chat.js';
 import { handlers } from '../handlers/index.js';
 import * as rpc from '../rpc.js';
 
@@ -46,6 +47,73 @@ describe('chat tools (worktree redesign)', () => {
     expect(inputSchema.properties.chat_bufnr).toBeDefined();
     expect(inputSchema.properties.rpc_port).toBeDefined();
     expect(inputSchema.properties.questions).toBeDefined();
+  });
+
+  it('registers nvim_chat_create with rpc_port required and everything else optional', () => {
+    const tool = allTools.find((t) => t.name === 'nvim_chat_create');
+    expect(tool).toBeDefined();
+    const inputSchema = tool?.inputSchema as {
+      required?: string[];
+      properties: Record<string, any>;
+    };
+    // It creates a buffer, so it is a write: it must name its instance rather than fall back to
+    // the registry (see requireRpcPort in ../tools/common.ts).
+    expect(inputSchema.required).toEqual(['rpc_port']);
+    expect(inputSchema.properties.position.enum).toEqual([...CHAT_POSITIONS]);
+    expect(inputSchema.properties.working_dir).toBeDefined();
+  });
+
+  it('nvim_chat_create defaults to no position and lets Neovim apply "back"', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ bufnr: 7, file_path: '/tmp/chat.md' });
+
+    const result = await handlers.nvim_chat_create({ rpc_port: 9878 });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'create_chat',
+      { position: undefined, working_dir: undefined },
+      9878
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result._meta).toEqual({ bufnr: 7, file_path: '/tmp/chat.md' });
+  });
+
+  it('nvim_chat_create forwards position and working_dir, and returns the bufnr as text', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      bufnr: 12,
+      file_path: '/repo/.vibing/worktrees/x/.vibing/chat/chat-1.md',
+      working_dir: '.vibing/worktrees/x',
+    });
+
+    const result = await handlers.nvim_chat_create({
+      rpc_port: 9878,
+      position: 'back',
+      working_dir: '.vibing/worktrees/x',
+    });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'create_chat',
+      { position: 'back', working_dir: '.vibing/worktrees/x' },
+      9878
+    );
+    // The orchestrator has to read bufnr back out of the transcript on a later turn, so it has
+    // to be in the text, not only in _meta.
+    expect(result.content[0].text).toContain('"bufnr": 12');
+  });
+
+  it('nvim_chat_create rejects a call missing rpc_port instead of guessing an instance', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ bufnr: 7 });
+
+    await expect(handlers.nvim_chat_create({ position: 'back' })).rejects.toThrow();
+    expect(rpc.callNeovim).not.toHaveBeenCalled();
+  });
+
+  it('nvim_chat_create rejects a position the Lua handler would refuse anyway', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ bufnr: 7 });
+
+    await expect(
+      handlers.nvim_chat_create({ rpc_port: 9878, position: 'sideways' })
+    ).rejects.toThrow();
+    expect(rpc.callNeovim).not.toHaveBeenCalled();
   });
 
   it('registers nvim_chat_send_message with rpc_port required', () => {

--- a/mcp-server/src/handlers/buffer.ts
+++ b/mcp-server/src/handlers/buffer.ts
@@ -1,20 +1,50 @@
 import { callNeovim } from '../rpc.js';
 import { validateBufferParams, validateFilePath, validateRequired } from '../validation/schema.js';
 
+const CHAT_STATUS_TEXT: Record<string, string> = {
+  responding:
+    'vibing.nvim chat buffer status: responding. A reply is being streamed into this buffer ' +
+    'right now, so what you just read is incomplete. Read it again later to see the finished ' +
+    'response.',
+  idle: 'vibing.nvim chat buffer status: idle. No request is in flight for this buffer, so what you just read is the complete transcript so far.',
+};
+
 /**
  * Retrieve the contents of a Neovim buffer and return them as a single text node.
  *
+ * For a vibing.nvim chat buffer a second text node reports whether a reply is currently being
+ * streamed into it. That is what lets an orchestrator poll a worker chat for completion
+ * (see the `vibing-orchestrate` skill) instead of guessing from the transcript's shape — a
+ * turn that ended in an error, or one still running silent tool calls, both look "finished"
+ * to a text heuristic.
+ *
+ * It is a separate content block rather than a line appended to the transcript so it can never
+ * be mistaken for something the buffer actually contains.
+ *
  * @param args - An object with `bufnr`, the buffer number to retrieve, and optional `rpc_port`.
- * @returns An object with `content` containing a single text node whose `text` is the buffer's contents (lines joined with `\n`).
+ * @returns An object with `content` containing the buffer's contents (lines joined with `\n`),
+ *   plus a chat-status node when the buffer is a vibing.nvim chat.
  */
 export async function handleGetBuffer(args: any) {
   if (args?.bufnr !== undefined) {
     validateBufferParams({ bufnr: args.bufnr });
   }
-  const lines = await callNeovim('buf_get_lines', { bufnr: args?.bufnr }, args?.rpc_port);
-  return {
-    content: [{ type: 'text', text: lines.join('\n') }],
-  };
+  const result = await callNeovim(
+    'buf_get_lines',
+    { bufnr: args?.bufnr, include_chat_status: true },
+    args?.rpc_port
+  );
+
+  // A Neovim running an older plugin version ignores include_chat_status and answers with the
+  // bare line array this tool used to get.
+  const lines: string[] = Array.isArray(result) ? result : result.lines;
+  const state: string | undefined = Array.isArray(result) ? undefined : result.chat_status;
+
+  const content = [{ type: 'text', text: lines.join('\n') }];
+  if (state && CHAT_STATUS_TEXT[state]) {
+    content.push({ type: 'text', text: CHAT_STATUS_TEXT[state] });
+  }
+  return { content };
 }
 
 /**

--- a/mcp-server/src/handlers/chat.ts
+++ b/mcp-server/src/handlers/chat.ts
@@ -1,5 +1,34 @@
 import { callNeovim } from '../rpc.js';
 import { z } from 'zod';
+import { CHAT_POSITIONS } from '../tools/chat.js';
+
+const chatCreateArgsSchema = z.object({
+  position: z.enum(CHAT_POSITIONS).optional(),
+  working_dir: z.string().optional(),
+  rpc_port: z.number(),
+});
+
+/**
+ * Handler for nvim_chat_create
+ *
+ * Creates a chat buffer the caller can then drive with `nvim_chat_send_message`. The result is
+ * JSON rather than prose because the orchestrator has to carry `bufnr` forward across turns —
+ * it is the only handle to a worker chat, and a `back` chat has no window to find it by.
+ *
+ * The chat file is written to disk by the Lua handler at creation time, so `file_path` names a
+ * file that actually exists; `saved: false` means that write failed and the chat lives only in
+ * the buffer.
+ */
+export async function handleChatCreate(args: any): Promise<any> {
+  const { position, working_dir, rpc_port } = chatCreateArgsSchema.parse(args);
+
+  const result = await callNeovim('create_chat', { position, working_dir }, rpc_port);
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    _meta: { bufnr: result?.bufnr, file_path: result?.file_path },
+  };
+}
 
 // Zod schemas for validation
 const chatSendMessageArgsSchema = z.object({

--- a/mcp-server/src/handlers/index.ts
+++ b/mcp-server/src/handlers/index.ts
@@ -50,6 +50,7 @@ export const handlers: Record<string, (args: any) => Promise<any>> = {
   nvim_list_instances: instances.handleListInstances,
 
   // Chat operations
+  nvim_chat_create: chat.handleChatCreate,
   nvim_chat_send_message: chat.handleChatSendMessage,
   nvim_ask_user_question: chat.handleAskUserQuestion,
 

--- a/mcp-server/src/tools/buffer.ts
+++ b/mcp-server/src/tools/buffer.ts
@@ -3,7 +3,10 @@ import { withRpcPort, requireRpcPort } from './common.js';
 export const bufferTools = [
   {
     name: 'nvim_get_buffer',
-    description: 'Get current buffer content',
+    description:
+      'Get current buffer content. For a vibing.nvim chat buffer the result also reports ' +
+      'whether a reply is being streamed into it right now — poll this to tell whether a ' +
+      'worker chat has finished.',
     inputSchema: {
       type: 'object' as const,
       properties: withRpcPort({

--- a/mcp-server/src/tools/chat.ts
+++ b/mcp-server/src/tools/chat.ts
@@ -5,7 +5,45 @@ import { withRpcPort, requireRpcPort } from './common.js';
  * Chat-related MCP tools
  */
 
+/**
+ * Window positions nvim_chat_create accepts, mirroring `lua/vibing/core/constants/chat.lua`.
+ * Exported so the handler's zod schema validates against the same list the advertised schema
+ * offers — otherwise the two can drift and a value one accepts the other rejects.
+ */
+export const CHAT_POSITIONS = ['back', 'current', 'right', 'left', 'top', 'bottom'] as const;
+
 export const chatTools: Tool[] = [
+  {
+    name: 'nvim_chat_create',
+    description:
+      'Create a new vibing.nvim chat buffer and return its bufnr and chat file path. ' +
+      'Use it to spawn worker chats you then drive with nvim_chat_send_message — the ' +
+      'multi-agent orchestration workflow (see the vibing-orchestrate skill). ' +
+      'Leave position at its "back" default for workers: that creates the buffer without ' +
+      "opening a window, so the user's layout is untouched. " +
+      'The new chat starts empty and shares nothing with yours, so every message you send it ' +
+      'must be self-contained.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({
+        position: {
+          type: 'string',
+          enum: [...CHAT_POSITIONS],
+          description:
+            'Where to put the chat window (default "back": buffer only, no window). ' +
+            'Same values as :VibingChat.',
+        },
+        working_dir: {
+          type: 'string',
+          description:
+            'Optional working directory for the chat, as a path relative to the git root ' +
+            '(e.g. ".vibing/worktrees/fix-auth"). Must already exist. Omit to use the ' +
+            "Neovim instance's own working directory.",
+        },
+      }),
+      required: requireRpcPort([]),
+    },
+  },
   {
     name: 'nvim_chat_send_message',
     description:

--- a/skills/vibing-orchestrate/SKILL.md
+++ b/skills/vibing-orchestrate/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: vibing-orchestrate
+description: Run several independent tasks in parallel by creating worker vibing.nvim chats, handing each one a self-contained brief, and aggregating their results. Use when the user asks for parallel work ("do these three in parallel", "split this across separate chats", "並行でやって", "この2つを別々のチャットで").
+---
+
+# vibing-orchestrate
+
+This chat becomes the orchestrator: it splits the work, creates one worker chat per task, sends
+each worker a brief, and later reports back. It does **not** babysit the workers — see "Hand
+control back" below, which is the part that most needs following.
+
+Every MCP call here takes `rpc_port`, the value in this chat's system prompt. Without it the
+server falls back to the instance registry, which only answers when exactly one Neovim is live —
+and orchestration is precisely the case where several are.
+
+## 1. Split the work
+
+Break the request into tasks that can run without waiting on each other. If two tasks would edit
+the same files, either merge them into one task or give each its own worktree with the
+`vibing-worktree-create` skill (`git worktree add -b <branch> .vibing/worktrees/<branch>`) — two
+chats editing one working tree will overwrite each other, and nothing in vibing.nvim prevents it.
+
+If the split isn't obvious, ask with `nvim_ask_user_question` before creating anything. Creating
+five chats for a job that was really one is expensive and the user has to clean them up.
+
+## 2. Create one worker chat per task
+
+```text
+nvim_chat_create({ rpc_port, position: "back" })
+nvim_chat_create({ rpc_port, position: "back", working_dir: ".vibing/worktrees/fix-auth" })
+```
+
+- `position: "back"` (the default) creates the buffer without opening a window, so the user's
+  layout is untouched. Don't use a split position for workers unless the user asked to watch them.
+- `working_dir` is relative to the git root and must already exist — create the worktree first.
+- Keep the returned `bufnr` **and** `file_path` for every worker, and write them into your reply
+  in this chat. That list is the only record of which worker owns which task; if the conversation
+  is resumed later, the transcript is where you will read it back from.
+
+## 3. Send each worker a self-contained brief
+
+```text
+nvim_chat_send_message({ rpc_port, bufnr: <worker bufnr>, message: "<the whole task>" })
+```
+
+A worker chat starts empty. It has none of this conversation's context: not the user's original
+request, not the files already discussed, not the decisions already made. Write the brief as if to
+someone who just walked in — goal, the files or directories involved, the constraints, and what
+"done" looks like. A brief that says "do the refactor we discussed" produces nothing useful.
+
+Say in the brief that the worker should report its result in its own chat and stop; workers cannot
+message you back.
+
+## 4. Hand control back to the user
+
+Do **not** loop on `nvim_get_buffer` waiting for workers to finish. A turn spent polling burns
+tokens, blocks this chat, and will hit the turn limit long before a real task completes.
+
+Once every brief is sent, end the turn with the worker list and an explicit handle:
+
+> 3件のワーカーチャットにタスクを配りました（bufnr 12 / 14 / 16）。進捗を見たいときは「進捗は?」
+> と聞いてください。
+
+## 5. Report progress when asked
+
+When the user asks, read each worker with `nvim_get_buffer({ rpc_port, bufnr })`. Alongside the
+transcript the result carries a chat-status line:
+
+- `status: responding` — a reply is still being streamed in. Whatever you just read is partial;
+  report it as in progress and do not summarize its conclusion.
+- `status: idle` — nothing is in flight. The transcript is complete as far as that worker got, so
+  read its last Assistant section for the outcome.
+
+Note that `idle` means "not currently running", not "succeeded" — a worker that failed, that
+stopped to ask the user something, or that is waiting on a tool approval prompt is also idle. Read
+the tail of the transcript before calling a task done.
+
+Report per worker: task, state, and the one-line outcome. Then either hand control back again
+(some still running) or move to aggregation.
+
+## 6. Aggregate and clean up
+
+When every worker is idle and finished, summarize the results together — what changed, what
+failed, what still needs the user. Point at each worker's `file_path` so the user can open the
+full transcript.
+
+If you used worktrees, offer the `vibing-worktree-finish` skill for each branch once its work has
+been merged or abandoned. Don't remove a worktree on your own initiative; unmerged work lives
+there.

--- a/tests/helpers/chat_buffers.lua
+++ b/tests/helpers/chat_buffers.lua
@@ -1,0 +1,40 @@
+--- Test seam for specs that render real chat buffers.
+---
+--- `view` keeps rendered chats in two module-level places (`_attached_buffers` and
+--- `_current_buffer`), so a spec that renders one leaks it into every spec after it in the same
+--- Neovim: the next `get_chat_buffer` finds a stale entry, and `setup()` alone does not clear
+--- them. Every such spec therefore needs the same reset before and the same buffer sweep after.
+---
+--- Shared rather than pasted per spec so a change to `view`'s bookkeeping is repaired once.
+--- @module tests.helpers.chat_buffers
+
+local M = {}
+
+--- Point chat storage at a fresh temp directory and clear `view`'s registries.
+---
+--- The temp `save_dir` matters: with the default `save_location_type = "project"` these specs
+--- would write real chat files into the repository checkout.
+---
+--- @return string save_dir the temp directory chats will be written to
+function M.setup()
+  local save_dir = vim.fn.tempname() .. "_chat/"
+  vim.fn.mkdir(save_dir, "p")
+  require("vibing").setup({ chat = { save_location_type = "custom", save_dir = save_dir } })
+
+  M.reset()
+  return save_dir
+end
+
+--- Delete every buffer `view` is tracking and empty its registries.
+function M.reset()
+  local view = require("vibing.presentation.chat.view")
+  for bufnr, _ in pairs(view._attached_buffers) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end
+  view._attached_buffers = {}
+  view._current_buffer = nil
+end
+
+return M

--- a/tests/lua/application/chat/use_case_spec.lua
+++ b/tests/lua/application/chat/use_case_spec.lua
@@ -1,0 +1,43 @@
+-- Tests for `use_case.create_new`'s optional working_dir.
+--
+-- The guard here is deliberately not left to the caller. `create_chat.lua` happens to filter an
+-- empty working_dir before it ever reaches this function, but deciding the default is this
+-- function's job, and in Lua `""` is truthy — so `opts.working_dir or <default>` silently keeps
+-- the empty string and writes `working_dir:` into the frontmatter with nothing after it.
+
+local ChatBuffers = require("tests.helpers.chat_buffers")
+
+describe("chat use_case.create_new", function()
+  local use_case
+
+  before_each(function()
+    ChatBuffers.setup()
+    use_case = require("vibing.application.chat.use_case")
+  end)
+
+  after_each(ChatBuffers.reset)
+
+  it("derives working_dir from the cwd when no opts are given", function()
+    local Git = require("vibing.core.utils.git")
+
+    local session = use_case.create_new()
+
+    assert.equals(Git.get_relative_path(vim.fn.getcwd()), session.working_dir)
+  end)
+
+  it("uses an explicit working_dir as given", function()
+    local session = use_case.create_new({ working_dir = "some/where" })
+
+    assert.equals("some/where", session.working_dir)
+    assert.equals("some/where", session.frontmatter.working_dir)
+  end)
+
+  it("falls back to the cwd default when working_dir is the empty string", function()
+    local Git = require("vibing.core.utils.git")
+
+    local session = use_case.create_new({ working_dir = "" })
+
+    assert.equals(Git.get_relative_path(vim.fn.getcwd()), session.working_dir)
+    assert.are_not.equal("", session.working_dir)
+  end)
+end)

--- a/tests/lua/infrastructure/rpc/handlers/chat_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/chat_spec.lua
@@ -1,0 +1,131 @@
+-- Tests for the `create_chat` RPC method backing the nvim_chat_create MCP tool.
+-- The orchestrator (skills/vibing-orchestrate) has no other way to make a worker chat, and the
+-- bufnr this returns is its only handle on that worker, so the return shape is the contract.
+
+local ChatConstants = require("vibing.core.constants.chat")
+local ChatBuffers = require("tests.helpers.chat_buffers")
+
+describe("rpc handlers: create_chat", function()
+  local handler, view
+
+  before_each(function()
+    ChatBuffers.setup()
+    view = require("vibing.presentation.chat.view")
+    handler = require("vibing.infrastructure.rpc.handlers.chat")
+  end)
+
+  after_each(ChatBuffers.reset)
+
+  it("defaults to the windowless 'back' position so a worker never disturbs the layout", function()
+    local win_count_before = #vim.api.nvim_list_wins()
+
+    local result = handler.create_chat({})
+
+    assert.equals("back", result.position)
+    assert.equals(win_count_before, #vim.api.nvim_list_wins())
+    assert.is_true(vim.api.nvim_buf_is_valid(result.bufnr))
+  end)
+
+  it("returns a chat file path that actually exists on disk", function()
+    -- :VibingChat leaves the file unwritten until the first response comes back. Returning a
+    -- path to the orchestrator only helps if the path is real, so the handler saves immediately.
+    local result = handler.create_chat({})
+
+    assert.is_true(result.saved)
+    assert.equals(1, vim.fn.filereadable(result.file_path))
+    local content = table.concat(vim.fn.readfile(result.file_path), "\n")
+    assert.is_truthy(content:find("vibing.nvim: true", 1, true))
+  end)
+
+  it("registers the new buffer so nvim_chat_send_message can find it", function()
+    local result = handler.create_chat({})
+
+    assert.is_not_nil(view.get_chat_buffer(result.bufnr))
+  end)
+
+  it("leaves the user's own chat as the current one", function()
+    -- view._current_buffer is the fallback :VibingCancel, :VibingToggleChat and :VibingMoteDir
+    -- use when the cursor is outside a chat buffer. A worker created in the background is not
+    -- the chat the user opened: letting it take that slot made :VibingCancel stop the worker
+    -- instead of the user's in-flight request, and made :VibingToggleChat report the (windowless)
+    -- worker as "not open" and open a third chat.
+    local users_chat = view.render({ session_id = "the-user-chat" }, "right")
+    assert.is_true(view.is_open())
+
+    local worker = handler.create_chat({})
+
+    assert.equals(users_chat.buf, view._current_buffer.buf)
+    assert.is_true(view.is_open())
+    -- ...and the worker is still reachable by bufnr, which is all the orchestrator needs
+    assert.is_not_nil(view.get_chat_buffer(worker.bufnr))
+  end)
+
+  it("creates two independent worker buffers rather than reusing one", function()
+    local first = handler.create_chat({})
+    local second = handler.create_chat({})
+
+    assert.are_not.equal(first.bufnr, second.bufnr)
+    assert.are_not.equal(first.file_path, second.file_path)
+  end)
+
+  it("rejects a position outside the :VibingChat set instead of falling back silently", function()
+    local ok, err = pcall(handler.create_chat, { position = "sideways" })
+
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("Invalid position", 1, true))
+    for _, position in ipairs(ChatConstants.POSITIONS) do
+      assert.is_truthy(tostring(err):find(position, 1, true))
+    end
+  end)
+
+  it("rejects a working_dir that does not exist", function()
+    local ok, err = pcall(handler.create_chat, { working_dir = "nope/not/here" })
+
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("working_dir", 1, true))
+  end)
+
+  it("treats an empty working_dir as absent", function()
+    local result = handler.create_chat({ working_dir = "" })
+
+    assert.is_true(vim.api.nvim_buf_is_valid(result.bufnr))
+  end)
+end)
+
+describe("rpc handlers: create_chat with working_dir", function()
+  local handler, save_dir, repo, original_cwd
+
+  before_each(function()
+    original_cwd = vim.fn.getcwd()
+    repo = vim.fn.tempname() .. "_repo"
+    vim.fn.mkdir(repo .. "/sub", "p")
+    vim.fn.system({ "git", "-C", repo, "init", "-q" })
+    -- Git.get_root() resolves against Neovim's cwd, so the handler only sees this repo from here.
+    vim.cmd("cd " .. vim.fn.fnameescape(repo))
+
+    save_dir = ChatBuffers.setup()
+    handler = require("vibing.infrastructure.rpc.handlers.chat")
+  end)
+
+  after_each(function()
+    ChatBuffers.reset()
+    vim.cmd("cd " .. vim.fn.fnameescape(original_cwd))
+  end)
+
+  it("writes the git-relative working_dir into the new chat's frontmatter", function()
+    local result = handler.create_chat({ working_dir = "sub" })
+
+    assert.equals("sub", result.working_dir)
+    local content = table.concat(vim.fn.readfile(result.file_path), "\n")
+    assert.is_truthy(content:find("working_dir: sub", 1, true))
+  end)
+
+  it("keeps the chat file in the configured save dir, not inside the working_dir", function()
+    -- A worker attached to a worktree must outlive `git worktree remove`; storing its transcript
+    -- under the worktree would delete the conversation along with the branch.
+    local result = handler.create_chat({ working_dir = "sub" })
+
+    assert.is_truthy(result.file_path:find(save_dir, 1, true))
+    assert.is_nil(result.file_path:find("/sub/", 1, true))
+  end)
+end)

--- a/tests/lua/presentation/chat/modules/chat_status_spec.lua
+++ b/tests/lua/presentation/chat/modules/chat_status_spec.lua
@@ -1,0 +1,74 @@
+-- Tests for the chat status an orchestrator polls to tell whether a worker chat is still busy.
+-- Also pins buf_get_lines' two return shapes: the MCP server and this plugin install separately,
+-- so an older server that sends no include_chat_status must keep getting the bare line array.
+
+local ChatBuffers = require("tests.helpers.chat_buffers")
+
+describe("chat status", function()
+  local ChatStatus, BufferHandler, view
+
+  before_each(function()
+    ChatBuffers.setup()
+    view = require("vibing.presentation.chat.view")
+    ChatStatus = require("vibing.presentation.chat.modules.chat_status")
+    BufferHandler = require("vibing.infrastructure.rpc.handlers.buffer")
+  end)
+
+  after_each(ChatBuffers.reset)
+
+  it("reports nil for a buffer that is not a vibing chat", function()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+
+    assert.is_nil(ChatStatus.get(bufnr))
+  end)
+
+  it("reports idle for a chat with no request in flight", function()
+    local chat_buf = view.render({ session_id = "idle-session" }, "back")
+
+    assert.equals("idle", ChatStatus.get(chat_buf.buf))
+  end)
+
+  it("reports responding while the CLI process is streaming", function()
+    local chat_buf = view.render({ session_id = "busy-session" }, "back")
+    chat_buf._current_handle_id = "handle-1"
+
+    assert.equals("responding", ChatStatus.get(chat_buf.buf))
+  end)
+
+  it("reports responding in the gap between <CR> and the CLI actually starting", function()
+    -- _current_handle_id is only set once the adapter spawns; without _is_sending those few
+    -- dozen milliseconds read as "finished" and an orchestrator would summarize an empty reply.
+    local chat_buf = view.render({ session_id = "sending-session" }, "back")
+    chat_buf._is_sending = true
+
+    assert.equals("responding", ChatStatus.get(chat_buf.buf))
+  end)
+
+  describe("buf_get_lines", function()
+    it("returns the bare line array when no status was asked for", function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "a", "b" })
+
+      assert.same({ "a", "b" }, BufferHandler.buf_get_lines({ bufnr = bufnr }))
+    end)
+
+    it("wraps lines and status together when asked", function()
+      local chat_buf = view.render({ session_id = "wrapped" }, "back")
+
+      local result = BufferHandler.buf_get_lines({ bufnr = chat_buf.buf, include_chat_status = true })
+
+      assert.is_table(result.lines)
+      assert.equals("idle", result.chat_status)
+    end)
+
+    it("omits the status for a non-chat buffer even when asked", function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "plain" })
+
+      local result = BufferHandler.buf_get_lines({ bufnr = bufnr, include_chat_status = true })
+
+      assert.same({ "plain" }, result.lines)
+      assert.is_nil(result.chat_status)
+    end)
+  end)
+end)

--- a/tests/view_spec.lua
+++ b/tests/view_spec.lua
@@ -2,26 +2,18 @@
 -- Regression: a chat buffer created earlier must still be recognized as a
 -- chat buffer after a newer chat becomes the most-recently-rendered one.
 
+local ChatBuffers = require("tests.helpers.chat_buffers")
+
 describe("vibing.presentation.chat.view", function()
   local view
 
   before_each(function()
     package.loaded["vibing.presentation.chat.view"] = nil
-    require("vibing").setup({})
+    ChatBuffers.setup()
     view = require("vibing.presentation.chat.view")
-    view._attached_buffers = {}
-    view._current_buffer = nil
   end)
 
-  after_each(function()
-    for bufnr, _ in pairs(view._attached_buffers) do
-      if vim.api.nvim_buf_is_valid(bufnr) then
-        vim.api.nvim_buf_delete(bufnr, { force = true })
-      end
-    end
-    view._attached_buffers = {}
-    view._current_buffer = nil
-  end)
+  after_each(ChatBuffers.reset)
 
   describe("render", function()
     it("tracks every rendered chat buffer, not just the most recent one", function()
@@ -31,6 +23,30 @@ describe("vibing.presentation.chat.view", function()
       view.render({ session_id = "session-2" }, "back")
 
       assert.is_not_nil(view._attached_buffers[first_buf])
+    end)
+
+    it("returns the chat buffer it created", function()
+      local chat_buf = view.render({ session_id = "session-1" }, "back")
+
+      assert.is_not_nil(chat_buf)
+      assert.equals(view._current_buffer.buf, chat_buf.buf)
+    end)
+
+    it("does not leak a one-off position into the global config", function()
+      -- ChatBuffer holds a reference to config.chat, so overriding the position in place used to
+      -- change the user's default for the rest of the session — right down to Config.defaults,
+      -- which survives a later setup(). nvim_chat_create always renders "back", which would have
+      -- left every subsequent :VibingChat opening no window at all.
+      -- Asserting the literal "current" rather than a value read beforehand is deliberate: a
+      -- leak from an earlier render in this file would have made the read-first form pass.
+      local config = require("vibing").get_config()
+
+      local chat_buf = view.render({ session_id = "session-1" }, "back")
+
+      assert.equals("back", chat_buf.config.window.position)
+      assert.equals("current", config.chat.window.position)
+      assert.equals("current", require("vibing.config").defaults.chat.window.position)
+      assert.is_false(chat_buf.config.window == config.chat.window)
     end)
   end)
 


### PR DESCRIPTION
Closes #498

## 概要

「配る・見守る・報告する」の最小ループ（MVP）を実装しました。1つのチャットがオーケストレーターになり、ワーカーチャットを立ち上げてタスクを配り、進捗を集約して報告できます。

issue の「スコープ外」に従い、**双方向対話・ワーカーからの自動報告・イベント駆動の完了通知は実装していません**。

## 成果物

### 1. 新規 MCP ツール `nvim_chat_create`

```text
nvim_chat_create({ rpc_port, position?, working_dir? })
  → { bufnr, file_path, working_dir, position, saved }
```

- `position` 既定は `back`（ウィンドウを作らずバッファのみ）。モデルが勝手に作ったワーカーでユーザーの画面を散らかさないため
- `working_dir` は git ルートからの相対パス。**存在しないディレクトリは作成時に弾く**（受け入れると、ユーザーが見ていないバッファで初回リクエスト時に初めて失敗する）
- チャットファイルは**作成時点でディスクに書く**。`:VibingChat` は初回応答まで書かないので、存在しないパスを返さないため（fork と同じ扱い）
- チャットファイルの置き場所は `working_dir` の中ではなく**設定どおりの `save_dir`**。worktree に置くと `git worktree remove` で会話ごと消えてしまい、`vibing-worktree-create`（frontmatter だけ書き換える）とも食い違うため

経路: `mcp-server/src/tools/chat.ts` → `handlers/chat.ts` → `lua/vibing/infrastructure/rpc/handlers/chat.lua` → `application/chat/use_cases/create_chat.lua` → `view.render`

### 2. `nvim_get_buffer` にチャット実行状態

vibing.nvim のチャットバッファに対しては、本文とは**別の content block** で `responding` / `idle` を返します。本文に混ざらないので、バッファの中身と取り違える余地がありません。

本文の形（最後のセクションが Assistant か等）から推測する方法は採りませんでした。エラーで終わったターンも、ツール実行だけで無言のまま進んでいるターンも「完了」に見えてしまうためです。

`include_chat_status` は**オプトインのパラメータ**にしています。MCP サーバーは Claude Code の user scope に別途インストールされ、プラグイン本体とバージョンがずれうるため、フラグを送らない古いサーバーには従来どおり生の配列を返します（Node 側も両方の形を受けます）。

### 3. バンドルスキル `skills/vibing-orchestrate/SKILL.md`

分割 →（必要なら worktree）→ `nvim_chat_create` → 自己完結した指示を `nvim_chat_send_message` → **ユーザーに主導権を返す** → 聞かれたら `nvim_get_buffer` で集約報告 → `vibing-worktree-finish` への導線。

自ターン内でポーリングし続けない点と、「ワーカーには一切の文脈が無いので指示は自己完結させる」点をスキル本文で強く言っています。`idle` は「成功」ではなく「実行中でない」だけ（失敗・承認待ち・質問中も idle）という注意も書きました。

## ついでに直した既存バグ 2件

どちらもこの機能が踏み抜いて初めて実害が出るもので、レビューで発覚しました。

**1. `view.render` がグローバル設定を書き換えていた**

`chat_buf.config.window.position = position` が、`ChatBuffer` が参照で持っているライブの `config.chat.window` をそのまま書き換えていました。`:VibingChat back` を1回実行するとユーザーの既定位置が永久に `back` になり、実測では `Config.defaults` まで書き換わって後の `setup()` でも戻りませんでした。ワーカーを常に `back` で作る本機能では致命的です。

> 注意点として `vim.tbl_deep_extend("force", {}, cfg)` では直りません。空テーブルをベースにすると衝突が起きず、ネストしたテーブルは参照のまま代入されるので `config.window` は同じテーブルのままです。`window` テーブルごと差し替える必要があります。

**2. `view.render` が `_current_buffer` シングルトンを奪っていた**

`view._current_buffer` は「ユーザーが最後に開いたチャット」で、カーソルがチャット外にあるときの `:VibingCancel` / `:VibingToggleChat` / `:VibingMoteDir` のフォールバック先です。バックグラウンドのワーカーがここを奪うと、`:VibingCancel` がユーザーの実行中リクエストではなくワーカーを止め、`back` のワーカーにはウィンドウが無いので `is_open()` が false になり `:VibingToggleChat` が既に開いているチャットをトグルせず新しいチャットを作ってしまいます。`render` に `background` オプションを足して解決しました（ワーカーは `_attached_buffers` 側に登録されるので bufnr での検索には影響しません）。

## 検証

すべてローカルで green です。

| コマンド | 結果 |
| --- | --- |
| `pnpm run check` | OK |
| `pnpm run check:doc` | OK（1 help file OK） |
| `pnpm run lint` | OK |
| `pnpm run format:check` | OK |
| `pnpm run test:lua` | exit 0 |
| `pnpm run test:node` | 32 pass / 0 fail |
| `pnpm run build` | OK |
| `mcp-server` の `tsc --noEmit` | OK |
| `mcp-server` の `vitest run` | 123 pass / 12 files |

`test:e2e` と `test:eval` は実トークンを消費するため実行していません。

追加したテスト:

- `tests/lua/infrastructure/rpc/handlers/chat_spec.lua`（10件）— `back` 既定、ファイルが実在すること、bufnr で引けること、position 不正・working_dir 不在の拒否、`_current_buffer` を奪わないこと、保存先が `working_dir` の中でないこと
- `tests/lua/presentation/chat/modules/chat_status_spec.lua`（7件）— responding/idle/非チャット、`buf_get_lines` の2つの戻り値形状
- `tests/view_spec.lua` に設定リーク回帰テスト
- `mcp-server/src/__tests__/buffer-tools.test.ts`（新規）、`chat-tools.test.ts`（追記）

`_current_buffer` の回帰テストと設定リークの回帰テストは、修正を戻すと実際に落ちることを確認済みです。

## 未検証（手動確認をお願いしたい点）

**Acceptance Criteria の「2つのワーカーチャットに同時にタスクを配って両方の応答が混線しない」は実トークンを使うため実行していません。** 以下の手順で確認できます。

1. Neovim で `:VibingChat` を開き、`rpc_port` をシステムプロンプトから確認する
2. そのチャットに「この2つを並行でやって」と依頼し、`vibing-orchestrate` スキルが発動することを確認する（もしくは手動で以下を実行）
3. `nvim_chat_create({ rpc_port, position: "back" })` を2回呼び、異なる `bufnr` が返ることを確認
4. それぞれの `bufnr` に `nvim_chat_send_message` で**別々の**タスク（例: 「1から10までの素数を列挙して」「日本の都道府県を3つ挙げて」）を送る
5. 送信直後に両方の `nvim_get_buffer` を呼び、`responding` が返ることを確認
6. 応答完了後に両方を読み、**それぞれのバッファに自分宛のタスクの答えだけが書かれている**（相手の応答が混ざっていない）ことを確認
7. `:VibingCancel` がオーケストレーター側のチャットに効くこと、`:VibingToggleChat` が正しく動くことも併せて確認（上記バグ2の実地確認）

理屈の上では、各チャットが独自の `session_id` と handle ID を持つ既存の並行実行保証（`docs/adr/002-concurrent-execution-support.md`）にそのまま乗っているだけで、新しい共有状態は増やしていません。

## その他の未対応・気づいた点

- **`Git.resolve_working_dir` にパス境界チェックが無い**（`../..` で git ルート外を指せる）。本 PR で導入した経路ではありませんし、同じ MCP ツール群には `nvim_execute`（任意 Ex コマンド）が既にあるので権限境界としては新設ではありませんが、一般的な堅牢化としては別 issue の価値があります
- **「チャットバッファを書き出す」処理がリポジトリ内に5箇所ある**（`buffer.lua` ×2、`fork.lua`、`init.lua`、本 PR の `save_now`）。挙動が微妙に違うので `ChatBuffer:save()` への集約は別 PR 向きと判断しました
- `use_case.create_new_in_directory` は呼び出し元ゼロのまま残しています（保存先の方針が本 PR と逆なので使わず、削除はスコープ外としました）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
