### PR TITLE
test(copilot): reset the binary path cache so the exepath stub is authoritative

### DIFF
--- a/tests/copilot_cli_spec.lua
+++ b/tests/copilot_cli_spec.lua
@@ -1,9 +1,18 @@
+local CopilotCommandBuilder = require("vibing.infrastructure.adapter.modules.copilot_command_builder")
+
 describe("copilot_cli adapter", function()
   local CopilotCLI
 
   before_each(function()
     package.loaded["vibing.infrastructure.adapter.copilot_cli"] = nil
     CopilotCLI = require("vibing.infrastructure.adapter.copilot_cli")
+    -- The resolved binary path lives in the builder, a separate module the reload above does not
+    -- touch, so the missing-binary test below would otherwise build against a cached path.
+    CopilotCommandBuilder._reset_path_cache()
+  end)
+
+  after_each(function()
+    CopilotCommandBuilder._reset_path_cache()
   end)
 
   it("creates an instance named copilot_cli", function()

--- a/tests/copilot_command_builder_spec.lua
+++ b/tests/copilot_command_builder_spec.lua
@@ -30,6 +30,10 @@ describe("copilot_command_builder", function()
   local original_exepath
 
   before_each(function()
+    -- The builder's resolved path is module-level and therefore process-wide. Without this the
+    -- stub below is only honoured while nothing has resolved `copilot` first, which makes every
+    -- assertion on cmd[1] depend on execution order.
+    Builder._reset_path_cache()
     original_exepath = vim.fn.exepath
     vim.fn.exepath = function()
       return "/usr/local/bin/copilot"
@@ -42,6 +46,7 @@ describe("copilot_command_builder", function()
 
   after_each(function()
     vim.fn.exepath = original_exepath
+    Builder._reset_path_cache()
   end)
 
   describe("build", function()
@@ -157,6 +162,18 @@ describe("copilot_command_builder", function()
     it("skips the language instruction for en", function()
       local cmd = Builder.build("hi", { language = "en" }, nil, {})
       assert.are.equal("hi", cmd[#cmd])
+    end)
+
+    -- binary_cache_spec covers the caching contract for every backend; what is copilot's own is
+    -- the wording the user actually sees, and this case is only reachable at all because the
+    -- hooks above clear the cache.
+    it("names the copilot CLI when it is not on PATH", function()
+      vim.fn.exepath = function()
+        return ""
+      end
+      local ok, err = pcall(Builder.build, "hi", {}, nil, {})
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("Copilot CLI not found in PATH", 1, true))
     end)
   end)
 

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -4,6 +4,7 @@ describe("cli_command_builder", function()
   local original_exepath
 
   before_each(function()
+    cli_command_builder._reset_path_cache()
     original_exepath = vim.fn.exepath
     vim.fn.exepath = function(name)
       if name == "claude" then
@@ -15,6 +16,7 @@ describe("cli_command_builder", function()
 
   after_each(function()
     vim.fn.exepath = original_exepath
+    cli_command_builder._reset_path_cache()
   end)
 
   local function find_flag(cmd, flag)

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_subagent_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_subagent_spec.lua
@@ -5,6 +5,7 @@ describe("cli_command_builder subagent chat", function()
   local AGENT_ID = "ab2e2379a4f9c8c52"
 
   before_each(function()
+    cli_command_builder._reset_path_cache()
     original_exepath = vim.fn.exepath
     vim.fn.exepath = function(name)
       if name == "claude" then
@@ -16,6 +17,7 @@ describe("cli_command_builder subagent chat", function()
 
   after_each(function()
     vim.fn.exepath = original_exepath
+    cli_command_builder._reset_path_cache()
   end)
 
   local function find_flag(cmd, flag)


### PR DESCRIPTION
Closes #589

## 問題

`binary_resolver` のキャッシュ（#581 で導入）はプロセス横断で保持される設計で、`_reset_path_cache()` が「テストが呼ぶ前提」の seam です。`tests/copilot_command_builder_spec.lua` は `vim.fn.exepath` を差し替えるだけでこれを呼んでおらず、スタブが効くかどうかが「それ以前に誰も `copilot` を解決していないこと」に依存していました。つまり `cmd[1]` に対する全アサーションが実行順依存です。

## 「呼べば直った」で終わらせないための確認（mutation check）

キャッシュを先に埋めてから spec を同一プロセスで走らせ、修正前後を比較しました。plenary の `PlenaryBustedDirectory` は spec ファイルごとに子 nvim を起動するので、子と同じ形（`require("plenary.busted").run(path)`）で再現しています。

```
nvim --headless --noplugin -u tests/minimal_init.lua \
  -c "set rtp+=<plenary> | runtime plugin/plenary.vim" \
  -c "lua vim.fn.exepath = function() return '/poisoned/bin/x' end; <builder>.build(...)" \
  -c "lua require('plenary.busted').run('<spec>')"
```

| spec | 修正前（キャッシュ汚染下） | 修正後 |
| --- | --- | --- |
| `tests/copilot_command_builder_spec.lua` | **Failed: 1** | Success: 15 / Failed: 0 |
| `tests/copilot_cli_spec.lua` | **Failed: 1** | Success: 7 / Failed: 0 |
| `tests/lua/.../cli_command_builder_spec.lua` | Failed: 0 | Failed: 0 |
| `tests/lua/.../cli_command_builder_subagent_spec.lua` | Failed: 0 | Failed: 0 |

## 横展開（`binary_resolver` を使う全ビルダーの spec）

- `copilot_command_builder_spec` — issue の対象。修正。
- `copilot_cli_spec` — **より悪いケースだったので併せて修正**。「missing copilot binary を on_done で報告する」テストは、キャッシュが埋まっていると build が成功して実際に spawn し、別のエラーでアサートに失敗します。`package.loaded[...copilot_cli] = nil` のリロードはビルダー側（別モジュール）のキャッシュを消さないため、このテストは「たまたま先行テストが解決していない」ことだけに支えられていました。
- `cli_command_builder_spec` / `cli_command_builder_subagent_spec` — 同じ形の抜けだが `cmd[1]` をアサートしないため、汚染下でも落ちません。**予防目的**でリセットを追加し、`codex_command_builder_spec` と同じ形に揃えました。
- `codex_command_builder_spec` — 既に正しい形。変更なし。
- `grok_command_builder_spec` — 対処不要。`package.loaded` から落として re-require するので、モジュールごとキャッシュが破棄されます（そもそも grok は `binary_resolver` を使っていません）。

## 追加テスト

「copilot が PATH に無い」経路を1件追加しました。これはリセットを入れて初めて書けるようになったケースです。`binary_cache_spec` はキャッシュの契約をバックエンド横断で見ていますが、copilot 固有のメッセージ文言はビルダーレベルでどこもアサートしていなかったため、そこを pin しています。

## 現実的な露出について（正直な範囲）

`pnpm run test:lua` の実行経路では spec ファイルごとに子 nvim が立つため、**ファイル間**の順序依存は現状では顕在化しません。実際に刺さるのは (a) 同一ファイル内で先行テストがバイナリを解決するケース（`copilot_cli_spec` がまさにこれになりかけていた）、(b) `PlenaryBustedFile` やエディタ内から複数 spec を同一プロセスで回すケースです。それでも「exepath をスタブするなら必ずキャッシュもリセットする」という規則を全 spec で揃えておくほうが、「今日は `cmd[1]` を見ていないから大丈夫」という例外を覚えておくより安全だと判断しました。

## 検証

`check` / `check:doc` / `lint` / `format:check` / `test:lua`（exit 0）/ `test:node`（32 pass）すべて green。`test:e2e` と `test:eval` は実トークンを消費するため未実行（本 PR はテストのみの変更で、プロダクションコードには一切触れていません）。

## マージ時の注意

未マージの #583 / #585 が同じ `tests/copilot_command_builder_spec.lua` に変更を入れています。本ブランチは main ベースでそれらを取り込んでいないため、マージ順によっては `before_each` / `after_each` 周辺でコンフリクトする可能性があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)