### PR TITLE
perf: move startup-path disk I/O off setup()

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -284,6 +284,37 @@ Tests:
 - tests/e2e/*.spec.lua         - E2E tests against a spawned Neovim instance
 ```
 
+## Startup Cost
+
+`setup()` runs eagerly — the lazy.nvim example deliberately has no `cmd`/`event` trigger, because
+the RPC server has to be listening and in the instance registry for Claude Code to find this
+Neovim at all. So everything `setup()` does is on the user's startup path, and the module tree is
+not what costs: measured on a warm cache, requiring every module `setup()` touches is ~9ms of it.
+The cost is synchronous I/O.
+
+Two pieces were therefore moved off that path, taking a measured ~32ms `setup()` to ~11ms:
+
+- **Custom slash commands are scanned on first use, not at startup.**
+  `custom_commands.scan()` globs `.claude/commands/*.md` for the project, the user, _and_ every
+  installed Claude Code plugin, then `readfile`s each one whole — 76 files / ~417KB on one
+  developer's machine, ~13ms, and it grows with every plugin installed. `commands.lua` owns the
+  trigger now (`ensure_custom_loaded`), fired from `execute()` and `list_all()`, which are the
+  only two readers of `M.custom_commands`. A Neovim that never opens a chat never pays it.
+
+  The guard is set **before** the scan, not after, so a scan that finds nothing does not retry:
+  `list_all()` is on the completion path and runs per keystroke.
+
+  `:VibingReloadCommands` goes through `commands.reload_custom()` rather than clearing
+  `custom_commands.lua`'s cache and re-running the loop itself. Assigning
+  `commands.custom_commands = {}` from outside would empty the table while leaving the
+  already-loaded flag set, and the commands would never come back.
+
+- **`hook_cleanup.cleanup_stale_dirs()` is deferred to `vim.schedule`.** Hooks only run once a
+  request is in flight, so nothing needs the sweep before the UI is up.
+
+A scan moved to first use also reads `vim.fn.getcwd()` at first use, which is the more accurate
+cwd for picking up a project's `.claude/commands/` anyway.
+
 ## Session Persistence
 
 Chat files are saved as Markdown with YAML frontmatter:

--- a/lua/vibing/application/chat/commands.lua
+++ b/lua/vibing/application/chat/commands.lua
@@ -14,6 +14,35 @@ M.commands = {}
 ---@type table<string, Vibing.SlashCommand>
 M.custom_commands = {}
 
+---カスタムコマンドはsetup()ではなく初回利用時にスキャンする。
+---スキャンはプロジェクト・ユーザー・インストール済み全プラグインの .claude/commands/*.md を
+---全文読み込みするため、実測で ~32ms の setup() のうち ~13ms を占めていた。チャットを一度も
+---開かないセッションはスラッシュコマンドを解決しないので、その分は丸ごと不要なコストになる。
+local custom_loaded = false
+
+---M.custom_commands にスキャン結果が入っていることを保証する
+local function ensure_custom_loaded()
+  if custom_loaded then
+    return
+  end
+  -- スキャンが失敗しても再試行しない。ここはキー入力ごとの補完経路から呼ばれるので、
+  -- 失敗のたびに数十msのI/Oを繰り返すほうが、カスタムコマンドが無いことより害が大きい。
+  custom_loaded = true
+
+  local custom_commands = require("vibing.application.chat.custom_commands")
+  for _, custom_cmd in ipairs(custom_commands.get_all()) do
+    M.register_custom(custom_cmd)
+  end
+end
+
+---カスタムコマンドを再スキャンして登録し直す（:VibingReloadCommands）
+function M.reload_custom()
+  require("vibing.application.chat.custom_commands").clear_cache()
+  M.custom_commands = {}
+  custom_loaded = false
+  ensure_custom_loaded()
+end
+
 ---@param command Vibing.SlashCommand
 function M.register(command)
   M.commands[command.name] = command
@@ -91,6 +120,7 @@ function M.execute(message, chat_buffer)
   local is_custom = false
 
   if not command then
+    ensure_custom_loaded()
     command = M.custom_commands[command_name]
     is_custom = command ~= nil
   end
@@ -180,6 +210,8 @@ end
 
 ---@return table<string, Vibing.SlashCommand>
 function M.list_all()
+  ensure_custom_loaded()
+
   local all = {}
 
   for name, cmd in pairs(M.commands) do

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -62,9 +62,14 @@ function M.setup(opts)
   local adapter_factory = require("vibing.infrastructure.adapter.factory")
   M.adapter = adapter_factory.create(M.config.adapter, M.config)
 
-  -- Cleanup stale hook communication directories from previous sessions
-  local hook_cleanup = require("vibing.infrastructure.adapter.modules.hook_cleanup")
-  hook_cleanup.cleanup_stale_dirs()
+  -- Cleanup stale hook communication directories from previous sessions.
+  -- 起動直後に必要な処理ではない（hookが動くのは最初のリクエスト時）ので、/tmp のscanと
+  -- 削除を起動パスから外す。
+  vim.schedule(function()
+    pcall(function()
+      require("vibing.infrastructure.adapter.modules.hook_cleanup").cleanup_stale_dirs()
+    end)
+  end)
 
   -- 使用量リミット待ちのチャットのタイマーを張り直す。
   -- 5時間/週次リミットのリセットはNeovimの再起動を跨ぐことが多いため、
@@ -106,12 +111,8 @@ function M.setup(opts)
   -- チャットコマンド初期化
   require("vibing.application.chat").setup()
 
-  -- カスタムコマンドのスキャンと登録
-  local custom_commands = require("vibing.application.chat.custom_commands")
-  local commands = require("vibing.application.chat.commands")
-  for _, custom_cmd in ipairs(custom_commands.get_all()) do
-    commands.register_custom(custom_cmd)
-  end
+  -- カスタムコマンド（.claude/commands/*.md）はここでは読まない。
+  -- commands.lua が初回利用時にスキャンする（理由は同ファイルの ensure_custom_loaded 参照）。
 
   -- コマンド登録
   M._register_commands()
@@ -459,17 +460,11 @@ function M._register_commands()
   })
 
   vim.api.nvim_create_user_command("VibingReloadCommands", function()
-    local custom_commands = require("vibing.application.chat.custom_commands")
     local commands = require("vibing.application.chat.commands")
     local completion = require("vibing.application.completion")
     local skills = require("vibing.infrastructure.completion.providers.skills")
 
-    custom_commands.clear_cache()
-    commands.custom_commands = {}
-
-    for _, custom_cmd in ipairs(custom_commands.get_all()) do
-      commands.register_custom(custom_cmd)
-    end
+    commands.reload_custom()
 
     completion.clear_cache()
     skills.preload()

--- a/tests/lua/application/chat/commands_lazy_custom_spec.lua
+++ b/tests/lua/application/chat/commands_lazy_custom_spec.lua
@@ -7,6 +7,16 @@ describe("commands custom command lazy loading", function()
   local Commands
   local scan_count
 
+  -- このspecは package.loaded を3つ差し替える。PlenaryBustedDirectory はspecファイルごとに
+  -- 別のnvimを起動するので他ファイルには漏れないが、それはこのファイルの外の都合であって
+  -- ここが保証していることではない。元の値を持って帰る。
+  local MOCKED_MODULES = {
+    "vibing.application.chat.commands",
+    "vibing.application.chat.custom_commands",
+    "vibing.core.utils.notify",
+  }
+  local original_loaded
+
   local function fake_custom_commands(commands)
     scan_count = 0
     package.loaded["vibing.application.chat.custom_commands"] = {
@@ -19,8 +29,12 @@ describe("commands custom command lazy loading", function()
   end
 
   before_each(function()
+    original_loaded = {}
+    for _, name in ipairs(MOCKED_MODULES) do
+      original_loaded[name] = package.loaded[name]
+    end
+
     package.loaded["vibing.application.chat.commands"] = nil
-    package.loaded["vibing.core.utils.notify"] = nil
     package.loaded["vibing.core.utils.notify"] = {
       error = function() end,
       warn = function() end,
@@ -43,7 +57,9 @@ describe("commands custom command lazy loading", function()
   end)
 
   after_each(function()
-    package.loaded["vibing.application.chat.custom_commands"] = nil
+    for _, name in ipairs(MOCKED_MODULES) do
+      package.loaded[name] = original_loaded[name]
+    end
   end)
 
   it("does not scan the disk just because the module was loaded", function()

--- a/tests/lua/application/chat/commands_lazy_custom_spec.lua
+++ b/tests/lua/application/chat/commands_lazy_custom_spec.lua
@@ -1,0 +1,115 @@
+-- カスタムコマンドが setup() ではなく初回利用時にスキャンされることを固定する。
+-- スキャンは .claude/commands/*.md を全文読み込みする同期I/Oで、起動時間の約4割を占めていた。
+-- 「起動時には呼ばれない」ことと「使う直前には必ず呼ばれる」ことの両方が壊れやすいので、
+-- 呼び出し回数そのものを見る。
+
+describe("commands custom command lazy loading", function()
+  local Commands
+  local scan_count
+
+  local function fake_custom_commands(commands)
+    scan_count = 0
+    package.loaded["vibing.application.chat.custom_commands"] = {
+      get_all = function()
+        scan_count = scan_count + 1
+        return commands
+      end,
+      clear_cache = function() end,
+    }
+  end
+
+  before_each(function()
+    package.loaded["vibing.application.chat.commands"] = nil
+    package.loaded["vibing.core.utils.notify"] = nil
+    package.loaded["vibing.core.utils.notify"] = {
+      error = function() end,
+      warn = function() end,
+      info = function() end,
+    }
+
+    fake_custom_commands({
+      {
+        name = "mycmd",
+        description = "my custom command",
+        source = "project",
+        file_path = "/tmp/mycmd.md",
+        content = "do the thing",
+      },
+    })
+
+    Commands = require("vibing.application.chat.commands")
+    Commands.commands = {}
+    Commands.custom_commands = {}
+  end)
+
+  after_each(function()
+    package.loaded["vibing.application.chat.custom_commands"] = nil
+  end)
+
+  it("does not scan the disk just because the module was loaded", function()
+    assert.equals(0, scan_count)
+    assert.is_nil(Commands.custom_commands["mycmd"])
+  end)
+
+  it("scans on the first list_all() and registers what it found", function()
+    local all = Commands.list_all()
+
+    assert.equals(1, scan_count)
+    assert.is_not_nil(all["mycmd"])
+    assert.equals("my custom command", all["mycmd"].description)
+  end)
+
+  it("scans on the first execute() of an unknown command", function()
+    local handled, expanded = Commands.execute("/mycmd", nil)
+
+    assert.equals(1, scan_count)
+    assert.is_true(handled)
+    assert.equals("do the thing", expanded)
+  end)
+
+  it("scans only once across repeated use", function()
+    Commands.list_all()
+    Commands.list_all()
+    Commands.execute("/mycmd", nil)
+
+    assert.equals(1, scan_count)
+  end)
+
+  it("does not rescan after a scan that found nothing", function()
+    -- 失敗/空振りのたびに再スキャンすると、補完のキー入力ごとに数十msのI/Oが走る。
+    fake_custom_commands({})
+    package.loaded["vibing.application.chat.commands"] = nil
+    Commands = require("vibing.application.chat.commands")
+    Commands.commands = {}
+    Commands.custom_commands = {}
+
+    Commands.execute("/nope", nil)
+    Commands.execute("/nope", nil)
+    Commands.list_all()
+
+    assert.equals(1, scan_count)
+  end)
+
+  it("reload_custom() rescans and drops commands that no longer exist", function()
+    Commands.list_all()
+    assert.equals(1, scan_count)
+
+    fake_custom_commands({
+      { name = "other", description = "other", source = "project", file_path = "/tmp/o.md", content = "x" },
+    })
+
+    Commands.reload_custom()
+
+    assert.equals(1, scan_count) -- fake を差し替えたのでカウンタもリセットされている
+    assert.is_nil(Commands.custom_commands["mycmd"])
+    assert.is_not_nil(Commands.custom_commands["other"])
+  end)
+
+  it("a builtin command never triggers the scan", function()
+    Commands.register({ name = "save", handler = function() return true end, description = "save" })
+
+    Commands.execute("/save", nil)
+
+    assert.equals(0, scan_count)
+  end)
+end)

--- a/tests/lua/presentation/chat/buffer_schedule_spec.lua
+++ b/tests/lua/presentation/chat/buffer_schedule_spec.lua
@@ -83,27 +83,36 @@ describe("ChatBuffer:_try_schedule_instead_of_send", function()
   --- Build a ChatBuffer whose `:write` deterministically fails, WITHOUT changing its directory
   --- from tmp_root. This matters: the helper looks up the active limit via
   --- `LimitState.get_active(fnamemodify(chat_file_path, ":h"))`, and every test in this file
-  --- records the limit under `tmp_root`. An earlier version of this fixture pointed the buffer at
-  --- `tmp_root .. "/no-such-subdir/chat.md"` to force a write failure, which silently broke that
-  --- lookup (dirname became `tmp_root/no-such-subdir`, a different, empty store) — the helper then
-  --- returned false at the earlier "no active limit" guard, never reaching the save/arm code the
-  --- test claimed to cover. Pre-creating the target path itself as a directory reproduces a real
-  --- `:write` failure (can't write a file where a directory already exists) while keeping the
-  --- buffer's dirname exactly `tmp_root`, so the lookup still lines up.
+  --- records the limit under `tmp_root`. Get the path wrong and the helper returns false at the
+  --- earlier "no active limit" guard, never reaching the save/arm code the test claims to cover —
+  --- a vacuous pass. Two filesystem tricks were tried and both did exactly that:
+  ---
+  ---  1. Naming the buffer `tmp_root .. "/no-such-subdir/chat.md"`. The dirname became
+  ---     `tmp_root/no-such-subdir`, a different and empty store.
+  ---  2. Pre-creating `tmp_root/chat.md` as a *directory*, so a real `:write` cannot create a file
+  ---     there. But `nvim_buf_set_name` on a path that exists as a directory hands back a name
+  ---     with a **trailing slash** (`.../chat.md/`), so `:h` yields `.../chat.md` rather than
+  ---     `tmp_root` — the same mismatch by a different route. This is what the sanity assertion in
+  ---     the test below actually caught.
+  ---
+  --- So the write is failed at the buffer instead of at the filesystem: `:write` refuses a
+  --- buffer with 'readonly' set (E45, and the helper writes without `!`), which leaves `modified`
+  --- set — the exact signal the helper reads. The file name never has to exist or be special, so
+  --- the dirname stays `tmp_root` verbatim. It is also the only variant that holds when the suite
+  --- runs as root, which both chmod-based alternatives silently lose.
   --- @param message string
   --- @return table chat_buffer, string chat_path
   local function make_unwritable_buffer(message)
-    local chat_path = tmp_root .. "/chat.md"
-    vim.fn.mkdir(chat_path, "p")
-
     local bufnr = vim.api.nvim_create_buf(false, false)
     table.insert(created_bufs, bufnr)
-    vim.api.nvim_buf_set_name(bufnr, chat_path)
+    vim.api.nvim_buf_set_name(bufnr, tmp_root .. "/chat.md")
     vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
       "## User <!-- unsent -->",
       message,
     })
-    chat_path = vim.api.nvim_buf_get_name(bufnr)
+    vim.bo[bufnr].readonly = true
+
+    local chat_path = vim.api.nvim_buf_get_name(bufnr)
     table.insert(created_chat_paths, chat_path)
     local instance = setmetatable({ buf = bufnr, _pending_approval = nil }, ChatBuffer)
     return instance, chat_path


### PR DESCRIPTION
## 概要

`setup()` の同期ディスク I/O を起動パスから外し、実測で **32ms → 11ms**（約3倍）にしました。あわせて、調査中に見つかった既存のテスト失敗（macOS で `main` から落ちていたもの）を修正しています。

## なぜ起動時が問題になるか

`setup()` は毎回の Neovim 起動で必ず走ります。lazy.nvim の例に `cmd`/`event` トリガが無いのは意図的で、Claude Code がこの Neovim を発見するには RPC サーバーが listen して instance registry に載っている必要があるためです。つまり `setup()` がやることはすべてユーザーの起動時間に乗ります。

計測してみると、**モジュールツリーは原因ではありませんでした**。`setup()` が触る全モジュールの `require` は合計 ~9ms。残りは同期 I/O です。

```
修正前（ウォーム、合計 ~32ms）
  13.4 ms  custom_commands.get_all          ← 41%
   5.0 ms  rpc.server.start
   4.5 ms  hook_cleanup.cleanup_stale_dirs
   2.1 ms  commands.register_custom
   1.9 ms  completion.setup
   ...

修正後（ウォーム、合計 ~11ms）
   5.0 ms  rpc.server.start
   1.9 ms  completion.setup
   1.4 ms  adapter.factory.create
   1.1 ms  chat.setup
   0.0 ms  custom_commands.get_all
   0.0 ms  hook_cleanup.cleanup_stale_dirs
```

| | 修正前 | 修正後 |
| --- | --- | --- |
| `setup()` ウォーム | 32 ms | **11 ms** |
| `setup()` 全体（require 込み） | 38–40 ms | **18–23 ms** |

## 変更内容

### 1. カスタムスラッシュコマンドを初回利用時スキャンに

`custom_commands.scan()` はプロジェクト・ユーザー・**インストール済み Claude Code プラグイン全部**の `.claude/commands/*.md` を glob して、各ファイルを `readfile` で全文読み込みします。手元では **76ファイル / 約417KB / 13ms**。プラグインを入れるほど線形に増えます。

`commands.lua` が `ensure_custom_loaded()` でトリガを持つようにし、`execute()` と `list_all()`（= `M.custom_commands` の読み手はこの2つだけ）から発火させました。チャットを一度も開かないセッションはこのコストを一切払いません。

意図的にそうしている点が2つあります:

- **ロード済みフラグはスキャンの「前」に立てる。** 空振りしても再スキャンしないためです。`list_all()` は補完経路にあってキー入力ごとに走るので、毎回数十msの I/O を繰り返すほうが害が大きい。
- **`:VibingReloadCommands` は新設の `commands.reload_custom()` を通す。** 従来どおり外部から `commands.custom_commands = {}` すると、テーブルは空になるのにフラグが立ったままになり、カスタムコマンドが二度と復活しません。

副次的に、スキャンが初回利用時になったことで `vim.fn.getcwd()` も初回利用時に読まれるようになります。プロジェクトの `.claude/commands/` を拾う目的ではこちらのほうが正確です。

### 2. `hook_cleanup.cleanup_stale_dirs()` を `vim.schedule` に

hook が動くのは最初のリクエストが飛んだあとなので、`/tmp` の走査と削除を UI 表示前にやる理由がありません。

### 3. 既存のテスト失敗を修正（別コミット）

`buffer_schedule_spec.lua` の「保存に失敗したら予約しない（fail open）」ケースが、#560 以降 macOS で落ちていました。**実装ではなくフィクスチャのバグ**で、テスト自身が仕込んでいた sanity assertion がそれを検知していた形です。

`_try_schedule_instead_of_send` は `LimitState.get_active(fnamemodify(chat_file_path, ":h"))` でリミット記録を引くので、バッファの dirname が `tmp_root` と完全一致している必要があります。フィクスチャは `:write` を失敗させるために `tmp_root/chat.md` を**ディレクトリとして**先に作っていましたが、`nvim_buf_set_name` はディレクトリとして実在するパスを渡されると**末尾スラッシュ付きの名前を返します**:

```
buf_get_name = /private/.../0/chat.md/     ← 末尾スラッシュ
dirname (:h) = /private/.../0/chat.md      ← tmp_root ではない
lookup       = /private/.../0/chat.md/.vibing/limit-state.json   ← 空のストア
```

結果、検証したい保存失敗ガードに到達する前に「リミット記録なし」ガードで抜けていました。フィクスチャのコメント自身が「避けるために書いた」と言っているミスマッチが、別ルートから再発していたものです。

修正は、失敗をファイルシステムではなく**バッファ側**で起こす方式にしました。`'readonly'` を立てると `:write`（実装は `!` なしの `silent! write`）が E45 で拒否され、`modified` が立ったまま残ります。これは実装がまさに読んでいるシグナルそのものです。ファイル名に特別な状態が要らないので dirname が `tmp_root` のまま保たれ、chmod 系の代替案と違い **root で走らせても失敗しつづけます**（chmod だと root は素通りして黙って空振りに戻る）。

## テスト

- `tests/lua/application/chat/commands_lazy_custom_spec.lua` を新規追加（7ケース）。「起動時には呼ばれない」「使う直前には必ず呼ばれる」「空振りで再スキャンしない」「reload で消えたコマンドが落ちる」「ビルトインコマンドではスキャンしない」を、呼び出し回数そのもので固定しています。
- **Lua スイート全体: 1560 成功 / 0 失敗（exit 0）**
- 実動作確認: `setup()` 直後は登録 0 件 → `list_all()` で 32 件登録 → `reload_custom()` で 32 件維持
- テスト修正側は mutation で検証済み。`buffer.lua` の `modified` ガードを潰すと当該テストが落ちるので、名前どおりのブランチを覆っています

## ドキュメント

`.claude/rules/architecture.md` に `## Startup Cost` を追記し、なぜ `setup()` が eager でなければならないか、なぜフラグをスキャン前に立てるか、なぜ `reload_custom()` を経由するかを記録しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced startup time by deferring custom command discovery until commands are first used.
  - Moved stale hook-directory cleanup off the startup path.

- **New Features**
  - Added reliable custom-command reloading through `:VibingReloadCommands`.
  - Custom commands now load once, including when no commands are found, and can be refreshed on demand.

- **Bug Fixes**
  - Improved reload behavior to prevent stale or missing command registrations.
  - Fixed test coverage for failed writes in read-only buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->