### PR TITLE
fix: exclude markdown decorations and brackets from gx URL matching

### DIFF
--- a/lua/vibing/presentation/chat/modules/keymap_handler.lua
+++ b/lua/vibing/presentation/chat/modules/keymap_handler.lua
@@ -105,7 +105,9 @@ function M.setup(buf, callbacks, keymaps)
       local line = vim.fn.getline(".")
       local col = vim.api.nvim_win_get_cursor(0)[2] + 1 -- 1-indexed
 
-      local url_pat = "(https?://[^ \t\n%]%)>\"']+)"
+      -- マークダウン装飾（**bold**, `code`）や括弧で囲まれた URL の閉じ記号を取り込まないよう、
+      -- `*`・バッククォート・各種括弧も URL の区切りとして扱う
+      local url_pat = "(https?://[^ \t\n%]%)%(%[<>{}\"'*`]+)"
       local found_url = nil
       local best_dist = math.huge
       local max_dist = 10

--- a/lua/vibing/presentation/chat/modules/keymap_handler.lua
+++ b/lua/vibing/presentation/chat/modules/keymap_handler.lua
@@ -2,6 +2,88 @@ local Context = require("vibing.application.context.manager")
 
 local M = {}
 
+-- URL 本体はできるだけ広くマッチさせ（空白と、URL でまず生では使われない
+-- `< > " ' バッククォート` のみを区切りとする）、末尾の Markdown 装飾・句読点・
+-- 対応の取れていない閉じ括弧だけを後から削る。括弧類を文字クラスから除外する
+-- 方式だと、IPv6 の `https://[2001:db8::1]/` や `/foo_(bar)`・`/a*b` のような
+-- 括弧・アスタリスクを含む正当な URL まで途中で切ってしまうため。
+local URL_PAT = "(https?://[^ \t\n<>\"'`]+)"
+
+-- 末尾から削る Markdown 装飾（**bold**, `code`）と句読点
+local TRAILING_PUNCT_PAT = "[%*`.,;:!?]+$"
+
+-- 閉じ括弧 → 対応する開き括弧
+local CLOSERS = { [")"] = "(", ["]"] = "[", ["}"] = "{" }
+
+---文字列中に特定の1文字が現れる回数を数える（Lua パターンのエスケープを避けるため素朴に走査）
+---@param s string
+---@param ch string 1文字
+---@return number
+local function count_char(s, ch)
+  local n = 0
+  for i = 1, #s do
+    if s:sub(i, i) == ch then
+      n = n + 1
+    end
+  end
+  return n
+end
+
+---URL 末尾の Markdown 装飾・句読点・対応の取れていない閉じ括弧を安定するまで削る。
+---`Foo_(bar)` のように括弧が対応している場合は保持する。
+---@param url string
+---@return string
+local function trim_url(url)
+  while true do
+    local before = url
+    url = url:gsub(TRAILING_PUNCT_PAT, "")
+    local last = url:sub(-1)
+    local opener = CLOSERS[last]
+    if opener and count_char(url, last) > count_char(url, opener) then
+      url = url:sub(1, -2)
+    end
+    if url == before then
+      break
+    end
+  end
+  return url
+end
+
+---行内からカーソル位置（1-indexed）に対応する URL を探す。
+---カーソルが URL 上にあればそれを、なければ最も近い URL を（max_dist 以内で）返す。
+---@param line string 行全体
+---@param col number カーソルの 1-indexed カラム
+---@return string|nil
+function M.find_url_on_line(line, col)
+  local found_url = nil
+  local best_dist = math.huge
+  local max_dist = 10
+
+  local search_pos = 1
+  while true do
+    local url_start, raw_end, url = line:find(URL_PAT, search_pos)
+    if not url_start then
+      break
+    end
+
+    url = trim_url(url)
+    local url_end = url_start + #url - 1
+
+    if col >= url_start and col <= url_end then
+      return url
+    end
+    local dist = math.min(math.abs(col - url_start), math.abs(col - url_end))
+    if dist < best_dist and dist <= max_dist then
+      best_dist = dist
+      found_url = url
+    end
+    -- 広くマッチした範囲全体をスキップ（トリムした末尾を再走査しない）
+    search_pos = raw_end + 1
+  end
+
+  return found_url
+end
+
 ---キーマップを設定
 ---@param buf number バッファ番号
 ---@param callbacks table コールバック関数テーブル
@@ -105,34 +187,7 @@ function M.setup(buf, callbacks, keymaps)
       local line = vim.fn.getline(".")
       local col = vim.api.nvim_win_get_cursor(0)[2] + 1 -- 1-indexed
 
-      -- マークダウン装飾（**bold**, `code`）や括弧で囲まれた URL の閉じ記号を取り込まないよう、
-      -- `*`・バッククォート・各種括弧も URL の区切りとして扱う
-      local url_pat = "(https?://[^ \t\n%]%)%(%[<>{}\"'*`]+)"
-      local found_url = nil
-      local best_dist = math.huge
-      local max_dist = 10
-
-      local search_pos = 1
-      while true do
-        local url_start, url_end, url = line:find(url_pat, search_pos)
-        if not url_start then
-          break
-        end
-        -- 末尾の句読点を除去
-        url = url:gsub("[.,;:!?]+$", "")
-        url_end = url_start + #url - 1
-
-        if col >= url_start and col <= url_end then
-          found_url = url
-          break
-        end
-        local dist = math.min(math.abs(col - url_start), math.abs(col - url_end))
-        if dist < best_dist and dist <= max_dist then
-          best_dist = dist
-          found_url = url
-        end
-        search_pos = url_end + 1
-      end
+      local found_url = M.find_url_on_line(line, col)
 
       if found_url then
         local err = vim.ui.open(found_url)

--- a/tests/lua/presentation/chat/modules/keymap_handler_spec.lua
+++ b/tests/lua/presentation/chat/modules/keymap_handler_spec.lua
@@ -1,0 +1,113 @@
+-- Tests for vibing.presentation.chat.modules.keymap_handler.find_url_on_line
+--
+-- gx (open_url) は行内の URL を抽出して vim.ui.open に渡す。Markdown 装飾や括弧で
+-- 囲まれた URL の閉じ記号を取り込むと 404 になる一方、URL 自体に括弧・アスタリスク・
+-- IPv6 のブラケットを含む正当な URL は保持しなければならない。両立を回帰で守る。
+
+local KeymapHandler = require("vibing.presentation.chat.modules.keymap_handler")
+
+describe("keymap_handler.find_url_on_line", function()
+  -- カーソルは URL 上（先頭付近）に置く前提。col は URL の "h" にほぼ重なる位置で十分。
+  local function url_at(line)
+    local col = line:find("https?://") or 1
+    return KeymapHandler.find_url_on_line(line, col)
+  end
+
+  describe("strips Markdown decorations and enclosing brackets", function()
+    local cases = {
+      {
+        name = "bold-wrapped URL",
+        line = "**PR: https://github.com/kintone/llm-wiki/pull/28**",
+        want = "https://github.com/kintone/llm-wiki/pull/28",
+      },
+      {
+        name = "inline-code-wrapped URL",
+        line = "`https://github.com/kintone/llm-wiki/pull/28`",
+        want = "https://github.com/kintone/llm-wiki/pull/28",
+      },
+      {
+        name = "markdown link target",
+        line = "[docs](https://example.com/foo/bar)",
+        want = "https://example.com/foo/bar",
+      },
+      {
+        name = "parenthesized URL",
+        line = "see (https://example.com/a) here",
+        want = "https://example.com/a",
+      },
+      {
+        name = "angle-bracket-wrapped URL",
+        line = "<https://example.com/x>",
+        want = "https://example.com/x",
+      },
+      {
+        name = "brace-wrapped URL",
+        line = "text {https://example.com/y} end",
+        want = "https://example.com/y",
+      },
+      {
+        name = "trailing sentence punctuation",
+        line = "visit https://example.com/path.",
+        want = "https://example.com/path",
+      },
+      {
+        name = "trailing closer then punctuation",
+        line = "(https://example.com/path).",
+        want = "https://example.com/path",
+      },
+    }
+
+    for _, c in ipairs(cases) do
+      it(c.name, function()
+        assert.equals(c.want, url_at(c.line))
+      end)
+    end
+  end)
+
+  describe("preserves valid URL characters", function()
+    local cases = {
+      {
+        name = "IPv6 host in brackets",
+        line = "https://[2001:db8::1]/",
+        want = "https://[2001:db8::1]/",
+      },
+      {
+        name = "balanced parentheses in path",
+        line = "https://en.wikipedia.org/wiki/Foo_(disambiguation)",
+        want = "https://en.wikipedia.org/wiki/Foo_(disambiguation)",
+      },
+      {
+        name = "parentheses mid-path",
+        line = "https://example.com/a(b)c",
+        want = "https://example.com/a(b)c",
+      },
+      {
+        name = "asterisk mid-path",
+        line = "https://example.com/a*b",
+        want = "https://example.com/a*b",
+      },
+    }
+
+    for _, c in ipairs(cases) do
+      it(c.name, function()
+        assert.equals(c.want, url_at(c.line))
+      end)
+    end
+  end)
+
+  it("returns the URL under the cursor when several are on the line", function()
+    local line = "a https://example.com/one b https://example.com/two c"
+    local col = line:find("two") -- カーソルは2つ目の URL 上
+    assert.equals("https://example.com/two", KeymapHandler.find_url_on_line(line, col))
+  end)
+
+  it("returns nil when the line has no URL", function()
+    assert.is_nil(KeymapHandler.find_url_on_line("just some plain text", 3))
+  end)
+
+  it("returns nil when the cursor is far from any URL", function()
+    -- 行末付近にカーソル。URL は先頭で max_dist(10) を大きく超える。
+    local line = "https://example.com/x" .. string.rep(" ", 40) .. "tail"
+    assert.is_nil(KeymapHandler.find_url_on_line(line, #line))
+  end)
+end)


### PR DESCRIPTION
## 概要

チャットバッファ内で `gx`（`open_url` キーマップ）を使ったとき、URL がマークダウン装飾や括弧で囲まれていると閉じ記号まで URL に取り込まれ、404 になっていた問題を修正します。

- `**PR: https://.../pull/28**` → 末尾の `**` が付いて 404
- `` `https://.../pull/28` `` → 末尾のバッククォートが付いて 404
- `(https://.../a)` / `[..](https://.../b)` などの括弧付きも同様

## 変更内容

`lua/vibing/presentation/chat/modules/keymap_handler.lua` の URL マッチパターンの区切り文字集合に `*`・バッククォート・`(` `[` `<` `{` `}` を追加しました（`)` `>` は元から除外済み）。

```lua
-- before
local url_pat = "(https?://[^ \t\n%]%)>\"']+)"
-- after
local url_pat = "(https?://[^ \t\n%]%)%(%[<>{}\"'*`]+)"
```

## 検証

稼働中の Neovim 上でパターンを実行し、以下すべてで装飾・括弧を除いた URL だけがマッチすることを確認済み。

| 入力 | マッチ |
|---|---|
| `**PR: https://.../pull/28**` | `https://.../pull/28` |
| `` `https://.../pull/28` `` | `https://.../pull/28` |
| `[docs](https://example.com/foo/bar)` | `https://example.com/foo/bar` |
| `(https://example.com/a)` | `https://example.com/a` |
| `<https://example.com/x>` | `https://example.com/x` |
| `{https://example.com/y}` | `https://example.com/y` |

全角括弧 `（）` はマルチバイトのため今回のバイト単位文字集合には含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL detection in chat messages by excluding Markdown formatting and closing brackets from matched links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->