### PR TITLE
refactor: drop plugin/vibing.lua, which setup() already did

### DIFF
--- a/plugin/vibing.lua
+++ b/plugin/vibing.lua
@@ -1,8 +1,0 @@
--- vibing.nvim auto-detection for chat files
-
----@diagnostic disable-next-line: undefined-global
-local vim = vim
-
--- chat_detect.lua モジュールを使用してチャットバッファを自動検知
-local ChatDetect = require("vibing.infrastructure.storage.chat_detect")
-ChatDetect.setup()


### PR DESCRIPTION
## 概要

`plugin/vibing.lua` を削除した。中身は `chat_detect.setup()` の呼び出し1行だけで、これは `lua/vibing/init.lua` の `M.setup()` からも呼ばれている。

## なぜ不要か

- `chat_detect.setup()` は augroup を `clear = true` で作るので、後から走る `setup()` が plugin/ 側の登録を破棄して張り直す。plugin/ の登録が生きているのは「plugin ファイルが読まれてから `setup()` が呼ばれるまで」の間だけ
- `setup()` を呼ばないユーザーだけがこのファイルの恩恵を受けるが、その状態では `:Vibing*` コマンドもアダプタ (`M.adapter`) も存在しないため、チャットバッファにアタッチできても送信できない。単体では使えない自動検知だった
- ファイル内の `local vim = vim` はどこからも参照されていなかった

`plugin/` はこれで空になったのでディレクトリごと消えている。

## 検証

| コマンド | 結果 |
| --- | --- |
| `pnpm run check` | exit 0 |
| `pnpm run test:lua` | exit 0 |
| `pnpm run test:node` | exit 0 (32 pass) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic chat-buffer detection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->