### PR TITLE
fix: register the markdown treesitter parser for the vibing filetype

### DIFF
--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -21,6 +21,12 @@ function M.setup(opts)
   Config.setup(opts)
   M.config = Config.get()
 
+  -- vibing filetype 専用の treesitter パーサは存在しないため markdown を割り当てる。
+  -- これがないと vibing バッファで treesitter ハイライトも
+  -- render-markdown.nvim のレンダリングも一切効かない。
+  -- (vim.bo.syntax = "markdown" は旧来の syntax エンジンにしか効かない)
+  pcall(vim.treesitter.language.register, "markdown", "vibing")
+
   -- チャットファイル自動検知（.md と .vibing の両方をサポート）
   -- フロントマターに vibing.nvim: true が含まれている場合にアタッチ
   local chat_detect = require("vibing.infrastructure.storage.chat_detect")


### PR DESCRIPTION
## What

`vibing` filetype に markdown の treesitter パーサを割り当てます（`setup()` 内で `vim.treesitter.language.register("markdown", "vibing")`）。

## Why

`.vibing` 拡張子のチャットバッファは `filetype = "vibing"` と `syntax = "markdown"` を設定していますが、`syntax` の指定は旧来の syntax エンジンにしか効きません。そのため treesitter ベースの機能から見ると `vibing` は未知の言語で、

- treesitter ハイライトが効かない
- render-markdown.nvim が何も描画しない

状態でした。render-markdown の namespace の extmark 数を数えて確認しています。

| バッファ | extmark |
|---|---|
| 同じ内容を `filetype=markdown` で開く | 25〜82 |
| `filetype=vibing` | **0** |

チャット履歴ファイルを利用者側で `vibing` filetype に寄せている場合も同じくレンダリングが黙って失われるため、filetype を定義している側でパーサも用意しておくのが筋だと考えました。

## How

`M.setup()` の冒頭で登録します。`vim.treesitter.language.register` を持たない古い Neovim で `setup` が壊れないよう `pcall` で包んでいます。

## 動作確認

- `filetype=vibing` のチャットバッファで extmark が 25〜82 個付くこと（この変更のみで復活、利用者側の設定は不要）を確認
- Lua 構文チェック: 220 ファイル、失敗 0
- `pnpm run test:lua`: `buffer_schedule_spec.lua:218` の 1 件が失敗しますが、変更を退避して `main` で実行しても同じ 1 件が失敗するため既存の失敗で本変更とは無関係です

🤖 Generated with [Claude Code](https://claude.com/claude-code)