### PR TITLE
perf: defer RPC server start and adapter creation off setup()

### DIFF
--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -48,19 +48,23 @@ function M.setup(opts)
     desc = "Apply correct wrap settings when entering any window",
   })
 
-  -- MCP統合の初期化
-  if M.config.mcp and M.config.mcp.enabled then
-    -- RPCサーバー起動
-    local rpc_server = require("vibing.infrastructure.rpc.server")
-    local port = rpc_server.start(M.config.mcp.rpc_port)
-    if port > 0 then
-      notify.info(string.format("MCP RPC server started on port %d", port))
+  -- MCP RPCサーバー起動とアダプター初期化はどちらも同期I/Oを伴う
+  -- （ポートbindの探索ループ・レジストリファイル書き込み・アダプターの長いrequire連鎖）。
+  -- セッション復元で ft=vibing バッファが開くと setup() が起動中に走るため、起動パスから外す。
+  -- 同一コールバック内で順に実行するので、RPCサーバーが受信可能になった時点でadapterは必ず存在する。
+  -- また後続の vim.schedule(auto_resume.restore 等) より先に登録されるため、実行順も従来通り。
+  vim.schedule(function()
+    if M.config.mcp and M.config.mcp.enabled then
+      local rpc_server = require("vibing.infrastructure.rpc.server")
+      local port = rpc_server.start(M.config.mcp.rpc_port)
+      if port > 0 then
+        notify.info(string.format("MCP RPC server started on port %d", port))
+      end
     end
-  end
 
-  -- アダプターの初期化
-  local adapter_factory = require("vibing.infrastructure.adapter.factory")
-  M.adapter = adapter_factory.create(M.config.adapter, M.config)
+    local adapter_factory = require("vibing.infrastructure.adapter.factory")
+    M.adapter = adapter_factory.create(M.config.adapter, M.config)
+  end)
 
   -- Cleanup stale hook communication directories from previous sessions.
   -- 起動直後に必要な処理ではない（hookが動くのは最初のリクエスト時）ので、/tmp のscanと

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -133,6 +133,11 @@ describe("vibing.init", function()
     it("should initialize adapter", function()
       Vibing.setup()
 
+      -- Adapter creation is deferred via vim.schedule to keep it off the
+      -- startup path; drain the scheduled callback before asserting.
+      vim.wait(1000, function()
+        return Vibing.adapter ~= nil
+      end)
       assert.is_not_nil(Vibing.adapter)
     end)
 
@@ -684,6 +689,10 @@ describe("vibing.init", function()
 
       assert.is_true(config_setup_called)
       assert.is_true(chat_setup_called)
+      -- Adapter creation is deferred via vim.schedule (see setup); drain it.
+      vim.wait(1000, function()
+        return Vibing.adapter ~= nil
+      end)
       assert.is_not_nil(Vibing.adapter)
       -- Should have at least 8 commands
       assert.is_true(commands_registered >= 8)


### PR DESCRIPTION
## Summary

`setup()` が起動パス上で行っていた同期処理2つを `vim.schedule` に移し、セッション復元で `ft=vibing` バッファが開いた際の起動ブロック（プラグインロード ~25ms の大半）を解消します。

- **RPC サーバー起動**: ポート探索の blocking bind/listen ループ + レジストリファイル書き込み
- **アダプター生成**: `claude_cli` の長い require 連鎖（トップレベルで8モジュール）

## Design notes

- 両者を**同一の schedule コールバック内で順に実行**するため、RPC サーバーがリクエストを受け付ける時点でアダプターは必ず存在します
- このコールバックは既存の `auto_resume.restore` / `hook_cleanup` の schedule より先に登録されるので、それらがアダプター初期化後に走る従来の実行順も維持されます

## Test plan

- [x] `ft=vibing` バッファでプラグインをロードし、schedule 実行後に `get_adapter() ~= nil` と RPC サーバー稼働を確認（headless）
- [x] dotfiles 側の起動計測: headless 70ms → 37ms（本変更と dotfiles 側の遅延化の合算）

🤖 Generated with [Claude Code](https://claude.com/claude-code)