### PR TITLE
fix(codex): say when a lightweight call leaves the configured provider

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -334,6 +334,43 @@ tools with `--tools ""`, codex can only fence them, and no shared vocabulary spa
 `core/types.lua` states the obligation each adapter owes for `lightweight` — no tools, no project
 config, no hooks, `utility_model` — rather than the mechanism any one of them uses.
 
+**The `model_provider` that `--ignore-user-config` drops is announced rather than left to be
+discovered** (#587). `codex_provider_notice.lua` warns once per Neovim session when the configured
+provider is not codex's own `openai` default. `codex_cli.lua` triggers it on `--ignore-user-config`
+actually being in the argv it just built, not on `opts.lightweight` alone: the builder documents
+that flag as a stand-in for a narrower switch codex does not have yet, so reading the built command
+is what makes the warning disarm itself the day the flag stops being used, rather than going on
+describing a loss that no longer happens. `lightweight` still guards the scan because the prompt is
+the last element of the argv, and a message consisting of exactly that flag would otherwise match.
+
+It warns and does not repair, because codex will hand over the provider's _name_ and not its
+_definition_: `codex doctor --json` reports the resolved provider at
+`checks["config.load"].details["model provider"]`, but nothing reports the
+`[model_providers.<name>]` table — not `doctor`, and not the app-server protocol, whose
+`ConfigReadResponse.Config` carries `model_provider` as a bare string and no provider map at all
+(`codex app-server generate-json-schema --experimental`). Re-injecting the provider would still
+mean hand-parsing `config.toml`, which is why #587's option 2 was not taken.
+
+Asking codex is the whole point: the name comes back **resolved**, by codex's own config loader,
+so there is no TOML parsing and none of the false positives (an inactive profile section) or false
+negatives (a profile) that kept the warning out of #582. Three properties of the probe are
+load-bearing:
+
+- **The exit status says nothing.** `codex doctor --json` exits 1 whenever any check fails, and a
+  missing login alone is enough — it exits 1 even on a config that loaded cleanly. Only
+  `checks["config.load"].status` answers the question, and stdout is valid JSON either way.
+- **The key is `"model provider"`, with a space.** Captured from codex 0.147 into
+  `tests/fixtures/codex_doctor.json` rather than read off a schema.
+- **Unreadable means silent.** Every parse failure returns nil and nothing is said, because an
+  unreliable warning is worse than none — its silence gets read as "you are fine".
+
+It runs on the first lightweight call rather than at `setup()` because `doctor` makes one
+reachability request to the active provider's endpoint; it is asynchronous and nothing waits for
+it. The `profile = "x"` config key that #582 named as a false-negative route is moot from codex
+0.147, which rejects it outright (`legacy profile = "x" config is no longer supported`); the
+surviving route is the `-p/--profile` flag, which vibing.nvim passes to neither `codex exec` nor
+the probe, so the two resolve identically.
+
 Configured permissions are recorded in frontmatter for
 transparency and auditability. The optional `language` field ensures consistent AI response language
 across sessions.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -366,7 +366,11 @@ load-bearing:
 
 It runs on the first lightweight call rather than at `setup()` because `doctor` makes one
 reachability request to the active provider's endpoint; it is asynchronous and nothing waits for
-it. The `profile = "x"` config key that #582 named as a false-negative route is moot from codex
+it. `agent.codex_provider_notice.enabled` turns the whole thing off, probe included, and is the
+one toggle of this shape that **defaults to `true`** — `subagent`, `auto_resume_on_limit` and
+`dap` all default to `false` because they spend tokens or run unattended, and this spends none. A
+warning about a change the user cannot otherwise see fails at its only job if it is off until
+asked for. Absent config reads as enabled, so a hand-built config table does not silently lose it. The `profile = "x"` config key that #582 named as a false-negative route is moot from codex
 0.147, which rejects it outright (`legacy profile = "x" config is no longer supported`); the
 surviving route is the `-p/--profile` flag, which vibing.nvim passes to neither `codex exec` nor
 the probe, so the two resolve identically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,22 @@
   of silently removing a restriction. Both flags were verified present in 0.140.0 and 0.147.0;
   older releases were not tested. Ordinary chat is unaffected — only lightweight calls would fail,
   with an unknown-argument error. Note that `--ignore-user-config` also drops `model_provider`, so
-  on a custom provider these utility calls now go to the default OpenAI endpoint.
+  on a custom provider these utility calls now go to the default OpenAI endpoint. vibing.nvim
+  warns about that once per Neovim session (see below) rather than letting it be discovered from a
+  bill or an unexplained 401.
 
 - **Remove the inline code action feature.** The `:VibingInline` command, its
   action picker/preview UI, and the `language.inline` configuration option have
   been removed. Use the chat interface (`:VibingChat`) for code assistance instead.
+
+### Added
+
+- **Codex: warn when lightweight calls leave your configured provider.** On the first lightweight
+  Codex call of a Neovim session, vibing.nvim asks Codex itself which provider is configured
+  (`codex doctor --json`, which reports the _resolved_ `model_provider` — no `config.toml` parsing,
+  so a provider set through a profile is not missed and one in an inactive section is not
+  misreported) and warns once if it is not the `openai` default. The probe is asynchronous and
+  nothing waits for it; if Codex cannot answer, nothing is said.
 
 ## 5.2.0 (2026-08-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@
   (`codex doctor --json`, which reports the _resolved_ `model_provider` — no `config.toml` parsing,
   so a provider set through a profile is not missed and one in an inactive section is not
   misreported) and warns once if it is not the `openai` default. The probe is asynchronous and
-  nothing waits for it; if Codex cannot answer, nothing is said.
+  nothing waits for it; if Codex cannot answer, nothing is said. Controlled by
+  `agent.codex_provider_notice.enabled`, which — unlike `subagent` and `auto_resume_on_limit` —
+  defaults to `true`: it spends no tokens, and a warning about a change you cannot otherwise see is
+  useless if it is off until you ask for it. Set it to `false` to stop the warning and its probe.
 
 ## 5.2.0 (2026-08-13)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -90,6 +90,12 @@ vibing.nvim は補完プラグイン(Copilot、Codeium)や他のチャットプ�
 > `codex exec` / `codex exec resume` の双方に存在することを確認済みです。それより古いバージョンは未検証
 > で、フラグが無い場合は通常のチャットには影響しませんが、軽量呼び出しが unknown argument エラーで
 > 失敗します。その場合は Codex を更新してください。
+>
+> `--ignore-user-config` は `model_provider` も落とします。`config.toml` でカスタムプロバイダや
+> ローカルプロバイダを指定している場合、**軽量呼び出しだけが既定の OpenAI エンドポイントに向きます**
+> (通常のチャットは指定どおりのプロバイダを使います)。該当する場合は Neovim セッションごとに一度だけ
+> 警告します。プロバイダの判定は Codex 自身 (`codex doctor --json`) に問い合わせており、Codex が
+> 答えられなかったときは何も表示しません。
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim) を使う場合
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -95,7 +95,8 @@ vibing.nvim は補完プラグイン(Copilot、Codeium)や他のチャットプ�
 > ローカルプロバイダを指定している場合、**軽量呼び出しだけが既定の OpenAI エンドポイントに向きます**
 > (通常のチャットは指定どおりのプロバイダを使います)。該当する場合は Neovim セッションごとに一度だけ
 > 警告します。プロバイダの判定は Codex 自身 (`codex doctor --json`) に問い合わせており、Codex が
-> 答えられなかったときは何も表示しません。
+> 答えられなかったときは何も表示しません。`agent.codex_provider_notice.enabled = false` で警告と
+> probe をまとめて止められます。
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim) を使う場合
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ they compose well.
 > `codex exec` and `codex exec resume` alike. Older releases were not tested; if they lack the
 > flags, ordinary chat is unaffected but lightweight calls fail with an unknown-argument error.
 > Upgrade Codex if you see that.
+>
+> `--ignore-user-config` also drops `model_provider`, so if your `config.toml` points Codex at a
+> custom or local provider, **those lightweight calls go to the default OpenAI endpoint instead**.
+> Ordinary chat still uses your provider. vibing.nvim warns once per Neovim session when this
+> applies to you, asking Codex itself (`codex doctor --json`) which provider is configured; it says
+> nothing if Codex cannot answer.
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ they compose well.
 > custom or local provider, **those lightweight calls go to the default OpenAI endpoint instead**.
 > Ordinary chat still uses your provider. vibing.nvim warns once per Neovim session when this
 > applies to you, asking Codex itself (`codex doctor --json`) which provider is configured; it says
-> nothing if Codex cannot answer.
+> nothing if Codex cannot answer. Set `agent.codex_provider_notice.enabled = false` to turn the
+> warning and its probe off.
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ require("vibing").setup({
     subagent = { enabled = false, show_prefix = false },
     auto_resume_on_limit = { enabled = false, max_retries = 1 },
     scheduled_requests = { enabled = true, max_retries = 3 },
+    codex_provider_notice = { enabled = true },
   },
   chat = {
     window = {
@@ -175,8 +176,39 @@ agent = {
     fallback_delay_sec = 300, -- Used only when no reset timestamp was reported
     grace_sec = 10,         -- Added to the reset time to avoid firing on the boundary
   },
+
+  codex_provider_notice = {
+    enabled = true,         -- Warn when a Codex lightweight call leaves your model_provider.
+                            -- On by default, unlike the toggles above: it spends no tokens,
+                            -- and a warning about a silent change is useless if it is itself
+                            -- off by default. Turn it off to stop the `codex doctor --json`
+                            -- probe it needs. Codex backend only.
+  },
 }
 ```
+
+### Codex Provider Notice
+
+Only applies to the Codex backend. Codex's lightweight calls (chat title generation, `/summarize`,
+daily summary) run with `--ignore-user-config`, which is what keeps them out of your MCP servers —
+and which also drops `model_provider`. So if your `config.toml` points Codex at a custom or local
+provider, those calls go to the default OpenAI endpoint while ordinary chat still uses yours. That
+is unexpected billing for some and an unexplained 401 for anyone on a local provider, with nothing
+said either way.
+
+With this on, the first lightweight Codex call of a Neovim session runs `codex doctor --json` in
+the background to ask Codex which provider is actually configured, and warns once if it is not
+`openai`. Nothing waits for the probe, and if Codex cannot answer, nothing is said — a warning that
+cannot be trusted is worse than none, because its silence reads as "you are fine".
+
+**Why this one defaults to on** while `subagent` and `auto_resume_on_limit` default to off: those
+two spend tokens unattended, so the safe default is silence. This one spends none and exists to
+stop a change happening behind your back — off by default, it would fail at exactly the job it has.
+
+Turn it off if you would rather Neovim never spawn the extra process. `codex doctor` has no flag to
+run a single check, so the probe also makes one reachability request to the active provider's
+endpoint. That is also why an unreachable local provider gets its warning late: the probe waits out
+its 10-second timeout first.
 
 ### Subagent Output
 

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -100,6 +100,14 @@
 ---@field subagent Vibing.SubagentConfig? subagent（Task/Agentツール）の出力表示設定
 ---@field auto_resume_on_limit Vibing.AutoResumeOnLimitConfig 使用量リミット自動継続設定
 ---@field scheduled_requests Vibing.ScheduledRequestsConfig 予約リクエスト設定
+---@field codex_provider_notice Vibing.CodexProviderNoticeConfig codex軽量呼び出しのプロバイダ警告設定
+
+---@class Vibing.CodexProviderNoticeConfig
+---codexの軽量呼び出し（タイトル生成・要約等）が設定済みプロバイダから外れることを警告するか
+---警告のために`codex doctor --json`を1セッション1回だけ起動する。他の多くのトグルと違い既定で
+---有効なのは、これがトークンを使う機能ではなく「黙って宛先が変わる」ことを防ぐ安全側の通知で、
+---既定で無効ではそもそも気づけないため。probeのプロセス起動自体を避けたい場合に無効化する。
+---@field enabled boolean? falseでプロバイダ警告とそのprobeを完全に止める（デフォルト: true）
 
 ---@class Vibing.SubagentConfig
 ---subagentが喋った内容をチャットに出すかどうかの設定
@@ -259,6 +267,16 @@ M.defaults = {
       -- 予約したリクエストがまた弾かれたときに許可する再予約の回数。
       -- これがループの唯一の歯止めなので 0 未満にはしない。
       max_retries = 3,
+    },
+    -- codexの軽量呼び出しは --ignore-user-config で走るので、ユーザーの model_provider が落ちて
+    -- 既定のOpenAIエンドポイントに向く。それを1セッション1回だけ警告する。
+    --
+    -- auto_resume_on_limit や dap と違って既定で有効なのは、これがトークンを使う機能ではなく、
+    -- 黙って宛先が変わることを防ぐ通知だから。既定で無効なら、気づけないという当の問題が残る。
+    -- 代償は `codex doctor --json` の起動が1回入ることで、doctorには単一チェックだけ走らせる
+    -- フラグが無いためプロバイダへの到達性通信も付いてくる。それを避けたい場合はfalseにする。
+    codex_provider_notice = {
+      enabled = true,
     },
   },
   chat = {

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -194,7 +194,11 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   -- happens. `lightweight` still guards it because the prompt is the last element of `cmd`, and a
   -- message consisting of exactly that flag would otherwise match. Fired after the spawn above,
   -- since the probe exists to describe that call and must not delay it.
-  if opts.lightweight and vim.tbl_contains(cmd, "--ignore-user-config") then
+  --
+  -- Absent config reads as enabled, not disabled: the default is on (see config.lua), so a caller
+  -- that built its config table by hand must not silently lose the warning.
+  local notice_enabled = vim.tbl_get(self.config or {}, "agent", "codex_provider_notice", "enabled") ~= false
+  if notice_enabled and opts.lightweight and vim.tbl_contains(cmd, "--ignore-user-config") then
     CodexProviderNotice.check(cmd[1], cwd)
   end
 

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -5,6 +5,7 @@
 local Base = require("vibing.infrastructure.adapter.base")
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local CodexCommandBuilder = require("vibing.infrastructure.adapter.modules.codex_command_builder")
+local CodexProviderNotice = require("vibing.infrastructure.adapter.modules.codex_provider_notice")
 local CodexEventProcessor = require("vibing.infrastructure.adapter.modules.codex_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
 local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
@@ -184,6 +185,18 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
     end),
     stderr = codex_stderr_handler,
   }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done))
+
+  -- `--ignore-user-config` drops the user's model_provider along with their MCP servers (#587),
+  -- so say once where these calls are actually going. The argv is what decides, not
+  -- `opts.lightweight` alone: the builder documents that flag as a stand-in for a narrower switch
+  -- codex does not have yet, so reading the built command is what makes the warning disarm itself
+  -- the day the flag stops being used, instead of going on describing a loss that no longer
+  -- happens. `lightweight` still guards it because the prompt is the last element of `cmd`, and a
+  -- message consisting of exactly that flag would otherwise match. Fired after the spawn above,
+  -- since the probe exists to describe that call and must not delay it.
+  if opts.lightweight and vim.tbl_contains(cmd, "--ignore-user-config") then
+    CodexProviderNotice.check(cmd[1], cwd)
+  end
 
   if debug_mode then
     local pid = self._handles[handle_id] and self._handles[handle_id].pid or "unknown"

--- a/lua/vibing/infrastructure/adapter/modules/codex_provider_notice.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_provider_notice.lua
@@ -1,0 +1,114 @@
+--- Tells the user, once, that codex's lightweight calls are not reaching their configured
+--- provider.
+---
+--- `codex_command_builder` runs lightweight calls (title generation, `/summarize`, daily summary)
+--- with `--ignore-user-config`, which is the only thing that actually keeps them out of the user's
+--- MCP servers (#574). It also drops `model_provider`, so a user on a custom provider has those
+--- calls silently retargeted at codex's default OpenAI endpoint -- unexpected billing for some, a
+--- wordless 401 for anyone pointed at a local provider (#587).
+---
+--- The warning is not derived from the config file: `codex doctor --json` resolves it for us. That
+--- is what makes it worth shipping at all -- a regex over `config.toml` misses a provider set
+--- through a profile and matches one in an inactive section, and a warning that is wrong in either
+--- direction is worse than none, because its silence reads as "you are fine". The rest of the
+--- reasoning, including why the provider is announced rather than restored, is in
+--- `.claude/rules/architecture.md` -> "Session Persistence".
+---
+--- @module vibing.infrastructure.adapter.modules.codex_provider_notice
+
+local Notify = require("vibing.core.utils.notify")
+
+local M = {}
+
+--- codex's own default. A user who names it explicitly loses nothing, so they hear nothing.
+local DEFAULT_PROVIDER = "openai"
+
+--- The probe is diagnostic and nothing waits for it, so it can afford to give up rather than
+--- linger. Measured at 0.2-0.5s against codex 0.147, but `doctor` also probes the active
+--- provider's endpoint for reachability, and an unreachable local provider -- exactly the case
+--- this warning exists for -- is the one that can sit here.
+local PROBE_TIMEOUT_MS = 10000
+
+local probed = false
+
+--- Forget that the probe ran. Test seam only -- the flag is process-wide by design.
+function M._reset()
+  probed = false
+end
+
+--- The resolved provider name from a `codex doctor --json` report, or nil if it cannot be read.
+---
+--- Every failure is nil rather than a guess. `doctor` exits non-zero on any unrelated failing
+--- check -- a missing login alone is enough, so it exits 1 even on a config that loaded cleanly --
+--- which is why the caller ignores the exit status and only `checks["config.load"].status`
+--- decides.
+---
+--- The key really is `"model provider"`, with a space, captured from codex 0.147 rather than read
+--- off a schema (`tests/fixtures/codex_doctor.json`). If a future codex renames it this returns
+--- nil and the warning goes quiet, which is the safe direction to degrade in.
+---
+--- @param stdout string|nil
+--- @return string|nil
+function M.parse_provider(stdout)
+  local ok, report = pcall(vim.json.decode, stdout)
+  if not ok or type(report) ~= "table" then
+    return nil
+  end
+
+  local check = vim.tbl_get(report, "checks", "config.load")
+  if type(check) ~= "table" or check.status ~= "ok" then
+    return nil
+  end
+
+  local provider = vim.tbl_get(check, "details", "model provider")
+  return (type(provider) == "string" and provider ~= "") and provider or nil
+end
+
+--- Warn once per Neovim session if lightweight codex calls are leaving the configured provider.
+---
+--- Runs `codex doctor --json` asynchronously and returns immediately: the call it describes must
+--- not wait on a diagnostic. `doctor` has no flag to run one check in isolation (verified against
+--- 0.147 -- its only options are `--json`, `--summary`, `--all`, `-c` and formatting), so the
+--- reachability request it makes comes with it. That is why this fires on the first lightweight
+--- call rather than at `setup()`: a user who never generates a title never pays for it.
+---
+--- @param codex_path string resolved codex binary (argv[1] of the command already built)
+--- @param cwd string? the directory the described call runs in, so both resolve the same config
+function M.check(codex_path, cwd)
+  if probed then
+    return
+  end
+  probed = true
+
+  local on_exit = function(result)
+    local provider = M.parse_provider(result.stdout)
+    if not provider or provider == DEFAULT_PROVIDER then
+      return
+    end
+
+    vim.schedule(function()
+      Notify.warn(
+        string.format(
+          "lightweight calls (chat title, /summarize, daily summary) run with "
+            .. "--ignore-user-config to keep them out of your MCP servers, which also drops "
+            .. "model_provider -- so they go to the default %q provider, not the configured %q. "
+            .. "Ordinary chat is unaffected.",
+          DEFAULT_PROVIDER,
+          provider
+        ),
+        "codex"
+      )
+    end)
+  end
+
+  -- pcall because a spawn failure here must not take the lightweight call down with it; the
+  -- binary resolved a moment ago, so this is the narrow window in which it stopped existing.
+  pcall(
+    vim.system,
+    { codex_path, "doctor", "--json" },
+    { text = true, cwd = cwd, timeout = PROBE_TIMEOUT_MS },
+    on_exit
+  )
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/codex_provider_notice.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_provider_notice.lua
@@ -87,12 +87,15 @@ function M.check(codex_path, cwd)
     end
 
     vim.schedule(function()
+      -- %s with explicit quotes, not %q: %q escapes for Lua to read back, so a provider name
+      -- carrying a quote or a control character would reach the user as `\"` or a Lua newline
+      -- escape. The name comes from the user's own config.toml and is only ever displayed.
       Notify.warn(
         string.format(
           "lightweight calls (chat title, /summarize, daily summary) run with "
             .. "--ignore-user-config to keep them out of your MCP servers, which also drops "
-            .. "model_provider -- so they go to the default %q provider, not the configured %q. "
-            .. "Ordinary chat is unaffected.",
+            .. 'model_provider -- so they go to the default "%s" provider, not the configured '
+            .. '"%s". Ordinary chat is unaffected.',
           DEFAULT_PROVIDER,
           provider
         ),
@@ -101,6 +104,13 @@ function M.check(codex_path, cwd)
     end)
   end
 
+  -- No `env`, deliberately, where the `codex exec` call it describes passes `vim.fn.environ()`
+  -- plus the VIBING_* variables. Inheriting is the same environment minus those, and those exist
+  -- to tell a *stream* which chat and RPC port it belongs to -- a probe that reads config and
+  -- talks to nobody has no use for them. What both must agree on is what selects the config
+  -- (CODEX_HOME, PATH, cwd), and inheriting is what keeps that true by construction. If a future
+  -- change starts overriding one of those on the exec call, this has to follow.
+  --
   -- pcall because a spawn failure here must not take the lightweight call down with it; the
   -- binary resolved a moment ago, so this is the narrow window in which it stopped existing.
   pcall(

--- a/tests/fixtures/codex_doctor.json
+++ b/tests/fixtures/codex_doctor.json
@@ -1,0 +1,29 @@
+{
+  "checks": {
+    "config.load": {
+      "category": "config",
+      "details": {
+        "CODEX_HOME": "/tmp/codex-home",
+        "config.toml": "/tmp/codex-home/config.toml",
+        "config.toml parse": "ok",
+        "cwd": "/tmp/project",
+        "enabled feature flags": "shell_tool, view_image, unified_exec",
+        "feature flag overrides": "none",
+        "feature flags enabled": "3",
+        "log dir": "/tmp/codex-home/log",
+        "mcp servers": "0",
+        "model": "gpt-5",
+        "model provider": "myprov",
+        "sqlite home": "/tmp/codex-home"
+      },
+      "durationMs": 0,
+      "id": "config.load",
+      "remediation": null,
+      "status": "ok",
+      "summary": "config loaded"
+    }
+  },
+  "codexVersion": "0.147.0",
+  "overallStatus": "fail",
+  "schemaVersion": 1
+}

--- a/tests/helpers/adapter_stream.lua
+++ b/tests/helpers/adapter_stream.lua
@@ -60,6 +60,20 @@ function M.stub_system(exe_path, rpc_port)
     return state.calls[1]
   end
 
+  --- The call that launched the CLI, ignoring any side process the adapter fires alongside it.
+  ---
+  --- `stream()` is no longer always one spawn: a lightweight codex run also probes
+  --- `codex doctor --json` to report the provider `--ignore-user-config` drops (#587). The CLI
+  --- itself is the call whose stdout the adapter is streaming, which no side process has.
+  --- @return Vibing.Test.SystemCall
+  function state.cli_call()
+    local streamed = vim.tbl_filter(function(call)
+      return type(call.opts.stdout) == "function"
+    end, state.calls)
+    assert(#streamed == 1, "expected exactly one streamed vim.system call, got " .. #streamed)
+    return streamed[1]
+  end
+
   return state
 end
 

--- a/tests/lua/infrastructure/adapter/codex_cli_spec.lua
+++ b/tests/lua/infrastructure/adapter/codex_cli_spec.lua
@@ -77,4 +77,19 @@ describe("codex_cli hook registration", function()
     adapter:stream("--ignore-user-config", opts, function() end, function() end)
     assert.are.equal(1, #system.calls)
   end)
+
+  it("does not probe when the notice is turned off", function()
+    local off = codex:new(vim.tbl_deep_extend("force", CONFIG, {
+      agent = { codex_provider_notice = { enabled = false } },
+    }))
+    helper.run_stream(off, { permission_mode = "default", lightweight = true })
+    assert.are.equal(1, #system.calls)
+  end)
+
+  -- The default is on, so a config that never mentions the notice must still get it. CONFIG here
+  -- is exactly that: an agent table with only default_model in it.
+  it("probes when the config does not mention the notice at all", function()
+    helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
+    assert.are.equal(2, #system.calls)
+  end)
 end)

--- a/tests/lua/infrastructure/adapter/codex_cli_spec.lua
+++ b/tests/lua/infrastructure/adapter/codex_cli_spec.lua
@@ -7,6 +7,7 @@
 
 local helper = require("tests.helpers.adapter_stream")
 local codex = require("vibing.infrastructure.adapter.codex_cli")
+local notice = require("vibing.infrastructure.adapter.modules.codex_provider_notice")
 
 local CONFIG = { agent = { default_model = "sonnet" } }
 
@@ -26,31 +27,54 @@ describe("codex_cli hook registration", function()
   before_each(function()
     system = helper.stub_system("/usr/local/bin/codex")
     adapter = codex:new(CONFIG)
+    notice._reset()
   end)
 
   after_each(function()
     system.restore()
+    notice._reset()
   end)
 
   it("registers the PreToolUse hook for an ordinary call", function()
     helper.run_stream(adapter, { permission_mode = "default" })
-    assert.is_true(registers_hook(system.only_call().cmd))
+    assert.is_true(registers_hook(system.cli_call().cmd))
   end)
 
   it("skips it for a lightweight call, matching claude_cli", function()
     -- Routing a title-generation tool call into the chat's approval UI would prompt the user
     -- about a request they never made. The read-only sandbox is what constrains it instead.
     helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
-    assert.is_false(registers_hook(system.only_call().cmd))
+    assert.is_false(registers_hook(system.cli_call().cmd))
   end)
 
   it("skips it in bypassPermissions, as before", function()
     helper.run_stream(adapter, { permission_mode = "bypassPermissions" })
-    assert.is_false(registers_hook(system.only_call().cmd))
+    assert.is_false(registers_hook(system.cli_call().cmd))
   end)
 
   it("still fences the lightweight call even with the hook gone", function()
     helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
-    assert.is_true(vim.tbl_contains(system.only_call().cmd, 'sandbox_mode="read-only"'))
+    assert.is_true(vim.tbl_contains(system.cli_call().cmd, 'sandbox_mode="read-only"'))
+  end)
+
+  -- The other half of that fence: --ignore-user-config takes the user's model_provider with the
+  -- MCP servers it was aimed at, so the run also asks codex where it is now pointed (#587).
+  it("probes for the provider the lightweight call gives up", function()
+    helper.run_stream(adapter, { permission_mode = "default", lightweight = true })
+    assert.are.equal(2, #system.calls)
+    assert.are.same({ "/usr/local/bin/codex", "doctor", "--json" }, system.calls[2].cmd)
+  end)
+
+  it("does not probe for an ordinary call, which keeps the user's provider", function()
+    helper.run_stream(adapter, { permission_mode = "default" })
+    assert.are.equal(1, #system.calls)
+  end)
+
+  -- The prompt is the last element of the argv, so the flag scan alone would match a message
+  -- that happens to be exactly that flag and warn about a loss this call never took.
+  it("does not probe because the prompt looks like the flag", function()
+    local opts = { permission_mode = "default", permissions_allow = {} }
+    adapter:stream("--ignore-user-config", opts, function() end, function() end)
+    assert.are.equal(1, #system.calls)
   end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/codex_provider_notice_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_provider_notice_spec.lua
@@ -94,6 +94,17 @@ describe("codex_provider_notice", function()
       assert.is_truthy(notified[1].msg:find("openai", 1, true))
     end)
 
+    -- %q would render this as `\"weird\"` plus a Lua escape for the newline. The name comes
+    -- straight from the user's config.toml, so it is only ever displayed, never re-parsed.
+    it("shows an awkward provider name as written, without Lua escapes", function()
+      stub_system(report_with('we"ird\nname'))
+      notice.check("/usr/local/bin/codex")
+      drain()
+
+      assert.is_truthy(notified[1].msg:find('we"ird\nname', 1, true))
+      assert.is_nil(notified[1].msg:find("\\", 1, true))
+    end)
+
     it("asks codex to resolve the provider rather than reading config.toml", function()
       stub_system(report_with("myprov"))
       notice.check("/usr/local/bin/codex", "/tmp/some-worktree")

--- a/tests/lua/infrastructure/adapter/modules/codex_provider_notice_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_provider_notice_spec.lua
@@ -1,0 +1,142 @@
+local notice = require("vibing.infrastructure.adapter.modules.codex_provider_notice")
+
+describe("codex_provider_notice", function()
+  local original_system, original_notify
+  local spawned, notified
+
+  before_each(function()
+    notice._reset()
+    spawned, notified = {}, {}
+
+    original_system = vim.system
+    original_notify = vim.notify
+
+    vim.notify = function(msg, level)
+      table.insert(notified, { msg = msg, level = level })
+    end
+  end)
+
+  after_each(function()
+    -- The warning is scheduled, so a test that did not wait for it would otherwise leak its
+    -- notification into the next test's list.
+    vim.wait(50)
+    vim.system = original_system
+    vim.notify = original_notify
+  end)
+
+  --- Replace vim.system with a recorder that hands `stdout` straight to the callback.
+  local function stub_system(stdout)
+    vim.system = function(cmd, opts, on_exit)
+      table.insert(spawned, { cmd = cmd, opts = opts })
+      on_exit({ code = 1, stdout = stdout, stderr = "" })
+      return { pid = 1 }
+    end
+  end
+
+  --- The warning is emitted from inside vim.schedule, so drain the scheduler before asserting.
+  local function drain()
+    vim.wait(200, function()
+      return #notified > 0
+    end, 10)
+  end
+
+  describe("parse_provider", function()
+    --- Captured from codex 0.147 (`codex doctor --json` with a custom provider in config.toml),
+    --- then trimmed to the checks this module reads and stripped of machine-specific paths. The
+    --- point of pinning it is the key name: `"model provider"`, with a space, not `model_provider`.
+    local function real_report()
+      local path = vim.fn.getcwd() .. "/tests/fixtures/codex_doctor.json"
+      return table.concat(vim.fn.readfile(path), "\n")
+    end
+
+    it("reads the resolved provider out of a real doctor report", function()
+      assert.are.equal("myprov", notice.parse_provider(real_report()))
+    end)
+
+    it("ignores a report whose config check did not succeed", function()
+      local report = vim.json.decode(real_report())
+      report.checks["config.load"].status = "fail"
+      assert.is_nil(notice.parse_provider(vim.json.encode(report)))
+    end)
+
+    it("returns nil when the provider key is renamed", function()
+      local report = vim.json.decode(real_report())
+      report.checks["config.load"].details["model provider"] = nil
+      report.checks["config.load"].details["model_provider"] = "myprov"
+      assert.is_nil(notice.parse_provider(vim.json.encode(report)))
+    end)
+
+    it("returns nil for output that is not a doctor report", function()
+      assert.is_nil(notice.parse_provider(nil))
+      assert.is_nil(notice.parse_provider(""))
+      assert.is_nil(notice.parse_provider("not json at all"))
+      assert.is_nil(notice.parse_provider("[]"))
+      assert.is_nil(notice.parse_provider('{"checks":{}}'))
+      assert.is_nil(notice.parse_provider('{"checks":{"config.load":{"status":"ok"}}}'))
+    end)
+  end)
+
+  describe("check", function()
+    local function report_with(provider)
+      return vim.json.encode({
+        checks = { ["config.load"] = { status = "ok", details = { ["model provider"] = provider } } },
+      })
+    end
+
+    it("warns once, naming the configured provider", function()
+      stub_system(report_with("myprov"))
+      notice.check("/usr/local/bin/codex")
+      drain()
+
+      assert.are.equal(1, #notified)
+      assert.are.equal(vim.log.levels.WARN, notified[1].level)
+      assert.is_truthy(notified[1].msg:find("myprov", 1, true))
+      assert.is_truthy(notified[1].msg:find("openai", 1, true))
+    end)
+
+    it("asks codex to resolve the provider rather than reading config.toml", function()
+      stub_system(report_with("myprov"))
+      notice.check("/usr/local/bin/codex", "/tmp/some-worktree")
+
+      assert.are.same({ "/usr/local/bin/codex", "doctor", "--json" }, spawned[1].cmd)
+      -- Same directory as the call being described, so the two cannot resolve different configs.
+      assert.are.equal("/tmp/some-worktree", spawned[1].opts.cwd)
+      assert.is_truthy(spawned[1].opts.timeout)
+    end)
+
+    it("probes at most once per session, however many lightweight calls run", function()
+      stub_system(report_with("myprov"))
+      notice.check("/usr/local/bin/codex")
+      notice.check("/usr/local/bin/codex")
+      notice.check("/usr/local/bin/codex")
+      drain()
+
+      assert.are.equal(1, #spawned)
+      assert.are.equal(1, #notified)
+    end)
+
+    it("stays quiet when nothing is being taken away", function()
+      stub_system(report_with("openai"))
+      notice.check("/usr/local/bin/codex")
+      vim.wait(50)
+      assert.are.equal(0, #notified)
+    end)
+
+    it("stays quiet rather than guessing when the report is unreadable", function()
+      stub_system("codex: unknown subcommand 'doctor'")
+      notice.check("/usr/local/bin/codex")
+      vim.wait(50)
+      assert.are.equal(0, #notified)
+    end)
+
+    it("survives a codex that cannot be spawned", function()
+      vim.system = function()
+        error("ENOENT")
+      end
+      assert.has_no.errors(function()
+        notice.check("/usr/local/bin/codex")
+      end)
+      assert.are.equal(0, #notified)
+    end)
+  end)
+end)


### PR DESCRIPTION
> **base について**: 当初 base にしていた `fix-codex-lightweight-config`(PR #582)が main に
> マージされたため、`git rebase origin/main` で main の上に載せ替えました。現在 base は main です。

## 結論

**案1(警告を出す)を採用しました。** issue が「実装コストが高い」としていた `model_provider` の解決は、
**codex 自身に解決済みの値を吐かせられる**ことが分かったため、TOML パースも正規表現も不要になりました。

案2(プロバイダを保持する)は採れないことも実測で確定しました。詳細は下記。

## 調査: codex に解決済み設定を吐かせる手段はあるか

codex 0.147.0 を一時ディレクトリに入れ、`CODEX_HOME` を一時ディレクトリに向けて実施しました
(#582 と同じ手法。ユーザーの `~/.codex/config.toml` は一切読み書きしていません)。

### あった: `codex doctor --json`

`checks["config.load"].details["model provider"]` に**解決済みの** `model_provider` が入ります。

| CODEX_HOME の中身                       | `model provider` |
| --------------------------------------- | ---------------- |
| `model_provider = "myprov"` + provider 定義 | `myprov`         |
| config.toml なし                        | `openai`         |
| config.toml が壊れている                | (`status: fail`、値なし) |

codex 自身の config ローダが解決した値なので、issue が挙げていた誤りは**両方向とも消えます**。

- 偽陽性(非アクティブな `[profiles.<name>]` にマッチ)→ 起きない
- 偽陰性(profile 経由の設定を見逃す)→ 起きない。加えて **0.147 では `profile = "x"` という
  config.toml のキー自体が廃止**されており(`legacy profile = "x" config is no longer supported`
  でエラー)、残る経路は CLI の `-p/--profile` のみ。vibing.nvim は `codex exec` にも probe にも
  渡していないので、両者は同じ設定を解決します。

### 無かった: プロバイダ**定義**を吐く手段(= 案2が採れない理由)

`[model_providers.<name>]` テーブルそのものを出力する経路は**どこにもありません**。

- `codex doctor --json` … プロバイダ**名**のみ
- app-server プロトコル … `codex app-server generate-json-schema --experimental` で確認したところ、
  `ConfigReadResponse` の `Config` が持つのは `model_provider`(ただの string)だけで、
  `model_providers` のマップは存在しない

つまり `-c model_providers.<name>={...}` を再注入するには結局 config.toml を手で読むしかなく、
issue が問題視していたコストがそのまま残ります。よって**名前は復元できるが定義は復元できない**
── 保持ではなく告知にしました。

### その他叩いて分かったこと

- `codex config` サブコマンドは存在しない(`codex --help`)
- `codex doctor` は `--ignore-user-config` を受け付けない(`unexpected argument`)。probe は
  常にユーザー設定を読む側なので、これはむしろ都合が良い
- `codex doctor` に「特定チェックだけ走らせる」フラグは無い(オプションは `--json` / `--summary` /
  `--all` / `-c` / 表示系のみ)。よって provider へのリーチャビリティ通信は probe に付いてきます

## 実装

`lua/vibing/infrastructure/adapter/modules/codex_provider_notice.lua` を追加。
`codex_cli.lua` から、**組み上がった argv に `--ignore-user-config` が実際に入っているとき**に呼びます。

```text
[vibing] codex: lightweight calls (chat title, /summarize, daily summary) run with
--ignore-user-config to keep them out of your MCP servers, which also drops model_provider
-- so they go to the default "openai" provider, not the configured "myprov".
Ordinary chat is unaffected.
```

設計上、意図的にそうしている点:

- **Neovim セッションごとに一度だけ。** 非同期で、誰も待ちません。`setup()` ではなく最初の軽量
  呼び出し時に走るので、タイトル生成を使わないユーザーはリーチャビリティ通信のコストも払いません。
- **`opts.lightweight` だけでなく argv を見る。** builder は `--ignore-user-config` を「codex に
  もっと狭いスイッチが無いための代用」と明記しています。argv を条件にしておけば、将来その狭い
  スイッチが来てフラグが外れた日に、**警告が自動的に止まります**(存在しない損失を語り続けない)。
  `lightweight` も併用しているのは、プロンプトが argv の最後の要素なので、本文がちょうどその
  フラグ文字列と一致するメッセージを誤検知しないためです。
- **読めなければ黙る。** パース失敗はすべて nil を返し、何も出しません。信頼できない警告は
  無いより悪い(出ないことを「大丈夫」と読まれる)という #582 の判断をそのまま踏襲しています。
- **exit code は見ない。** `codex doctor --json` は無関係なチェックが1つ落ちるだけで exit 1 に
  なります(未ログインだけで十分)。正常に読めた config でも exit 1 なので、判定は
  `checks["config.load"].status` だけで行います。stdout はどちらでも有効な JSON です。
- **キーは `"model provider"`(スペース入り)。** スキーマから読んだのではなく codex 0.147 の実出力を
  `tests/fixtures/codex_doctor.json` に取り込んで固定しています。

`--ignore-user-config` そのものは触っていません。#582 が塞いだ MCP の穴はそのままです。

## 検証

実バイナリ(codex 0.147.0)相手にパーサと全経路を通しました。

| CODEX_HOME | パーサ出力 | 実際の通知 |
| ---------- | ---------- | ---------- |
| カスタムプロバイダ | `myprov` | 警告が出る(プロバイダ名込み) |
| 空 | `openai` | 何も出ない |
| 壊れた config | `nil` | 何も出ない |

下段は headless Neovim から `codex_cli:stream({ lightweight = true })` を実際に走らせて確認しています。

`pnpm run check` / `check:doc` / `lint` / `format:check` / `test:node`(32/32)、
`test:lua` は exit 0(連続3回で安定を確認)。`test:e2e` と `test:eval` は実トークンを消費するため未実行です。

## レビュー反映 (2026-08-15)

### 1. 無効化する設定項目を追加

`agent.codex_provider_notice.enabled` を追加しました。警告だけでなく **probe(`codex doctor --json`
の起動)ごと**止まります。断れるようにする価値があるのは実質そちらなので、トグルはそこに効かせています。

**既定は `true` です。** `subagent` / `auto_resume_on_limit` / `dap` が既定 `false` なのは、
**無人でトークンを消費する**からです。この警告はトークンを一切使わず、目的は「ユーザーが他の手段では
気づけない宛先の変更を知らせること」です。既定で無効にすると、**気づけないという当の問題がそのまま残り**、
機能として成立しません。トグルが無いのが方針と不整合、というご指摘はそのとおりなので入れましたが、
既定値は逆向きが正しいと判断しました。

設定が**無い**場合は「有効」として読みます(`~= false`)。既定が有効なので、手で config テーブルを
組んだ呼び出し元が黙って警告を失わないようにするためです。この分岐にもテストを足しています。

ドキュメントは `docs/configuration.md`(新設の "Codex Provider Notice" 節)、`.claude/rules/architecture.md`、
README / README.ja / CHANGELOG を更新しました。

### 2. `%q` → `%s` + 明示的なクオート

対応しました。ご指摘のとおり `%q` は Lua が読み戻すためのエスケープなので、`we"ird\nname` のような値だと
`\"` や Lua 由来の改行エスケープがそのまま通知に出ます。プロバイダ名はユーザーの config.toml 由来で
**表示しかしない**値なので `%s` が正解でした。まさにその値を使う回帰テストを追加しています。

### 3. probe に `env` を渡していない件 → 意図的、コメントを追加

意図どおりです。理由をコメントに残しました。

`codex exec` 側が足している `VIBING_*` は「その**ストリーム**がどのチャット・どの RPC ポートに属するか」を
伝えるための変数で、設定を読んで誰とも通信しない probe には使い道がありません。一方で両者が必ず一致して
いなければならないのは**どの設定を選ぶか**を決める `CODEX_HOME` / `PATH` / cwd で、継承はそれを構造的に
保証します(明示的に渡すとむしろズレる余地が生まれます)。将来 exec 側でこれらを上書きし始めたら probe も
追随が必要、という条件もコメントに書きました。

### 追加検証

codex 0.147 を一時ディレクトリに入れ、headless Neovim から実際に `codex_cli:stream({ lightweight = true })`
を走らせて 3 ケース確認しました(ユーザーの `~/.codex/config.toml` は不使用)。

| CODEX_HOME | 設定 | 結果 |
| ---------- | ---- | ---- |
| カスタムプロバイダ | 既定(有効) | 警告が出る。クオートは `"myprov"` と素直に表示される |
| カスタムプロバイダ | `enabled = false` | 何も出ない(probe も起動しない) |
| 空 | 既定(有効) | 何も出ない |

`pnpm run check` / `check:doc` / `lint` / `format:check` / `test:node`(32/32) / `test:lua`(exit 0)は
rebase 後に再実行して全て通っています。

## 未検証・スコープ外

- **`--ignore-user-config` が落とす `model_provider` 以外のキー**(`shell_environment_policy`、
  `notify` 等)は引き続き網羅していません。警告も `model_provider` に限定しています。
- **probe が走るのは codex バックエンドの軽量呼び出しだけ**です。copilot / grok は `lightweight` を
  そもそも解釈しないので、この issue の対象外のままです(#582 で挙げられた別件)。
- **リーチャビリティ通信は止められません**(`doctor` に単一チェック実行フラグが無いため)。到達
  できないローカルプロバイダの場合、10 秒のタイムアウトまで待ってから警告が出ます。まさに
  この機能が対象とするユーザーで警告が最も遅いという歪みは残っています。
- **トグルは probe の有無だけを切り替えます。** `--ignore-user-config` 自体は無効化できません(#582 が塞いだ MCP の穴を開け直すことになるため、意図的にスコープ外です)。オフにすると宛先が変わること自体は変わらず、知らされなくなるだけです。
- codex がこのキーをリネームした場合、警告は**黙って出なくなります**。警告としては安全側の
  劣化ですが、それに気づく仕組みはありません(fixture が形を固定しているだけです)。

## テスト側の変更について

`tests/helpers/adapter_stream.lua` に `cli_call()` を追加しました。軽量呼び出しの `stream()` は
もう「1回の `vim.system`」ではなくなったため、`only_call()`(ちょうど1回を要求する)では
`codex_cli_spec` が落ちます。`cli_call()` は「アダプタが stdout をストリームしている呼び出し」を
選ぶので、付随する probe を無視して CLI 本体の argv を見られます。`only_call()` は他の spec の
ガードとしてそのまま残しています。

Closes #587

