### PR TITLE
feat: use an existing ## summary as the title-generation input

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -719,6 +719,13 @@ one answer an orchestrator's polling loop can never recover from. So the second 
 `unregister` in `wrapped_on_done`, which makes the registry the only place that knows a run is
 over without also being the place that has to remember how to kill it.
 
+One window stays uncovered, and only under `diff.tool = "mote"`: `_handle_response` clears
+`_is_sending` before mote's asynchronous callbacks write `### Modified Files` and the next
+`## User`, so a poll landing in between reads `idle` while the buffer is still growing. The reply
+itself is already complete by then — what is pending is the diff footer — and the default git path
+finalizes synchronously, so it cannot happen there. The old boolean check did cover this window,
+but only as a side effect of being true forever.
+
 The flag is opt-in rather than a new return shape because the MCP server installs at Claude
 Code's _user_ scope and updates independently of the plugin: without a parameter to key on, a
 newer Neovim answering an older server would hand it an object where it calls `.join()`. Both

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -705,11 +705,19 @@ reference and `config.window` stays the same table.
 
 **Completion detection is a status field, not a text heuristic.** `nvim_get_buffer` passes
 `include_chat_status` to `buf_get_lines`, which attaches `presentation/chat/modules/chat_status`'s
-verdict: `"responding"` when `ChatBuffer:is_responding()` (either `_is_sending` or a
-`_current_handle_id`), `"idle"` otherwise, and nothing at all for a buffer that is not a chat.
-Both fields are needed — `_current_handle_id` is only set once the adapter spawns the CLI, so the
-gap after `<CR>` would otherwise read as finished. Reading the transcript's shape instead would
-call a turn that died on an error, or one part-way through silent tool calls, complete.
+verdict: `"responding"` when `ChatBuffer:is_responding()`, `"idle"` otherwise, and nothing at all
+for a buffer that is not a chat. Reading the transcript's shape instead would call a turn that died
+on an error, or one part-way through silent tool calls, complete.
+
+`is_responding()` needs two signals, and the second one is **not** `_current_handle_id`'s
+existence. `_is_sending` covers `<CR>` until the adapter spawns the CLI; after that the handle id
+is what marks the run — but `send_message.lua` deliberately never clears it on completion, so the
+next `send_message()` can kill a process that outlived its own `result` event. Read as a boolean
+that field therefore reports every chat as `responding` forever after its first turn, which is the
+one answer an orchestrator's polling loop can never recover from. So the second signal is
+`ActiveStreamRegistry.get(handle_id)`: all four adapters `register` when the stream starts and
+`unregister` in `wrapped_on_done`, which makes the registry the only place that knows a run is
+over without also being the place that has to remember how to kill it.
 
 The flag is opt-in rather than a new return shape because the MCP server installs at Claude
 Code's _user_ scope and updates independently of the plugin: without a parameter to key on, a

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -11,7 +11,7 @@
 | `:VibingChatJumpNextUser [count]`     | Move the cursor to the next User section in the chat buffer                                                                                                   |
 | `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                                                                               |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                                                                             |
-| `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                                                                                        |
+| `:VibingSetFileTitle`                 | Generate AI title and rename chat file (prefers an existing `## summary` section as input)                                                                    |
 | `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                                                                                    |
 | `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                                                                             |
 | `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                                                                             |

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ help tags.
 | `:VibingChatJumpNextUser [count]`     | Move the cursor to the next User section in the chat buffer                                                                           |
 | `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                                                       |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                                                     |
-| `:VibingSetFileTitle`                 | Generate AI title and rename chat file                                                                                                |
+| `:VibingSetFileTitle`                 | Generate AI title and rename chat file (uses an existing `## summary` if present)                                                     |
 | `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                                                            |
 | `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                                                     |
 | `:VibingContext [path]`               | Add context: oil.nvim entry, visual selection (range), path argument, or current buffer when no args                                  |

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -152,11 +152,16 @@ section is not kept in sync field by field.
 
                                                         *:VibingSetFileTitle*
 :VibingSetFileTitle
-    Generate a title from the conversation and rename the chat file.
+    Generate a title from the conversation and rename the chat file. When the
+    buffer already holds a `## summary` section written by |:VibingSummarize|,
+    that summary is used as the input instead of a conversation excerpt, which
+    keeps long chats from being titled after their last step. Refused while a
+    response is streaming.
 
                                                            *:VibingSummarize*
 :VibingSummarize
-    Summarise the conversation so far and insert it into the buffer.
+    Summarise the conversation so far and insert it into the buffer. Refused
+    while a response is streaming.
 
                                                          *:VibingDeleteChats*
 :VibingDeleteChats [--unrenamed]

--- a/lua/vibing/application/chat/handlers/set_file_title.lua
+++ b/lua/vibing/application/chat/handlers/set_file_title.lua
@@ -5,6 +5,7 @@ local FileManager = require("vibing.presentation.chat.modules.file_manager")
 local SyncManager = require("vibing.application.link.sync_manager")
 local DailySummaryScanner = require("vibing.infrastructure.link.daily_summary_scanner")
 local ForkedChatScanner = require("vibing.infrastructure.link.forked_chat_scanner")
+local SummaryInserter = require("vibing.presentation.chat.modules.summary_inserter")
 local Fs = require("vibing.core.utils.fs")
 
 ---@param dir string
@@ -71,6 +72,10 @@ return function(_, chat_buffer)
     return false
   end
 
+  -- ストリーミング中はバッファがまだ確定していない。会話は途中状態なのでそこからタイトルを
+  -- 作ることになるし、リネームのための `:write!` が応答の追記と競合する。
+  -- （#475 当時の理由だった「同一 session_id への resume 競合」は、タイトル生成が resume を
+  -- やめた時点で消えている。残っているのは上の2つ。）
   if chat_buffer:is_sending() then
     notify.warn("Cannot generate title while a response is streaming")
     return false
@@ -81,6 +86,11 @@ return function(_, chat_buffer)
     notify.warn("No conversation to generate title from")
     return false
   end
+
+  -- `:VibingSummarize` が書いた `## summary` があれば、抜粋ではなくそちらを入力にする。
+  -- summary は既に「会話全体で何をしたか」に圧縮されているので、長い会話でも主題を外しにくく、
+  -- 送るテキストも短い。無ければ従来どおり抜粋にフォールバックする（後方互換）。
+  local summary = SummaryInserter.extract(chat_buffer.buf)
 
   local old_file_path = chat_buffer.file_path
   local vibing = require("vibing")
@@ -219,7 +229,7 @@ return function(_, chat_buffer)
         notify.warn(string.format("Failed to update %d file(s)", total_failed), "Link Sync")
       end
     end
-  end, title_adapter)
+  end, title_adapter, { summary = summary })
 
   return true
 end

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -193,6 +193,14 @@ function M.generate_and_insert_summary(chat_buffer)
     return
   end
 
+  -- set_file_title と同じ理由でストリーミング中は断る。summary は `# Vibing Chat` の直下へ
+  -- `nvim_buf_set_lines` で差し込むので、末尾に追記中のストリーミングと行番号で競合しうる。
+  -- 加えて、途中状態の会話から要約を作ることにもなる。
+  if chat_buffer:is_sending() then
+    notify.warn("Cannot summarize while a response is streaming")
+    return
+  end
+
   local conversation = chat_buffer:extract_conversation()
 
   if #conversation == 0 or not has_conversation_content(conversation) then

--- a/lua/vibing/core/utils/title_generator.lua
+++ b/lua/vibing/core/utils/title_generator.lua
@@ -25,15 +25,72 @@ local function first_title_line(text)
   return vim.trim((text or ""):match("^([^\n]*)") or "")
 end
 
+---タイトルの体裁に関する共通ルール。入力が抜粋でも summary でも変わらない部分。
+---@param lang_name string?
+---@return string[]
+local function format_rules(lang_name)
+  local rules = {
+    "- Be specific: name the feature, bug, file, or component involved.",
+    "- 30 characters maximum.",
+    "- No date, no file extension, no quotes, no surrounding punctuation.",
+  }
+  if lang_name then
+    rules[#rules + 1] = "- Write the title in " .. lang_name .. "."
+  end
+  return rules
+end
+
+---@param lead string[] 入力の説明と主題の取り方（入力の種類ごとに違う部分）
+---@param lang_name string?
+---@return string
+local function build_instruction(lead, lang_name)
+  local lines = vim.list_extend(vim.deepcopy(lead), format_rules(lang_name))
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "Respond with ONLY the title, nothing else."
+  return table.concat(lines, "\n")
+end
+
+-- 抜粋入力。「主題 = ユーザーが達成しようとしたこと」を明示する。これを言わないと、モデルは
+-- 抜粋の末尾（マージ・クリーンアップ等の後始末）や実行したコマンドをタイトルにしてしまう。
+local EXCERPT_LEAD = {
+  "The text above is an excerpt of a conversation between a user and an AI coding assistant.",
+  "",
+  "Write a title naming WHAT THE USER WAS TRYING TO ACCOMPLISH across the whole conversation.",
+  "",
+  "Rules:",
+  "- The subject comes from the user's requests, not from the assistant's replies.",
+  "- Do not title it after the last step, the wrap-up work, or the tools and commands that were run.",
+}
+
+-- summary 入力。抜粋固有の防御（主題は user 側から / 末尾に引きずられるな）はここでは不要で、
+-- 代わりに summary 自身の構成（`### 一行要約` / `### 決定事項` が主題、`### やったこと` と
+-- `### 未解決 / 次の一手` は主題ではない）に沿った取り方を指示する。
+-- 見出し名を直接は書かない: `prompts/chat_summary.md` のテンプレートを変えたときに、
+-- ここが黙って古い見出しを指し続けるのを避けるため。
+local SUMMARY_LEAD = {
+  "The text above is a summary of a conversation between a user and an AI coding assistant.",
+  "",
+  "Write a title naming WHAT THE CONVERSATION WAS ABOUT.",
+  "",
+  "Rules:",
+  "- The subject is the one-line overview and the decisions, not the file-by-file work log.",
+  "- Do not title it after the open questions, the next steps, or the files that were touched.",
+}
+
 ---会話履歴からAIにタイトルを生成させる
----会話の抜粋（`chat_excerpt` がツール実況を落として user 発言中心に組み立てたもの）を
----アダプタに送り、簡潔なファイル名用タイトルを生成する。結果はコールバックで非同期に返される。
----セッションの resume/fork は行わない（全履歴を読み込んで context を超過し
----"Prompt is too long" になるのを避けるため）。抜粋を都度フレッシュに送るだけなので session_id は不要。
+---
+---入力は2種類ある。`opts.summary`（`:VibingSummarize` がバッファに書いた `## summary`）が
+---あればそれを使い、無ければ会話の抜粋（`chat_excerpt` がツール実況を落として user 発言中心に
+---組み立てたもの）にフォールバックする。summary を優先するのは、それが既に「会話全体で
+---何をしたか」に圧縮されていて、長い会話でも主題を外しにくく、送るテキストも短いため。
+---
+---どちらの場合もセッションの resume/fork は行わない（全履歴を読み込んで context を超過し
+---"Prompt is too long" になるのを避けるため）。都度フレッシュに送るだけなので session_id は不要。
 ---@param conversation {role: string, content: string}[] 会話履歴
 ---@param callback fun(title: string?, error: string?) 結果コールバック
 ---@param adapter table? タイトル生成に使うアダプタ。省略時はグローバル既定を使う。
-function M.generate_from_conversation(conversation, callback, adapter)
+---@param opts {summary: string?}? summary があれば抜粋の代わりにそれを入力にする
+function M.generate_from_conversation(conversation, callback, adapter, opts)
   if not conversation or #conversation == 0 then
     callback(nil, "No conversation to generate title from")
     return
@@ -51,39 +108,26 @@ function M.generate_from_conversation(conversation, callback, adapter)
   local lang_code = language_utils.get_language_code(config.language, "chat")
   local lang_name = lang_code and language_utils.language_names[lang_code]
 
-  -- 「主題 = ユーザーが達成しようとしたこと」を明示する。これを言わないと、モデルは
-  -- 抜粋の末尾（マージ・クリーンアップ等の後始末）や実行したコマンドをタイトルにしてしまう。
-  local lines = {
-    "The text above is an excerpt of a conversation between a user and an AI coding assistant.",
-    "",
-    "Write a title naming WHAT THE USER WAS TRYING TO ACCOMPLISH across the whole conversation.",
-    "",
-    "Rules:",
-    "- The subject comes from the user's requests, not from the assistant's replies.",
-    "- Do not title it after the last step, the wrap-up work, or the tools and commands that were run.",
-    "- Be specific: name the feature, bug, file, or component involved.",
-    "- 30 characters maximum.",
-    "- No date, no file extension, no quotes, no surrounding punctuation.",
-  }
-  if lang_name then
-    lines[#lines + 1] = "- Write the title in " .. lang_name .. "."
+  local summary = opts and opts.summary
+  if summary == "" then
+    summary = nil
   end
-  lines[#lines + 1] = ""
-  lines[#lines + 1] = "Respond with ONLY the title, nothing else."
-  local title_instruction = table.concat(lines, "\n")
+
+  local input = summary or chat_excerpt.build(conversation)
+  local title_instruction = build_instruction(summary and SUMMARY_LEAD or EXCERPT_LEAD, lang_name)
 
   -- Title generation is a lightweight utility call: no tools/CLAUDE.md/MCP needed
-  local opts = {
+  local stream_opts = {
     lightweight = true,
   }
 
-  -- Always send a bounded excerpt as a fresh prompt (no resume/fork), so long
+  -- Always send a bounded input as a fresh prompt (no resume/fork), so long
   -- chats never exceed the context window.
-  local prompt = chat_excerpt.build(conversation) .. "\n\n" .. title_instruction
+  local prompt = input .. "\n\n" .. title_instruction
 
   local collected_response = ""
 
-  adapter:stream(prompt, opts, function(chunk)
+  adapter:stream(prompt, stream_opts, function(chunk)
     collected_response = collected_response .. chunk
   end, function(response)
     if response.error then

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -149,6 +149,11 @@ end
 ---残している）ので、存在だけを見ると1ターン目以降ずっと"responding"になる。
 ---実行中かどうかはActiveStreamRegistryが唯一の答えを持っている: 全アダプタがstream開始で
 ---registerし、on_doneでunregisterする。
+---
+---既知の隙間: `diff.tool = "mote"` のときだけ、_handle_responseがmoteの非同期コールバックから
+---`### Modified Files`と次の`## User`を書き終える前にidleを返す。応答本文はこの時点で完成して
+---いるのでdiff脚注だけの話で、既定のgitパスは同期なので起きない。旧実装はこの窓も
+---"responding"にできていたが、それは1ターン目以降ずっとtrueだったからで、代償が大きすぎた。
 ---@return boolean
 function ChatBuffer:is_responding()
   if self:is_sending() then

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -5,6 +5,7 @@ local FrontmatterHandler = require("vibing.presentation.chat.modules.frontmatter
 local Renderer = require("vibing.presentation.chat.modules.renderer")
 local StreamingHandler = require("vibing.presentation.chat.modules.streaming_handler")
 local ConversationExtractor = require("vibing.presentation.chat.modules.conversation_extractor")
+local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
 local KeymapHandler = require("vibing.presentation.chat.modules.keymap_handler")
 local Fs = require("vibing.core.utils.fs")
 
@@ -142,11 +143,21 @@ function ChatBuffer:is_sending()
 end
 
 ---このチャットがリクエストを実行中か（送信開始からCLI終了まで）
----`_is_sending`は<CR>からCLI起動までの隙間、`_current_handle_id`は起動後の実行中をカバーする。
----片方だけを見ると送信直後の数十msを「完了」と読んでしまうので、両方を見る必要がある
+---
+---`_is_sending`は<CR>からCLI起動までの隙間をカバーする。`_current_handle_id`はその後だが、
+---応答完了時にクリアされない（次のsend_message()でkillしてゾンビプロセスを刈るため意図的に
+---残している）ので、存在だけを見ると1ターン目以降ずっと"responding"になる。
+---実行中かどうかはActiveStreamRegistryが唯一の答えを持っている: 全アダプタがstream開始で
+---registerし、on_doneでunregisterする。
 ---@return boolean
 function ChatBuffer:is_responding()
-  return self:is_sending() or self._current_handle_id ~= nil
+  if self:is_sending() then
+    return true
+  end
+  if not self._current_handle_id then
+    return false
+  end
+  return ActiveStreamRegistry.get(self._current_handle_id) ~= nil
 end
 
 ---バッファを作成

--- a/lua/vibing/presentation/chat/modules/summary_inserter.lua
+++ b/lua/vibing/presentation/chat/modules/summary_inserter.lua
@@ -116,4 +116,41 @@ function M.insert_or_update(buf, summary_content)
   return true
 end
 
+---バッファから `## summary` セクションを取り出す。
+---
+---探索範囲も終端の判定も `M.insert_or_update` と同じもの（`find_insertion_points` /
+---`find_summary_section`）を使う。読む側と書く側でセクション境界の定義がずれると、
+---次の `:VibingSummarize` が上書きするのと違う範囲をタイトル生成が読むことになるため、
+---別モジュールに切り出さずここに置いている。
+---
+---見出しだけで本文が空のセクションは nil を返す。タイトル生成側はこれを
+---「summary は無い」と読んで抜粋にフォールバックする。
+---@param buf number バッファ番号
+---@return string? summary `## summary` 見出しを含む本文。無ければ nil
+function M.extract(buf)
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then
+    return nil
+  end
+
+  local all_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local vibing_chat_line, separator_line = find_insertion_points(all_lines)
+
+  if not vibing_chat_line or not separator_line then
+    return nil
+  end
+
+  local summary_start, summary_end = find_summary_section(all_lines, vibing_chat_line, separator_line)
+
+  if not summary_start or not summary_end then
+    return nil
+  end
+
+  local body = vim.trim(table.concat(vim.list_slice(all_lines, summary_start + 1, summary_end), "\n"))
+  if body == "" then
+    return nil
+  end
+
+  return vim.trim(all_lines[summary_start]) .. "\n\n" .. body
+end
+
 return M

--- a/tests/lua/application/chat/handlers/set_file_title_spec.lua
+++ b/tests/lua/application/chat/handlers/set_file_title_spec.lua
@@ -143,3 +143,81 @@ describe("set_file_title handler - streaming guard", function()
     end
   end)
 end)
+
+describe("set_file_title handler - summary as input", function()
+  local handler, title_generator, original_generate
+
+  local function chat_buffer_with(lines)
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    return {
+      buf = buf,
+      is_sending = function()
+        return false
+      end,
+      extract_conversation = function()
+        return { { role = "user", content = "hi" } }
+      end,
+      get_session_id = function()
+        return nil
+      end,
+    }
+  end
+
+  before_each(function()
+    package.loaded["vibing.application.chat.handlers.set_file_title"] = nil
+    handler = require("vibing.application.chat.handlers.set_file_title")
+    title_generator = require("vibing.core.utils.title_generator")
+    original_generate = title_generator.generate_from_conversation
+  end)
+
+  after_each(function()
+    title_generator.generate_from_conversation = original_generate
+    package.loaded["vibing.application.chat.handlers.set_file_title"] = nil
+  end)
+
+  it("passes the buffer's `## summary` section to the title generator", function()
+    local passed_opts
+    title_generator.generate_from_conversation = function(_, _, _, opts)
+      passed_opts = opts
+    end
+
+    handler({}, chat_buffer_with({
+      "---",
+      "vibing.nvim: true",
+      "---",
+      "# Vibing Chat",
+      "",
+      "## summary",
+      "",
+      "### 一行要約",
+      "- タイトル生成の入力を summary 優先にした",
+      "",
+      "---",
+      "## User",
+      "hi",
+    }))
+
+    assert.is_truthy(passed_opts.summary:find("タイトル生成の入力を summary 優先にした", 1, true))
+  end)
+
+  it("passes no summary when the buffer has none, so the excerpt path stays the default", function()
+    local passed_opts
+    title_generator.generate_from_conversation = function(_, _, _, opts)
+      passed_opts = opts
+    end
+
+    handler({}, chat_buffer_with({
+      "---",
+      "vibing.nvim: true",
+      "---",
+      "# Vibing Chat",
+      "---",
+      "## User",
+      "hi",
+    }))
+
+    assert.is_table(passed_opts)
+    assert.is_nil(passed_opts.summary)
+  end)
+end)

--- a/tests/lua/application/chat/use_case_spec.lua
+++ b/tests/lua/application/chat/use_case_spec.lua
@@ -41,3 +41,32 @@ describe("chat use_case.create_new", function()
     assert.are_not.equal("", session.working_dir)
   end)
 end)
+
+describe("chat use_case.generate_and_insert_summary", function()
+  local use_case
+
+  before_each(function()
+    use_case = require("vibing.application.chat.use_case")
+  end)
+
+  it("refuses while a response is streaming", function()
+    -- The summary goes in just below `# Vibing Chat` with nvim_buf_set_lines, so writing it
+    -- while the stream appends at the end shifts the line numbers under the streaming handler.
+    -- Symmetrical with the guard :VibingSetFileTitle has had since #475.
+    local extracted = false
+    local chat_buffer = {
+      buf = vim.api.nvim_create_buf(false, true),
+      is_sending = function()
+        return true
+      end,
+      extract_conversation = function()
+        extracted = true
+        return { { role = "user", content = "hi" } }
+      end,
+    }
+
+    use_case.generate_and_insert_summary(chat_buffer)
+
+    assert.is_false(extracted)
+  end)
+end)

--- a/tests/lua/core/utils/title_generator_spec.lua
+++ b/tests/lua/core/utils/title_generator_spec.lua
@@ -116,4 +116,50 @@ describe("title_generator.generate_from_conversation", function()
     assert.is_nil(captured_prompt:find("git rebase", 1, true))
     assert.is_not_nil(captured_prompt:find("認証のバグを直して", 1, true))
   end)
+
+  describe("summary input", function()
+    it("summary が渡されたら抜粋の代わりにそれを送る", function()
+      title_generator.generate_from_conversation(CONVERSATION, function() end, nil, {
+        summary = "## summary\n\n### 一行要約\n- タイトル生成の入力を summary 優先にした",
+      })
+
+      assert.is_truthy(captured_prompt:find("タイトル生成の入力を summary 優先にした", 1, true))
+      -- 抜粋側の構造も、抜粋固有の防御ルールも混ざらない
+      assert.is_nil(captured_prompt:find("USER REQUESTS", 1, true))
+      assert.is_nil(captured_prompt:find("Hello there", 1, true))
+      assert.is_nil(captured_prompt:find("the last step", 1, true))
+      assert.is_truthy(captured_prompt:find("is a summary of a conversation", 1, true))
+    end)
+
+    it("summary が無ければ従来どおり抜粋を送る", function()
+      title_generator.generate_from_conversation(CONVERSATION, function() end, nil, {})
+
+      assert.is_truthy(captured_prompt:find("USER REQUESTS", 1, true))
+      assert.is_truthy(captured_prompt:find("Hello there", 1, true))
+      assert.is_nil(captured_prompt:find("is a summary of a conversation", 1, true))
+    end)
+
+    it("空文字の summary は「無し」として扱う", function()
+      title_generator.generate_from_conversation(CONVERSATION, function() end, nil, { summary = "" })
+
+      assert.is_truthy(captured_prompt:find("USER REQUESTS", 1, true))
+    end)
+
+    it("体裁のルールはどちらの入力でも共通で付く", function()
+      for _, opts in ipairs({ {}, { summary = "## summary\n\n- 決めたこと" } }) do
+        title_generator.generate_from_conversation(CONVERSATION, function() end, nil, opts)
+
+        assert.is_truthy(captured_prompt:find("30 characters maximum", 1, true))
+        assert.is_truthy(captured_prompt:find("Respond with ONLY the title", 1, true))
+      end
+    end)
+
+    it("軽量呼び出しのフラグは summary 入力でも立つ", function()
+      title_generator.generate_from_conversation(CONVERSATION, function() end, nil, {
+        summary = "## summary\n\n- 決めたこと",
+      })
+
+      assert.is_true(captured_opts.lightweight)
+    end)
+  end)
 end)

--- a/tests/lua/presentation/chat/modules/chat_status_spec.lua
+++ b/tests/lua/presentation/chat/modules/chat_status_spec.lua
@@ -5,16 +5,21 @@
 local ChatBuffers = require("tests.helpers.chat_buffers")
 
 describe("chat status", function()
-  local ChatStatus, BufferHandler, view
+  local ChatStatus, BufferHandler, view, Registry
 
   before_each(function()
     ChatBuffers.setup()
     view = require("vibing.presentation.chat.view")
     ChatStatus = require("vibing.presentation.chat.modules.chat_status")
     BufferHandler = require("vibing.infrastructure.rpc.handlers.buffer")
+    Registry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
   end)
 
-  after_each(ChatBuffers.reset)
+  after_each(function()
+    ChatBuffers.reset()
+    Registry.unregister("handle-1")
+    Registry.unregister("handle-2")
+  end)
 
   it("reports nil for a buffer that is not a vibing chat", function()
     local bufnr = vim.api.nvim_create_buf(false, true)
@@ -31,8 +36,22 @@ describe("chat status", function()
   it("reports responding while the CLI process is streaming", function()
     local chat_buf = view.render({ session_id = "busy-session" }, "back")
     chat_buf._current_handle_id = "handle-1"
+    Registry.register({ handle_id = "handle-1", adapter = {} })
 
     assert.equals("responding", ChatStatus.get(chat_buf.buf))
+  end)
+
+  it("reports idle once the stream ended, even though the handle id is still set", function()
+    -- send_message.lua deliberately never clears _current_handle_id: the next send uses it to
+    -- kill a process that outlived its own result event. Read as a boolean it would pin every
+    -- chat at "responding" from its first turn onward, which is the one answer a polling
+    -- orchestrator can never recover from. The registry is what actually knows the run is over.
+    local chat_buf = view.render({ session_id = "finished-session" }, "back")
+    chat_buf._current_handle_id = "handle-2"
+    Registry.register({ handle_id = "handle-2", adapter = {} })
+    Registry.unregister("handle-2")
+
+    assert.equals("idle", ChatStatus.get(chat_buf.buf))
   end)
 
   it("reports responding in the gap between <CR> and the CLI actually starting", function()

--- a/tests/summary_inserter_spec.lua
+++ b/tests/summary_inserter_spec.lua
@@ -282,4 +282,87 @@ describe("vibing.presentation.chat.modules.summary_inserter", function()
       assert.is_true(summary_found)
     end)
   end)
+
+  describe("extract()", function()
+    it("`## summary` セクションを見出しごと取り出す", function()
+      mock_buf_lines = {
+        "---",
+        "vibing.nvim: true",
+        "---",
+        "# Vibing Chat",
+        "",
+        "## summary",
+        "",
+        "### 一行要約",
+        "- タイトル生成の入力を summary 優先にした",
+        "",
+        "---",
+        "## User",
+        "Hello",
+      }
+
+      assert.equals(
+        "## summary\n\n### 一行要約\n- タイトル生成の入力を summary 優先にした",
+        SummaryInserter.extract(1)
+      )
+    end)
+
+    it("summary が無ければ nil を返す", function()
+      mock_buf_lines = {
+        "---",
+        "vibing.nvim: true",
+        "---",
+        "# Vibing Chat",
+        "---",
+        "## User",
+        "Hello",
+      }
+
+      assert.is_nil(SummaryInserter.extract(1))
+    end)
+
+    it("見出しだけで本文が空なら nil を返す（抜粋にフォールバックさせるため）", function()
+      mock_buf_lines = {
+        "---",
+        "vibing.nvim: true",
+        "---",
+        "# Vibing Chat",
+        "",
+        "## summary",
+        "",
+        "---",
+        "## User",
+        "Hello",
+      }
+
+      assert.is_nil(SummaryInserter.extract(1))
+    end)
+
+    it("`## User` は本文に含めない（insert_or_update と同じ終端判定）", function()
+      -- 挿入側とセクション境界の定義がずれると、次の :VibingSummarize が上書きする範囲と
+      -- タイトル生成が読む範囲が食い違う。同じ locals を通っていることをここで固定する。
+      mock_buf_lines = {
+        "---",
+        "vibing.nvim: true",
+        "---",
+        "# Vibing Chat",
+        "",
+        "## summary",
+        "",
+        "- 決めたこと",
+        "",
+        "## User",
+        "Hello",
+        "---",
+      }
+
+      assert.equals("## summary\n\n- 決めたこと", SummaryInserter.extract(1))
+    end)
+
+    it("無効なバッファでは nil を返す", function()
+      mock_buf_valid = false
+
+      assert.is_nil(SummaryInserter.extract(1))
+    end)
+  end)
 end)


### PR DESCRIPTION
Closes #606

## 何をしたか

`:VibingSetFileTitle` の入力を次の優先順にしました。

1. チャットバッファに `## summary` セクション（`:VibingSummarize` が書いたもの）があれば、それを使う
2. なければ従来どおり `chat_excerpt.build(conversation)` にフォールバック

summary は「会話全体で何をしたか」に既に圧縮されているので、長い会話でも主題を外しにくく、送るテキストも短いぶん軽量呼び出しが安くなります。summary が無い場合の挙動は完全に現状維持です。

## 実装のポイント

**`summary_inserter.extract` は挿入側と同じ locals を通る**

`find_insertion_points` / `find_summary_section` を `insert_or_update` と共有しています。読む範囲と「次の `:VibingSummarize` が上書きする範囲」が食い違うと、タイトル生成が要約の一部しか読まない／次の要約が別の範囲を潰す、という形で静かにずれます。別モジュールに切り出すとこの2つの local を公開APIにする必要があり、消費者は結局この2関数だけなので、同居させています。

見出しだけで本文が空のセクションは `nil` を返し、抜粋にフォールバックします。

**プロンプトは前置きだけ分岐、体裁ルールは共通**

`EXCERPT_LEAD` / `SUMMARY_LEAD` に分け、文字数上限・言語・出力形式は `format_rules` で共有しました。抜粋固有の防御（「主題は user の依頼から取れ」「末尾の後始末を題にするな」）は summary には不適なので外し、代わりに「一行要約と決定事項から取れ / やったこと・次の一手からは取るな」を指示しています。

summary 側の指示に**見出し名は書いていません**。`prompts/chat_summary.md` のテンプレートを変えたときに、ここが黙って古い見出しを指し続けるのを避けるためです。

## あわせて入れた2件（issue の「関連論点」）

**`:VibingSummarize` に `is_sending` ガード**

summary は `# Vibing Chat` の直下へ `nvim_buf_set_lines` で差し込むので、ストリーミングが末尾に追記している最中だと行番号がずれます。`:VibingSetFileTitle` 側のガードにも、理由が #475 の「同一 session への resume 競合」ではなく「会話が未確定 + `:write!` の競合」であることをコメントで書き直しました。resume をやめた時点で当時の理由は消えています。

`/summarize` スラッシュコマンドは別ハンドラ（フロート表示）で、しかも `<CR>` 経路なので常に `_is_sending` 中です。こちらには入れていません。

**`ChatBuffer:is_responding()` の sticky バグ修正**

調査の副産物です。`_current_handle_id` は応答完了時にクリアされません（次の `send_message()` でゾンビプロセスを刈るための意図的な設計）。存在だけを見ていたので、**1ターン目以降そのチャットは永久に `responding` を返していました**。`nvim_get_buffer` でワーカーをポーリングするオーケストレーターが絶対に回復できない状態です。

`ActiveStreamRegistry.get(handle_id)` を見る形にしました。全4アダプタが stream 開始で register / `on_done` で unregister するので、実行が終わったことを知っているのはここだけです。

## 既知のトレードオフ

セルフレビューで挙がったもののうち、この PR では直していない2件です。

**1. `diff.tool = "mote"` のときだけ `is_responding()` に隙間が残る**

`_handle_response` は mote の非同期コールバックが `### Modified Files` と次の `## User` を書き終える前に `_is_sending` を落とすので、その間のポーリングは `idle` を読みます。応答本文はこの時点で完成していて残っているのは diff の脚注だけ、かつ既定の git パスは同期なので起きません。旧実装はこの窓も `responding` にできていましたが、それは「常に true」だった副作用です。コードと `.claude/rules/architecture.md` に明記しました。

**2. summary が日本語固定なので、英語の会話でもタイトルが日本語になりうる**

`prompts/chat_summary.md` が `config.language` に関係なく "Write the summary in Japanese." としているため、`config.language` 未設定だと summary 経路のタイトルが日本語に寄ります（抜粋経路は会話の言語に従っていた）。根本は要約テンプレート側が言語設定を見ていないことなので、別途 issue を立てるのが筋だと考えています。

**3.（仕様どおり）古い summary がそのまま勝つ**

25ターン前の summary でも鮮度チェックなしで採用されます。issue の提案がその形で、想定ユースケースも `:VibingSummarize` → `:VibingSetFileTitle` を続けて叩くものなので、意図した挙動として残しています。

## テスト

新規・更新12件。`summary_inserter.extract` の境界（本文空 / `## User` 終端 / summary 無し / 無効バッファ）、`title_generator` の入力分岐と共通ルール、ハンドラが summary を渡すこと、`is_responding` が「完了後は idle」を返すこと。

```
test:lua    Success 1663 / Failed 0
test:node   pass 38 / fail 0
check / check:doc / lint / format:check  すべて OK
```

`tests/lua/application/chat/summary_prompt_spec.lua` は worktree から実行すると1件 error になりますが、この変更とは無関係の既存事象です。`PromptLoader.get_plugin_root()` が runtimepath から `vibing%.nvim/?$` にマッチするパスを探すため、`.vibing/worktrees/<branch>/` では見つかりません。main のチェックアウトでは green で、実行時はインストール済みプラグインが rtp にあるので実害はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
