### PR TITLE
fix(copilot,grok): restrict lightweight utility calls

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -370,6 +370,16 @@ property of its CLI rather than something left undone here. `--tools` filters bu
 MCP tools are added on top regardless (the advertised count stays ~254 higher either way) and
 grok 0.2.101 has no per-run flag to disable MCP servers, so the builder can only deny their
 _execution_ with `--deny "MCPTool(*)"`, in the `MCPTool(server__tool)` form grok's rules require.
+
+That wildcard is measured, not assumed, because a rule grok does not recognise is dropped in
+silence — `grok inspect`'s permission count goes 1 → 2 for `MCPTool(*)` loaded from a
+`.grok/config.toml` but stays at 1 for an invented kind, which it still reports as "0 skipped".
+Enforcement was then checked through the flag itself against a real MCP call: same prompt, same
+flags, `--deny` the only difference. Without it the model reports the tool called successfully;
+with it, "denied by a permission policy", and the debug log records
+`deny rule matched (enforced before YOLO) tool="mcp:vibing-nvim__nvim_list_instances"`. Both runs
+passed `--always-approve`, so "before YOLO" is where the `deny` > `ask` > `allow` precedence gets
+confirmed too — which is what makes this not redundant with `dontAsk`.
 Project instructions have no escape hatch at all: grok reads `AGENTS.md`/`CLAUDE.md` from the repo
 and the home directory, and the only switches (`[compat.claude]`, `[mcp_servers]`) are persistent
 config, not per-invocation. `--sandbox read-only` was considered and rejected — grok's own docs

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -326,6 +326,56 @@ _chat_ in that mode, and a title generated behind their back is not the call the
 `utility_model` still goes through the Claude-name filter, so its `sonnet` default becomes no
 `-m` at all rather than a model codex would reject.
 
+**Copilot can remove the tools outright, and does it in one flag.** `--available-tools` is the
+filter deciding "which tools the model can see" (`copilot help permissions`), so a list naming
+nothing leaves nothing. Measured against copilot 1.0.78 by counting tool schemas in
+`--log-level debug` output: an ordinary run offers 62 tools, `--available-tools=view` offers 1,
+and `--available-tools=__vibing_no_tools__` offers 0 — with the turn still completing normally
+(`toolRequests: []`, exit 0). That count includes the user's MCP tools, so the one flag also
+covers what claude needs `--strict-mcp-config` for; the MCP servers are still spawned, but expose
+nothing. `--no-custom-instructions` is the `--setting-sources ""` half, verified by planting a
+sentinel string in `AGENTS.md` and watching it reach the prompt twice without the flag and not at
+all with it. Nothing to skip on the hook side: `copilot_cli` registers none at all.
+
+The sentinel has to be a name, not an empty string. `--available-tools=` parses as an empty list
+and copilot ignores it, leaving all 62 tools — so the flag reads as working while doing nothing.
+
+**Grok fails open on exactly that trick, which is why it does the opposite.** Its `--tools` is an
+allowlist, but an entry it cannot map to a real tool id makes it discard the whole restriction:
+`--debug-file` on grok 0.2.101 records
+`tools allowlist had unmappable entries; keeping full grok toolset` for `--tools "none"`, and
+`--tools ""` is ignored the same way copilot's empty list is. So `grok_command_builder` names a
+real tool — `todo_write`, the only built-in reaching no file, shell or network — and the run logs
+`tools allowlist applied` with the toolset down from 26 to 3. `--permission-mode dontAsk` stands
+in for codex's `approval_policy="never"`.
+
+**Skipping the hook does not mean grok has no hook**, and that difference bites. Claude and codex
+register one per invocation (`--settings <path>`, `-c hooks.pre_tool_use=…`), so omitting the flag
+genuinely leaves the run hookless. Grok discovers `<cwd>/.grok/hooks/` instead, which
+`GrokSettingsGenerator.ensure` writes once per cwd and nothing ever removes — so `grok_cli`
+skipping `ensure` for a lightweight call only skips _rewriting_ it. Any project that has had one
+ordinary grok chat still has the hook on disk, and a utility call is by definition something that
+happens after a chat.
+
+That is why `todo_write` had to be added to `grok_tool_vocabulary`. It is claude's `TodoWrite`
+under another name; unmapped, the raw name reached `can_use_tool`, missed the `INTERNAL_TOOLS`
+always-allow list, matched nothing in the default allow list and resolved to `ask` — which
+`cancel_and_deny` serves by killing the CLI process _before_ checking for an approval UI. A
+lightweight call registers none, so a title generation would have died silently on the one tool
+its own allowlist leaves it. Deleting the hook file instead was rejected: the cwd is shared with
+every concurrent chat, which still needs it.
+
+**Grok is the one backend that cannot keep the whole `lightweight` bargain,** and that is a
+property of its CLI rather than something left undone here. `--tools` filters built-ins only —
+MCP tools are added on top regardless (the advertised count stays ~254 higher either way) and
+grok 0.2.101 has no per-run flag to disable MCP servers, so the builder can only deny their
+_execution_ with `--deny "MCPTool(*)"`, in the `MCPTool(server__tool)` form grok's rules require.
+Project instructions have no escape hatch at all: grok reads `AGENTS.md`/`CLAUDE.md` from the repo
+and the home directory, and the only switches (`[compat.claude]`, `[mcp_servers]`) are persistent
+config, not per-invocation. `--sandbox read-only` was considered and rejected — grok's own docs
+say its network blocking is a no-op on macOS, and resuming a session under a sandbox profile is
+constrained, which `/summarize` always is.
+
 The model half of that lives in `modules/non_claude_model.lua`, shared by codex, copilot and grok.
 It was three byte-identical private copies before, and #537 was filed against codex alone — so
 teaching one copy about `lightweight` would have left the same bug live on the other two, with

--- a/lua/vibing/core/types.lua
+++ b/lua/vibing/core/types.lua
@@ -42,7 +42,7 @@
 ---@field on_tool_use_full fun(tool: string, input: table)? 表示用に間引かない生のツール入力（eval用）
 ---@field _session_id string?
 ---@field _session_id_explicit boolean?
----@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ。各アダプタは「ツールを使わせない・プロジェクト設定とユーザー MCP サーバーを読ませない・フックを登録しない・utility_model を使う」、かつ「これらが CLI 側のスキーマ変更で黙って外れないこと」を果たす責務を負う（claude は --tools ""、codex は read-only サンドボックス + --ignore-user-config）
+---@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ。各アダプタは「ツールを使わせない・プロジェクト設定とユーザー MCP サーバーを読ませない・フックを登録しない・utility_model を使う」、かつ「これらが CLI 側のスキーマ変更で黙って外れないこと」を果たす責務を負う（claude は --tools ""、codex は read-only サンドボックス + --ignore-user-config、copilot は --available-tools にダミー名、grok は --tools todo_write）。grok だけは CLI 側に手段がなく、プロジェクト指示（AGENTS.md/CLAUDE.md）を読ませないことと MCP ツールの提示を止めることができない（提示は止められないため --deny "MCPTool(*)" で実行のみ拒否している。詳細は architecture.md）
 
 ---@class Vibing.AdapterResponse
 ---@field content string?

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -76,8 +76,12 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
 
   -- Install project PreToolUse hook (reuses bin/hooks/pre-tool-use.sh) unless fully bypassed.
   -- Grok discovers <cwd>/.grok/hooks/*.json when the folder is trusted.
+  --
+  -- Lightweight calls skip it too, matching claude_cli and codex_cli. The builder takes their
+  -- tools away instead, and routing a title-generation tool call into the chat's approval UI
+  -- would prompt the user about a request they never made.
   local permission_mode = opts.permission_mode or "default"
-  if permission_mode ~= "bypassPermissions" then
+  if permission_mode ~= "bypassPermissions" and not opts.lightweight then
     local ok_hook, hook_err = pcall(GrokSettingsGenerator.ensure, cwd)
     if not ok_hook then
       vim.notify(

--- a/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/copilot_command_builder.lua
@@ -14,6 +14,21 @@ local M = {}
 
 local ToolVocabulary = require("vibing.infrastructure.adapter.modules.copilot_tool_vocabulary")
 
+--- A tool name copilot does not have, handed to `--available-tools` to leave the model with an
+--- empty toolset.
+---
+--- `--available-tools` is documented as the filter that "disables all other tools" and decides
+--- "which tools the model can see" (`copilot help permissions`), so a list matching nothing
+--- resolves to nothing. Verified against copilot 1.0.78 by counting the tool schemas in
+--- `--log-level debug` output: an ordinary run offers 62 tools, `--available-tools=view` offers
+--- exactly 1, and this sentinel offers 0 — and the turn still completes normally
+--- (`toolRequests: []`, exit 0), so an empty toolset is not an error to copilot.
+---
+--- The value has to be a name rather than an empty string. `--available-tools=` parses as an
+--- empty list, which copilot ignores outright: it left all 62 tools in place, the same silent
+--- no-op grok has for `--tools ""`.
+local NO_TOOLS_SENTINEL = "__vibing_no_tools__"
+
 --- Append permission flags. copilot's non-interactive mode requires --allow-all-tools,
 --- so denies are expressed with --deny-tool rather than an allow list.
 --- @param cmd string[]
@@ -35,6 +50,29 @@ local function append_permission_flags(cmd, opts)
     table.insert(cmd, "--deny-tool")
     table.insert(cmd, pattern)
   end
+end
+
+--- Append the flags a lightweight utility call (title generation, /summarize, daily summary)
+--- runs under, in place of the permission flags.
+---
+--- This is copilot's half of what `lightweight` promises in `core/types.lua`. Unlike codex,
+--- copilot can genuinely take the tools away, so there is no sandbox to fence anything into:
+--- `--available-tools` filters the user's MCP tools too (the 62-tool baseline above includes
+--- them, and the sentinel leaves 0), which covers claude's `--strict-mcp-config` in one flag.
+--- The MCP servers themselves are still spawned, but expose nothing to the model.
+---
+--- `--allow-all-tools` stays because copilot requires it in non-interactive mode at all, not
+--- because anything is left to allow. `permission_mode` is deliberately ignored,
+--- `bypassPermissions` included: the user put the *chat* in that mode, and a title generated
+--- behind their back is not the call they made.
+--- @param cmd string[]
+local function append_lightweight_flags(cmd)
+  table.insert(cmd, "--allow-all-tools")
+  table.insert(cmd, "--available-tools=" .. NO_TOOLS_SENTINEL)
+  -- claude's `--setting-sources ""` and codex's `project_doc_max_bytes=0`. Verified on 1.0.78:
+  -- an AGENTS.md sentinel string reaches the prompt twice without this flag and not at all
+  -- with it.
+  table.insert(cmd, "--no-custom-instructions")
 end
 
 --- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec
@@ -62,7 +100,11 @@ function M.build(prompt, opts, session_id, config)
     table.insert(cmd, model)
   end
 
-  append_permission_flags(cmd, opts)
+  if opts.lightweight then
+    append_lightweight_flags(cmd)
+  else
+    append_permission_flags(cmd, opts)
+  end
 
   local full_prompt = prompt
   if not session_id then

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -15,6 +15,38 @@ local GROK_PERMISSION_MODE_FALLBACK = {
   auto = "default",
 }
 
+--- The tool allowlist a lightweight utility call runs under.
+---
+--- Grok's `--tools` is an allowlist ("only the listed tools will be available; all others are
+--- removed"), but it **fails open** on anything it cannot map to a real tool id. Verified against
+--- grok 0.2.101 via `--debug-file`: `--tools "none"` logs
+--- `tools allowlist had unmappable entries; keeping full grok toolset` and leaves every tool in
+--- place, and `--tools ""` is ignored outright — the advertised tool count is unchanged from a
+--- plain run either way. So the copilot trick of naming nothing is exactly wrong here; the list
+--- has to name a tool grok actually has.
+---
+--- `todo_write` is that tool. Of grok's built-ins (`run_terminal_cmd`, `grep`, `read_file`,
+--- `search_replace`, `list_dir`, `web_search`, `web_fetch`, `todo_write`, `task`) it is the only
+--- one that touches no file, no shell and no network — it writes an in-session todo list and
+--- nothing else. With it the run logs `tools allowlist applied allowed=["todo_write"]` and the
+--- toolset drops from 26 to 3 (the tool plus grok's two always-on MCP meta-tools).
+local LIGHTWEIGHT_TOOLS = "todo_write"
+
+--- Deny rule covering every MCP tool, in the `MCPTool(server__tool)` form grok's permission
+--- rules require -- an `mcp__server__tool` pattern never matches.
+---
+--- Needed because `--tools` filters grok's *built-in* tools only; the tools its MCP servers
+--- expose are added on top regardless, and grok offers no per-run way to turn those servers off.
+--- The allowlist cannot reach them, so execution is denied instead. This is weaker than claude's
+--- empty `--mcp-config`, which stops them being offered at all.
+---
+--- Not redundant with the `dontAsk` mode below, which is the tempting reading. grok's own docs
+--- say `dontAsk` stops short of auto-denying while always-approve is on, and grok imports the
+--- user's `settings.json` permission rules -- so an allow rule there could pre-approve an MCP
+--- tool. An explicit deny is what survives both: grok evaluates `deny` > `ask` > `allow`,
+--- "regardless of order or source".
+local LIGHTWEIGHT_MCP_DENY = "MCPTool(*)"
+
 local cached_grok_path = nil
 local cached_configured_executable = nil
 local verified_official = false
@@ -106,20 +138,53 @@ end
 --- name tools it cannot invoke. Only the backend-agnostic conventions go here.
 --- @param opts Vibing.AdapterOpts
 --- @param config Vibing.Config
---- @return string
+--- @return string|nil rules `nil` when there is nothing to say, so the caller omits the flag —
+---   grok reads an empty `--rules` as a rule rather than as silence. `nil` rather than `""`
+---   matches `CommonBuilder.language_instruction` and makes the omission impossible to drop:
+---   `table.insert(cmd, nil)` raises where an empty string would sail through.
 local function build_rules(opts, config)
-  local lines = {
-    "When creating a git worktree for isolated work, place it under "
-      .. worktree_constants.DIR
-      .. "<branch-name>/ at the repository root.",
-  }
+  local lines = {}
 
   local language_instruction = CommonBuilder.language_instruction(opts, config)
   if language_instruction then
-    table.insert(lines, 1, language_instruction)
+    table.insert(lines, language_instruction)
   end
 
+  -- A lightweight call has no tools to create a worktree with, so the convention would just be
+  -- wasted prompt tokens describing a capability that isn't there. Matches the claude builder,
+  -- which drops the same line from `--append-system-prompt`.
+  if not opts.lightweight then
+    table.insert(
+      lines,
+      "When creating a git worktree for isolated work, place it under "
+        .. worktree_constants.DIR
+        .. "<branch-name>/ at the repository root."
+    )
+  end
+
+  if #lines == 0 then
+    return nil
+  end
   return table.concat(lines, "\n")
+end
+
+--- Append the flags a lightweight utility call (title generation, /summarize, daily summary) runs
+--- under, in place of the chat's permission mode.
+---
+--- Takes no `opts` on purpose: "the utility call does not inherit the chat's permission mode,
+--- `bypassPermissions` included" is then enforced by the signature rather than by a comment. The
+--- user put the *chat* in that mode, and a title generated behind their back is not the call they
+--- made.
+--- @param cmd string[]
+local function append_lightweight_flags(cmd)
+  table.insert(cmd, "--tools")
+  table.insert(cmd, LIGHTWEIGHT_TOOLS)
+  table.insert(cmd, "--deny")
+  table.insert(cmd, LIGHTWEIGHT_MCP_DENY)
+  -- codex's `approval_policy="never"`, in grok's vocabulary. grok_cli registers no hook for a
+  -- lightweight call, so a mode that prompts would stall on an approval nothing can answer.
+  table.insert(cmd, "--permission-mode")
+  table.insert(cmd, "dontAsk")
 end
 
 --- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec that
@@ -166,7 +231,9 @@ function M.build(prompt, opts, session_id, config, handle_id, rpc_port)
     end
   end
 
-  if opts.permission_mode then
+  if opts.lightweight then
+    append_lightweight_flags(cmd)
+  elseif opts.permission_mode then
     local mode = GROK_PERMISSION_MODE_FALLBACK[opts.permission_mode] or opts.permission_mode
     table.insert(cmd, "--permission-mode")
     table.insert(cmd, mode)
@@ -177,8 +244,11 @@ function M.build(prompt, opts, session_id, config, handle_id, rpc_port)
     table.insert(cmd, opts.cwd)
   end
 
-  table.insert(cmd, "--rules")
-  table.insert(cmd, build_rules(opts, config))
+  local rules = build_rules(opts, config)
+  if rules then
+    table.insert(cmd, "--rules")
+    table.insert(cmd, rules)
+  end
 
   return cmd
 end

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -45,6 +45,20 @@ local LIGHTWEIGHT_TOOLS = "todo_write"
 --- user's `settings.json` permission rules -- so an allow rule there could pre-approve an MCP
 --- tool. An explicit deny is what survives both: grok evaluates `deny` > `ask` > `allow`,
 --- "regardless of order or source".
+---
+--- Both halves of that were measured against grok 0.2.101 rather than trusted to the docs:
+---
+--- 1. The rule *form* is recognised. Loading it from a `.grok/config.toml` moves
+---    `grok inspect`'s permission count from 1 to 2, while an invented kind
+---    (`TotallyBogusKind(*)`) leaves it at 1 -- and is reported as "0 skipped", so an
+---    unrecognised rule vanishes without a word. A wildcard that silently did nothing would look
+---    exactly like one that worked.
+--- 2. The rule is *enforced*, through this flag, against a real MCP call. Same prompt and flags
+---    twice, `--deny` the only difference: without it the model reports the tool called
+---    successfully; with it, "denied by a permission policy", and the debug log records
+---    `deny rule matched (enforced before YOLO) tool="mcp:vibing-nvim__nvim_list_instances"`.
+---    Both runs passed `--always-approve`, so "enforced before YOLO" is also the precedence
+---    claim above, confirmed rather than assumed.
 local LIGHTWEIGHT_MCP_DENY = "MCPTool(*)"
 
 local cached_grok_path = nil

--- a/lua/vibing/infrastructure/adapter/modules/grok_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_tool_vocabulary.lua
@@ -26,6 +26,19 @@ local NATIVE_TO_CANONICAL = {
   web_search = "WebSearch",
   web_fetch = "WebFetch",
   spawn_subagent = "Task",
+  -- Grok's in-session todo list, which is claude's `TodoWrite` under another name. Unmapped, the
+  -- raw `todo_write` reaches `can_use_tool` (`to_canonical(x) or x`), misses the `INTERNAL_TOOLS`
+  -- always-allow list that holds the capitalised spelling, matches nothing in the default allow
+  -- list, and so resolves to `ask` -- an approval prompt for a bookkeeping tool that touches no
+  -- file, shell or network.
+  --
+  -- That matters most where nothing can answer the prompt. `.grok/hooks/` is written once per cwd
+  -- and never removed, so a lightweight utility call (title generation, /summarize) still runs
+  -- with whatever hook an earlier ordinary chat left on disk -- and `todo_write` is the one tool
+  -- its allowlist leaves available. An `ask` there reaches `cancel_and_deny`, which kills the CLI
+  -- process before checking for an approval UI the lightweight call never registered, so the
+  -- title generation would fail with no prompt shown and no way to answer one.
+  todo_write = "TodoWrite",
 }
 
 --- Where Grok puts the path a tool is about. Granular permission rules read `file_path` (the

--- a/tests/copilot_command_builder_spec.lua
+++ b/tests/copilot_command_builder_spec.lua
@@ -34,6 +34,10 @@ describe("copilot_command_builder", function()
     vim.fn.exepath = function()
       return "/usr/local/bin/copilot"
     end
+    -- The builder's resolved path is cached at module scope, so without this only the first
+    -- test's stub would take effect and every later one would read test #1's value. It passes
+    -- today only because every test here stubs the same constant path.
+    require("tests.helpers.adapter_stream").reset_path_caches()
   end)
 
   after_each(function()
@@ -129,6 +133,81 @@ describe("copilot_command_builder", function()
     it("skips the language instruction for en", function()
       local cmd = Builder.build("hi", { language = "en" }, nil, {})
       assert.are.equal("hi", cmd[#cmd])
+    end)
+  end)
+
+  describe("lightweight mode", function()
+    --- The `--available-tools=<name>` argument, which copilot takes as one argv token.
+    local function available_tools(cmd)
+      for _, arg in ipairs(cmd) do
+        local value = arg:match("^%-%-available%-tools=(.*)$")
+        if value then
+          return value
+        end
+      end
+      return nil
+    end
+
+    it("leaves the model no tools, by naming one copilot does not have", function()
+      -- Unlike codex, copilot can genuinely remove the tools, so this pins an empty toolset
+      -- rather than a sandbox around a toolset that has to stay. `--available-tools=` would not
+      -- do it: an empty list is ignored outright, leaving every tool in place. The sentinel is
+      -- what makes the filter match nothing instead.
+      local cmd = Builder.build("hi", { lightweight = true }, nil, {})
+      local value = available_tools(cmd)
+      assert.is_not_nil(value)
+      assert.are_not.equal("", value)
+      for _, real_tool in ipairs({ "bash", "view", "create", "edit", "web_search", "task" }) do
+        assert.are_not.equal(real_tool, value)
+      end
+    end)
+
+    it("reads no AGENTS.md, the way the claude path reads no CLAUDE.md", function()
+      local cmd = Builder.build("hi", { lightweight = true }, nil, {})
+      assert.is_true(contains(cmd, "--no-custom-instructions"))
+    end)
+
+    it("keeps --allow-all-tools, which copilot requires in non-interactive mode", function()
+      local cmd = Builder.build("hi", { lightweight = true }, nil, {})
+      assert.is_true(contains(cmd, "--allow-all-tools"))
+    end)
+
+    it("does not inherit the chat's plan mode", function()
+      local cmd = Builder.build("hi", { lightweight = true, permission_mode = "plan" }, nil, {})
+      assert.is_false(contains(cmd, "--plan"))
+    end)
+
+    it("stays tool-free even when the chat is in bypassPermissions", function()
+      -- The user put the chat in that mode; a title generated behind their back is not the call
+      -- they made, so the utility call does not inherit it.
+      local cmd =
+        Builder.build("hi", { lightweight = true, permission_mode = "bypassPermissions" }, nil, {})
+      assert.is_false(contains(cmd, "--allow-all"))
+      assert.is_not_nil(available_tools(cmd))
+    end)
+
+    it("carries none of the chat's deny patterns", function()
+      -- With no tools to gate, a --deny-tool would be describing a toolset that isn't there.
+      local cmd = Builder.build("hi", { lightweight = true, permissions_deny = { "Bash" } }, nil, {})
+      assert.is_false(contains(cmd, "--deny-tool"))
+    end)
+
+    it("still restricts a resumed session, which /summarize always is", function()
+      local cmd = Builder.build("hi", { lightweight = true }, "sess-1", {})
+      assert.is_not_nil(available_tools(cmd))
+      assert.is_true(contains(cmd, "--no-custom-instructions"))
+    end)
+
+    it("leaves an ordinary call's tools untouched", function()
+      local cmd = Builder.build("hi", {}, nil, {})
+      assert.is_nil(available_tools(cmd))
+      assert.is_false(contains(cmd, "--no-custom-instructions"))
+    end)
+
+    it("uses utility_model rather than default_model", function()
+      local config = { agent = { default_model = "gpt-5", utility_model = "gpt-5-mini" } }
+      local cmd = Builder.build("hi", { lightweight = true }, nil, config)
+      assert.are.equal("gpt-5-mini", value_after(cmd, "--model"))
     end)
   end)
 end)

--- a/tests/lua/infrastructure/adapter/grok_cli_spec.lua
+++ b/tests/lua/infrastructure/adapter/grok_cli_spec.lua
@@ -1,0 +1,69 @@
+---@diagnostic disable: undefined-field
+--- Covers the one thing grok_cli decides for itself that the command builder cannot see:
+--- whether the PreToolUse hook gets installed at all.
+---
+--- The builder cuts a lightweight call down to a single inert tool, but the hook is written to
+--- disk by the adapter, so a spec on the builder alone would pass with the hook still wired up.
+--- Unlike codex the hook is not an argv flag here -- grok discovers `<cwd>/.grok/hooks/` -- so
+--- this asserts on the generator being called rather than on the command array.
+
+local helper = require("tests.helpers.adapter_stream")
+local GrokSettingsGenerator = require("vibing.infrastructure.hooks.grok_settings_generator")
+local grok = require("vibing.infrastructure.adapter.grok_cli")
+
+local CONFIG = { agent = { default_model = "sonnet" } }
+
+describe("grok_cli hook registration", function()
+  local system, adapter, ensure_calls, original_ensure, original_executable
+
+  before_each(function()
+    system = helper.stub_system("/usr/local/bin/grok")
+
+    -- The builder sniffs the binary to confirm it is the official CLI; reporting it as
+    -- non-executable skips that without needing grok on the machine.
+    original_executable = vim.fn.executable
+    vim.fn.executable = function(path)
+      if path == "/usr/local/bin/grok" then
+        return 0
+      end
+      return original_executable(path)
+    end
+
+    ensure_calls = 0
+    original_ensure = GrokSettingsGenerator.ensure
+    GrokSettingsGenerator.ensure = function()
+      ensure_calls = ensure_calls + 1
+    end
+
+    adapter = grok:new(CONFIG)
+  end)
+
+  after_each(function()
+    GrokSettingsGenerator.ensure = original_ensure
+    vim.fn.executable = original_executable
+    system.restore()
+  end)
+
+  it("installs the PreToolUse hook for an ordinary call", function()
+    helper.run_stream(adapter, { permission_mode = "default" })
+    assert.equals(1, ensure_calls)
+  end)
+
+  it("skips it for a lightweight call, matching claude_cli and codex_cli", function()
+    -- Routing a title-generation tool call into the chat's approval UI would prompt the user
+    -- about a request they never made. The tool allowlist is what constrains it instead.
+    helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
+    assert.equals(0, ensure_calls)
+  end)
+
+  it("skips it in bypassPermissions, as before", function()
+    helper.run_stream(adapter, { permission_mode = "bypassPermissions" })
+    assert.equals(0, ensure_calls)
+  end)
+
+  it("still restricts the lightweight call even with the hook gone", function()
+    helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
+    local cmd = system.only_call().cmd
+    assert.is_true(vim.tbl_contains(cmd, "todo_write"))
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
@@ -50,6 +50,11 @@ describe("grok_command_builder", function()
     return nil
   end
 
+  local function value_after(cmd, flag)
+    local index = find_flag(cmd, flag)
+    return index and cmd[index + 1] or nil
+  end
+
   local function find_prefixed(cmd, prefix)
     for _, arg in ipairs(cmd) do
       if arg:sub(1, #prefix) == prefix then
@@ -256,6 +261,72 @@ describe("grok_command_builder", function()
       assert.has_error(function()
         fresh_builder.build("hello again", {}, nil, config)
       end)
+    end)
+  end)
+
+  describe("lightweight mode", function()
+    it("allows only todo_write, the one tool with no file, shell or network reach", function()
+      -- Grok fails open on an allowlist it cannot map: `--tools ""` is ignored and an unknown
+      -- name logs "keeping full grok toolset". So this must name a real tool, which is the whole
+      -- reason it cannot copy copilot's sentinel.
+      local cmd = grok_command_builder.build("hi", { lightweight = true }, nil, {})
+      assert.equals("todo_write", value_after(cmd, "--tools"))
+    end)
+
+    it("denies the MCP tools the allowlist cannot reach", function()
+      -- `--tools` filters built-ins only; MCP tools are added on top regardless, and grok has no
+      -- per-run way to turn those servers off. Denying execution is all that is left.
+      local cmd = grok_command_builder.build("hi", { lightweight = true }, nil, {})
+      assert.equals("MCPTool(*)", value_after(cmd, "--deny"))
+    end)
+
+    it("never waits on an approval prompt no hook is registered to answer", function()
+      local cmd = grok_command_builder.build("hi", { lightweight = true }, nil, {})
+      assert.equals("dontAsk", value_after(cmd, "--permission-mode"))
+    end)
+
+    it("does not inherit the chat's permission mode, bypassPermissions included", function()
+      -- The user put the chat in that mode; a title generated behind their back is not the call
+      -- they made, so the utility call does not inherit it.
+      local cmd = grok_command_builder.build(
+        "hi",
+        { lightweight = true, permission_mode = "bypassPermissions" },
+        nil,
+        {}
+      )
+      assert.equals("dontAsk", value_after(cmd, "--permission-mode"))
+      assert.equals("todo_write", value_after(cmd, "--tools"))
+    end)
+
+    it("still restricts a resumed session, which /summarize always is", function()
+      local cmd = grok_command_builder.build("hi", { lightweight = true }, "sess-1", {})
+      assert.equals("todo_write", value_after(cmd, "--tools"))
+    end)
+
+    it("drops the worktree convention it has no tool to act on", function()
+      local cmd = grok_command_builder.build("hi", { lightweight = true }, nil, {})
+      assert.is_nil(find_flag(cmd, "--rules"))
+    end)
+
+    it("keeps a configured language instruction in --rules", function()
+      local cmd = grok_command_builder.build("hi", { lightweight = true, language = "ja" }, nil, {})
+      local rules = value_after(cmd, "--rules")
+      assert.is_not_nil(rules)
+      assert.is_nil(rules:find("worktree", 1, true))
+      assert.is_not_nil(rules:find("Japanese", 1, true))
+    end)
+
+    it("leaves an ordinary call unrestricted", function()
+      local cmd = grok_command_builder.build("hi", {}, nil, {})
+      assert.is_nil(find_flag(cmd, "--tools"))
+      assert.is_nil(find_flag(cmd, "--deny"))
+      assert.is_not_nil(find_flag(cmd, "--rules"))
+    end)
+
+    it("uses utility_model rather than default_model", function()
+      local config = { agent = { default_model = "grok-4", utility_model = "grok-3-mini" } }
+      local cmd = grok_command_builder.build("hi", { lightweight = true }, nil, config)
+      assert.equals("grok-3-mini", value_after(cmd, "--model"))
     end)
   end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/grok_tool_vocabulary_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_tool_vocabulary_spec.lua
@@ -22,6 +22,15 @@ describe("grok_tool_vocabulary", function()
       assert.equals("Bash", vocabulary.to_canonical("shell"))
     end)
 
+    it("maps todo_write onto TodoWrite, which is always-allowed", function()
+      -- Unmapped, the raw name reaches can_use_tool, misses the INTERNAL_TOOLS list (which holds
+      -- the capitalised spelling) and resolves to `ask` -- an approval prompt for a bookkeeping
+      -- tool. A lightweight utility call has no UI to show that prompt in and gets killed by
+      -- cancel_and_deny instead, so this mapping is what keeps title generation working on a
+      -- project whose .grok/hooks/ an earlier ordinary chat already wrote.
+      assert.equals("TodoWrite", vocabulary.to_canonical("todo_write"))
+    end)
+
     it("returns nil for a name it does not know, so the caller keeps the original", function()
       assert.is_nil(vocabulary.to_canonical("Bash"))
       assert.is_nil(vocabulary.to_canonical("something_new"))


### PR DESCRIPTION
Closes #573

## 背景

PR #571（issue #537）で codex の lightweight 呼び出しにツール制限を入れましたが、copilot と grok の command builder は `opts.lightweight` を一切参照していませんでした。`config.adapter = "copilot"` / `"grok"` の環境では、タイトル生成・`/summarize`・デイリーサマリーが通常のチャットと同じツール権限で走っていました。

`core/types.lua` が定める lightweight の4責務のうち、④ `utility_model` は #571 の `non_claude_model.lua` 集約で対応済み。本PRは残る ①ツールを使わせない ②プロジェクト設定を読ませない ③フックを登録しない を埋めます。

## 手段は実機で確認しました

**推測で実装していません。** 両CLIとも「一見効いているように見えて実際は無視される」失敗モードを持っていたため、実バイナリ（copilot 1.0.78 / grok 0.2.101）を叩いて確認しています。

### copilot — ツールを本当に削除できる

`--available-tools` は「モデルに見えるツール」を決めるフィルタ（`copilot help permissions`）なので、何にもマッチしない名前を渡せば0個になります。`--log-level debug` のツールスキーマ数で計測:

| 指定 | モデルに渡るツール数 |
| --- | --- |
| 通常実行 | 62 |
| `--available-tools=view` | 1 |
| `--available-tools=<ダミー名>` | **0**（`toolRequests: []`, exit 0 で正常完了） |
| `--available-tools=`（空） | **62（無視される）** |

この62個にはユーザーのMCPツールも含まれるため、claude が `--strict-mcp-config` でやっていることも同じ1フラグで賄えます（MCPサーバー自体は起動しますが、ツールは一切公開されません）。

`--no-custom-instructions` は `--setting-sources ""` 相当。`AGENTS.md` に目印の文字列を置いて検証し、フラグなしでプロンプトに2回到達、フラグありで0回を確認しました。

copilot はそもそもフックを登録しないので ③ は元から満たしています。

### grok — 同じ手が**逆に**効く

grok の `--tools` はマップできないエントリがあると **fail open** します。`--debug-file` で確認:

```
WARN xai_grok_agent::builder: tools allowlist had unmappable entries;
     keeping full grok toolset unresolved=["none"]
```

`--tools ""` も同様に無視されます。つまり copilot のダミー名戦略をそのまま持ち込むと**全ツールが復活**します。そこで実在するツール名を指定します — `todo_write` は grok の組み込みツール（`run_terminal_cmd` / `grep` / `read_file` / `search_replace` / `list_dir` / `web_search` / `web_fetch` / `todo_write` / `task`）の中で唯一ファイル・シェル・ネットワークのいずれにも触れないものです。結果 `tools allowlist applied` がログに出て、ツール数は 26 → 3 になります。

## フック skip は見た目より弱い（レビューで発見）

セルフレビューで見つかった、実装しながらは見えていなかった問題です。

claude / codex はフックを**起動ごとのフラグ**（`--settings <path>` / `-c hooks.pre_tool_use=`）で登録するので、渡さなければ本当にフックなしで走ります。ところが grok は `<cwd>/.grok/hooks/` を**ディスクから発見**する方式で、`GrokSettingsGenerator.ensure` が書いたファイルを消す処理はコードベースのどこにもありません。つまり lightweight で `ensure` を skip しても「書き直さない」だけで、**通常チャットを1回でも走らせたプロジェクトにはフックが残っています**。しかもユーティリティ呼び出しは定義上チャットの後に起きます。

そこで `todo_write` を `grok_tool_vocabulary` に追加しました。未マップだと生の名前が `can_use_tool` に届き、`INTERNAL_TOOLS`（`TodoWrite` という大文字綴りを持つ）の常時許可を外し、既定 allow リストにもマッチせず `ask` に落ちます。`ask` は `cancel_and_deny` に入り、**承認UIの有無を確認する前にCLIプロセスを kill します**。lightweight 呼び出しは `on_approval_required` を登録しないので、タイトル生成が「プロンプトも出ないまま失敗する」ことになっていました。許可リストが唯一残したツールでこれが起きるという、いちばん悪い噛み合わせです。

なおフックファイルを消す案は却下しました。cwd は同時実行中の他チャットと共有されており、そちらはフックを必要としています。

この修正は通常の grok チャットの既存の粗も直します（todo リスト書き込みごとに承認プロンプトが出ていた）。

## grok だけ責務を完全には果たせません

**「直った」と書けない部分を明示します。** これは実装の手抜きではなく grok CLI 側の制約です。

- **MCPツールを隠せない**: `--tools` は組み込みツールのみをフィルタし、MCPツールはその上に載ります（提示数は約254個多いまま）。grok 0.2.101 には MCPサーバーを実行単位で無効化するフラグがありません。そのため**実行の拒否**（`--deny "MCPTool(*)"`、grok のルールが要求する `MCPTool(server__tool)` 形式）に留まります。claude の空 `--mcp-config` のように提示自体を止めることはできません。
- **プロジェクト指示を止められない**: grok はリポジトリとホームの `AGENTS.md` / `CLAUDE.md` を読みますが、実行単位のフラグはありません（`[compat.claude]` / `[mcp_servers]` は永続設定であって per-invocation ではない）。②は grok では**未達**です。
- `--sandbox read-only` は検討して却下: grok 自身のドキュメントが macOS ではネットワーク遮断が no-op と明記しており、かつセッション resume 時の制約があります（`/summarize` は常に resume）。

`--deny "MCPTool(*)"` は `dontAsk` と冗長に見えますが冗長ではありません。grok のドキュメントによれば `dontAsk` は always-approve が有効な間は自動拒否まで行かず、また grok はユーザーの `settings.json` の許可ルールを取り込みます。明示 deny だけが両方を上書きします（`deny` > `ask` > `allow`、"regardless of order or source"）。

## テスト

`codex_command_builder_spec.lua` の `describe("lightweight mode", ...)` と `codex_cli_spec.lua` に相当するものを両バックエンド分用意しました。

- `tests/copilot_command_builder_spec.lua` — lightweight 9件
- `tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua` — lightweight 9件
- `tests/lua/infrastructure/adapter/grok_cli_spec.lua`（新規）— フック登録 skip 4件
- `grok_tool_vocabulary_spec.lua` — `todo_write` → `TodoWrite` の写像

いずれも「ダミー名を使う／使わない」という**逆方向の設計判断**そのものを固定しています。

## 検証

`check` / `check:doc` / `lint` / `format:check` / `test:node`(32) / `test:lua`(**1384 passing, 0 failed, 0 errors**) すべて green。

`test:e2e` と `test:eval` は実トークンを消費するため未実行です。特に eval は copilot/grok を実際に走らせて「lightweight がツールを使わない」ことを見る唯一の層なので、copilot のダミー名戦略が将来 grok のような fail open に変わった場合、**ユニットテストでは検出できません**（argv ではなくCLIの挙動のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lightweight request support for Copilot and Grok.
  * Copilot lightweight requests disable tools and custom instructions.
  * Grok lightweight requests restrict tools to task-list updates and block MCP tools.
  * Lightweight requests use the utility model and non-interactive permissions.

* **Bug Fixes**
  * Prevented project hooks from running during lightweight Grok requests.
  * Preserved expected tool behavior for regular requests and resumed sessions.

* **Documentation**
  * Documented backend-specific limitations for tools, hooks, instructions, sandboxing, and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->