### PR TITLE
fix: stop gx URL extraction at Japanese punctuation

### DIFF
--- a/lua/vibing/presentation/chat/modules/keymap_handler.lua
+++ b/lua/vibing/presentation/chat/modules/keymap_handler.lua
@@ -12,6 +12,47 @@ local URL_PAT = "(https?://[^ \t\n<>\"'`]+)"
 -- 末尾から削る Markdown 装飾（**bold**, `code`）と句読点
 local TRAILING_PUNCT_PAT = "[%*`.,;:!?]+$"
 
+-- URL の終端として扱う非 ASCII 文字のコードポイント範囲。
+-- 生の非 ASCII は RFC 3986 上 URL に使えないが `https://ja.wikipedia.org/wiki/日本語`
+-- のように貼られること自体はあるため、非 ASCII を丸ごと区切りにはせず
+-- 「URL 中に現れることがない約物・記号」だけを終端にする。
+-- Lua パターンの文字クラスに多バイト文字を書く方式は取れない（バイト単位の集合に
+-- なるため、`、`(E3 80 81) を除外すると先頭バイト E3 を共有するひらがな・カタカナ
+-- ごと弾いてしまう）。UTF-8 のコードポイントで判定する。
+local NON_ASCII_TERMINATORS = {
+  { 0x2000, 0x206F }, -- General Punctuation（“ ” … – — 各種スペース）
+  { 0x3000, 0x303F }, -- CJK 記号・約物（　、。「」『』【】〈〉《》〜）
+  { 0x30FB, 0x30FB }, -- ・（U+30FC の `ー` は語中に現れるので含めない）
+  { 0xFF01, 0xFF0F }, -- ！＂＃＄％＆＇（）＊＋，－．／
+  { 0xFF1A, 0xFF20 }, -- ：；＜＝＞？＠
+  { 0xFF3B, 0xFF40 }, -- ［＼］＾＿｀
+  { 0xFF5B, 0xFF65 }, -- ｛｜｝～ と半角カナ約物 ｡｢｣､･
+}
+
+---@param cp number コードポイント
+---@return boolean
+local function is_terminator(cp)
+  for _, range in ipairs(NON_ASCII_TERMINATORS) do
+    if cp >= range[1] and cp <= range[2] then
+      return true
+    end
+  end
+  return false
+end
+
+---URL を最初の非 ASCII 約物の直前で切る（`.../300（draft、…` → `.../300`）。
+---@param url string
+---@return string
+local function truncate_at_non_ascii_punct(url)
+  for i = 0, vim.fn.strchars(url) - 1 do
+    local cp = vim.fn.strgetchar(url, i)
+    if cp >= 0x80 and is_terminator(cp) then
+      return vim.fn.strcharpart(url, 0, i)
+    end
+  end
+  return url
+end
+
 -- 閉じ括弧 → 対応する開き括弧
 local CLOSERS = { [")"] = "(", ["]"] = "[", ["}"] = "{" }
 
@@ -61,12 +102,12 @@ function M.find_url_on_line(line, col)
 
   local search_pos = 1
   while true do
-    local url_start, raw_end, url = line:find(URL_PAT, search_pos)
+    local url_start, _, url = line:find(URL_PAT, search_pos)
     if not url_start then
       break
     end
 
-    url = trim_url(url)
+    url = trim_url(truncate_at_non_ascii_punct(url))
     local url_end = url_start + #url - 1
 
     if col >= url_start and col <= url_end then
@@ -77,8 +118,10 @@ function M.find_url_on_line(line, col)
       best_dist = dist
       found_url = url
     end
-    -- 広くマッチした範囲全体をスキップ（トリムした末尾を再走査しない）
-    search_pos = raw_end + 1
+    -- 確定した URL の直後から再開する。raw マッチ末尾まで飛ばすと
+    -- `https://a、https://b` のように空白なしで区切られた2つ目を取りこぼす。
+    -- URL は必ず `http://` 以上の長さなので search_pos は前進する。
+    search_pos = url_start + #url
   end
 
   return found_url

--- a/tests/lua/presentation/chat/modules/keymap_handler_spec.lua
+++ b/tests/lua/presentation/chat/modules/keymap_handler_spec.lua
@@ -3,6 +3,10 @@
 -- gx (open_url) は行内の URL を抽出して vim.ui.open に渡す。Markdown 装飾や括弧で
 -- 囲まれた URL の閉じ記号を取り込むと 404 になる一方、URL 自体に括弧・アスタリスク・
 -- IPv6 のブラケットを含む正当な URL は保持しなければならない。両立を回帰で守る。
+--
+-- 全角括弧・読点も同じ構図で、`.../pull/300（draft、…` を丸ごと URL として渡すと
+-- ブラウザが percent-encode して 404 になる。一方 `wiki/日本語` のように非 ASCII の
+-- 文字そのものが URL の一部であるケースは保持する必要がある。
 
 local KeymapHandler = require("vibing.presentation.chat.modules.keymap_handler")
 
@@ -93,6 +97,74 @@ describe("keymap_handler.find_url_on_line", function()
         assert.equals(c.want, url_at(c.line))
       end)
     end
+  end)
+
+  describe("stops at Japanese punctuation adjoining the URL", function()
+    local cases = {
+      {
+        name = "full-width paren right after the URL",
+        line = "**PR**: https://github.com/o/r/pull/300（draft、コミット 9 本）。本文も更新済みです。",
+        want = "https://github.com/o/r/pull/300",
+      },
+      {
+        name = "ideographic comma right after the URL",
+        line = "参照: https://example.com/a、あとで見る",
+        want = "https://example.com/a",
+      },
+      {
+        name = "ideographic full stop right after the URL",
+        line = "詳細は https://example.com/b。",
+        want = "https://example.com/b",
+      },
+      {
+        name = "corner brackets around the URL",
+        line = "「https://example.com/c」を参照",
+        want = "https://example.com/c",
+      },
+      {
+        name = "ideographic space after the URL",
+        line = "https://example.com/d\227\128\128次の語",
+        want = "https://example.com/d",
+      },
+    }
+
+    for _, c in ipairs(cases) do
+      it(c.name, function()
+        assert.equals(c.want, url_at(c.line))
+      end)
+    end
+  end)
+
+  describe("keeps non-ASCII letters that are part of the URL", function()
+    local cases = {
+      {
+        name = "kanji in the path",
+        line = "https://ja.wikipedia.org/wiki/日本語",
+        want = "https://ja.wikipedia.org/wiki/日本語",
+      },
+      {
+        name = "katakana long vowel mark in the path",
+        line = "https://example.com/サーバー",
+        want = "https://example.com/サーバー",
+      },
+      {
+        name = "kanji path followed by Japanese punctuation",
+        line = "https://ja.wikipedia.org/wiki/日本語（言語）を参照",
+        want = "https://ja.wikipedia.org/wiki/日本語",
+      },
+    }
+
+    for _, c in ipairs(cases) do
+      it(c.name, function()
+        assert.equals(c.want, url_at(c.line))
+      end)
+    end
+  end)
+
+  it("finds the second URL when two are separated only by a comma", function()
+    local line = "https://example.com/one、https://example.com/two"
+    local col = line:find("two")
+    assert.equals("https://example.com/two", KeymapHandler.find_url_on_line(line, col))
   end)
 
   it("returns the URL under the cursor when several are on the line", function()


### PR DESCRIPTION
## 概要

チャットバッファで `gx` を押すと、URL の直後に続く全角括弧・読点まで URL として拾ってしまい、ブラウザが percent-encode して 404 になっていた。

```
**PR**: https://github.com/o/r/pull/300（draft、コミット 9 本）。
                                        ^^^^^^^^^^^^^^^^^^ ここまで URL 扱い
```

## 原因

`gx` は Neovim 組み込みではなく vibing.nvim 自前の実装（`keymap_handler.find_url_on_line`）。`URL_PAT` が「空白と `<>"'` 以外は全部 URL」という広いマッチで、全角約物はここに引っかからない。後段の `trim_url` は半角の閉じ括弧と ASCII 句読点しか削らないため素通りしていた。

## 修正

`URL_PAT` の文字クラスに多バイト文字を書き足す方式は取れない。Lua パターンの文字クラスはバイト単位の集合なので、`、`(E3 80 81) を除外すると先頭バイト E3 を共有するひらがな・カタカナごと弾かれる。

そこでマッチ後に UTF-8 コードポイントで走査し、**最初の「URL に現れない非 ASCII 約物」の直前で切る**ようにした。終端扱いにするのは約物・記号だけで、非 ASCII を丸ごと区切りにはしていない — `https://ja.wikipedia.org/wiki/日本語` のように生の日本語を含む URL が貼られること自体はあるため。`ー`(U+30FC) は `サーバー` のように語中に現れるので範囲から意図的に外している。

あわせて、再走査の開始位置を raw マッチ末尾から確定した URL の直後に変更した。従来は `https://a、https://b` のように空白なしで並んだ 2 つ目を取りこぼしていた。

## テスト

`tests/lua/presentation/chat/modules/keymap_handler_spec.lua` に回帰を追加。

- 全角括弧 / 読点 / 句点 / 「」 / 全角スペースで終端する
- 漢字・カタカナがパスの一部である URL は保持する（`ー` を含むものも）
- 読点だけで区切られた 2 つ目の URL を拾える

`pnpm run test:lua` は該当 spec 24 件すべて成功、スイート全体も exit 0。

`pnpm run check` は実行環境に `luac` が入っておらず未実行（本変更とは無関係）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL detection around non-ASCII punctuation, including Japanese punctuation.
  * Preserved valid non-ASCII characters within URL paths.
  * Enabled reliable detection of adjacent URLs separated by punctuation or spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->