### PR TITLE
fix: scope the usage-limit record to the backend that hit it

### DIFF
--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -2,31 +2,31 @@
 
 ## User Commands
 
-| Command                               | Description                                                                                                                           |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `:VibingChat [position\|file]`        | Create new chat with optional position (current\|right\|left\|top\|bottom\|back) or open saved file                                   |
-| `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                                                           |
-| `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                                                           |
-| `:VibingSubagentChat [position]`      | Continue a subagent this chat started, in its own buffer                                                                              |
-| `:VibingChatJumpNextUser [count]`     | Move the cursor to the next User section in the chat buffer                                                                           |
-| `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                                                       |
-| `:VibingSlashCommands`                | Show slash command picker in chat                                                                                                     |
-| `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                                                                |
-| `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                                                            |
-| `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                                                     |
-| `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                                                     |
-| `:VibingClearContext`                 | Clear all context                                                                                                                     |
-| `:VibingCancel`                       | Cancel current request                                                                                                                |
-| `:VibingSchedule [when]`              | Schedule this chat's unsent message (default: the recorded limit reset; or `30m`, `18:30`, …)                                         |
-| `:VibingClearAnnotations`             | Remove inline review annotations from every buffer                                                                                    |
-| `:VibingDebugAnalyze`                 | Ask the agent to analyze the stopped debug session (needs nvim-dap)                                                                   |
-| `:VibingDebugHelp`                    | Ask the agent what to check next in the stopped debug session                                                                         |
-| `:VibingPendingResumes`               | List chats waiting on a usage limit reset or a scheduled send                                                                         |
-| `:VibingCancelResume [all]`           | Cancel the pending auto-resume/scheduled send for this chat (or every one with `all`); also clears the project's recorded usage limit |
-| `:VibingReloadCommands`               | Reload custom slash commands                                                                                                          |
-| `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                                                           |
-| `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                                                       |
-| `:VibingDailySummaryAll [YYYY-MM-DD]` | Generate daily summary from all chat files (default: today)                                                                           |
+| Command                               | Description                                                                                                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:VibingChat [position\|file]`        | Create new chat with optional position (current\|right\|left\|top\|bottom\|back) or open saved file                                                           |
+| `:VibingToggleChat`                   | Toggle existing chat window (preserve current conversation)                                                                                                   |
+| `:VibingChatFork [position]`          | Fork current chat (create branch from current conversation)                                                                                                   |
+| `:VibingSubagentChat [position]`      | Continue a subagent this chat started, in its own buffer                                                                                                      |
+| `:VibingChatJumpNextUser [count]`     | Move the cursor to the next User section in the chat buffer                                                                                                   |
+| `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                                                                               |
+| `:VibingSlashCommands`                | Show slash command picker in chat                                                                                                                             |
+| `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                                                                                        |
+| `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                                                                                    |
+| `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                                                                             |
+| `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                                                                             |
+| `:VibingClearContext`                 | Clear all context                                                                                                                                             |
+| `:VibingCancel`                       | Cancel current request                                                                                                                                        |
+| `:VibingSchedule [when]`              | Schedule this chat's unsent message (default: the recorded limit reset; or `30m`, `18:30`, …)                                                                 |
+| `:VibingClearAnnotations`             | Remove inline review annotations from every buffer                                                                                                            |
+| `:VibingDebugAnalyze`                 | Ask the agent to analyze the stopped debug session (needs nvim-dap)                                                                                           |
+| `:VibingDebugHelp`                    | Ask the agent what to check next in the stopped debug session                                                                                                 |
+| `:VibingPendingResumes`               | List chats waiting on a usage limit reset or a scheduled send                                                                                                 |
+| `:VibingCancelResume [all]`           | Cancel the pending auto-resume/scheduled send for this chat (or every one with `all`); also clears the project's recorded usage limit for that chat's backend |
+| `:VibingReloadCommands`               | Reload custom slash commands                                                                                                                                  |
+| `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                                                                                   |
+| `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                                                                               |
+| `:VibingDailySummaryAll [YYYY-MM-DD]` | Generate daily summary from all chat files (default: today)                                                                                                   |
 
 `:VibingChat`/`:VibingChatFork` position argument: `current` (replace current window), `right`,
 `left`, `top`, `bottom` (splits sized by `config.chat.window.width`/`height`), or `back`

--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -62,6 +62,23 @@ clears this record (in addition to cancelling the entry), so "send now" — canc
 actually sends instead of being re-parked by a stale record; if the limit is genuinely still in
 force, the next rejected response re-records it.
 
+**The record names the backend that hit the limit, and every reader is scoped to it.** The store
+is per project but a limit belongs to one provider's plan, so an unscoped record parked codex
+chats behind a claude limit — for the whole reset window, with no way to converse — and let a
+successful codex turn clear the claude record out from under the chats waiting on it.
+The two sides name the backend differently, and the difference is deliberate. **Writing** the
+record — and clearing it on a successful turn — asks `factory.agent_id(adapter)` about the adapter
+that actually ran, because "who was rejected" is a fact about the process, not about frontmatter a
+user can edit while the turn is in flight. **Reading** it before a request exists
+(`<CR>`, `:VibingSchedule`, `:VibingCancelResume`) has no adapter yet, so it predicts one with
+`Modes.resolve_agent` (frontmatter `agent` > `config.adapter` > claude) — the same precedence
+`send_message._resolve_adapter` applies a moment later.
+
+A record with no `agent` field reads as claude's, since claude is the only backend that reports a
+rate limit (`claude_cli.lua`) and so the only one that could have written one.
+`:VibingCancelResume all` is the one unscoped clear left: it has no chat in hand, and "forget
+everything" is the user saying so by hand.
+
 **Implementation:** `infrastructure/storage/limit_state.lua` (project limit record),
 `core/utils/when.lua` (time spec parser), plus the `kind` dispatch in
 `application/chat/auto_resume.lua`.

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -197,8 +197,9 @@ section is not kept in sync field by field.
                                                         *:VibingCancelResume*
 :VibingCancelResume [all]
     Cancel this chat's pending auto-resume or scheduled send, or every one
-    with `all`. Also clears the project's recorded usage limit, so a
-    follow-up `<CR>` actually sends instead of being parked again.
+    with `all`. Also clears the project's recorded usage limit for this
+    chat's backend (`all` clears it whichever backend it belongs to), so
+    a follow-up `<CR>` actually sends instead of being parked again.
 
 Scheduled requests:~
     A rejected turn, a `<CR>` sent while the project's recorded usage

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -342,6 +342,13 @@ rejection is still in force. It is written only when the rejection carried a res
 cleared on any successful response, so a limit that lifts early is forgotten as soon as one
 request gets through.
 
+The record also names the backend that hit the limit, and only chats on that backend are parked
+by it. A usage limit belongs to one provider's plan, so a claude limit leaves a codex chat in the
+same project free to send — and a codex response getting through does not clear the claude record.
+Which backend a chat is on is its frontmatter `agent`, falling back to `adapter` in `setup()`.
+`:VibingCancelResume` clears it only when it is the current chat's backend; `:VibingCancelResume
+all` has no chat in hand and clears whatever is recorded.
+
 **Re-scheduling.** `max_retries` bounds how many times a scheduled request may be rescheduled
 after being rejected again. Because the check is applied to the already-incremented retry count,
 the default of `3` permits only **2** re-schedules. The next rejection falls through to
@@ -354,9 +361,10 @@ The prompt only fires if `auto_resume_on_limit.max_retries` has been raised abov
 scheduled retries already consumed.
 
 **`:VibingCancelResume`** cancels either an auto-resume or a scheduled request, and also clears the
-project's recorded usage limit — so "send now" (cancel, then `<CR>`) actually sends instead of
-being re-parked by the stale record. If the limit is genuinely still in force, the next rejected
-response re-records it.
+project's recorded usage limit for this chat's backend — so "send now" (cancel, then `<CR>`)
+actually sends instead of being re-parked by the stale record, without unparking chats on a
+different backend. If the limit is genuinely still in force, the next rejected response re-records
+it.
 
 ## Chat
 

--- a/lua/vibing/application/chat/auto_resume.lua
+++ b/lua/vibing/application/chat/auto_resume.lua
@@ -543,14 +543,19 @@ end
 --- the record that would otherwise re-park the very next message is deliberately discarded. This
 --- is safe even if the limit is in fact still in force — the next rejected response re-records
 --- it, so the worst case is one attempted request that fails and gets parked again.
+---
+--- `agent` narrows that to the cancelling chat's own backend, since the record is per backend: a
+--- codex chat's "send now" is no reason to unpark every claude chat in the project. Cancelling
+--- *every* pending resume passes none, and clears whatever is recorded.
 --- @param chat_file_path string|nil When nil, cancels every pending resume
+--- @param agent string|nil Only forget the recorded limit if it is this backend's
 --- @return number cancelled_count
-function M.cancel(chat_file_path)
+function M.cancel(chat_file_path, agent)
   if chat_file_path then
     stop_timer(chat_file_path)
     local existed = PendingResume.get(chat_file_path) ~= nil
     PendingResume.remove(chat_file_path)
-    LimitState.clear(vim.fn.fnamemodify(chat_file_path, ":h"))
+    LimitState.clear(vim.fn.fnamemodify(chat_file_path, ":h"), agent)
     return existed and 1 or 0
   end
 

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -335,9 +335,12 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
   local LimitState = require("vibing.infrastructure.storage.limit_state")
   local chat_file_path = (bufnr and vim.api.nvim_buf_is_valid(bufnr)) and vim.api.nvim_buf_get_name(bufnr) or nil
   local chat_dir = chat_file_path and vim.fn.fnamemodify(chat_file_path, ":h") or nil
+  -- 記録も解除もバックエンド単位。誰がリミットに当たったか（誰のリクエストが通ったか）は
+  -- 実際に走ったアダプターそのものが答えで、ターン中に書き換わりうるfrontmatterではない。
+  local agent = require("vibing.infrastructure.adapter.factory").agent_id(adapter)
 
   if response._rate_limit_info then
-    pcall(LimitState.record, response._rate_limit_info, chat_dir)
+    pcall(LimitState.record, response._rate_limit_info, chat_dir, agent)
     local rescheduled = false
     local ok, result = pcall(
       M._reschedule_rejected_message,
@@ -355,7 +358,7 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
     end
   elseif not response.error then
     pcall(AutoResume.on_success, chat_file_path)
-    pcall(LimitState.clear, chat_dir)
+    pcall(LimitState.clear, chat_dir, agent)
   else
     -- リミット以外のエラーで終わったターンも、未送信Userセクションは消費済み。予約
     -- （scheduled）を残すと、その後そこに入った別のテキスト（書きかけの続きや承認UIの

--- a/lua/vibing/core/constants/modes.lua
+++ b/lua/vibing/core/constants/modes.lua
@@ -64,6 +64,28 @@ function M.is_valid_agent_mode(mode)
   return vim.tbl_contains(M.AGENT_MODES, mode)
 end
 
+---チャットが実際に話す相手のバックエンドを解決する
+---frontmatterの`agent` > `config.adapter` > 既定（claude）。未知の名前は
+---`send_message._resolve_adapter`と同じくフォールバックする（警告はそちらが1度だけ出す）。
+---バックエンド単位のスコープを持つもの（使用量リミットの記録など）は、実際に使われる
+---アダプターとここで一致していないと、使われないバックエンドに対して働いてしまう。
+---@param frontmatter table|nil
+---@param config table|nil
+---@return string
+function M.resolve_agent(frontmatter, config)
+  local from_frontmatter = frontmatter and frontmatter.agent
+  if M.is_valid_agent(from_frontmatter) then
+    return from_frontmatter
+  end
+
+  local from_config = config and config.adapter
+  if M.is_valid_agent(from_config) then
+    return from_config
+  end
+
+  return Agents.DEFAULT
+end
+
 ---agent modeとして使える値ならそのまま返し、そうでなければnilを返す
 ---呼び出し側は「nilが返った＋元がnilでない」で綴り間違いを検出できる
 ---@param mode any

--- a/lua/vibing/infrastructure/adapter/factory.lua
+++ b/lua/vibing/infrastructure/adapter/factory.lua
@@ -23,6 +23,21 @@ function M.adapter_name(agent_type)
   return resolve_module(agent_type):match("[^.]+$")
 end
 
+--- Get the agent type an adapter instance belongs to — the reverse of `adapter_name`.
+--- Lets a caller holding the adapter that actually ran name its backend, instead of re-deriving
+--- it from frontmatter that may have been edited since the request started.
+--- @param adapter table|nil Adapter instance (its `name`, e.g. "claude_cli", is what is matched)
+--- @return string agent_type Falls back to the default agent for an unrecognised adapter
+function M.agent_id(adapter)
+  local name = adapter and adapter.name
+  for _, id in ipairs(Agents.ORDER) do
+    if M.adapter_name(id) == name then
+      return id
+    end
+  end
+  return Agents.DEFAULT
+end
+
 --- Create an adapter instance for an agent type
 --- @param agent_type string|nil
 --- @param config Vibing.Config

--- a/lua/vibing/infrastructure/storage/limit_state.lua
+++ b/lua/vibing/infrastructure/storage/limit_state.lua
@@ -9,8 +9,15 @@
 --- fallback confirm a rejection without saying when it lifts, and a record that cannot answer
 --- "still active?" would strand every later request.
 ---
+--- The record is also scoped to the backend that hit the limit. A limit belongs to one provider's
+--- plan, while the store is per project, so a claude limit says nothing about a codex chat in the
+--- same repository — and a codex request getting through says nothing about the claude limit
+--- lifting. Callers that mean a specific backend pass its name; passing none means "whatever is
+--- recorded", which is what `:VibingCancelResume`'s explicit "forget it" wants.
+---
 --- @module vibing.infrastructure.storage.limit_state
 
+local Agents = require("vibing.core.constants.agents")
 local Git = require("vibing.core.utils.git")
 local Fs = require("vibing.core.utils.fs")
 
@@ -20,6 +27,8 @@ local M = {}
 --- @field resets_at number Unix seconds when the limit lifts
 --- @field limit_type string|nil e.g. "five_hour"
 --- @field observed_at number Unix seconds when the limit was observed
+--- @field agent string|nil Backend that hit the limit. Absent in stores written before this
+---   field existed, which are read as claude's — the only backend that reports a rate limit.
 
 --- Memoized `git rev-parse` results, keyed by the directory asked about — the same reason
 --- pending_resume.lua caches: one send/receive cycle resolves the path several times.
@@ -76,8 +85,9 @@ end
 --- Record an observed limit. Ignored unless the payload carried a reset timestamp.
 --- @param info Vibing.RateLimitInfo
 --- @param cwd? string
+--- @param agent? string Backend that hit the limit (default: claude)
 --- @return boolean recorded
-function M.record(info, cwd)
+function M.record(info, cwd, agent)
   if type(info) ~= "table" or type(info.resets_at) ~= "number" then
     return false
   end
@@ -89,6 +99,7 @@ function M.record(info, cwd)
     resets_at = info.resets_at,
     limit_type = info.limit_type,
     observed_at = os.time(),
+    agent = agent or Agents.DEFAULT,
   })
 
   local ok, err = pcall(vim.fn.writefile, { json }, path)
@@ -99,25 +110,38 @@ function M.record(info, cwd)
   return true
 end
 
---- The record, but only while the limit is still in force.
+--- Does the record belong to `agent`? A nil `agent` matches anything.
+--- @param state Vibing.LimitState
+--- @param agent string|nil
+--- @return boolean
+local function belongs_to(state, agent)
+  return agent == nil or (state.agent or Agents.DEFAULT) == agent
+end
+
+--- The record, but only while the limit is still in force — and only if it is `agent`'s.
 --- @param cwd? string
+--- @param agent? string Backend asking (default: any)
 --- @return Vibing.LimitState|nil
-function M.get_active(cwd)
+function M.get_active(cwd, agent)
   local state = M.load(cwd)
-  if state and state.resets_at > os.time() then
+  if state and state.resets_at > os.time() and belongs_to(state, agent) then
     return state
   end
   return nil
 end
 
 --- Forget the recorded limit. Called on any successful response — a request that got through
---- proves the limit is not in force, whatever the stored reset time claimed.
+--- proves *that backend's* limit is not in force, whatever the stored reset time claimed.
 --- @param cwd? string
-function M.clear(cwd)
-  local path = M.get_path(cwd)
-  if vim.fn.filereadable(path) == 1 then
-    pcall(vim.fn.delete, path)
+--- @param agent? string Only clear the record if it is this backend's (default: clear any)
+function M.clear(cwd, agent)
+  -- An unreadable record is cleared rather than kept: it can no longer answer "still active?"
+  -- for anyone, so leaving it in place would strand every later request behind a corrupt file.
+  local state = M.load(cwd)
+  if state and not belongs_to(state, agent) then
+    return
   end
+  pcall(vim.fn.delete, M.get_path(cwd))
 end
 
 return M

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -308,8 +308,11 @@ function M._register_commands()
         return
       end
     else
+      -- 別のバックエンドのリセット時刻は、このチャットが待つべき時刻ではない
+      local Modes = require("vibing.core.constants.modes")
       local LimitState = require("vibing.infrastructure.storage.limit_state")
-      local state = LimitState.get_active(vim.fn.fnamemodify(chat_file_path, ":h"))
+      local chat_agent = Modes.resolve_agent(chat_buffer:parse_frontmatter(), M.config)
+      local state = LimitState.get_active(vim.fn.fnamemodify(chat_file_path, ":h"), chat_agent)
       if not state then
         notify.warn("No usage limit on record. Give a time, e.g. ':VibingSchedule 30m'")
         return
@@ -405,7 +408,8 @@ function M._register_commands()
     end
 
     local path = vim.api.nvim_buf_get_name(chat_buffer:get_buffer())
-    if AutoResume.cancel(path) > 0 then
+    local Modes = require("vibing.core.constants.modes")
+    if AutoResume.cancel(path, Modes.resolve_agent(chat_buffer:parse_frontmatter(), M.config)) > 0 then
       notify.info("Cancelled the pending request for this chat")
     else
       notify.info("This chat has nothing scheduled")

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -337,8 +337,12 @@ function ChatBuffer:_try_schedule_instead_of_send(message)
     return false
   end
 
+  -- リミットはバックエンド単位。別のバックエンドで取られた記録でこのチャットを止めると、
+  -- リセットまでのあいだ会話そのものができなくなる。
+  local Modes = require("vibing.core.constants.modes")
   local LimitState = require("vibing.infrastructure.storage.limit_state")
-  local state = LimitState.get_active(vim.fn.fnamemodify(chat_file_path, ":h"))
+  local agent = Modes.resolve_agent(self:parse_frontmatter(), config)
+  local state = LimitState.get_active(vim.fn.fnamemodify(chat_file_path, ":h"), agent)
   if not state then
     return false
   end

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -383,7 +383,9 @@ describe("vibing.init", function()
 
       --- @param bufnr number
       --- @param message string|nil
-      local function stub_chat_buffer(bufnr, message)
+      --- @param frontmatter table|nil The chat's frontmatter; its `agent` decides which backend's
+      ---   recorded usage limit these commands read and clear.
+      local function stub_chat_buffer(bufnr, message, frontmatter)
         package.loaded["vibing.presentation.chat.view"] = {
           get_current = function()
             return {
@@ -392,6 +394,9 @@ describe("vibing.init", function()
               end,
               extract_user_message = function()
                 return message
+              end,
+              parse_frontmatter = function()
+                return frontmatter or {}
               end,
             }
           end,

--- a/tests/lua/application/chat/auto_resume_spec.lua
+++ b/tests/lua/application/chat/auto_resume_spec.lua
@@ -398,6 +398,19 @@ describe("auto_resume", function()
       assert.is_nil(LimitState.get_active(tmp_root))
     end)
 
+    it("leaves another backend's recorded limit alone when the cancelling chat names its own", function()
+      -- "Send now" in a codex chat is no reason to unpark every claude chat in the project: the
+      -- record is per backend, and clearing it would cost each of them a rejected round-trip.
+      local chat_path = tmp_root .. "/chat.md"
+      LimitState.record({ resets_at = os.time() + 3600, limit_type = "five_hour" }, tmp_root, "claude")
+
+      AutoResume.cancel(chat_path, "codex")
+
+      assert.is_not_nil(LimitState.get_active(tmp_root, "claude"))
+
+      LimitState.clear(tmp_root)
+    end)
+
     it("cancelling every pending resume also clears the current project's recorded limit", function()
       -- Stub the stores rather than touch real files: cancel(nil) resolves both stores through
       -- the *process* cwd (this repository), the same reason the `list` tests above stub

--- a/tests/lua/application/chat/send_message_spec.lua
+++ b/tests/lua/application/chat/send_message_spec.lua
@@ -52,13 +52,15 @@ describe("send_message", function()
     end)
   end)
 
-  describe("_handle_response pending-entry cleanup", function()
+  describe("_handle_response", function()
     local PendingResume = require("vibing.infrastructure.storage.pending_resume")
+    local LimitState = require("vibing.infrastructure.storage.limit_state")
     local tmp_root
 
     before_each(function()
       tmp_root = vim.fn.tempname()
       vim.fn.mkdir(tmp_root, "p")
+      LimitState.clear_cache()
     end)
 
     after_each(function()
@@ -67,18 +69,23 @@ describe("send_message", function()
       end
     end)
 
-    --- Store `entry` for a chat, then run a turn on it that ends with a plain error: not a usage
-    --- limit, not a success.
-    ---@param entry table Pending entry; its chat_file_path is filled in here.
-    ---@return string chat_path The key the entry was stored under.
-    local function handle_errored_turn(entry)
+    --- Run one turn through `_handle_response`, against a real, named scratch buffer.
+    ---@param response table What the adapter produced: `{ content }`, `{ error }`, ...
+    ---@param opts { adapter_name: string|nil, before: fun(chat_path: string)|nil }|nil
+    ---  `adapter_name` is the adapter instance's `name` ("claude_cli", "codex_cli", ...), which is
+    ---  how the handler tells which backend ran. `before` seeds a store once the chat's path is
+    ---  known but before the turn runs.
+    ---@return string chat_path The buffer's name, which is the key both stores use.
+    local function handle_turn(response, opts)
+      opts = opts or {}
       local buf = vim.api.nvim_create_buf(false, true)
       vim.api.nvim_buf_set_name(buf, tmp_root .. "/chat.md")
-      -- _handle_response keys the store by the buffer's name, and Neovim resolves that (on macOS
-      -- /var is a symlink to /private/var), so the entry has to be stored under the resolved one.
+      -- _handle_response keys the stores by the buffer's name, and Neovim resolves that (on macOS
+      -- /var is a symlink to /private/var), so anything seeded here has to use the resolved one.
       local chat_path = vim.api.nvim_buf_get_name(buf)
-      entry.chat_file_path = chat_path
-      PendingResume.put(entry)
+      if opts.before then
+        opts.before(chat_path)
+      end
 
       local callbacks = {
         clear_sending = function() end,
@@ -93,50 +100,101 @@ describe("send_message", function()
         add_user_section = function() end,
       }
       local adapter = {
+        name = opts.adapter_name,
         supports = function(_, _feature)
           return false
         end,
       }
 
-      SendMessage._handle_response({ error = "stream closed" }, callbacks, adapter, {}, {}, {}, "do the thing")
+      SendMessage._handle_response(response, callbacks, adapter, {}, {}, {}, "do the thing")
 
       vim.api.nvim_buf_delete(buf, { force = true })
       return chat_path
     end
 
-    it("drops a scheduled entry when the turn ends in a non-limit error", function()
-      -- A scheduled request has no stored body — it sends whatever sits in the unsent `## User`
-      -- section when it fires. This turn already consumed that section, so an entry outliving it
-      -- would later send whatever landed there next (a half-typed follow-up, an approval or
-      -- AskUserQuestion option block). Only a *successful* turn used to clear it.
-      local chat_path = handle_errored_turn({
-        kind = "scheduled",
-        resets_at = os.time() + 7200,
-        retry_count = 0,
-        recorded_at = os.time(),
-        state = "waiting",
-      })
+    describe("pending-entry cleanup", function()
+      --- Store `entry` for a chat, then run a turn on it that ends with a plain error: not a usage
+      --- limit, not a success.
+      ---@param entry table Pending entry; its chat_file_path is filled in here.
+      ---@return string chat_path The key the entry was stored under.
+      local function handle_errored_turn(entry)
+        return handle_turn({ error = "stream closed" }, {
+          before = function(chat_path)
+            entry.chat_file_path = chat_path
+            PendingResume.put(entry)
+          end,
+        })
+      end
 
-      assert.is_nil(PendingResume.get(chat_path))
+      it("drops a scheduled entry when the turn ends in a non-limit error", function()
+        -- A scheduled request has no stored body — it sends whatever sits in the unsent `## User`
+        -- section when it fires. This turn already consumed that section, so an entry outliving it
+        -- would later send whatever landed there next (a half-typed follow-up, an approval or
+        -- AskUserQuestion option block). Only a *successful* turn used to clear it.
+        local chat_path = handle_errored_turn({
+          kind = "scheduled",
+          resets_at = os.time() + 7200,
+          retry_count = 0,
+          recorded_at = os.time(),
+          state = "waiting",
+        })
+
+        assert.is_nil(PendingResume.get(chat_path))
+      end)
+
+      it("keeps an auto_resume entry when the turn ends in a non-limit error", function()
+        -- The auto_resume contract is untouched: its budget only moves when a limit is observed,
+        -- and an errored turn is no evidence the limit lifted.
+        local chat_path = handle_errored_turn({
+          kind = "auto_resume",
+          resets_at = os.time() + 7200,
+          retry_count = 1,
+          recorded_at = os.time(),
+          state = "waiting",
+        })
+
+        local entry = PendingResume.get(chat_path)
+        assert.is_not_nil(entry)
+        assert.equals("waiting", entry.state)
+        assert.equals(1, entry.retry_count)
+
+        PendingResume.remove(chat_path)
+      end)
     end)
 
-    it("keeps an auto_resume entry when the turn ends in a non-limit error", function()
-      -- The auto_resume contract is untouched: its budget only moves when a limit is observed,
-      -- and an errored turn is no evidence the limit lifted.
-      local chat_path = handle_errored_turn({
-        kind = "auto_resume",
-        resets_at = os.time() + 7200,
-        retry_count = 1,
-        recorded_at = os.time(),
-        state = "waiting",
-      })
+    describe("usage-limit record scoping", function()
+      --- Run a successful turn on `adapter_name` against a chat whose project already has a
+      --- claude limit on record. Seeding goes through `before` so the record lands in the same
+      --- directory the handler resolves — seeding under the unresolved `tmp_root` would leave
+      --- both assertions below passing against an empty store.
+      ---@param adapter_name string
+      ---@return string chat_dir
+      local function succeed_under_claude_limit(adapter_name)
+        local chat_path = handle_turn({ content = "ok" }, {
+          adapter_name = adapter_name,
+          before = function(path)
+            local dir = vim.fn.fnamemodify(path, ":h")
+            LimitState.record({ resets_at = os.time() + 3600 }, dir, "claude")
+            assert.is_not_nil(LimitState.get_active(dir, "claude"), "fixture failed to seed the limit")
+          end,
+        })
+        return vim.fn.fnamemodify(chat_path, ":h")
+      end
 
-      local entry = PendingResume.get(chat_path)
-      assert.is_not_nil(entry)
-      assert.equals("waiting", entry.state)
-      assert.equals(1, entry.retry_count)
+      it("keeps a claude limit on record when a codex turn succeeds", function()
+        -- A codex request getting through is no evidence Anthropic's plan limit lifted. Clearing
+        -- it would send the next claude message straight into the rejection it was parked to
+        -- avoid.
+        local chat_dir = succeed_under_claude_limit("codex_cli")
 
-      PendingResume.remove(chat_path)
+        assert.is_not_nil(LimitState.get_active(chat_dir, "claude"))
+      end)
+
+      it("clears the claude limit when a claude turn succeeds", function()
+        local chat_dir = succeed_under_claude_limit("claude_cli")
+
+        assert.is_nil(LimitState.load(chat_dir))
+      end)
     end)
   end)
 

--- a/tests/lua/core/constants/resolve_agent_spec.lua
+++ b/tests/lua/core/constants/resolve_agent_spec.lua
@@ -1,0 +1,32 @@
+-- Modes.resolve_agent: which backend a chat actually talks to.
+--
+-- Anything scoped per backend (the usage-limit record, for one) has to agree with what
+-- send_message._resolve_adapter picks, or it scopes itself to a backend the chat never uses.
+
+describe("Modes.resolve_agent", function()
+  local Modes = require("vibing.core.constants.modes")
+
+  it("prefers the chat's own frontmatter", function()
+    assert.equals("codex", Modes.resolve_agent({ agent = "codex" }, { adapter = "claude" }))
+  end)
+
+  it("falls back to the configured adapter", function()
+    assert.equals("grok", Modes.resolve_agent({}, { adapter = "grok" }))
+  end)
+
+  it("falls back to claude with neither", function()
+    assert.equals("claude", Modes.resolve_agent(nil, nil))
+  end)
+
+  it("ignores an unknown frontmatter agent, matching _resolve_adapter's own fallback", function()
+    assert.equals("codex", Modes.resolve_agent({ agent = "gpt9" }, { adapter = "codex" }))
+  end)
+
+  it("ignores an unknown configured adapter", function()
+    assert.equals("claude", Modes.resolve_agent({}, { adapter = "nonsense" }))
+  end)
+
+  it("ignores a non-string frontmatter agent", function()
+    assert.equals("claude", Modes.resolve_agent({ agent = true }, {}))
+  end)
+end)

--- a/tests/lua/infrastructure/storage/limit_state_spec.lua
+++ b/tests/lua/infrastructure/storage/limit_state_spec.lua
@@ -70,4 +70,55 @@ describe("limit_state", function()
   it("stores under .vibing/limit-state.json", function()
     assert.is_truthy(LimitState.get_path(tmp_root):find("/%.vibing/limit%-state%.json$"))
   end)
+
+  describe("agent scoping", function()
+    -- The record answers "is *this backend's* plan exhausted". A claude limit says nothing about
+    -- a codex chat in the same project, and a codex chat getting through says nothing about the
+    -- claude limit still being in force.
+
+    it("records which agent hit the limit", function()
+      LimitState.record({ resets_at = os.time() + 600 }, tmp_root, "claude")
+      assert.equals("claude", LimitState.load(tmp_root).agent)
+    end)
+
+    it("reports the limit as active for the agent that hit it", function()
+      LimitState.record({ resets_at = os.time() + 600 }, tmp_root, "claude")
+      assert.is_not_nil(LimitState.get_active(tmp_root, "claude"))
+    end)
+
+    it("reports no active limit for a different agent", function()
+      LimitState.record({ resets_at = os.time() + 600 }, tmp_root, "claude")
+      assert.is_nil(LimitState.get_active(tmp_root, "codex"))
+    end)
+
+    it("reads an agent-less record as claude's, for stores written before this field existed", function()
+      local path = LimitState.get_path(tmp_root)
+      vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+      vim.fn.writefile({ vim.json.encode({ resets_at = os.time() + 600, observed_at = os.time() }) }, path)
+
+      assert.is_not_nil(LimitState.get_active(tmp_root, "claude"))
+      assert.is_nil(LimitState.get_active(tmp_root, "codex"))
+    end)
+
+    it("answers without an agent as before, unscoped", function()
+      LimitState.record({ resets_at = os.time() + 600 }, tmp_root, "claude")
+      assert.is_not_nil(LimitState.get_active(tmp_root))
+    end)
+
+    it("clears only the matching agent's record", function()
+      LimitState.record({ resets_at = os.time() + 600 }, tmp_root, "claude")
+
+      LimitState.clear(tmp_root, "codex")
+      assert.is_not_nil(LimitState.get_active(tmp_root, "claude"))
+
+      LimitState.clear(tmp_root, "claude")
+      assert.is_nil(LimitState.load(tmp_root))
+    end)
+
+    it("clears unconditionally when given no agent", function()
+      LimitState.record({ resets_at = os.time() + 600 }, tmp_root, "claude")
+      LimitState.clear(tmp_root)
+      assert.is_nil(LimitState.load(tmp_root))
+    end)
+  end)
 end)

--- a/tests/lua/presentation/chat/buffer_schedule_spec.lua
+++ b/tests/lua/presentation/chat/buffer_schedule_spec.lua
@@ -55,15 +55,21 @@ describe("ChatBuffer:_try_schedule_instead_of_send", function()
   --- `## User` section, without going through :new()/open() (which need window_manager,
   --- file_manager, etc.). The helper under test only touches self.buf and self._pending_approval.
   --- @param message string
+  --- @param agent string|nil Written into the buffer's frontmatter when given
   --- @return table chat_buffer, string chat_path
-  local function make_buffer(message)
+  local function make_buffer(message, agent)
     local bufnr = vim.api.nvim_create_buf(false, false)
     table.insert(created_bufs, bufnr)
     vim.api.nvim_buf_set_name(bufnr, tmp_root .. "/chat.md")
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
+    local lines = {}
+    if agent then
+      vim.list_extend(lines, { "---", "vibing.nvim: true", "agent: " .. agent, "---", "" })
+    end
+    vim.list_extend(lines, {
       "## User <!-- unsent -->",
       message,
     })
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
     -- nvim_buf_set_name resolves symlinks in an already-existing directory (e.g. macOS
     -- /tmp -> /private/tmp), so the name actually stored can differ from what was passed in.
     -- Read it back rather than assuming it round-trips, since the helper under test and the
@@ -170,6 +176,34 @@ describe("ChatBuffer:_try_schedule_instead_of_send", function()
 
     local lines = vim.api.nvim_buf_get_lines(chat_buf.buf, 0, 1, false)
     assert.matches("unsent", lines[1])
+  end)
+
+  describe("agent scoping", function()
+    -- The record says one backend's plan is exhausted. Parking a chat that talks to a different
+    -- backend on the back of it makes that chat unusable for the whole reset window.
+    before_each(function()
+      stub_config()
+    end)
+
+    it("does not park a codex chat on a claude limit", function()
+      local chat_buf, chat_path = make_buffer("hello there", "codex")
+      LimitState.record({ resets_at = os.time() + 3600, limit_type = "five_hour" }, tmp_root, "claude")
+
+      local scheduled = chat_buf:_try_schedule_instead_of_send("hello there")
+
+      assert.is_false(scheduled)
+      assert.is_nil(PendingResume.get(chat_path))
+    end)
+
+    it("still parks a claude chat on a claude limit", function()
+      local chat_buf, chat_path = make_buffer("hello there", "claude")
+      LimitState.record({ resets_at = os.time() + 3600, limit_type = "five_hour" }, tmp_root, "claude")
+
+      local scheduled = chat_buf:_try_schedule_instead_of_send("hello there")
+
+      assert.is_true(scheduled)
+      assert.is_not_nil(PendingResume.get(chat_path))
+    end)
   end)
 
   it("does not arm a schedule when the chat file cannot be saved (fails open)", function()


### PR DESCRIPTION
## 問題

claude の usage limit が来ているときに、同じプロジェクトの **codex チャットまで一律で予約（schedule）に飛ばされ、リセットまで会話できない**。

`.vibing/limit-state.json` はプロジェクト単位の1レコードだが、リミットは**プロバイダのプラン単位**のもの。レコードにバックエンドが入っていなかったため、

- `<CR>` の予約振り替え（`buffer.lua`）が、チャットの `agent` を見ずに claude のリミットで codex チャットを止めていた
- 逆向きに、`send_message.lua` の成功時 `LimitState.clear` もバックエンド非依存で、**codex の応答が成功すると claude のリミット記録が消える**（待っていた claude チャットが予約されず素で弾かれる）

`_rate_limit_info` を出すのは `claude_cli.lua` だけなので、記録は常に claude 由来。

## 修正

レコードに `agent` を持たせ、`get_active` / `clear` が問い合わせ元のバックエンドを取るようにした。`agent` の無い既存レコードは claude 由来として読む（後方互換）。

**書く側と読む側でバックエンドの名指し方が違うのは意図的**:

- **書く側**（記録、成功時の解除）は新設の `factory.agent_id(adapter)` で**実際に走ったアダプター**に聞く。「誰が弾かれたか」はプロセスの事実であって、ターン中に編集されうる frontmatter の話ではない
- **読む側**（`<CR>` / `:VibingSchedule` / `:VibingCancelResume`）はまだアダプターが無いので、新設の `Modes.resolve_agent`（frontmatter `agent` > `config.adapter` > claude）で予測する。これは直後に `send_message._resolve_adapter` が使う優先順位と同じ

`:VibingCancelResume all` だけは非スコープのまま（手元にチャットが無く、「全部忘れる」はユーザーが明示的にそう言っている）。

## テスト

- `limit_state_spec`: agent スコープ（記録・一致/不一致・レガシーレコード・clear）
- `resolve_agent_spec`: 解決の優先順位（新規）
- `buffer_schedule_spec`: claude リミットで codex チャットが予約されない / claude チャットは予約される
- `send_message_spec`: codex ターン成功で claude 記録が残る / claude ターン成功で消える
- `auto_resume_spec`: `:VibingCancelResume` が他バックエンドの記録を消さない

実装を main に戻すと上記はすべて落ちることを確認済み。`test:lua` / `test:node` / `lint` / `check:doc` / prettier いずれも green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Usage limits are now tracked separately for each backend.
  - Chats are paused only when their active backend reaches its limit.
  - Successful responses clear only the matching backend’s limit.
  - Cancelling a scheduled resume no longer removes unrelated backend limits.
  - Legacy limit records remain compatible and default to Claude.

- **Documentation**
  - Updated command, configuration, feature, and cancellation guidance to explain backend-specific usage limits and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->