### PR TITLE
fix(adapter): re-validate the cached binary path, and guard every spawn

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -195,7 +195,9 @@ The tree is layered (`domain` / `application` / `infrastructure` / `presentation
 - `claude_cli.lua` / `codex_cli.lua` / `copilot_cli.lua` / `grok_cli.lua` - Backend adapters
   (`new()` and `stream()`; everything else comes from `cli_runtime`)
 - `modules/cli_runtime.lua` - `execute`/`cancel`/`supports` + session delegations, installed onto
-  each adapter class; plus `new_handle_id`, `kill_tree`, `report_build_failure`
+  each adapter class; plus `new_handle_id`, `kill_tree`, `spawn` (the guarded `vim.system` call —
+  a spawn that raises leaves no process, so the exit handler never cleans up), and
+  `report_build_failure`
 - `modules/command_builder_common.lua` - Language resolution, the response-language sentence, the
   `@file:` context prefix, and cached binary lookup — the backend-agnostic half of argv building
 - `modules/cli_command_builder.lua` - Claude CLI argv construction (flags, system prompt)

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -176,7 +176,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
     end
   end
 
-  self._handles[handle_id] = vim.system(cmd, {
+  local started = CliRuntime.spawn(self._handles, handle_id, cmd, {
     text = true,
     cwd = cwd,
     env = env,
@@ -186,7 +186,11 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
     stderr = StreamHandler.create_stderr_handler(error_output),
   }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done, function()
     return event_context.resultErrors
-  end))
+  end), wrapped_on_done)
+
+  if not started then
+    return handle_id
+  end
 
   if debug_mode then
     local pid = self._handles[handle_id] and self._handles[handle_id].pid or "unknown"

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -175,7 +175,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
     end
   end
 
-  self._handles[handle_id] = vim.system(cmd, {
+  local started = CliRuntime.spawn(self._handles, handle_id, cmd, {
     text = true,
     stdin = "",
     cwd = cwd,
@@ -184,7 +184,11 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
       return self._handles[handle_id] == nil
     end),
     stderr = codex_stderr_handler,
-  }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done))
+  }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done), wrapped_on_done)
+
+  if not started then
+    return handle_id
+  end
 
   -- `--ignore-user-config` drops the user's model_provider along with their MCP servers (#587),
   -- so say once where these calls are actually going. The argv is what decides, not

--- a/lua/vibing/infrastructure/adapter/copilot_cli.lua
+++ b/lua/vibing/infrastructure/adapter/copilot_cli.lua
@@ -153,11 +153,7 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
     end
   end
 
-  -- vim.system throws synchronously on spawn failure (e.g. invalid cwd) before any process
-  -- exists, so the registry/perm-handler state registered above would otherwise never be cleaned
-  -- up — and a stale permission entry is not inert: with a single entry left behind, the handler
-  -- falls back to it for hook calls that carry no matching handle_id. Matches grok_cli.lua.
-  local ok_spawn, handle_or_err = pcall(vim.system, cmd, {
+  local started = CliRuntime.spawn(self._handles, handle_id, cmd, {
     text = true,
     stdin = "",
     cwd = cwd,
@@ -166,16 +162,11 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
       return self._handles[handle_id] == nil
     end),
     stderr = StreamHandler.create_stderr_handler(error_output),
-  }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done))
+  }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done), wrapped_on_done)
 
-  if not ok_spawn then
-    ActiveStreamRegistry.unregister(handle_id)
-    perm_handler.clear_active_opts(handle_id)
-    on_done({ error = string.format("Failed to spawn copilot process: %s", tostring(handle_or_err)) })
+  if not started then
     return handle_id
   end
-
-  self._handles[handle_id] = handle_or_err
 
   if debug_mode then
     local pid = self._handles[handle_id] and self._handles[handle_id].pid or "unknown"

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -167,10 +167,7 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
     end
   end
 
-  -- vim.system throws synchronously on spawn failure (e.g. invalid cwd) before any process
-  -- exists, so the registry/perm-handler state registered above would otherwise never be
-  -- cleaned up (the exit handler that normally does it never runs).
-  local ok_spawn, handle_or_err = pcall(vim.system, cmd, {
+  local started = CliRuntime.spawn(self._handles, handle_id, cmd, {
     text = true,
     stdin = "",
     cwd = cwd,
@@ -179,16 +176,11 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
       return self._handles[handle_id] == nil
     end),
     stderr = StreamHandler.create_stderr_handler(error_output),
-  }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done))
+  }, StreamHandler.create_exit_handler(handle_id, self._handles, output, error_output, wrapped_on_done), wrapped_on_done)
 
-  if not ok_spawn then
-    ActiveStreamRegistry.unregister(handle_id)
-    perm_handler.clear_active_opts(handle_id)
-    on_done({ error = string.format("Failed to spawn grok process: %s", tostring(handle_or_err)) })
+  if not started then
     return handle_id
   end
-
-  self._handles[handle_id] = handle_or_err
 
   if debug_mode then
     local pid = self._handles[handle_id] and self._handles[handle_id].pid or "unknown"

--- a/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
@@ -56,21 +56,92 @@ function M.kill_tree(handle)
   end)
 end
 
+--- An error message with its `file.lua:123:` prefix removed.
+---
+--- The chat buffer should show a message, not a source location.
+---
+--- @param err any whatever pcall returned
+--- @return string
+local function strip_source_location(err)
+  return type(err) == "string" and (err:gsub("^.*:%d+:%s*", "")) or tostring(err)
+end
+
+--- Hand a failure that happened before the process existed back to the caller.
+---
+--- @param handle_id string
+--- @param message string
+--- @param on_done fun(response: Vibing.Response)
+local function report(handle_id, message, on_done)
+  vim.schedule(function()
+    on_done({ content = "", error = message, _handle_id = handle_id })
+  end)
+end
+
 --- Report a failure that happened before the process existed, through `on_done`.
 ---
 --- The command builders raise when their binary is missing, and `send_message.lua` does not wrap
---- `stream()` in pcall, so without this the chat buffer would show a raw Lua stack trace. The
---- `file:line` prefix is stripped for the same reason: the chat should show a message, not a
---- source location.
+--- `stream()` in pcall, so without this the chat buffer would show a raw Lua stack trace.
 ---
 --- @param handle_id string
 --- @param err any whatever pcall returned
 --- @param on_done fun(response: Vibing.Response)
 function M.report_build_failure(handle_id, err, on_done)
-  local message = type(err) == "string" and err:gsub("^.*:%d+:%s*", "") or tostring(err)
-  vim.schedule(function()
-    on_done({ content = "", error = message, _handle_id = handle_id })
-  end)
+  report(handle_id, strip_source_location(err), on_done)
+end
+
+--- What to tell the user when `vim.system` itself raised instead of starting the CLI.
+---
+--- The builder's own "not found in PATH" check cannot cover the missing-binary case: it resolved a
+--- path, and the binary went away between that answer and the spawn. libuv reports that as a bare
+--- `ENOENT: no such file or directory (cmd): '<path>'`, which reads as an internal error rather
+--- than a CLI to reinstall -- so that one case is named, and every other spawn failure is passed
+--- through with its own text.
+---
+--- **The `(cmd)` marker is what decides, not `ENOENT`.** A cwd that no longer exists raises ENOENT
+--- too, as `(cwd)`, and that is not a hypothetical: a chat's `working_dir` frontmatter outlives
+--- `git worktree remove`, and `Git.resolve_working_dir` does not check the directory is still
+--- there. Keying on the error code alone told those users to reinstall a CLI that was fine.
+---
+--- @param cmd string[] the argv that failed to spawn
+--- @param err any whatever pcall returned
+--- @return string
+local function spawn_error_message(cmd, err)
+  local message = strip_source_location(err)
+
+  if message:find("ENOENT", 1, true) and message:find("(cmd)", 1, true) then
+    return string.format("%s could not be started: it is no longer there. Reinstall the CLI.", cmd[1])
+  end
+
+  return string.format("Failed to spawn %s: %s", cmd[1], message)
+end
+
+--- Start the CLI, or report why it could not start.
+---
+--- `vim.system` raises synchronously when the spawn itself fails -- a binary that went missing
+--- between the builder resolving it and now, an invalid cwd -- before any process exists. Left
+--- unguarded that reaches the chat as a Lua stack trace, and the exit handler that would normally
+--- unregister the handle and clear the permission opts never runs. A permission entry left behind
+--- is not inert: with a single entry in the table, the handler falls back to it for hook calls
+--- carrying no matching handle_id.
+---
+--- Pass the adapter's own `wrapped_on_done`, which is what performs that cleanup.
+---
+--- @param handles table<string, table> the adapter's handle table
+--- @param handle_id string
+--- @param cmd string[] argv
+--- @param sys_opts table vim.system options
+--- @param on_exit function vim.system's exit callback
+--- @param on_done fun(response: Vibing.Response) the adapter's wrapped_on_done
+--- @return boolean started false when the failure has already been reported through on_done
+function M.spawn(handles, handle_id, cmd, sys_opts, on_exit, on_done)
+  local ok, handle_or_err = pcall(vim.system, cmd, sys_opts, on_exit)
+  if not ok then
+    report(handle_id, spawn_error_message(cmd, handle_or_err), on_done)
+    return false
+  end
+
+  handles[handle_id] = handle_or_err
+  return true
 end
 
 --- Install every method whose implementation does not depend on the backend.

--- a/lua/vibing/infrastructure/adapter/modules/command_builder_common.lua
+++ b/lua/vibing/infrastructure/adapter/modules/command_builder_common.lua
@@ -80,8 +80,25 @@ end
 --- A cached `exepath` lookup for one CLI binary.
 ---
 --- The cache is process-wide and deliberately so -- `exepath` is not free and PATH does not move
---- under a running Neovim. `reset()` is the test seam: a spec that wants the "CLI missing" path
---- has to clear what an earlier spec resolved.
+--- under a running Neovim. But the **binary** can: an uninstall, or a reinstall that relocates it,
+--- leaves the resolved path pointing at nothing. A cache that never looks again then hands that
+--- path back, so `error(missing_message)` is never reached and `vim.system` raises a raw ENOENT
+--- instead (#593). A cache hit is therefore confirmed with one `fs_stat` -- a single stat, not the
+--- PATH walk the cache exists to avoid -- and a path that has gone is re-resolved from scratch.
+---
+--- `fs_stat` rather than `vim.fn.executable`, which is how the rest of the codebase asks whether a
+--- binary is usable: those calls vet a path the *user* supplied, while this one only has to notice
+--- that a path `exepath` already vetted stopped existing. Asking the narrower question also keeps
+--- the exec bit out of it, which matters because `grok_command_builder`'s official-CLI sniff is
+--- keyed on `executable()` and would start firing against test doubles.
+---
+--- What this does **not** cover is a binary that still exists but is no longer the one PATH would
+--- pick: `nvm use` leaves the previous version's tree in place, so the cached path stays valid and
+--- keeps being used. Catching that would mean re-walking PATH on every request, which is the cost
+--- the cache exists to avoid. Restarting Neovim is the answer there, as it was before #581.
+---
+--- `reset()` is the test seam: a spec that wants the "CLI missing" path has to clear what an
+--- earlier spec resolved.
 ---
 --- @param binary string name to look up on PATH
 --- @param missing_message string raised when it is not there
@@ -92,6 +109,9 @@ function M.binary_resolver(binary, missing_message)
   return {
     --- @return string path
     resolve = function()
+      if cached and not vim.uv.fs_stat(cached) then
+        cached = nil
+      end
       if not cached then
         local found = vim.fn.exepath(binary)
         if found == "" then

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -103,16 +103,25 @@ end
 --- ENOENT out of vim.system. Grok keeps its own cache because it resolves a *configurable*
 --- executable and sniffs it for officialness, neither of which the shared resolver does.
 ---
---- Only an absolute path is checked. `config.grok.executable` is accepted as a bare command name
---- (`vim.fn.executable("grok")` searches PATH), and `fs_stat` would resolve that against Neovim's
---- cwd and answer nil forever -- defeating the cache on every request, which costs far more than
---- the lookup: the fallthrough re-runs `ensure_official_grok`, and that blocks the main loop on a
---- `grok --version` subprocess. Those paths simply keep the pre-#593 behaviour.
+--- What is skipped is a **bare command name**: no `/` at all. `config.grok.executable` accepts one
+--- (`vim.fn.executable("grok")` searches PATH for it), and `fs_stat` would resolve that against
+--- Neovim's cwd and answer nil forever -- defeating the cache on every request, which costs far
+--- more than the lookup: the fallthrough re-runs `ensure_official_grok`, and that blocks the main
+--- loop on a `grok --version` subprocess. Those keep the pre-#593 behaviour.
+---
+--- Anything with a `/` in it is a location, relative ones included, and is checked. `fs_stat`
+--- resolves a relative path against Neovim's cwd -- which is the same basis `vim.fn.executable`
+--- used to accept it in the first place, so the two agree. Gating on "starts with `/`" instead
+--- would leave `./bin/grok` permanently unchecked and #593 alive for it.
+---
+--- A Windows path written with backslashes only (`C:\bin\grok.exe`, a UNC share) reads as a bare
+--- name here and goes unchecked, i.e. keeps the pre-#593 behaviour. Not worth parsing drive
+--- letters for while the rest of the process handling (`pkill`, `sh -c`) is POSIX-only anyway.
 ---
 --- @param path string
 --- @return boolean
 local function still_installed(path)
-  if not vim.startswith(path, "/") then
+  if not path:find("/", 1, true) then
     return true
   end
   return vim.uv.fs_stat(path) ~= nil

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -95,13 +95,36 @@ local function ensure_official_grok(path)
   )
 end
 
+--- Whether a cached path still points at something, for the cases where we can tell.
+---
+--- The cached path is confirmed rather than trusted, for the reason
+--- `command_builder_common.binary_resolver` states (#593): an uninstall or a relocating reinstall
+--- leaves it pointing at nothing, and handing it back skips both errors below and turns into a raw
+--- ENOENT out of vim.system. Grok keeps its own cache because it resolves a *configurable*
+--- executable and sniffs it for officialness, neither of which the shared resolver does.
+---
+--- Only an absolute path is checked. `config.grok.executable` is accepted as a bare command name
+--- (`vim.fn.executable("grok")` searches PATH), and `fs_stat` would resolve that against Neovim's
+--- cwd and answer nil forever -- defeating the cache on every request, which costs far more than
+--- the lookup: the fallthrough re-runs `ensure_official_grok`, and that blocks the main loop on a
+--- `grok --version` subprocess. Those paths simply keep the pre-#593 behaviour.
+---
+--- @param path string
+--- @return boolean
+local function still_installed(path)
+  if not vim.startswith(path, "/") then
+    return true
+  end
+  return vim.uv.fs_stat(path) ~= nil
+end
+
 --- Resolve path to the grok binary
 --- @param config Vibing.Config
 --- @return string
 local function resolve_grok_path(config)
   local configured = config and config.grok and config.grok.executable
 
-  if cached_grok_path and cached_configured_executable == configured then
+  if cached_grok_path and cached_configured_executable == configured and still_installed(cached_grok_path) then
     return cached_grok_path
   end
 

--- a/tests/helpers/adapter_stream.lua
+++ b/tests/helpers/adapter_stream.lua
@@ -11,18 +11,41 @@
 
 local M = {}
 
+--- Created on first use and reused, so one spec file leaves one throwaway file behind.
+local default_binary = nil
+
 --- @class Vibing.Test.SystemCall
 --- @field cmd string[] argv as passed to vim.system
 --- @field opts table the options table (text/cwd/env/stdin/stdout/stderr)
 --- @field on_exit function the exit callback vim.system was given
 --- @field handle table the fake handle returned to the adapter
 
+--- A path to a file that really exists, standing in for a resolved CLI binary.
+---
+--- It has to exist on disk, not just look like a path: the builders confirm a cached path with
+--- `fs_stat` before reusing it (#593), so a made-up `/usr/local/bin/...` would be treated as a
+--- binary that has gone and re-resolved on every call -- which is precisely what the caching
+--- assertions are about.
+---
+--- Deliberately left non-executable: `grok_command_builder` skips its official-CLI sniff for a
+--- path `executable()` rejects, which is the seam its own spec already relies on.
+---
+--- @param name string? a distinguishing suffix, so two calls can differ
+--- @return string path
+function M.fake_binary(name)
+  local path = vim.fn.tempname() .. "-" .. (name or "cli")
+  local fd = assert(io.open(path, "w"))
+  fd:write("#!/bin/sh\n")
+  fd:close()
+  return path
+end
+
 --- Replace `vim.system`, `vim.fn.exepath` and the RPC port lookup for the duration of a test.
 ---
 --- The port is stubbed rather than left to the real server: whether one is listening depends on
 --- what else the test run started, and the env assertions need a fixed answer.
 ---
---- @param exe_path string? what exepath should report, defaults to a plausible binary path
+--- @param exe_path string? what exepath should report, defaults to a real throwaway file
 --- @param rpc_port number? what the RPC server should report, defaults to 9999
 --- @return table state `{ calls = Vibing.Test.SystemCall[], restore = fun() }`
 function M.stub_system(exe_path, rpc_port)
@@ -37,8 +60,9 @@ function M.stub_system(exe_path, rpc_port)
 
   local state = { calls = {} }
 
+  default_binary = default_binary or M.fake_binary("fake-cli")
   vim.fn.exepath = function()
-    return exe_path or "/usr/local/bin/fake-cli"
+    return exe_path or default_binary
   end
 
   vim.system = function(cmd, opts, on_exit)

--- a/tests/lua/infrastructure/adapter/modules/binary_cache_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/binary_cache_spec.lua
@@ -24,10 +24,11 @@ describe("command builder binary caching", function()
       local builder = require(def.command_builder_module)
 
       it(def.id .. " resolves its binary once, not once per request", function()
+        local installed = helper.fake_binary(def.id)
         local lookups = 0
-        vim.fn.exepath = function(name)
+        vim.fn.exepath = function()
           lookups = lookups + 1
-          return "/usr/local/bin/" .. name
+          return installed
         end
 
         builder.build("hi", {}, nil, {}, nil)
@@ -35,6 +36,25 @@ describe("command builder binary caching", function()
         builder.build("hi", {}, nil, {}, nil)
 
         assert.equals(1, lookups, def.id .. " called exepath " .. lookups .. " times")
+      end)
+
+      it(def.id .. " re-resolves a cached path once the binary has moved", function()
+        -- #593: `nvm use`, a reinstall or an uninstall relocates the CLI under a running Neovim.
+        -- The cache used to hand out the old path for the rest of the session, so the builder's
+        -- own "not found" check was skipped and vim.system raised a raw ENOENT instead.
+        local before = helper.fake_binary(def.id .. "-before")
+        local after = helper.fake_binary(def.id .. "-after")
+
+        vim.fn.exepath = function()
+          return before
+        end
+        assert.equals(before, builder.build("hi", {}, nil, {}, nil)[1])
+
+        os.remove(before)
+        vim.fn.exepath = function()
+          return after
+        end
+        assert.equals(after, builder.build("hi", {}, nil, {}, nil)[1], def.id .. " kept the stale path")
       end)
 
       it(def.id .. " exposes the reset seam every cached builder needs", function()
@@ -52,8 +72,9 @@ describe("command builder binary caching", function()
         assert.is_false(ok)
         assert.is_truthy(tostring(err):lower():find("not found", 1, true))
 
-        vim.fn.exepath = function(name)
-          return "/usr/local/bin/" .. name
+        local installed = helper.fake_binary(def.id)
+        vim.fn.exepath = function()
+          return installed
         end
         assert.is_true(pcall(builder.build, "hi", {}, nil, {}, nil), "a later lookup should succeed")
       end)

--- a/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
@@ -116,6 +116,82 @@ describe("cli_runtime", function()
       assert.is_truthy(response.error)
     end)
   end)
+
+  describe("spawn", function()
+    local original_system
+
+    before_each(function()
+      original_system = vim.system
+    end)
+
+    after_each(function()
+      vim.system = original_system
+    end)
+
+    --- @return boolean started, table response, table handles
+    local function spawn_raising(cmd, err)
+      vim.system = function()
+        error(err)
+      end
+
+      local handles, response = {}, nil
+      local started = CliRuntime.spawn(handles, "h1", cmd, {}, function() end, function(r)
+        response = r
+      end)
+      vim.wait(200, function()
+        return response ~= nil
+      end)
+      return started, response, handles
+    end
+
+    it("keeps the handle when the CLI starts", function()
+      local handle = { pid = 4242 }
+      vim.system = function()
+        return handle
+      end
+
+      local handles = {}
+      local reported = false
+      local started = CliRuntime.spawn(handles, "h1", { "/bin/claude" }, {}, function() end, function()
+        reported = true
+      end)
+
+      assert.is_true(started)
+      assert.equals(handle, handles.h1)
+      assert.is_false(reported)
+    end)
+
+    it("names the binary and drops libuv's wording when it is gone", function()
+      -- What the user gets when a CLI moves between the builder resolving it and the spawn (#593).
+      -- "ENOENT ... (cmd)" is an error code, not something to act on.
+      local raised = "vim/_system.lua:340: ENOENT: no such file or directory (cmd): '/old/bin/claude'"
+      local started, response, handles = spawn_raising({ "/old/bin/claude", "-p" }, raised)
+
+      assert.is_false(started)
+      assert.is_nil(handles.h1, "a handle was recorded for a process that never started")
+      assert.is_truthy(response.error:find("/old/bin/claude", 1, true))
+      assert.is_truthy(response.error:find("could not be started", 1, true))
+      assert.is_nil(response.error:find("ENOENT", 1, true))
+      assert.equals("h1", response._handle_id)
+    end)
+
+    it("does not blame the CLI for a working directory that is gone", function()
+      -- libuv raises ENOENT for a missing cwd as well, and the two are told apart only by the
+      -- (cwd)/(cmd) marker. A chat's working_dir outlives `git worktree remove`, so this is the
+      -- ordinary way to reach it -- and "reinstall the CLI" would be the wrong thing to do.
+      local raised = "vim/_core/system:338: ENOENT: no such file or directory (cwd): '/gone/worktree'"
+      local _, response = spawn_raising({ "/bin/claude" }, raised)
+
+      assert.is_truthy(response.error:find("/gone/worktree", 1, true))
+      assert.is_nil(response.error:find("Reinstall", 1, true), "blamed the CLI: " .. response.error)
+    end)
+
+    it("passes any other spawn failure through with its own text", function()
+      local _, response = spawn_raising({ "/bin/claude" }, "EACCES: permission denied")
+
+      assert.is_truthy(response.error:find("EACCES: permission denied", 1, true))
+    end)
+  end)
 end)
 
 -- The two behaviours below were not the same on every backend before the extraction: only grok

--- a/tests/lua/infrastructure/adapter/modules/command_builder_common_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/command_builder_common_spec.lua
@@ -1,4 +1,5 @@
 local Common = require("vibing.infrastructure.adapter.modules.command_builder_common")
+local helper = require("tests.helpers.adapter_stream")
 
 describe("command_builder_common", function()
   describe("resolve_language", function()
@@ -79,16 +80,54 @@ describe("command_builder_common", function()
     end)
 
     it("looks the binary up once and caches it", function()
+      local installed = helper.fake_binary("thing")
       local lookups = 0
       vim.fn.exepath = function()
         lookups = lookups + 1
-        return "/usr/local/bin/thing"
+        return installed
       end
 
       local resolver = Common.binary_resolver("thing", "missing")
       resolver.resolve()
       resolver.resolve()
       assert.equals(1, lookups)
+    end)
+
+    it("re-resolves when the cached binary is no longer there", function()
+      -- #593: a CLI can move under a running Neovim (`nvm use`, a reinstall). The cache used to
+      -- keep handing out the old path, so the missing-binary branch below was never reached and
+      -- vim.system raised a raw ENOENT on a path nothing had checked.
+      local before = helper.fake_binary("before")
+      local after = helper.fake_binary("after")
+
+      vim.fn.exepath = function()
+        return before
+      end
+      local resolver = Common.binary_resolver("thing", "missing")
+      assert.equals(before, resolver.resolve())
+
+      os.remove(before)
+      vim.fn.exepath = function()
+        return after
+      end
+      assert.equals(after, resolver.resolve())
+    end)
+
+    it("raises once a moved binary has no replacement on PATH", function()
+      local installed = helper.fake_binary("thing")
+      vim.fn.exepath = function()
+        return installed
+      end
+      local resolver = Common.binary_resolver("thing", "thing is not installed")
+      assert.equals(installed, resolver.resolve())
+
+      os.remove(installed)
+      vim.fn.exepath = function()
+        return ""
+      end
+      local ok, err = pcall(resolver.resolve)
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("thing is not installed", 1, true))
     end)
 
     it("raises the given message when the binary is absent", function()
@@ -113,19 +152,23 @@ describe("command_builder_common", function()
     end)
 
     it("forgets the cached path on reset, which is what the specs need", function()
+      local first = helper.fake_binary("first")
+      local second = helper.fake_binary("second")
+
       vim.fn.exepath = function()
-        return "/first"
+        return first
       end
       local resolver = Common.binary_resolver("thing", "missing")
-      assert.equals("/first", resolver.resolve())
+      assert.equals(first, resolver.resolve())
 
       vim.fn.exepath = function()
-        return "/second"
+        return second
       end
-      assert.equals("/first", resolver.resolve(), "should still be cached")
+      -- `first` is still installed, so nothing invalidates the cache on its own.
+      assert.equals(first, resolver.resolve(), "should still be cached")
 
       resolver.reset()
-      assert.equals("/second", resolver.resolve())
+      assert.equals(second, resolver.resolve())
     end)
 
     it("gives each caller its own cache", function()

--- a/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
@@ -1,4 +1,5 @@
 local grok_command_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+local helper = require("tests.helpers.adapter_stream")
 
 describe("grok_command_builder", function()
   local original_exepath
@@ -240,6 +241,51 @@ describe("grok_command_builder", function()
       assert.has_error(function()
         fresh_builder.build("hello", {}, nil, {})
       end)
+    end)
+
+    it("re-resolves a cached path once the binary has moved", function()
+      -- #593, for grok's own cache: the shared binary_resolver the other three backends use is not
+      -- this one, so the same "hands back a path that is gone, and vim.system raises a raw ENOENT"
+      -- bug lived here separately. Real files, because the check is an fs_stat.
+      local moved = helper.fake_binary("grok-moved")
+      local replacement = helper.fake_binary("grok-replacement")
+      vim.fn.exepath = function()
+        return moved
+      end
+
+      package.loaded["vibing.infrastructure.adapter.modules.grok_command_builder"] = nil
+      local fresh_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+      assert.equals(moved, fresh_builder.build("hello", {}, nil, {})[1])
+
+      os.remove(moved)
+      vim.fn.exepath = function()
+        return replacement
+      end
+      assert.equals(replacement, fresh_builder.build("hello", {}, nil, {})[1], "kept the stale path")
+    end)
+
+    it("still caches a bare command name, which no fs_stat can confirm", function()
+      -- config.grok.executable takes a name off PATH as well as a path, and fs_stat would resolve
+      -- that against Neovim's own cwd and answer nil forever. Losing the cache is not just a
+      -- lookup: the fallthrough re-runs the officialness sniff, blocking the main loop on a
+      -- `grok --version` subprocess on every single send.
+      local sniffs = 0
+      vim.fn.executable = function(path)
+        return path == "grok" and 1 or 0
+      end
+      vim.fn.system = function()
+        sniffs = sniffs + 1
+        return "grok 0.2.101 (5bc4b5dfadcf) [stable]\n"
+      end
+
+      package.loaded["vibing.infrastructure.adapter.modules.grok_command_builder"] = nil
+      local fresh_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+      local config = { grok = { executable = "grok" } }
+
+      fresh_builder.build("hello", {}, nil, config)
+      fresh_builder.build("hello again", {}, nil, config)
+
+      assert.equals(1, sniffs, "the sniff ran " .. sniffs .. " times: the cache is defeated")
     end)
 
     it("keeps rejecting an unofficial binary on every call, not just the first", function()

--- a/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
@@ -264,6 +264,35 @@ describe("grok_command_builder", function()
       assert.equals(replacement, fresh_builder.build("hello", {}, nil, {})[1], "kept the stale path")
     end)
 
+    it("re-validates a relative path, which is a location and not a PATH lookup", function()
+      -- `./bin/grok` is not a bare command name: `vim.fn.executable` resolves it against Neovim's
+      -- cwd, and so does fs_stat. Skipping the check for everything that does not start with "/"
+      -- left exactly this shape carrying #593 -- the cache would hand the path back after it was
+      -- gone, and vim.system would raise a raw ENOENT on it.
+      local relative = "./vibing-593-not-here/grok"
+      assert.is_nil(vim.uv.fs_stat(relative), "the fixture path must not exist")
+
+      local installed = true
+      vim.fn.executable = function(path)
+        return (path == relative and installed) and 1 or 0
+      end
+      vim.fn.system = function()
+        return "grok 0.2.101 (5bc4b5dfadcf) [stable]\n"
+      end
+
+      package.loaded["vibing.infrastructure.adapter.modules.grok_command_builder"] = nil
+      local fresh_builder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+      local config = { grok = { executable = relative } }
+      assert.equals(relative, fresh_builder.build("hello", {}, nil, config)[1])
+
+      -- Gone. The cached path must not survive it: the user gets the actionable "not found at
+      -- configured path" error instead of an ENOENT out of the spawn.
+      installed = false
+      assert.has_error(function()
+        fresh_builder.build("hello again", {}, nil, config)
+      end)
+    end)
+
     it("still caches a bare command name, which no fs_stat can confirm", function()
       -- config.grok.executable takes a name off PATH as well as a path, and fs_stat would resolve
       -- that against Neovim's own cwd and answer nil forever. Losing the cache is not just a

--- a/tests/lua/infrastructure/adapter/stream_options_spec.lua
+++ b/tests/lua/infrastructure/adapter/stream_options_spec.lua
@@ -121,6 +121,28 @@ for _, backend in ipairs(helper.adapters()) do
         assert.equals(0, #system.calls, "no process should be spawned when the CLI is missing")
       end)
 
+      it("reports a spawn that raises, instead of throwing out of stream()", function()
+        -- #593's second half. A binary can go missing between the builder resolving it and the
+        -- spawn, and libuv answers that with a raw `ENOENT: ... (cmd): '<path>'` that vim.system
+        -- raises. Unguarded, that reaches the user as a Lua stack trace and leaves the handle
+        -- registered, because the exit handler that unregisters it never runs.
+        vim.system = function()
+          error("ENOENT: no such file or directory (cmd): '/gone/cli'")
+        end
+
+        local result = helper.run_stream(adapter)
+        vim.wait(200, function()
+          return #result.done_responses > 0
+        end)
+
+        assert.equals(1, #result.done_responses)
+        -- The wording itself is cli_runtime_spec's business; what matters here is that the adapter
+        -- routes through it rather than handing libuv's text to the chat.
+        local message = result.done_responses[1].error or ""
+        assert.is_nil(message:find("ENOENT", 1, true), "raw libuv error leaked: " .. message)
+        assert.is_nil(ActiveStreamRegistry.get(result.handle_id), "the handle outlived the failed spawn")
+      end)
+
       it("strips the Lua file:line prefix so the chat shows a message, not a stack location", function()
         system.restore()
         system = helper.stub_system("")


### PR DESCRIPTION
Closes #593

## 問題

`command_builder_common.binary_resolver` のキャッシュ（#581）は一度解決したパスをプロセス終了まで保持し、**そのパスがまだ存在するかを二度と確認しません**。CLI をアンインストールした / 再インストールで場所が変わった場合、古いパスがそのまま返るため `error(missing_message)` の分岐に入らず、`vim.system` が **ENOENT の生スタックトレース**を出します。

## 直し方

issue の**案1・案2を両方**入れました。理由は下記の通りです。

### 案1（本筋）: キャッシュヒット時に `fs_stat` で1回確認する

`lua/vibing/infrastructure/adapter/modules/command_builder_common.lua`

```lua
if cached and not vim.uv.fs_stat(cached) then
  cached = nil
end
```

- キャッシュの意義は保たれます。`fs_stat` は stat 1回で、キャッシュが避けている PATH 走査（`exepath`）ではありません。存在すればそのまま返し、`exepath` は呼び直しません
- `vim.fn.executable()`（コードベースの他の4箇所が使っている書き方）ではなく `fs_stat` にしています。あちらは「ユーザーが指定したパスが使えるか」を検証する用途で、こちらは「`exepath` が既に検証したパスが消えていないか」だけを見れば足りるためです。加えて `grok_command_builder` の公式CLI判定が `executable()` を seam にしており、`executable()` にするとテストダブルに対して判定が走り始めてしまいます
- **直らないケースも明記しました**: `nvm use` は旧バージョンのツリーを残すので `fs_stat` は成功し、古いパスが使われ続けます。これを捕まえるには毎回 PATH を再走査するしかなく、それはキャッシュの存在意義そのものなので、docstring に「そこは Neovim 再起動」と書いてあります（issue 本文の `nvm use` 例は、正確には「アンインストール/移動を伴う場合のみ」直ります）

### grok も同じバグを持っていたので直しました

`binary_resolver` は claude / codex / copilot が使い、grok は**自前のキャッシュ**を持っています（設定可能な executable を解決し、公式CLIかを sniff するため）。その自前キャッシュも再確認していなかったので、同じ ENOENT が出ます。共有の1行を足しました。

ただし `config.grok.executable` は PATH 上のコマンド名（`"grok"`）も受け付けるので、絶対パスのときだけ確認します。相対名を `fs_stat` すると Neovim の cwd 基準で常に nil になり、毎リクエストでキャッシュが無効化 → `ensure_official_grok` が再実行 → `grok --version` の**同期サブプロセスでメインループがブロック**します。

### 案2（保険）: spawn 側の pcall を4バックエンドに揃える

`copilot` / `grok` にはすでにありましたが、`claude` / `codex` にはありませんでした。案1を入れても TOCTOU（stat と spawn の間で消える）や実行権限剥奪は残るため、保険として入れています。同時に、無防備だと `ActiveStreamRegistry` と permission opts の後始末（exit handler の仕事）が走らない問題も claude / codex で解消されます。

4箇所に同じ `pcall` + 後始末が並ぶことになるため、`CliRuntime.spawn()` に集約しました（`cli_runtime` が存在する理由そのもの、#515）。

メッセージは **`(cmd)` マーカーで判定**しています。`ENOENT` だけを見ると **cwd が消えた場合**（`working_dir` frontmatter は `git worktree remove` より長生きし、`Git.resolve_working_dir` は存在確認をしません）にも「CLI を再インストールしてください」と言ってしまうためです。

## 実際に直っていることの確認

「パスを解決 → バイナリを消す → もう一度解決」をテストで再現し、mutation check で**修正を外すと落ちること**を確認済みです：

| mutation | 落ちるテスト |
| --- | --- |
| `fs_stat` 再確認を削除 | `command_builder_common_spec` 2件 + `binary_cache_spec` の claude / codex / copilot 各1件 |
| grok の `still_installed` を削除 | `grok_command_builder_spec` 1件 |
| `(cmd)` 判定を `ENOENT` だけに戻す | `cli_runtime_spec`（cwd 消失を CLI のせいにしない） |
| grok の bare-name 除外を削除 | `grok_command_builder_spec`（sniff が毎回走る） |
| claude の spawn pcall を外す | `stream_options_spec`（claude） |

テストのフェイクバイナリは実在する一時ファイルにしています（`helper.fake_binary`）。`/usr/local/bin/fake-cli` のような架空パスだと `fs_stat` が常に失敗し、キャッシュのテストが意味を失うためです。

## 実行したチェック

`pnpm run check` / `check:doc` / `lint` / `format:check` / `test:lua`（exit 0）/ `test:node`（38 pass）。`test:e2e` と `test:eval` は実トークンを消費するため未実行です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching AI command-line tools.
  * Missing or unavailable executables now produce clearer error messages without exposing low-level system details.
  * Failed launches are handled cleanly without leaving behind stale processes or stream state.
  * Cached executable paths are refreshed automatically when binaries are removed, replaced, or relocated.
  * Distinguishes missing commands from other launch failures, including invalid working directories.
  * Prevents failed launches from being treated as active processes.
* **Documentation**
  * Updated architecture documentation for improved command-line launch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->