### PR TITLE
fix: give the two MCP tool-call rules one home, and gate the stale one

### DIFF
--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -17,6 +17,28 @@ vibing.nvim invokes the `claude` CLI with `--setting-sources user,project,local`
 `.claude/commands/` project slash commands, `.claude/skills/`, and global settings/subagents are
 all available inside vibing.nvim sessions automatically — no extra configuration needed.
 
+## Naming the Tool and the Instance
+
+Two facts decide whether a call reaches the editor the user is looking at, and both have one home
+in the distributed plugin: `claude-plugin/skills/nvim-context/SKILL.md` → "Calling the tools". The
+other skills and the `nvim-navigator` agent state the rule in a line each and point there, rather
+than restating the reasoning — a skill is loaded on its own, so a bare cross-reference would leave
+the rule unstated.
+
+**The prefix depends on how the server was registered.** `mcp__vibing-nvim__<tool>` for a plain
+user-level entry, `mcp__plugin_<marketplace>_vibing-nvim__<tool>` for a plugin install.
+`VIBING_NVIM_MCP_TOOL_PATTERNS` (`core/constants/tools.lua`) enumerates the prefixes for
+`--allowedTools`, which accepts nothing but literals — so it must be updated by hand on a
+marketplace rename. It silently went stale once when the marketplace became `vibing`;
+`tests/lua/core/constants/tools_spec.lua` now reads the name out of
+`.claude-plugin/marketplace.json` and fails if the matching entry is missing. The grant still
+works while that list is stale, because the hook's suffix match is what actually decides — which
+is exactly why nothing noticed.
+
+**The port has to be named explicitly**, and a subagent does not inherit the chat's. The system
+prompt therefore tells the model both to pass its own `rpc_port` and to forward it in any task
+prompt it hands a subagent.
+
 ## Available MCP Tools
 
 Prefix with `mcp__vibing-nvim__`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,14 @@ jobs:
             process.stdout.write(p.source.replace(/^\.\//, '').replace(/\/\$/, ''));
           ")"
           echo "marketplace.json source: $SRC"
+          # build.sh keeps its own copy of the marketplace *name*, which decides the plugin id it
+          # installs and updates. A rename that misses it leaves build.sh operating on a
+          # marketplace that no longer exists. (The matching copy in core/constants/tools.lua is
+          # checked by tests/lua/core/constants/tools_spec.lua, which reads the same manifest.)
+          NAME="$(node -e "process.stdout.write(require('./.claude-plugin/marketplace.json').name)")"
+          echo "marketplace.json name: $NAME"
+          grep -q "MARKETPLACE_NAME=\"$NAME\"" build.sh \
+            && echo "OK: build.sh MARKETPLACE_NAME matches"
           test -f "$SRC/.claude-plugin/plugin.json" && echo "OK: $SRC/.claude-plugin/plugin.json exists"
           test -d "$SRC/mcp-server" && echo "OK: $SRC/mcp-server/ exists"
           test -d "$SRC/agents" && echo "OK: $SRC/agents/ exists"

--- a/claude-plugin/agents/nvim-navigator.md
+++ b/claude-plugin/agents/nvim-navigator.md
@@ -8,14 +8,14 @@ disallowedTools: 'Write, Edit, NotebookEdit'
 You are a code navigation specialist working against a **live** Neovim instance through the
 vibing-nvim MCP server, not static file reads.
 
-**Before anything else, settle two things about the tools.**
+**Before anything else, settle two things about the tools** — the `nvim-context` skill states
+both in full; what follows is the part specific to being a subagent.
 
 _Which port._ Every vibing-nvim tool takes an `rpc_port` naming the Neovim instance to talk to,
-and you do not inherit the value the chat that spawned you was given. Take it from your task
+and you do **not** inherit the value the chat that spawned you was given. Take it from your task
 prompt; whoever delegates to you is expected to pass it along. If it isn't there, call
 `nvim_list_instances` once and use the port it reports — and if that lists more than one instance,
-say which ones you found and ask rather than guessing. Omitting `rpc_port` only works when exactly
-one Neovim is live, which stops being true as soon as worktrees or concurrent chats are in play.
+say which ones you found and ask rather than guessing.
 
 _Which prefix._ The tools below are written as `mcp__vibing-nvim__<tool>`, but a plugin-scoped
 install exposes them as `mcp__plugin_<marketplace>_vibing-nvim__<tool>` instead. If the plain

--- a/claude-plugin/skills/nvim-context/SKILL.md
+++ b/claude-plugin/skills/nvim-context/SKILL.md
@@ -11,6 +11,31 @@ in-memory state (open buffers, splits, cursor position, unsaved edits) is the gr
 it can differ from what's on disk. Prefer live state over assumptions whenever the user
 references "this file", "current buffer", "my selection", "what I have open", etc.
 
+## Calling the tools
+
+Two things decide whether a `vibing-nvim` tool call reaches the editor the user is looking at.
+Both apply to every skill and subagent in this plugin, so they are stated once here.
+
+**Which name.** Tools are written below as `mcp__vibing-nvim__<tool>`, which is the plain
+user-level MCP server registration. A Claude Code plugin install exposes them as
+`mcp__plugin_<marketplace>_vibing-nvim__<tool>` instead, where `<marketplace>` is fixed at
+`claude plugin marketplace add` time. If the plain prefix is not available, look for a tool whose
+name **ends** in the one you need rather than assuming it is missing.
+
+**Which instance.** Every tool takes an `rpc_port` naming the target Neovim.
+
+- Inside a vibing.nvim chat, the port is in your system prompt for the turn — pass that exact
+  value on every call.
+- A subagent does **not** inherit it. Take it from your task prompt, and if it isn't there, call
+  `nvim_list_instances` and use the port it reports.
+- Anywhere else (an ordinary Claude Code session — this MCP server installs at user scope, so it
+  is visible in sessions that have nothing to do with vibing.nvim), `nvim_list_instances` is the
+  only way to know. If it lists more than one, say which you found and ask rather than guessing.
+
+Omitting `rpc_port` works only while exactly one Neovim is live: reads fall back to the instance
+registry, and writes refuse outright. Worktrees and concurrent chats make more than one the normal
+case, so treat the fallback as a diagnostic, not a default.
+
 ## Workflow
 
 1. **Ground yourself first.** Call `mcp__vibing-nvim__nvim_get_info` for the active file and

--- a/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
+++ b/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
@@ -10,11 +10,12 @@ Text search (`Grep`/`Glob`) finds string matches; a language server understands 
 overloads, generics, and cross-file symbol resolution. When `vibing-nvim` MCP tools are
 available and the target filetype has an LSP client attached, prefer LSP-backed answers.
 
-**Before calling anything:** pass `rpc_port` on every tool call (your system prompt has it inside
-a vibing.nvim chat; otherwise `nvim_list_instances` reports it), and if the `mcp__vibing-nvim__`
-prefix below is unavailable, look for a tool name **ending** in the one you need — a plugin
-install registers them as `mcp__plugin_<marketplace>_vibing-nvim__<tool>`. The `nvim-context`
-skill explains both in full.
+**Before calling anything:** pass `rpc_port` on every tool call — the exact value from your system
+prompt inside a vibing.nvim chat, or from your task prompt if you are a subagent. Only when
+neither supplies one, call `nvim_list_instances`; if that reports more than one instance, say
+which you found and ask rather than picking one. And if the `mcp__vibing-nvim__` prefix below is
+unavailable, look for a tool name **ending** in the one you need — a plugin install registers them
+as `mcp__plugin_<marketplace>_vibing-nvim__<tool>`. The `nvim-context` skill explains both in full.
 
 ## Tool mapping
 

--- a/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
+++ b/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
@@ -10,6 +10,12 @@ Text search (`Grep`/`Glob`) finds string matches; a language server understands 
 overloads, generics, and cross-file symbol resolution. When `vibing-nvim` MCP tools are
 available and the target filetype has an LSP client attached, prefer LSP-backed answers.
 
+**Before calling anything:** pass `rpc_port` on every tool call (your system prompt has it inside
+a vibing.nvim chat; otherwise `nvim_list_instances` reports it), and if the `mcp__vibing-nvim__`
+prefix below is unavailable, look for a tool name **ending** in the one you need — a plugin
+install registers them as `mcp__plugin_<marketplace>_vibing-nvim__<tool>`. The `nvim-context`
+skill explains both in full.
+
 ## Tool mapping
 
 | Question                                  | Tool                                                 |

--- a/claude-plugin/skills/vibing-chat-recall/SKILL.md
+++ b/claude-plugin/skills/vibing-chat-recall/SKILL.md
@@ -39,7 +39,9 @@ and stop.
 
 ## Reading the buffer
 
-Pass this turn's `rpc_port` (also in the system prompt) on both calls below. If the
+Pass this turn's `rpc_port` (also in the system prompt) on both calls below — this skill only runs
+inside a vibing.nvim chat, so the port is always there and `nvim_list_instances` is never the
+route. If the
 `mcp__vibing-nvim__` prefix is unavailable, look for a tool name **ending** in the one you need —
 a plugin install registers them as `mcp__plugin_<marketplace>_vibing-nvim__<tool>`. The
 `nvim-context` skill explains both in full.

--- a/claude-plugin/skills/vibing-chat-recall/SKILL.md
+++ b/claude-plugin/skills/vibing-chat-recall/SKILL.md
@@ -39,6 +39,11 @@ and stop.
 
 ## Reading the buffer
 
+Pass this turn's `rpc_port` (also in the system prompt) on both calls below. If the
+`mcp__vibing-nvim__` prefix is unavailable, look for a tool name **ending** in the one you need —
+a plugin install registers them as `mcp__plugin_<marketplace>_vibing-nvim__<tool>`. The
+`nvim-context` skill explains both in full.
+
 1. Call `mcp__vibing-nvim__nvim_get_buffer` with the `bufnr` from the system prompt to fetch the
    buffer's current content. This is the _live_ in-memory content, including edits that haven't
    been written to disk yet — vibing.nvim chat buffers are not auto-saved, so the on-disk file

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -83,7 +83,7 @@ registers vibing.nvim as a Claude Code plugin (user scope). That plugin ships
 the `vibing-nvim` MCP server, the bundled skills and the `nvim-navigator`
 subagent. To install it by hand instead: >
     /plugin marketplace add shabaraba/vibing.nvim
-    /plugin install vibing-nvim@vibing-nvim
+    /plugin install vibing-nvim@vibing
 <
 ==============================================================================
 4. CONFIGURATION                                        *vibing-configuration*

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -97,18 +97,25 @@ M.INTERNAL_TOOLS_MAP = to_map(M.INTERNAL_TOOLS)
 ---（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*）の
 ---両方に対応する。
 ---
----プラグイン側の接頭辞は`mcp__plugin_vibing-nvim_vibing-nvim__`。マーケットプレイス名は
----.claude-plugin/marketplace.jsonの`name`（"vibing"）ではなく`claude plugin marketplace add`が
----実際に登録した名前で決まり、build.shが入れるのは`vibing-nvim@vibing-nvim`である（`claude plugin
----list --json`のidと、実際に配られるツール名の両方で確認済み）。
+---プラグイン側の接頭辞は`mcp__plugin_<marketplace>_vibing-nvim__`で、マーケットプレイス名は
+---`claude plugin marketplace add`が実際に登録した名前で決まる。build.shはそれを
+---.claude-plugin/marketplace.jsonの`name`から取るので、現行は`vibing`（=`vibing-nvim@vibing`）。
+---`vibing-nvim`は改名前の名前で、build.shの移行処理を通していない既存インストールがまだそちらの
+---接頭辞でツールを配るため残してある。
 ---
----ただしこのリストにマーケットプレイス名の追従を頼ってはいけない。--allowedToolsは具体的な
----プレフィックスしか受け付けず、ここがずれると当該ツールはCLI自身のゲートで止まる（#564）。
+---**この列挙は手で追従させるしかない。** --allowedToolsは具体的なプレフィックスしか受け付けず、
+---ここがずれると当該ツールはCLI自身のゲートで止まる（#564）。実際に一度ずれた: marketplace.jsonが
+---`vibing`に改名された後もここは`vibing-nvim`のままで、事前承認が黙って空振りしていた。
+---tools_spec.luaがmarketplace.jsonの`name`を読んで対応する要素の存在を検証するので、次に改名する人は
+---テストで気づく。
+---
 ---最終的な担保はPreToolUseフックが返す明示的なallow決定のほうで、そちらは
 ---can_use_tool.M.is_vibing_nvim_mcp_toolのサフィックスマッチなのでマーケットプレイス名に依存しない。
+---だからこのリストが古くても通常のチャットは動く（それが上のずれが表面化しなかった理由でもある）。
 ---@type string[]
 M.VIBING_NVIM_MCP_TOOL_PATTERNS = {
   "mcp__vibing-nvim__*",
+  "mcp__plugin_vibing_vibing-nvim__*",
   "mcp__plugin_vibing-nvim_vibing-nvim__*",
 }
 

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -98,20 +98,22 @@ M.INTERNAL_TOOLS_MAP = to_map(M.INTERNAL_TOOLS)
 ---両方に対応する。
 ---
 ---プラグイン側の接頭辞は`mcp__plugin_<marketplace>_vibing-nvim__`で、マーケットプレイス名は
----`claude plugin marketplace add`が実際に登録した名前で決まる。build.shはそれを
----.claude-plugin/marketplace.jsonの`name`から取るので、現行は`vibing`（=`vibing-nvim@vibing`）。
----`vibing-nvim`は改名前の名前で、build.shの移行処理を通していない既存インストールがまだそちらの
----接頭辞でツールを配るため残してある。
+---`claude plugin marketplace add`が実際に登録した名前で決まる。現行は`vibing`
+---（`claude plugin list --json`のidが`vibing-nvim@vibing`であることで確認済み）。`vibing-nvim`は
+---改名前の名前で、build.shの移行処理を通していない既存インストールがまだそちらの接頭辞でツールを
+---配るため残してある。
 ---
----**この列挙は手で追従させるしかない。** --allowedToolsは具体的なプレフィックスしか受け付けず、
----ここがずれると当該ツールはCLI自身のゲートで止まる（#564）。実際に一度ずれた: marketplace.jsonが
----`vibing`に改名された後もここは`vibing-nvim`のままで、事前承認が黙って空振りしていた。
----tools_spec.luaがmarketplace.jsonの`name`を読んで対応する要素の存在を検証するので、次に改名する人は
----テストで気づく。
+---**この列挙は手で追従させるしかない。** --allowedToolsは具体的なプレフィックスしか受け付けない。
+---tools_spec.luaが.claude-plugin/marketplace.jsonの`name`を読んで対応する要素の存在を検証するので、
+---次に改名する人はテストで気づく。build.shの`MARKETPLACE_NAME`も同じ名前を別に持っているので、
+---そちらはCIの"Check Claude Code plugin layout"が突き合わせる。
 ---
----最終的な担保はPreToolUseフックが返す明示的なallow決定のほうで、そちらは
----can_use_tool.M.is_vibing_nvim_mcp_toolのサフィックスマッチなのでマーケットプレイス名に依存しない。
----だからこのリストが古くても通常のチャットは動く（それが上のずれが表面化しなかった理由でもある）。
+---**ただしここがずれても通常のチャットは止まらない。** PreToolUseフックが
+---can_use_tool.M.is_vibing_nvim_mcp_tool（サフィックスマッチなのでマーケットプレイス名に依存しない）
+---で明示的なallowを返し、CLIは自前のゲートをスキップするため。実際`vibing`への改名後もここは
+---`vibing-nvim`のままだったが、誰も気づかないまま動いていた。この列挙が効くのはフックの手前、
+---CLIが最初に見る関門としてであって、最終的な担保ではない。
+---#564以前は逆で、フックが黙って通す実装だったためここのずれがそのまま拒否になっていた。
 ---@type string[]
 M.VIBING_NVIM_MCP_TOOL_PATTERNS = {
   "mcp__vibing-nvim__*",

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -277,7 +277,8 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
           .. tostring(rpc_port)
           .. ". You MUST pass this exact value as the rpc_port argument on every vibing-nvim MCP tool "
           .. "call — never omit it or guess, since other unrelated Neovim instances may be running and "
-          .. "reachable on other ports."
+          .. "reachable on other ports. A subagent does not inherit this system prompt, so when you "
+          .. "delegate work that will touch Neovim, state the rpc_port in the task prompt you hand it."
       )
     end
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -103,11 +103,12 @@ local function add_permission_args(cmd, opts)
     permissions_allow = {}
   end
   local allow_tools = vim.deepcopy(permissions_allow)
-  -- Both of vibing-nvim's own possible MCP registration styles (see
-  -- tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS) must be pre-approved here so the CLI's own
-  -- --allowedTools gate doesn't block calls before they ever reach vibing.nvim's PreToolUse hook,
-  -- which already recognizes both via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match, so it
-  -- isn't tied to a specific marketplace name).
+  -- Every vibing-nvim MCP registration style (see tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS)
+  -- is pre-approved here, as the CLI's first gate. It is not the load-bearing one: the PreToolUse
+  -- hook recognizes them all via can_use_tool.M.is_vibing_nvim_mcp_tool (suffix match, so it isn't
+  -- tied to a marketplace name) and returns an explicit allow, which makes the CLI skip its own
+  -- gate entirely. A stale entry here is therefore invisible rather than fatal — which is exactly
+  -- how the list came to name a marketplace that had already been renamed.
   local always_allowed = vim.list_extend(
     vim.deepcopy(tools_constants.ALWAYS_ALLOWED_TOOLS),
     vim.deepcopy(tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS)

--- a/tests/lua/core/constants/tools_spec.lua
+++ b/tests/lua/core/constants/tools_spec.lua
@@ -1,0 +1,43 @@
+local Tools = require("vibing.core.constants.tools")
+
+---Read the marketplace name the plugin is actually published under.
+---@return string
+local function marketplace_name()
+  local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h:h:h:h")
+  local path = root .. "/.claude-plugin/marketplace.json"
+  assert.equals(1, vim.fn.filereadable(path), "marketplace.json not found at " .. path)
+  local manifest = vim.json.decode(table.concat(vim.fn.readfile(path), "\n"))
+  assert.is_string(manifest.name)
+  return manifest.name
+end
+
+describe("tools constants", function()
+  describe("VIBING_NVIM_MCP_TOOL_PATTERNS", function()
+    -- `--allowedTools` takes literal prefixes, so this list cannot be derived from the
+    -- marketplace name at runtime — it has to be maintained by hand. It fell out of date
+    -- exactly once already: marketplace.json was renamed to "vibing" and this list kept
+    -- saying "vibing-nvim", so the pre-approval silently matched nothing. Nothing caught it,
+    -- because the PreToolUse hook's suffix match kept ordinary chats working.
+    it("covers the marketplace name the plugin is currently published under", function()
+      local expected = ("mcp__plugin_%s_vibing-nvim__*"):format(marketplace_name())
+      assert.is_true(
+        vim.tbl_contains(Tools.VIBING_NVIM_MCP_TOOL_PATTERNS, expected),
+        ("%s is missing; add it when renaming the marketplace"):format(expected)
+      )
+    end)
+
+    it("covers the plain user-level MCP server registration", function()
+      assert.is_true(vim.tbl_contains(Tools.VIBING_NVIM_MCP_TOOL_PATTERNS, "mcp__vibing-nvim__*"))
+    end)
+
+    -- Every entry has to survive can_use_tool's suffix match too, or the two halves of the
+    -- grant disagree: --allowedTools would pre-approve a name the hook then refuses to allow.
+    it("only lists prefixes the PreToolUse hook also recognises", function()
+      local CanUseTool = require("vibing.infrastructure.permissions.can_use_tool")
+      for _, pattern in ipairs(Tools.VIBING_NVIM_MCP_TOOL_PATTERNS) do
+        local sample = pattern:gsub("%*$", "") .. "nvim_get_buffer"
+        assert.is_true(CanUseTool.is_vibing_nvim_mcp_tool(sample), sample .. " is not recognised")
+      end
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -288,10 +288,14 @@ describe("cli_command_builder", function()
       assert.is_not_nil(idx)
       local allowed = cmd[idx + 1]
       assert.is_true(allowed:find("mcp__vibing-nvim__*", 1, true) ~= nil)
-      -- The plugin-scoped prefix has to be the one build.sh actually installs
-      -- (`vibing-nvim@vibing-nvim`); --allowedTools takes literal prefixes, so a stale
-      -- marketplace name here silently matches nothing at all (#564).
-      assert.is_true(allowed:find("mcp__plugin_vibing-nvim_vibing-nvim__*", 1, true) ~= nil)
+      -- --allowedTools takes literal prefixes, so every plugin-scoped name has to appear
+      -- verbatim: the current marketplace (`vibing-nvim@vibing`) and the pre-rename one that
+      -- installs which never ran build.sh's migration still use. Which names belong in the list
+      -- is tests/lua/core/constants/tools_spec.lua's job; this only pins that the builder
+      -- forwards all of them.
+      for _, pattern in ipairs(require("vibing.core.constants.tools").VIBING_NVIM_MCP_TOOL_PATTERNS) do
+        assert.is_true(allowed:find(pattern, 1, true) ~= nil, pattern .. " missing from --allowedTools")
+      end
     end)
   end)
 

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -131,6 +131,16 @@ describe("cli_command_builder", function()
       assert.is_true(prompt_text:find("mcp__plugin_<marketplace>_vibing-nvim__", 1, true) ~= nil)
     end)
 
+    -- A subagent gets its own system prompt, so the port never reaches it on its own. Without
+    -- this half the bundled nvim-navigator agent falls back to nvim_list_instances, which only
+    -- resolves while exactly one Neovim is live.
+    it("tells the model to forward the rpc_port when it delegates to a subagent", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil, 9878)
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+      assert.is_true(prompt_text:find("subagent does not inherit this system prompt", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("state the rpc_port in the task prompt", 1, true) ~= nil)
+    end)
+
     it("omits the rpc_port line when rpc_port is not provided", function()
       local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
       local idx = find_flag(cmd, "--append-system-prompt")


### PR DESCRIPTION
#598 のレビューとセルフレビューで別Issue送りにした残課題をまとめて処理します。

vibing-nvim のツール呼び出しが「ユーザーが見ている Neovim」に届くかどうかは2つの事実で決まります — **どの接頭辞で登録されているか**と、**`rpc_port` がどのインスタンスを指すか**。この2つが、書いてある場所と本当に必要な場所がズレていました。

## 1. 接頭辞の列挙が黙って古くなっていた

`VIBING_NVIM_MCP_TOOL_PATTERNS` は `mcp__plugin_vibing-nvim_vibing-nvim__*` のままでしたが、`build.sh` が登録するマーケットプレイス名は #557 以降 `vibing` なので、実際の接頭辞は `mcp__plugin_vibing_vibing-nvim__` です。実インストールで確認済み（`claude plugin list --json` の id が `vibing-nvim@vibing`）。

`--allowedTools` は literal な接頭辞しか受け付けないため、この事前承認は**何にもマッチしていませんでした**。

**ただし実害はありませんでした。** `can_use_tool.lua` は allow リスト判定より前の段階で vibing-nvim MCP ツールに `allow` を返し、フックが明示的な allow を書くことで CLI は自前のゲートをスキップします。つまりこのリストは「CLI が最初に見る関門」であって最終的な担保ではありません。**それこそが、誰にも気づかれずに腐った理由です。**

現行の接頭辞を追加し（移行を通していないインストール向けに旧名も残置）、`.claude-plugin/marketplace.json` の `name` を読んで対応する要素の存在を検証する spec を追加しました。**「今日通ること」ではなく「ズレたときに落ちること」を確認済み**です。

もう1件、列挙されたすべての接頭辞がフックのサフィックスマッチも満たすことを検証するケースも入れています。両者が食い違うと、`--allowedTools` は事前承認するのにフックが許可しない、という状態になり得るためです。

## 2. ルールを最も必要とするスキルに、どちらも書かれていなかった

`nvim-context` は plain な接頭辞を6箇所、`nvim-lsp-navigation` は9箇所で名指ししながら、**両方とも `rpc_port` に一言も触れていませんでした**。

この MCP サーバーは Claude Code の**ユーザースコープ**にインストールされるため、これらのスキルは vibing.nvim のシステムプロンプトを一度も見ていないセッションでも発火します。そこではポートを渡されておらず、しかもプラグイン導入時には名指ししている接頭辞が存在しません。

`nvim-context` に完全な説明を置き、`nvim-lsp-navigation` / `vibing-chat-recall` / `nvim-navigator` は**ルール本体を1行で述べたうえで**そこを指すようにしました。単なる相互参照にしていないのは、スキルは単独で読み込まれるためです — ポインタだけではルールが伝わりません。

## 3. `rpc_port` を「渡す側」の指示が存在しなかった

`nvim-navigator` には「タスクプロンプトから受け取れ」と書いてあるのに、**渡す側に何も指示がありませんでした**。システムプロンプトに追記し、spec で固定しています。

## セルフレビューで直したもの

- **コメントが矛盾していた。** 「ズレると CLI のゲートで止まる」（既存）と「ズレても動く」（今回追記）が併記されていました。コードを読むと後者だけが正しく、前者は #564 以前の挙動の記述です。真である側を残し、偽である側に時期を明記しました。
- **ゲートが2つある写しの片方しか守っていなかった。** `build.sh` は `MARKETPLACE_NAME` を別に持っているため、改名時にテストだけ通って `build.sh` が存在しないマーケットプレイスを操作し続け得ました。CI の "Check Claude Code plugin layout" に突き合わせを追加。
- **`doc/vibing.txt:86`** がまだ `/plugin install vibing-nvim@vibing-nvim` と案内していました。README 類は改名時に更新済みでしたが、ヘルプファイルは漏れており、`check:doc` は幅とタグしか見ないため検知されません。
- **spec の assertion** が旧接頭辞だけを固定していたので、`VIBING_NVIM_MCP_TOOL_PATTERNS` を回すよう変更しました。

## 検証

`check` / `check:doc` / `lint` / `format:check` / `test:node`（38 pass）/ `test:lua`（exit 0）すべてグリーン。`lint:md` は main と同じ 444 件（既存分のみ）。新しい CI ゲートはローカルで通過と drift 時の失敗を両方確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use the current plugin name.
  * Added guidance for resolving MCP tools, targeting Neovim instances, and forwarding connection ports to delegated tasks.

* **Bug Fixes**
  * Improved compatibility with current and legacy MCP tool registrations.
  * Clarified instance selection when multiple Neovim sessions are available.

* **Tests**
  * Added coverage for tool permissions, marketplace naming, and port forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->