### PR TITLE
fix: bound and clean the input to :VibingSummarize

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -348,12 +348,12 @@ via `/model` slash command.
 `effort` is the second cost/quality knob, passed to the CLI as `--effort`. Unlike `model` it is
 **omitted unless configured**: with no `agent.default_effort` vibing.nvim passes no flag and the
 CLI applies its own default, which Anthropic tunes over time — pinning a level here would freeze
-it. Set it per chat with `/effort`. Lightweight calls (title generation, `/summarize`, daily
-summary) use `agent.utility_effort` (default `low`) instead. It does **not** pair with a cheap
-model: `utility_model` defaults to `sonnet`, because those calls summarize a noisy chat transcript
-and haiku measurably picks the wrong subject. Low effort on a capable model is the trade actually
-being made here. An unrecognised level is dropped with a warning rather than passed
-through: the CLI accepts unknown levels silently and then ignores them.
+it. Set it per chat with `/effort`. Lightweight calls (title generation, `/summarize`,
+`:VibingSummarize`, daily summary) use `agent.utility_effort` (default `low`) instead. It does
+**not** pair with a cheap model: `utility_model` defaults to `sonnet`, because those calls
+summarize a noisy chat transcript and haiku measurably picks the wrong subject. Low effort on a
+capable model is the trade actually being made here. An unrecognised level is dropped with a
+warning rather than passed through: the CLI accepts unknown levels silently and then ignores them.
 
 **Lightweight calls are restricted differently per backend, because the CLIs differ in kind.**
 Claude removes the tools outright with `--tools ""`. Codex cannot: probing its config schema with

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -143,27 +143,124 @@ local function has_conversation_content(conversation)
 end
 
 ---Maximum number of messages to include in summary (to avoid token limits)
-local MAX_MESSAGES_FOR_SUMMARY = 50
+M.MAX_MESSAGES_FOR_SUMMARY = 50
+
+---1メッセージあたりの上限（文字数）。
+---
+---件数の上限だけでは効かない。実測したチャットは43通で `MAX_MESSAGES_FOR_SUMMARY` に
+---掛からないまま261,741文字あり、うち1通が76,026バイトだった。1通ぶんを縛らないと、
+---会話全体の上限を掛けても「巨大な1通だけが残る」形になる。
+M.MAX_MESSAGE_CHARS = 3000
+
+---会話全体の上限（文字数）。
+---
+---`title_generator` が抜粋を6,000文字に縛っているのと同じ理由で、こちらにも上限が要る。
+---要約は決定と却下理由が本体なので抜粋よりずっと厚く取るが、上限そのものは要る:
+---長すぎるとモデルが `prompts/chat_summary.md` の出力形式を守れなくなり、先頭行が
+---`## summary` にならない応答を `summary_inserter` が丸ごと捨てる（= 課金だけされて
+---何も挿入されない）。
+M.MAX_TOTAL_CHARS = 60000
+
+---中略したことを明示するマーカー。黙って落とすと、要約が会話の一部しか見ていないことが
+---読む側にもモデルにも分からない。
+M.OMISSION_MARKER = "(… 古いメッセージは省略 …)"
+
+---長すぎるメッセージを中略する。前半と後半の両方を残すのは、assistant の応答では
+---「何をしようとしたか」が冒頭に、「何が決まったか」が末尾に来るため。末尾を捨てると
+---要約の本体である決定事項がそのまま落ちる。
+---@param text string
+---@param max_chars integer
+---@return string
+local function elide_middle(text, max_chars)
+  local len = vim.fn.strchars(text)
+  if len <= max_chars then
+    return text
+  end
+
+  local head = math.floor(max_chars * 2 / 3)
+  local tail = max_chars - head
+  return vim.fn.strcharpart(text, 0, head)
+    .. "\n(… 中略 …)\n"
+    .. vim.fn.strcharpart(text, len - tail, tail)
+end
+
+---要約に渡すメッセージを選ぶ。
+---
+---ここが `:VibingSummarize` と `title_generator` の分かれ目になる。タイトル生成は
+---`chat_excerpt.build` をそのまま使えるが、要約は使えない: `build` は assistant を冒頭2通・
+---各400文字しか残さない設計で、要約の本体である「何を決め、何を却下したか」が
+---ちょうど落ちる。そこで `chat_excerpt` からはノイズ除去（`clean` / `clean_user`）だけを
+---借りて、件数と文字数の制限は要約用に別途かける。
+---@param conversation {role: string, content: string}[]
+---@return {role: string, content: string}[] messages 新しい順ではなく時系列順
+---@return boolean omitted 落としたメッセージがあるか
+function M._select_messages_for_summary(conversation)
+  local ChatExcerpt = require("vibing.core.utils.chat_excerpt")
+
+  local cleaned = {}
+  for _, msg in ipairs(conversation or {}) do
+    local text = msg.role == "user" and ChatExcerpt.clean_user(msg.content) or ChatExcerpt.clean(msg.content)
+    -- クリーニングで全部消える会話（応答がフェンス済みコードブロックだけ等）は実在する。
+    -- 空の <conversation> を送るより、生のテキストを中略して送るほうがまだ要約になる。
+    if text == "" then
+      text = msg.content or ""
+    end
+    if vim.trim(text) ~= "" then
+      cleaned[#cleaned + 1] = { role = msg.role, content = elide_middle(text, M.MAX_MESSAGE_CHARS) }
+    end
+  end
+
+  if #cleaned == 0 then
+    return {}, false
+  end
+
+  -- 新しい側から詰める。引き継ぎ要約の読者が知りたいのは「どこまで進んだか」なので、
+  -- 予算が足りないときに落とすのは古いほうが正しい。
+  local selected = {}
+  local budget = M.MAX_TOTAL_CHARS
+  for i = #cleaned, 1, -1 do
+    if #selected >= M.MAX_MESSAGES_FOR_SUMMARY then
+      break
+    end
+    local cost = vim.fn.strchars(cleaned[i].content)
+    if budget - cost < 0 and #selected > 0 then
+      break
+    end
+    budget = budget - cost
+    table.insert(selected, 1, cleaned[i])
+  end
+
+  local omitted = #selected < #cleaned
+
+  -- 会話の主題は最初の依頼にある。予算で落ちたときだけ先頭に戻す。1通は中略済みなので
+  -- 超過は高々 MAX_MESSAGE_CHARS で、これは上限を緩めるのではなく上限の外の固定費。
+  if omitted and selected[1] ~= cleaned[1] then
+    table.insert(selected, 1, cleaned[1])
+  end
+
+  return selected, omitted
+end
 
 ---Format conversation for summary prompt with XML protection
 ---@param conversation table[]
 ---@return string
 local function format_conversation_for_prompt(conversation)
-  -- Trim to last N messages if conversation is too long
-  local messages = conversation
-  if #conversation > MAX_MESSAGES_FOR_SUMMARY then
-    messages = {}
-    local start_idx = #conversation - MAX_MESSAGES_FOR_SUMMARY + 1
-    for i = start_idx, #conversation do
-      table.insert(messages, conversation[i])
-    end
-  end
+  local messages, omitted = M._select_messages_for_summary(conversation)
 
   local parts = {}
-  for _, msg in ipairs(messages) do
+  for i, msg in ipairs(messages) do
+    -- 省略マーカーは先頭の依頼の直後に置く。先頭は主題の固定用に戻したものなので、
+    -- そこと次のメッセージのあいだが実際に飛んでいる箇所になる。
+    if omitted and i == 2 then
+      parts[#parts + 1] = M.OMISSION_MARKER
+    end
     -- Wrap in XML tags to prevent prompt injection
     table.insert(parts, string.format("<message role=\"%s\">\n%s\n</message>", msg.role, msg.content))
   end
+  if omitted and #messages < 2 then
+    parts[#parts + 1] = M.OMISSION_MARKER
+  end
+
   return "<conversation>\n" .. table.concat(parts, "\n") .. "\n</conversation>"
 end
 
@@ -227,7 +324,9 @@ function M.generate_and_insert_summary(chat_buffer)
   -- Capture buffer reference for async callback validation
   local buf = chat_buffer.buf
 
-  adapter:stream(full_prompt, {}, function(_) end, function(response)
+  -- 要約はタイトル生成と同じ軽量ユーティリティ呼び出し: ツールも CLAUDE.md も
+  -- ユーザーの MCP サーバーも要らず、載せた分だけコンテキストを食う。
+  adapter:stream(full_prompt, { lightweight = true }, function(_) end, function(response)
     -- Re-validate buffer in async callback (buffer may be deleted during AI processing)
     if not buf or not vim.api.nvim_buf_is_valid(buf) then
       notify.warn("Chat buffer was closed during summary generation")

--- a/lua/vibing/core/utils/chat_excerpt.lua
+++ b/lua/vibing/core/utils/chat_excerpt.lua
@@ -121,6 +121,94 @@ local function paren_balance(s)
   return opens - closes
 end
 
+-- ツールヘッダーの引数を追う行数の上限。ここまでに括弧の釣り合いが取れなければ、
+-- 空行での打ち切り（保守的な旧挙動）にフォールバックする。
+local MAX_TOOL_HEADER_LINES = 500
+
+---行が開く heredoc の終端デリミタを集める。
+---
+---heredoc の本文はシェルのコードではなく**データ**なので、そこの括弧を数えてはいけない。
+---実測したチャットでは `python3 - <<'PY'` の本文にある `s.replace("""..."""` のような
+---複数行文字列が釣り合いを崩し、ブロックの終端を見失って heredoc の中身（書き込む markdown や
+---スクリプト）が地の文として残っていた。
+---@param line string
+---@param pending string[] 見つけたデリミタの追記先
+local function collect_heredoc_delimiters(line, pending)
+  -- herestring (`<<<`) は heredoc ではないので先に潰す
+  local s = line:gsub("<<<", "  ")
+  for name in s:gmatch("<<%-?%s*'([%a_][%w_]*)'") do
+    pending[#pending + 1] = name
+  end
+  for name in s:gmatch('<<%-?%s*"([%a_][%w_]*)"') do
+    pending[#pending + 1] = name
+  end
+  -- 引用符なしの `<<EOF`。上2つの形は `<<` の次が引用符なのでここには落ちてこない。
+  -- 先頭を `[%a_]` に限るのは `x << 2`（シフト）を拾わないため。
+  for name in s:gmatch("<<%-?%s*([%a_][%w_]*)") do
+    pending[#pending + 1] = name
+  end
+end
+
+---ツールヘッダーの引数ブロックが終わった次の行番号を返す。
+---
+---描画形式は `\n<marker> <Tool>(<input>)\n` の1ブロックで、`<input>` は
+---`tool_input.command` の生文字列なので heredoc のように**空行を含む複数行**になりうる。
+---だから空行では打ち切れない。打ち切ると heredoc の中身（書き込む markdown や python
+---スクリプト）がそのまま地の文として残り、タイトル生成にも `:VibingSummarize` の入力にも
+---入り込む。実測では1つのチャットでこれが数万文字を占めていた。
+---
+---とはいえ括弧の釣り合いだけに頼ると `case x)` のような釣り合わないコマンドで後続の地の文を
+---丸ごと食べる。そこで2段構えにしてある: 上限行数までに釣り合いが取れればそこで終端し、
+---取れなければ最初の空行で打ち切る。後者は以前からの挙動そのもので、「食べ過ぎるより
+---食べ足りないほうがまし」という判断は変えていない。
+---@param lines string[]
+---@param start integer ヘッダー行の行番号
+---@return integer next 次に処理する行番号
+local function tool_header_end(lines, start)
+  local pending = {}
+  local balance = paren_balance(lines[start])
+  collect_heredoc_delimiters(lines[start], pending)
+
+  if balance <= 0 and #pending == 0 then
+    return start + 1
+  end
+
+  local first_blank
+  local limit = math.min(#lines, start + MAX_TOOL_HEADER_LINES)
+  for i = start + 1, limit do
+    if #pending > 0 then
+      -- heredoc 本文。括弧も空行も見ない（本文の空行で打ち切るのがまさに漏れの原因だった）
+      --
+      -- 終端行は `PY` だけとは限らない。描画は `<marker> Tool(<command>)` なので、
+      -- コマンドが heredoc で終わっていると最後の行は `PY)` になる。閉じ括弧はデリミタの
+      -- 一部ではなく描画側のものなので、そこだけ数に入れる。
+      local closing = vim.trim(lines[i]):match("^" .. vim.pesc(pending[1]) .. "(%)*)$")
+      if closing then
+        table.remove(pending, 1)
+        if #pending == 0 then
+          balance = balance + paren_balance(closing)
+          if balance <= 0 then
+            return i + 1
+          end
+        end
+      end
+    else
+      balance = balance + paren_balance(lines[i])
+      if balance <= 0 then
+        return i + 1
+      end
+      collect_heredoc_delimiters(lines[i], pending)
+      if not first_blank and vim.trim(lines[i]) == "" then
+        first_blank = i
+      end
+    end
+  end
+
+  -- 上限まで釣り合わなかった。空行が無ければヘッダー1行だけ落とす: 残り全部を食べる
+  -- 旧挙動より、地の文を残すほうが安全側に倒れる。
+  return first_blank or (start + 1)
+end
+
 ---@param text string
 ---@param glyphs string[]
 ---@param allow_glyph_prefix boolean マーカーで始まるだけの行もツール実況として落とすか（assistant のみ）
@@ -161,15 +249,7 @@ local function clean_with(text, glyphs, allow_glyph_prefix)
       end
       i = i + 1
     elseif is_tool_header(trimmed, glyphs, allow_glyph_prefix) then
-      -- ヘッダーの引数は複数行になりうる（Bashの複数行コマンド等）。括弧の釣り合いで終端を探す。
-      -- 空行でも打ち切るのは、`case x)` のように釣り合わない括弧を含むコマンドで
-      -- 後続の地の文まで丸ごと食べてしまわないため。
-      local balance = paren_balance(line)
-      i = i + 1
-      while i <= #lines and balance > 0 and vim.trim(lines[i]) ~= "" do
-        balance = balance + paren_balance(lines[i])
-        i = i + 1
-      end
+      i = tool_header_end(lines, i)
     elseif
       trimmed:match("^@file:")
       or trimmed:match("^Context:")

--- a/tests/lua/application/chat/summary_input_spec.lua
+++ b/tests/lua/application/chat/summary_input_spec.lua
@@ -1,0 +1,160 @@
+-- `:VibingSummarize` の入力側の上限を固定する。
+--
+-- 発端は 43通 / 261,741文字のチャットで要約が一度も通らなかったこと。当時の上限は
+-- `MAX_MESSAGES_FOR_SUMMARY`（件数）だけで、43通は上限に掛からず全文がそのまま1プロンプトに
+-- なった（うち1通で76,026バイト）。実測では 110,497 トークンを消費して応答自体は返るが、
+-- モデルが `prompts/chat_summary.md` の出力形式を守れず先頭行が `## summary` にならないため、
+-- `summary_inserter` が応答を丸ごと捨てて "Invalid summary format" だけが残る。
+--
+-- つまりここで守っているのは「送る量」であって、要約の文面ではない。件数の上限だけでは
+-- この症状を防げないことがこのファイルの主題なので、文字数の主張を件数の主張に
+-- 置き換えないこと。
+
+local use_case = require("vibing.application.chat.use_case")
+
+---@param n integer
+---@param char string
+---@return string
+local function filler(n, char)
+  return string.rep(char or "あ", n)
+end
+
+describe("summary prompt input", function()
+  it("strips tool transcript noise before sending", function()
+    local conversation = {
+      { role = "user", content = "レイヤー構成を整理して" },
+      {
+        role = "assistant",
+        content = table.concat({
+          "分類の方針を決めます。",
+          "⏺ Read(lua/vibing/init.lua)",
+          "  ⎿ local M = {}",
+          "     return M",
+          "handler → service → repository の一方向にします。",
+        }, "\n"),
+      },
+    }
+
+    local prompt = assert(use_case._build_summary_prompt(conversation))
+
+    assert.is_truthy(prompt:find("handler → service → repository", 1, true))
+    assert.is_nil(prompt:find("Read(lua/vibing/init.lua)", 1, true), "tool header reached the prompt")
+    assert.is_nil(prompt:find("local M = {}", 1, true), "tool result reached the prompt")
+  end)
+
+  it("elides an oversized message from the middle, keeping both ends", function()
+    local content = "決定の前置き" .. filler(20000) .. "最終的にrepositoryへ寄せる"
+    local prompt = assert(use_case._build_summary_prompt({
+      { role = "assistant", content = content },
+    }))
+
+    assert.is_truthy(prompt:find("決定の前置き", 1, true), "the head of the message was dropped")
+    assert.is_truthy(prompt:find("最終的にrepositoryへ寄せる", 1, true), "the tail of the message was dropped")
+    assert.is_true(vim.fn.strchars(prompt) < vim.fn.strchars(content), "nothing was elided")
+  end)
+
+  it("bounds the whole prompt for a conversation the size of the one that broke it", function()
+    -- 実測ベース: 43通、assistant 1通あたり最大 76,026 バイト、合計 261,741 文字。
+    local conversation = { { role = "user", content = "レイヤー構成規約を策定したい" } }
+    for i = 1, 21 do
+      conversation[#conversation + 1] = { role = "assistant", content = "応答" .. i .. filler(12000) }
+      conversation[#conversation + 1] = { role = "user", content = "続けて" .. i }
+    end
+
+    local prompt = assert(use_case._build_summary_prompt(conversation))
+
+    assert.is_true(
+      vim.fn.strchars(prompt) <= use_case.MAX_TOTAL_CHARS + 10000,
+      ("prompt was %d chars"):format(vim.fn.strchars(prompt))
+    )
+  end)
+
+  it("keeps the opening request when older messages are dropped for budget", function()
+    local conversation = { { role = "user", content = "最初の依頼: レイヤー構成規約を策定したい" } }
+    for i = 1, 40 do
+      conversation[#conversation + 1] = { role = "assistant", content = filler(8000) }
+    end
+    conversation[#conversation + 1] = { role = "user", content = "最後の依頼: PRを出して" }
+
+    local prompt = assert(use_case._build_summary_prompt(conversation))
+
+    assert.is_truthy(prompt:find("最初の依頼", 1, true), "the opening request was dropped")
+    assert.is_truthy(prompt:find("最後の依頼", 1, true), "the newest message was dropped")
+  end)
+
+  it("says so in the prompt when messages were dropped", function()
+    local conversation = {}
+    for i = 1, 60 do
+      conversation[#conversation + 1] = { role = "user", content = "依頼" .. i .. filler(4000) }
+    end
+
+    local prompt = assert(use_case._build_summary_prompt(conversation))
+
+    assert.is_truthy(prompt:find(use_case.OMISSION_MARKER, 1, true), "the elision was silent")
+  end)
+
+  it("leaves a short conversation untouched", function()
+    local prompt = assert(use_case._build_summary_prompt({
+      { role = "user", content = "これは短い依頼" },
+      { role = "assistant", content = "これは短い応答" },
+    }))
+
+    assert.is_truthy(prompt:find('<message role="user">\nこれは短い依頼\n</message>', 1, true))
+    assert.is_truthy(prompt:find('<message role="assistant">\nこれは短い応答\n</message>', 1, true))
+    assert.is_nil(prompt:find(use_case.OMISSION_MARKER, 1, true), "a short conversation was elided")
+  end)
+
+  it("falls back to the raw text when cleaning removes everything", function()
+    -- 応答がフェンス済みコードブロックだけ、という会話は実在する。クリーニングは
+    -- コードブロックを丸ごと落とすので、そのまま渡すと空の <conversation> が飛ぶ。
+    local conversation = {
+      { role = "assistant", content = "```lua\nlocal M = {}\nreturn M\n```" },
+    }
+
+    local prompt = assert(use_case._build_summary_prompt(conversation))
+
+    assert.is_truthy(prompt:find("local M = {}", 1, true), "the only content in the chat was dropped")
+  end)
+end)
+
+describe("summary call options", function()
+  local captured_opts
+
+  before_each(function()
+    captured_opts = nil
+    package.loaded["vibing"] = {
+      get_config = function()
+        return { permissions = { mode = "acceptEdits", allow = { "Read" }, deny = { "Bash" } } }
+      end,
+      get_adapter = function()
+        return {
+          stream = function(_, _prompt, opts, _on_chunk, on_done)
+            captured_opts = opts
+            on_done({ error = "stubbed" })
+          end,
+        }
+      end,
+    }
+  end)
+
+  after_each(function()
+    package.loaded["vibing"] = nil
+  end)
+
+  it("marks the call lightweight, like the /summarize handler does", function()
+    -- 非 lightweight だと frontmatter の model（opus 等）に加えて全ツール・CLAUDE.md・
+    -- ユーザーの MCP サーバー定義・開いているバッファの context prefix まで載る。要約には
+    -- どれも要らず、コンテキストだけを食う。
+    use_case.generate_and_insert_summary({
+      buf = vim.api.nvim_create_buf(false, true),
+      is_sending = function()
+        return false
+      end,
+      extract_conversation = function()
+        return { { role = "user", content = "hi" } }
+      end,
+    })
+
+    assert.is_true(captured_opts.lightweight)
+  end)
+end)

--- a/tests/lua/core/utils/chat_excerpt_spec.lua
+++ b/tests/lua/core/utils/chat_excerpt_spec.lua
@@ -242,3 +242,91 @@ describe("chat_excerpt.build", function()
     assert.is_true(vim.fn.strchars(excerpt) <= 6001)
   end)
 end)
+
+describe("chat_excerpt.clean heredoc bodies in tool headers", function()
+  it("does not count parens inside a heredoc body", function()
+    -- 本文はシェルのコードではなくデータ。python の複数行文字列のように釣り合わない括弧を
+    -- 含むと、数えたとたんブロックの終端を見失って中身が地の文として残る。
+    local text = table.concat({
+      "計測します。",
+      "💻 Bash(python3 - <<'PY'",
+      'p = pathlib.Path("plan.md")',
+      's = s.replace("""## リスク',
+      "",
+      '## リスク""")',
+      "PY",
+      "wc -l plan.md)",
+      "計測しました。",
+    }, "\n")
+
+    assert.equals("計測します。\n計測しました。", chat_excerpt.clean(text))
+  end)
+
+  it("ends the block on a terminator carrying the render's own closing paren", function()
+    -- 描画は `<marker> Tool(<command>)` なので、コマンドが heredoc で終わると最後の行は
+    -- `PY)` になる。`PY` だけを探すと終端を見つけられない。
+    local text = "💻 Bash(python3 - <<'PY'\nprint(1)\nPY)\n実測しました。"
+
+    assert.equals("実測しました。", chat_excerpt.clean(text))
+  end)
+
+  it("does not end a heredoc on a word that merely starts with the delimiter", function()
+    local text = table.concat({
+      "💻 Bash(cat <<'PY'",
+      "PYTHON",
+      "PY)",
+      "書きました。",
+    }, "\n")
+
+    assert.equals("書きました。", chat_excerpt.clean(text))
+  end)
+
+  it("treats a herestring as an ordinary argument, not a heredoc", function()
+    -- `<<<` は heredoc ではない。デリミタとして拾うと終端が永遠に来ず、
+    -- 続く地の文まで落としてしまう。
+    local text = "💻 Bash(grep x <<< \"$y\")\n見つかりました。"
+
+    assert.equals("見つかりました。", chat_excerpt.clean(text))
+  end)
+end)
+
+describe("chat_excerpt.clean tool headers spanning blank lines", function()
+  it("follows a heredoc command past its blank lines to the closing paren", function()
+    -- 描画は `<marker> Tool(<command>)` の1ブロックで、command は生文字列なので heredoc の
+    -- 空行がそのまま入る。空行で打ち切ると heredoc の中身が地の文として残り、書き込んだ
+    -- markdown やスクリプトが要約・タイトルの入力に混ざる。
+    local text = table.concat({
+      "適用結果を追記します。",
+      "💻 Bash(cat >> report.md <<'MD'",
+      "",
+      "## 適用結果",
+      "",
+      "判定表どおりに移動した。",
+      "MD",
+      "wc -l report.md)",
+      "追記しました。",
+    }, "\n")
+
+    assert.equals("適用結果を追記します。\n追記しました。", chat_excerpt.clean(text))
+  end)
+
+  it("still stops at a blank line when the parens never balance", function()
+    -- `case x)` のように釣り合わないコマンドでは、上限まで走ったあと最初の空行に戻る。
+    -- 食べ過ぎるより食べ足りないほうがまし、という以前からの判断のまま。
+    local text = table.concat({
+      "💻 Bash(case $x in",
+      "  echo ((",
+      "",
+      "この後の説明は残す",
+    }, "\n")
+
+    assert.equals("この後の説明は残す", chat_excerpt.clean(text))
+  end)
+
+  it("keeps the prose when an unbalanced command has no blank line to stop at", function()
+    -- 旧実装はここで残り全部を食べていた。地の文を残すほうが安全側に倒れる。
+    local text = "💻 Bash(echo ((\nこの説明は残す"
+
+    assert.equals("この説明は残す", chat_excerpt.clean(text))
+  end)
+end)


### PR DESCRIPTION
## Why

`:VibingSummarize` が特定のチャットで一度も成功しませんでした。症状は毎回これだけです。

```
Error [vibing] Invalid summary format: must start with '## summary'
```

原因は入力サイズです。`generate_and_insert_summary` の唯一の上限 `MAX_MESSAGES_FOR_SUMMARY = 50`
は**メッセージ「件数」しか見ておらず**、報告のあったチャット（43通）は上限に掛からないまま
261,741文字が丸ごと1プロンプトになっていました（うち1通が76,026バイト）。

実際にそのプロンプトを組んで CLI に投げて確認しました（sonnet / ツール無しという最も条件の
良い構成）。応答自体は返りますが **110,497 トークンを消費したうえで
`prompts/chat_summary.md` の出力形式を無視**し、先頭行が `# Handoff Summary — …` になります。
`summary_inserter.prepare_summary_lines` は先頭行を `^##%s*summary` で厳密照合するので、
応答は丸ごと捨てられます。課金だけされて何も挿入されない、という状態でした。

タイトル生成側（`title_generator`）は同じ問題を認識していて `chat_excerpt` で入力を
6,000文字に縛っています。要約側だけがその仕組みを使っていませんでした。

## What

### 1. ツール実況を落とす（`use_case.lua`）

`chat_excerpt` の `clean` / `clean_user` を通してから送ります。`chat_excerpt.build` を
そのまま使わなかった理由はコード内にコメントしてあります: `build` は assistant を冒頭2通・
各400文字しか残さない設計で、要約の本体である「何を決め、何を却下したか」がちょうど落ちます。
借りるのはノイズ除去だけです。

### 2. 文字数ベースの上限（`use_case.lua`）

| 定数 | 値 | 役割 |
| --- | --- | --- |
| `MAX_MESSAGE_CHARS` | 3,000 | 1メッセージの上限。前半2/3・後半1/3を残して中略（assistantは冒頭に「何をしようとしたか」、末尾に「何が決まったか」が来るため） |
| `MAX_TOTAL_CHARS` | 60,000 | 会話全体の上限。新しい側から詰め、予算切れで古いものを落とす |
| `OMISSION_MARKER` | — | 落としたことをプロンプトに明示。予算で先頭が落ちたときは最初の依頼を戻す（主題の固定） |

件数の上限（`MAX_MESSAGES_FOR_SUMMARY`）も残してあります。今回の症状は件数上限では防げない、
というのがこの PR の主題なので、そこは置き換えではなく追加です。

### 3. `lightweight = true`（`use_case.lua`）

`/summarize` ハンドラ（`handlers/summarize.lua`）は既に渡していましたが、`:VibingSummarize`
だけ `{}` でした。非 lightweight だと frontmatter の model（このチャットでは opus）に加えて
全ツール・CLAUDE.md・ユーザーの MCP サーバー定義・開いているバッファの context prefix まで
載ります。要約にはどれも要らず、コンテキストを食うだけです。

### 4. `chat_excerpt` のツールヘッダー追従を2点修正

これはタイトル生成にも効きます。描画は `\n<marker> <Tool>(<command>)\n` の1ブロックで、
`<command>` は `tool_input.command` の生文字列です。

- **空行で打ち切っていた**。heredoc は本文に空行を含むので、`cat >> report.md <<'MD'` の
  中身（書き込む markdown や python スクリプト）がそのまま地の文として残っていました。
  括弧の釣り合いで終端を探し、上限行数までに釣り合わなければ従来どおり最初の空行で
  打ち切ります（「食べ過ぎるより食べ足りないほうがまし」という判断は変えていません）。
- **heredoc 本文の括弧を数えていた**。本文はシェルのコードではなくデータです。
  `python3 - <<'PY'` の中の `s.replace("""..."""` のような複数行文字列が釣り合いを崩し、
  終端を見失っていました。デリミタまで読み飛ばすようにしています。終端行が `PY` だけとは
  限らず、コマンドが heredoc で終わると描画側の閉じ括弧が付いて `PY)` になる点も込みです。

## How to test

```bash
pnpm run test:lua
```

新規 `tests/lua/application/chat/summary_input_spec.lua`（8件）と、
`tests/lua/core/utils/chat_excerpt_spec.lua` への追加（7件）。既存の
「空行で打ち切る」仕様もそのまま通ります。

実ファイル（43通 / 5,070行 / 350KB）での実測:

| | 修正前 | 修正後 |
| --- | ---: | ---: |
| プロンプト | 354,308 bytes | **53,085 bytes**（-85%） |
| 消費トークン | 110,497 | **19,320** |
| コスト | $0.79 | **$0.16** |
| 漏れたシェル/コード行 | 13 | **0** |
| 応答の先頭行 | `# Handoff Summary — …` ❌ | **`## summary`** ✅ |
| 行数 | — | 53行（テンプレート上限60以内） |
| `summary_inserter` | 破棄 | **挿入成功**（再挿入で尾が孤立しないことも確認） |

実際の CLI 応答を `insert_or_update` に2回通し、`extract` で往復することまで確認しています。

## Checklist

- [x] `pnpm run test:lua` exit 0
- [x] `pnpm run lint` / `lint:md` / `format:check`
- [ ] `pnpm run check`（ローカルに `luac` が無く未実行。CI で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved conversation summaries by prioritizing recent context and preserving the initial request.
  * Long messages and conversations are now safely shortened with clear omission markers.
  * Summary generation uses lightweight processing for faster, more efficient results.
  * Improved handling of tool output, including multiline commands, heredocs, blank lines, and embedded parentheses.
  * Unrecognized effort settings are now ignored with a warning instead of being passed through.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->