### PR TITLE
fix(git): bound working_dir to the git root

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -318,6 +318,25 @@ path from git root (e.g., `.vibing/worktrees/<branch>`). When a chat is reopened
 and mote commands are executed in this directory. This ensures consistent file operations across
 sessions, even when using a worktree or a custom directory.
 
+`Git.resolve_working_dir` **bounds it to the git root**, symmetrically with `get_relative_path`:
+a value resolving outside (`../../etc`, or a symlink inside the repo pointing out of it) is
+warned about once and treated as unset, so the chat falls back to Neovim's own cwd rather than
+failing to open. Returning `nil` rather than substituting the git root is what keeps the meaning
+single — `nil` already means "no chat-specific cwd" at every call site — and is what lets a
+caller that validates the directory (`create_chat.lua`) reject an out-of-bounds request outright
+instead of silently succeeding at the root.
+
+Two things about that check are not interchangeable, both verified against the real functions
+rather than read off the docs. `vim.fn.fnamemodify(path, ":p")` does **not** collapse `..` in a
+path that is already absolute (`/a/b/../c` comes back unchanged), so it cannot do this job;
+`vim.fn.resolve()` collapses `..` _and_ follows symlinks, and unlike `vim.uv.fs_realpath()` it
+works on a path that does not exist yet. And the comparison is between physical paths on both
+sides: `git rev-parse --show-toplevel` always reports the symlink-resolved path, which on macOS
+is `/private/tmp/...` for anything under `/tmp`, so comparing it against an unresolved candidate
+would reject directories that are genuinely inside. The boundary is decided on the resolved
+form, but the string handed back is the plain `git_root .. "/" .. working_dir` — a chat whose
+`working_dir` goes through a symlink keeps seeing the path it wrote.
+
 ## Concurrent Execution Support
 
 vibing.nvim supports running multiple chat sessions simultaneously without interference:

--- a/lua/vibing/core/utils/git.lua
+++ b/lua/vibing/core/utils/git.lua
@@ -7,6 +7,16 @@ local M = {}
 local PathSanitizer = require("vibing.domain.security.path_sanitizer")
 local CommandValidator = require("vibing.domain.security.command_validator")
 
+---境界チェック用にパスを実体パスへ正規化する
+---vim.fn.resolve()はシンボリックリンクを辿ったうえで".."を畳み、存在しないパスでも動く。
+---fnamemodify(path, ":p")は絶対パスの".."を畳まないので、ここでは使えない。
+---@param path string
+---@return string
+local function to_real_path(path)
+  local resolved = vim.fn.resolve(path):gsub("/+$", "")
+  return resolved
+end
+
 ---Gitリポジトリのルートディレクトリを取得
 ---@param cwd string|nil 基準ディレクトリ（nilの場合はNeovim自身のカレントディレクトリ）
 ---@return string|nil gitルートパス（Git管理外の場合はnil）
@@ -35,11 +45,11 @@ function M.get_relative_path(abs_path)
 
   local normalized = vim.fn.fnamemodify(abs_path, ":p"):gsub("/$", "")
 
-  -- パス境界をチェック（完全一致または"/"で分離）
+  if not PathSanitizer.is_within_root(git_root, normalized) then
+    return nil
+  end
   if normalized == git_root then
     return "."
-  elseif normalized:sub(1, #git_root + 1) ~= git_root .. "/" then
-    return nil
   end
 
   local relative = normalized:sub(#git_root + 2)
@@ -47,8 +57,9 @@ function M.get_relative_path(abs_path)
 end
 
 ---working_dir（gitルートからの相対パス）から絶対パスを算出
+---gitルート外を指す値は無視してnilを返す（get_relative_pathの境界チェックと対称）
 ---@param working_dir string|nil 相対パス（"."はgitルートを表す）
----@return string|nil 絶対パス（working_dirがnilまたはGit管理外の場合はnil）
+---@return string|nil 絶対パス（working_dirがnil・Git管理外・gitルート外の場合はnil）
 function M.resolve_working_dir(working_dir)
   if not working_dir or working_dir == "" or working_dir == "~" then
     return nil
@@ -62,7 +73,28 @@ function M.resolve_working_dir(working_dir)
   if working_dir == "." then
     return git_root
   end
-  return git_root .. "/" .. working_dir
+
+  local resolved = git_root .. "/" .. working_dir
+  -- git rev-parse --show-toplevel は常に実体パス（末尾"/"なし）を返すので、比較の左辺は
+  -- そのまま使える。右辺だけを実体パスへ揃える
+  local real_path = to_real_path(resolved)
+  if not PathSanitizer.is_within_root(git_root, real_path) then
+    require("vibing.core.utils.notify").warn_once(
+      -- gitルートまで含めて数える。同じworking_dir文字列でも別プロジェクトなら別の警告
+      git_root .. "\0" .. working_dir,
+      string.format(
+        "working_dir '%s' points outside the git root (resolved to %s) and was ignored - "
+          .. "set it to a path inside the repository",
+        working_dir,
+        real_path
+      )
+    )
+    return nil
+  end
+
+  -- 境界判定は実体パスで行うが、返すのは連結したままのパス。シンボリックリンク経由の
+  -- working_dirでも、これまでと同じ文字列が呼び出し元に渡る
+  return resolved
 end
 
 ---Git管理下のプロジェクトかチェック

--- a/lua/vibing/core/utils/notify.lua
+++ b/lua/vibing/core/utils/notify.lua
@@ -40,6 +40,23 @@ function M.warn(message, action)
   M.notify(message, M.levels.WARN, action)
 end
 
+---warn_onceが既に通知したkey
+---テストは`package.loaded`から外して再requireすればリセットできる
+local warned_keys = {}
+
+---同じkeyについて一度だけ警告する（WARN レベル）
+---毎リクエスト・毎パス解決のように何度も通る経路から出す警告のためのもの
+---@param key string 重複判定のキー
+---@param message string 警告メッセージ
+---@param action string? アクション名（省略可）
+function M.warn_once(key, message, action)
+  if warned_keys[key] then
+    return
+  end
+  warned_keys[key] = true
+  M.warn(message, action)
+end
+
 ---情報メッセージを送信（INFO レベル）
 ---正常な操作の完了通知に使用
 ---@param message string 情報メッセージ

--- a/lua/vibing/domain/security/path_sanitizer.lua
+++ b/lua/vibing/domain/security/path_sanitizer.lua
@@ -35,6 +35,18 @@ function M.normalize(path)
   return resolved, nil
 end
 
+---Whether an absolute path is `root` itself or a descendant of it
+---Both arguments must already be normalized (absolute, no trailing "/"); this is a pure string
+---predicate so that callers stay in charge of how much resolving their case needs.
+---Unlike `validate_within_roots`, the root itself counts as inside — a caller that means
+---"strictly below" should compare for equality separately.
+---@param root string
+---@param path string
+---@return boolean
+function M.is_within_root(root, path)
+  return path == root or path:sub(1, #root + 1) == root .. "/"
+end
+
 ---Validate that a path is within allowed directories
 ---@param path string Path to validate
 ---@param allowed_roots string[] List of allowed root directories

--- a/tests/git_utils_spec.lua
+++ b/tests/git_utils_spec.lua
@@ -205,6 +205,91 @@ describe("vibing.core.utils.git", function()
     end)
   end)
 
+  describe("resolve_working_dir path boundary", function()
+    -- A fixture tree stands in for the git root so symlinks can be created without
+    -- touching the real repository. `git rev-parse --show-toplevel` always reports the
+    -- physical path, so the stub resolves the tempdir the same way (on macOS
+    -- vim.fn.tempname() lives under the /tmp -> /private/tmp symlink).
+    local Fs = require("vibing.core.utils.fs")
+    local root, outside, real_get_root, notifications
+
+    before_each(function()
+      local base = vim.fn.resolve(vim.fn.tempname())
+      root = base .. "/repo"
+      outside = base .. "/outside"
+      Fs.ensure_dir(root .. "/sub")
+      Fs.ensure_dir(outside)
+      assert(vim.uv.fs_symlink(root .. "/sub", root .. "/link_inside"))
+      assert(vim.uv.fs_symlink(outside, root .. "/link_outside"))
+
+      real_get_root = Git.get_root
+      Git.get_root = function()
+        return root
+      end
+
+      -- Notify holds warn_once's memo table, so reloading it between tests is what makes each
+      -- rejection warn again
+      package.loaded["vibing.core.utils.notify"] = nil
+      notifications = {}
+      ---@diagnostic disable-next-line: duplicate-set-field
+      require("vibing.core.utils.notify").notify = function(message)
+        table.insert(notifications, message)
+      end
+    end)
+
+    after_each(function()
+      Git.get_root = real_get_root
+      package.loaded["vibing.core.utils.notify"] = nil
+    end)
+
+    it("allows a directory inside the git root", function()
+      assert.equals(root .. "/sub", Git.resolve_working_dir("sub"))
+      assert.same({}, notifications)
+    end)
+
+    it("allows the git root itself reached through '..'", function()
+      -- The boundary itself is inside, not outside
+      assert.equals(root .. "/sub/..", Git.resolve_working_dir("sub/.."))
+      assert.same({}, notifications)
+    end)
+
+    it("rejects a path that escapes the git root with '..'", function()
+      assert.is_nil(Git.resolve_working_dir("../outside"))
+      assert.is_nil(Git.resolve_working_dir("../.."))
+    end)
+
+    it("rejects a sibling directory whose name merely shares the root's prefix", function()
+      -- "<root>-evil" starts with the root string but is not under it
+      assert.is_nil(Git.resolve_working_dir("../repo-evil"))
+    end)
+
+    it("follows symlinks: one pointing inside the root is allowed", function()
+      assert.equals(root .. "/link_inside", Git.resolve_working_dir("link_inside"))
+      assert.same({}, notifications)
+    end)
+
+    it("follows symlinks: one pointing outside the root is rejected", function()
+      -- A pure string comparison would accept this, since the literal path is under the root
+      assert.is_nil(Git.resolve_working_dir("link_outside"))
+    end)
+
+    it("rejects a '..' that climbs out through a symlink", function()
+      -- link_inside resolves to <root>/sub, so this lands on <root>/../outside
+      assert.is_nil(Git.resolve_working_dir("link_inside/../../outside"))
+    end)
+
+    it("warns once per rejected working_dir instead of on every call", function()
+      Git.resolve_working_dir("../outside")
+      Git.resolve_working_dir("../outside")
+      Git.resolve_working_dir("../outside")
+      assert.equals(1, #notifications)
+      assert.is_truthy(notifications[1]:find("../outside", 1, true))
+
+      Git.resolve_working_dir("../..")
+      assert.equals(2, #notifications)
+    end)
+  end)
+
   describe("is_git_repo", function()
     it("should return boolean", function()
       local result = Git.is_git_repo()

--- a/tests/security_spec.lua
+++ b/tests/security_spec.lua
@@ -60,6 +60,26 @@ describe("PathSanitizer", function()
     end)
   end)
 
+  describe("is_within_root", function()
+    it("should accept a descendant", function()
+      assert.is_true(PathSanitizer.is_within_root("/a/repo", "/a/repo/sub/file.lua"))
+    end)
+
+    it("should accept the root itself", function()
+      -- Unlike validate_within_roots, which requires a strict descendant
+      assert.is_true(PathSanitizer.is_within_root("/a/repo", "/a/repo"))
+    end)
+
+    it("should reject a sibling that merely shares the root's prefix", function()
+      assert.is_false(PathSanitizer.is_within_root("/a/repo", "/a/repo-other/file.lua"))
+      assert.is_false(PathSanitizer.is_within_root("/a/repo", "/a/repository"))
+    end)
+
+    it("should reject an unrelated path", function()
+      assert.is_false(PathSanitizer.is_within_root("/a/repo", "/etc/passwd"))
+    end)
+  end)
+
   describe("validate_within_roots", function()
     it("should allow path within allowed root", function()
       local valid, err = PathSanitizer.validate_within_roots(


### PR DESCRIPTION
Closes #586

## 概要

`Git.resolve_working_dir` は git ルートと `working_dir` を連結するだけで、結果がリポジトリ内に
収まっているかを見ていませんでした。`working_dir: ../../etc` のようなチャットは CLI 子プロセスの
cwd をリポジトリ外に向けられます。同ファイルの `get_relative_path` が既に持っている境界チェックと
対称になるよう、`resolve_working_dir` 側にも入れました。

## 破壊的変更をどう避けたか

issue 本文が警告しているとおり、`resolve_working_dir` は `working_dir` を持つ既存チャット全部が
通る経路です。実際に書かれうる値を調べたうえで落とし方を決めました。

**書き込み元は全て「git ルート配下の相対パス」しか作りません。** `use_case.lua` の 2 箇所は
`Git.get_relative_path()`（既に境界チェック済み）の戻り値をそのまま入れ、fork / subagent_chat は
それを継承し、worktree スキルは `.vibing/worktrees/<branch>` を書きます。絶対パスや `~/foo` は
連結すると `<root>//abs/path` になるので**そもそも今も動いていません**。つまり今回弾かれるように
なるのは「手書きで `..` を使ってリポジトリ外を指したチャット」だけです。

**そのうえで「弾く」ではなく「警告して無視する」を選びました。** 具体的には `nil` を返します。

- `nil` は**全ての呼び出し元で既に「チャット固有の cwd 無し」を意味しています**
  （`file_path.lua` は `chat_buf:get_cwd() or vim.fn.getcwd()`、4 つのアダプタは
  `opts.cwd or vim.fn.getcwd()`）。したがって呼び出し元は 1 行も変えずに済み、
  境界外の `working_dir` を持つ既存チャットは**開けなくなるのではなく Neovim の cwd で動きます**
- 「警告して git ルートにフォールバックする」も検討しましたが採りませんでした。`nil` は既に
  「Git 管理外」と「working_dir 未設定」の 2 つを表しており、ここで git ルートを返すと 3 つ目の
  意味が増えます。加えて、ディレクトリを検証する呼び出し元（#584 の `create_chat.lua`）が
  `working_dir: "../.."` を**エラーとして拒否できなくなり**、ユーザーが指定していないルートで
  黙って成功してしまいます
- 黙って無視すると気づけないので、`Notify.warn_once` で同じ値につき一度だけ警告します。
  `get_cwd()` はリクエストごと・ファイルパス解決ごとに呼ばれるため、都度通知すると氾濫します

## パス正規化：実際に確かめたこと

issue の提案どおり `vim.fn.fnamemodify(..., ":p")` を使うと**動きません**。実測:

| 式 | 結果 |
| --- | --- |
| `fnamemodify("/a/b/../c", ":p")` | `/a/b/../c` ← **`..` を畳まない** |
| `simplify("/a/b/../c")` | `/a/c`（文字列だけ。シンボリックリンクは見ない） |
| `resolve("/tmp")` (macOS) | `/private/tmp` |
| `resolve("/tmp/nonexistent")` | `/private/tmp/nonexistent` ← 存在しなくても動く |
| `uv.fs_realpath("/tmp/nonexistent")` | `nil` ← 存在しないと使えない |

`:p` が `..` を畳むのは相対パスを渡したときだけで、既に絶対パスなら素通しです。採用したのは
`vim.fn.resolve()` で、これ 1 つでシンボリックリンクを辿り、そのうえで `..` を畳み、しかも
存在しないパスでも動きます（`working_dir` はまだ作られていない worktree を指しうるので、
`fs_realpath` は使えません）。

比較の左辺（git ルート）は**追加の正規化をしていません**。`git rev-parse --show-toplevel` は
常に実体パスを返すことを実測で確認しました（`/tmp/vtest/repo` で実行しても
`/private/tmp/vtest/repo` を返す）。逆に、片側だけ解決して比較すると macOS の
`/tmp` → `/private/tmp` でリポジトリ内のディレクトリを誤って弾きます。

**境界判定は実体パスで行いますが、返すのは連結したままの文字列**です。シンボリックリンク経由の
`working_dir` を持つチャットには、これまでと同じパスが渡ります。

## ついでの整理（simplify レビューの指摘）

- `is_within_root` を `PathSanitizer` に置きました。同じプレフィックス比較が `lua/` 内に既に
  6 箇所あり、7 個目のローカルコピーを足したくなかったためです。既存の
  `validate_within_roots` は「ルート自身」を配下と見なさないので、そのままでは流用できません
  （`get_relative_path` が `"."` を返す分岐と、`working_dir: "sub/.."` が通る必要がある）
- `Notify.warn_once(key, message)` を追加しました。「キーごとに一度だけ警告」は既に
  `send_message.lua` / `copilot_tool_vocabulary.lua` / `grok_settings_generator.lua` に
  3 つ独立コピーがあります。**既存 3 箇所の置き換えは本 PR のスコープ外**にしましたが、
  別 PR で寄せられます

## テスト

`tests/git_utils_spec.lua` に境界のテストを追加（fixture の一時ツリーを git ルートに見立て、
`Git.get_root` をスタブ。実リポジトリにシンボリックリンクを作らないため）:

| ケース | 期待 |
| --- | --- |
| 内側（`sub`） | 許可 |
| 境界そのもの（`.`、`sub/..`） | 許可 |
| 外側（`../outside`、`../..`） | `nil` |
| プレフィックスだけ一致する兄弟（`../repo-evil`） | `nil` |
| 内側を指すシンボリックリンク | 許可 |
| **外側を指すシンボリックリンク** | `nil`（文字列比較だけなら通ってしまう） |
| シンボリックリンク経由で `..` で出る | `nil` |
| 同じ値を 3 回 → 警告 1 回 | OK |

境界チェックを外すとこのうち 5 件が実際に落ちることを確認済みです。
`tests/security_spec.lua` に `PathSanitizer.is_within_root` の単体テストも追加しました。

| コマンド | 結果 |
| --- | --- |
| `pnpm run check` | OK |
| `pnpm run check:doc` | OK |
| `pnpm run lint` | OK |
| `pnpm run format:check` | OK |
| `pnpm run test:lua` | exit 0（104 spec files、Failed 0 / Errors 0） |
| `pnpm run test:node` | 32 pass / 0 fail |

`test:e2e` と `test:eval` は実トークンを消費するため実行していません。
`pnpm run lint:md` は本 PR 以前から `docs/superpowers/`・`mcp-server/README.md`・
`prompts/daily_summary.md`・`tests/README.md` で落ちており、本 PR で触ったファイルは
すべて clean です。

## PR #584 との関係

`gh pr diff 584` で確認しました。**衝突しません** — #584 の `create_chat.lua` は
`Git.resolve_working_dir` の `nil` を既にエラーとして扱っているので、本 PR を入れると
`nvim_chat_create({ working_dir: "../.." })` は自動的に拒否されます（issue が求めていた挙動）。

ただし**エラーメッセージだけずれます**。#584 の該当行は

```lua
error("Cannot resolve working_dir '" .. working_dir .. "': not inside a git repository")
```

で、境界外のケースにも「not inside a git repository」と表示されます。#584 側で
「git 管理外、または git ルート外」に直すのが妥当だと思いますが、本 PR は main ベースなので
#584 のコードは取り込んでいません。マージ順に関わらず動作は正しく、直すのは文言だけです。

## 未検証

- 実際の Neovim で境界外の `working_dir` を持つチャットを開いたときの警告表示は、手動確認して
  いません（自動テストでは `Notify.notify` をスタブして検証しています）
- `git rev-parse --show-toplevel` が実体パスを返すことは macOS の通常リポジトリで確認しました。
  linked worktree・`GIT_WORK_TREE` 指定・bare repo では確認していません。ただし仮にルート側が
  未解決で返ってきた場合の影響は「リポジトリ内が誤って弾かれる」＝警告のうえ Neovim の cwd で
  動く、であって、境界を破る方向ではありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
