### PR TITLE
feat: expose a completion callback for :VibingSummarize

### DIFF
--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -12,7 +12,7 @@
 | `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                                                                               |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                                                                             |
 | `:VibingSetFileTitle`                 | Generate AI title and rename chat file (prefers an existing `## summary` section as input)                                                                    |
-| `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                                                                                    |
+| `:VibingSummarize [--with-title]`     | Generate AI summary of chat history and insert into buffer (`--with-title` chains `:VibingSetFileTitle` on success)                                           |
 | `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                                                                             |
 | `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                                                                             |
 | `:VibingClearContext`                 | Clear all context                                                                                                                                             |

--- a/README.ja.md
+++ b/README.ja.md
@@ -183,7 +183,7 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 | `:VibingChatFork [position]`          | 現在のチャットをフォーク(会話を分岐)                                                               |
 | `:VibingSlashCommands`                | スラッシュコマンドピッカーを表示                                                                   |
 | `:VibingSetFileTitle`                 | AI がタイトルを生成しチャットファイルをリネーム                                                    |
-| `:VibingSummarize`                    | チャット履歴の AI 要約を生成してバッファに挿入                                                     |
+| `:VibingSummarize [--with-title]`     | チャット履歴の AI 要約を生成してバッファに挿入(--with-title で続けて要約からリネーム)              |
 | `:VibingDeleteChats [--unrenamed]`    | チャットファイルを削除(--unrenamed で未リネームのファイルを一括削除)                               |
 | `:VibingContext [path]`               | コンテキスト追加: oil.nvim のエントリ、ビジュアル選択(range)、パス引数、引数なしなら現在のバッファ |
 | `:VibingClearContext`                 | コンテキストを全クリア                                                                             |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ help tags.
 | `:VibingChatJumpPrevUser [count]`     | Move the cursor to the previous User section in the chat buffer                                                                       |
 | `:VibingSlashCommands`                | Show slash command picker in chat                                                                                                     |
 | `:VibingSetFileTitle`                 | Generate AI title and rename chat file (uses an existing `## summary` if present)                                                     |
-| `:VibingSummarize`                    | Generate AI summary of chat history and insert into buffer                                                                            |
+| `:VibingSummarize [--with-title]`     | Generate AI summary of chat history and insert into buffer (`--with-title` then renames the file from that summary)                   |
 | `:VibingDeleteChats [--unrenamed]`    | Delete chat files (use --unrenamed to delete all unrenamed files)                                                                     |
 | `:VibingContext [path]`               | Add context: oil.nvim entry, visual selection (range), path argument, or current buffer when no args                                  |
 | `:VibingClearContext`                 | Clear all context                                                                                                                     |

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -258,6 +258,9 @@ adapter 無しといった同期的な早期リターンでも呼ぶので、呼
 `SummaryInserter` が通知するので、`err` には `Failed to insert summary into chat buffer`
 という粗い文言が入る。
 
+`on_done` の中で投げられたエラーは `pcall` で捕まえて通知に落とす。非同期パスでは CLI の
+完了ハンドラ（luv のコールバック内）から呼ばれるので、素通しにするとそこで例外になる。
+
 要約とタイトル生成には本質的な順序依存がある（タイトル生成はバッファの `## summary` を
 入力に使う）。この2つを繋ぐだけなら `:VibingSummarize --with-title` で足りるので、
 コールバックはそれ以外の連携先向け。

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -7,6 +7,7 @@ vibing.nvim が公開している API のリファレンス。設定項目その
 
 - [Core API](#core-api)
 - [Adapter API](#adapter-api)
+- [Chat API](#chat-api)
 - [Internal Modules](#internal-modules)
 - [Types](#types)
 
@@ -236,10 +237,55 @@ OpenAI の `codex` CLI（`codex exec --json`）を使用するアダプター。
 
 **Implementation:** `lua/vibing/infrastructure/adapter/codex_cli.lua`
 
+## Chat API
+
+### `use_case.generate_and_insert_summary(chat_buffer, opts?)`
+
+`:VibingSummarize` の本体。会話を要約して `# Vibing Chat` の直下に `## summary` として
+書き込む。
+
+```lua
+---@param chat_buffer Vibing.ChatBuffer
+---@param opts? {on_done?: fun(ok: boolean, err: string?)}
+```
+
+`opts.on_done` は成否にかかわらず**必ず1回だけ**呼ばれる。ストリーミング中・会話が空・
+adapter 無しといった同期的な早期リターンでも呼ぶので、呼び出し側は「まだ来ていない」と
+「もう来ない」を区別する必要がない。
+
+`err` は原則としてユーザーに通知したのと同じ文言だが、バッファへの挿入に失敗したときだけは
+例外。理由（`Invalid summary format: must start with '## summary'` など）は
+`SummaryInserter` が通知するので、`err` には `Failed to insert summary into chat buffer`
+という粗い文言が入る。
+
+要約とタイトル生成には本質的な順序依存がある（タイトル生成はバッファの `## summary` を
+入力に使う）。この2つを繋ぐだけなら `:VibingSummarize --with-title` で足りるので、
+コールバックはそれ以外の連携先向け。
+
+```lua
+local use_case = require("vibing.application.chat.use_case")
+local view = require("vibing.presentation.chat.view")
+
+local chat_buffer = view.get_current()
+use_case.generate_and_insert_summary(chat_buffer, {
+  on_done = function(ok, err)
+    if not ok then
+      vim.notify("summary failed: " .. tostring(err), vim.log.levels.WARN)
+      return
+    end
+    -- 非同期なので、完了時点のカレントバッファは別のチャットになっていることがある。
+    -- 連鎖先には最初に掴んだバッファをそのまま渡す。
+    require("vibing.application.chat.handlers.set_file_title")({}, chat_buffer)
+  end,
+})
+```
+
+**Implementation:** `lua/vibing/application/chat/use_case.lua`
+
 ## Internal Modules
 
-`vibing.setup()` / `vibing.get_adapter()` / `vibing.get_config()` と、上のアダプター
-インターフェース以外は内部実装であり、予告なく変わる。
+`vibing.setup()` / `vibing.get_adapter()` / `vibing.get_config()`、上のアダプター
+インターフェースと Chat API 以外は内部実装であり、予告なく変わる。
 
 現在のモジュール構成は `.claude/rules/architecture.md` の "Module Structure" を参照。
 

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -159,9 +159,15 @@ section is not kept in sync field by field.
     response is streaming.
 
                                                            *:VibingSummarize*
-:VibingSummarize
+:VibingSummarize [--with-title]
     Summarise the conversation so far and insert it into the buffer. Refused
     while a response is streaming.
+
+    With `--with-title`, run |:VibingSetFileTitle| once the summary is in the
+    buffer, so the title is generated from the summary rather than from a
+    conversation excerpt. The title step is skipped when summarising failed:
+    it would otherwise fall back to the excerpt and spend a second request
+    the user did not ask for. Run |:VibingSetFileTitle| by hand for that.
 
                                                          *:VibingDeleteChats*
 :VibingDeleteChats [--unrenamed]

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -352,7 +352,18 @@ require("vibing").get_adapter()                        *vibing.get_adapter()*
 require("vibing").get_config()                          *vibing.get_config()*
     The merged, validated configuration table.
 
-Everything under `lua/vibing/` beyond these three functions is internal and
+                                        *vibing.generate_and_insert_summary()*
+require("vibing.application.chat.use_case")
+        .generate_and_insert_summary({chat_buffer}, {opts})
+    The body of |:VibingSummarize|. {opts.on_done} is a
+    `fun(ok: boolean, err: string?)` called exactly once, whether the summary
+    succeeded or not — the synchronous refusals (streaming, empty
+    conversation, no adapter) included, so a caller chaining on it never has
+    to tell "not yet" from "never". An error raised inside it is caught and
+    reported rather than propagated into the CLI's completion handler. See
+    `doc/api-reference.md` for the full contract.
+
+Everything under `lua/vibing/` beyond these four entry points is internal and
 may change without notice.
 
 ==============================================================================

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -300,7 +300,13 @@ function M.generate_and_insert_summary(chat_buffer, opts)
     end
     finished = true
     if on_done then
-      on_done(ok, err)
+      -- on_done は利用側（dotfiles 等）が書くコールバックで、非同期パスでは CLI の完了
+      -- ハンドラの中から呼ばれる。素通しにすると luv のコールバック内で例外になるので、
+      -- ここで捕まえて通知に落とす。
+      local ok_call, call_err = pcall(on_done, ok, err)
+      if not ok_call then
+        notify.error("Summary completion callback failed: " .. tostring(call_err))
+      end
     end
   end
 

--- a/lua/vibing/application/chat/use_case.lua
+++ b/lua/vibing/application/chat/use_case.lua
@@ -281,13 +281,32 @@ function M._build_summary_prompt(conversation)
 end
 
 ---チャット履歴からサマリーを生成してバッファに挿入
+---
+---`opts.on_done` は成否にかかわらず必ず1回だけ呼ばれる。同期的な早期リターン（ストリーミング
+---中・会話が空・adapter 無し）でも呼ぶのが要点で、呼ばれない経路が1つでもあると連鎖する
+---呼び出し側は「まだ来ていない」と「もう来ない」を区別できず待ち続ける。`err` は原則として
+---ユーザーに通知したのと同じ文言。挿入失敗だけは例外で、詳しい理由は `SummaryInserter` が
+---通知するため `err` は粗い文言になる。
 ---@param chat_buffer Vibing.ChatBuffer
-function M.generate_and_insert_summary(chat_buffer)
+---@param opts? {on_done?: fun(ok: boolean, err: string?)}
+function M.generate_and_insert_summary(chat_buffer, opts)
   local notify = require("vibing.core.utils.notify")
+  local on_done = opts and opts.on_done
+
+  local finished = false
+  local function finish(ok, err)
+    if finished then
+      return
+    end
+    finished = true
+    if on_done then
+      on_done(ok, err)
+    end
+  end
 
   if not chat_buffer or not chat_buffer.buf or not vim.api.nvim_buf_is_valid(chat_buffer.buf) then
     notify.error("No valid chat buffer")
-    return
+    return finish(false, "No valid chat buffer")
   end
 
   -- set_file_title と同じ理由でストリーミング中は断る。summary は `# Vibing Chat` の直下へ
@@ -295,14 +314,14 @@ function M.generate_and_insert_summary(chat_buffer)
   -- 加えて、途中状態の会話から要約を作ることにもなる。
   if chat_buffer:is_sending() then
     notify.warn("Cannot summarize while a response is streaming")
-    return
+    return finish(false, "Cannot summarize while a response is streaming")
   end
 
   local conversation = chat_buffer:extract_conversation()
 
   if #conversation == 0 or not has_conversation_content(conversation) then
     notify.warn("No conversation content to summarize")
-    return
+    return finish(false, "No conversation content to summarize")
   end
 
   local vibing = require("vibing")
@@ -310,13 +329,13 @@ function M.generate_and_insert_summary(chat_buffer)
 
   if not adapter then
     notify.error("No adapter configured")
-    return
+    return finish(false, "No adapter configured")
   end
 
   local full_prompt, err = M._build_summary_prompt(conversation)
   if err then
     notify.error("Failed to load summary prompt: " .. err)
-    return
+    return finish(false, "Failed to load summary prompt: " .. err)
   end
 
   notify.info("Generating summary...")
@@ -330,29 +349,34 @@ function M.generate_and_insert_summary(chat_buffer)
     -- Re-validate buffer in async callback (buffer may be deleted during AI processing)
     if not buf or not vim.api.nvim_buf_is_valid(buf) then
       notify.warn("Chat buffer was closed during summary generation")
-      return
+      return finish(false, "Chat buffer was closed during summary generation")
     end
 
     if not response then
       notify.error("No response received from AI")
-      return
+      return finish(false, "No response received from AI")
     end
 
     if response.error then
       notify.error(string.format("Summarization failed: %s", response.error))
-      return
+      return finish(false, string.format("Summarization failed: %s", response.error))
     end
 
     local summary = response.content
     if not summary or type(summary) ~= "string" or summary == "" then
       notify.warn("AI returned empty summary")
-      return
+      return finish(false, "AI returned empty summary")
     end
 
     local SummaryInserter = require("vibing.presentation.chat.modules.summary_inserter")
-    if SummaryInserter.insert_or_update(buf, summary) then
-      notify.info("Summary written to chat buffer")
+    -- 失敗の内訳（バッファ無効・`## summary` で始まらない等）は Inserter 側が通知済みなので、
+    -- ここでは連鎖する呼び出し側に成否だけを渡す。
+    if not SummaryInserter.insert_or_update(buf, summary) then
+      return finish(false, "Failed to insert summary into chat buffer")
     end
+
+    notify.info("Summary written to chat buffer")
+    finish(true)
   end)
 end
 

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -212,9 +212,21 @@ function M._register_commands()
     require("vibing.presentation.chat.controller").handle_set_file_title()
   end, { desc = "Generate AI title and rename chat file" })
 
-  vim.api.nvim_create_user_command("VibingSummarize", function()
-    require("vibing.presentation.chat.controller").handle_summarize()
-  end, { desc = "Generate and insert summary from chat history" })
+  vim.api.nvim_create_user_command("VibingSummarize", function(opts)
+    require("vibing.presentation.chat.controller").handle_summarize(opts.args)
+  end, {
+    nargs = "?",
+    desc = "Generate and insert summary from chat history (--with-title also renames the file)",
+    complete = function(arg_lead)
+      local matches = {}
+      for _, flag in ipairs({ "--with-title" }) do
+        if flag:find("^" .. vim.pesc(arg_lead)) then
+          table.insert(matches, flag)
+        end
+      end
+      return matches
+    end,
+  })
 
   vim.api.nvim_create_user_command("VibingDeleteChats", function(opts)
     require("vibing.presentation.chat.deletion_controller").handle_delete_command(opts, M.config)

--- a/lua/vibing/presentation/chat/controller.lua
+++ b/lua/vibing/presentation/chat/controller.lua
@@ -89,8 +89,24 @@ function M.handle_set_file_title()
   handler({}, current_view)
 end
 
+---`:VibingSummarize` の引数をパースする（未知の引数は警告して要約自体は続行）
+---@param args string?
+---@return boolean with_title
+local function parse_summarize_flags(args)
+  local with_title = false
+  for arg in (args or ""):gmatch("%S+") do
+    if arg == "--with-title" then
+      with_title = true
+    else
+      notify.warn("Unknown argument: " .. arg)
+    end
+  end
+  return with_title
+end
+
 ---チャット履歴からサマリーを生成してバッファに挿入
-function M.handle_summarize()
+---@param args string? 引数文字列（`--with-title` で続けてタイトル生成まで行う）
+function M.handle_summarize(args)
   local view = require("vibing.presentation.chat.view")
   local current_view = view.get_current()
 
@@ -99,8 +115,22 @@ function M.handle_summarize()
     return
   end
 
+  local with_title = parse_summarize_flags(args)
+
   local use_case = require("vibing.application.chat.use_case")
-  use_case.generate_and_insert_summary(current_view)
+  use_case.generate_and_insert_summary(current_view, {
+    on_done = with_title and function(ok)
+      -- 失敗時は通知済みなので追わない。summary が無いまま走らせるとタイトル生成は抜粋に
+      -- フォールバックし、ユーザーが頼んでいない API 呼び出しが1回余分に走る。
+      if not ok then
+        return
+      end
+      -- `M.handle_set_file_title()` ではなくハンドラを直接呼び、最初に掴んだバッファを渡す。
+      -- 要約は非同期なので、完了時点のカレントバッファは別のチャット（あるいは非チャット）に
+      -- なっていることがある。
+      require("vibing.application.chat.handlers.set_file_title")({}, current_view)
+    end or nil,
+  })
 end
 
 ---チャットをフォーク

--- a/tests/lua/application/chat/summary_completion_spec.lua
+++ b/tests/lua/application/chat/summary_completion_spec.lua
@@ -176,6 +176,21 @@ describe("generate_and_insert_summary on_done", function()
     assert.is_truthy(SummaryInserter.extract(buffer.buf))
   end)
 
+  it("contains an error thrown by the callback", function()
+    -- on_done は利用側が書くコールバックで、非同期パスでは CLI の完了ハンドラの中から
+    -- 呼ばれる。そこまで例外が届くと luv のコールバック内でのエラーになるので、
+    -- `generate_and_insert_summary` の側で捕まえる。
+    stub_vibing({ error = "usage limit reached" })
+
+    assert.has_no.errors(function()
+      use_case.generate_and_insert_summary(chat_buffer(), {
+        on_done = function()
+          error("callback blew up")
+        end,
+      })
+    end)
+  end)
+
   it("still works without an on_done callback", function()
     stub_vibing({ content = "## summary\n\n- 決めたこと" })
 

--- a/tests/lua/application/chat/summary_completion_spec.lua
+++ b/tests/lua/application/chat/summary_completion_spec.lua
@@ -1,0 +1,186 @@
+-- `generate_and_insert_summary` の完了コールバックの契約を固定する。
+--
+-- 主題は「必ず1回だけ呼ばれる」こと。summary → title は本質的に順序依存で（タイトル生成は
+-- バッファの `## summary` を入力に使う）、連鎖する呼び出し側は完了通知だけを頼りに待つ。
+-- 呼ばれない脱出経路が1つでもあると、そこでは「まだ来ていない」と「もう来ない」が
+-- 区別できず、呼び出し側はバッファ内容のポーリングに逆戻りする（#615）。
+--
+-- したがって以下の主張は「同期的な失敗でも呼ぶ」ことに寄せてある。非同期パスだけを
+-- 確かめるテストに置き換えないこと。
+
+local use_case = require("vibing.application.chat.use_case")
+
+---@param opts? {is_sending?: boolean, conversation?: table[]}
+---@return table
+local function chat_buffer(opts)
+  opts = opts or {}
+  return {
+    buf = vim.api.nvim_create_buf(false, true),
+    is_sending = function()
+      return opts.is_sending or false
+    end,
+    extract_conversation = function()
+      return opts.conversation or { { role = "user", content = "レイヤー構成を整理して" } }
+    end,
+  }
+end
+
+---呼ばれた回数まで数えたいので、記録先のテーブルとコールバックを組で返す。
+---@return table calls
+---@return fun(ok: boolean, err: string?) on_done
+local function recorder()
+  local calls = {}
+  return calls, function(ok, err)
+    calls[#calls + 1] = { ok = ok, err = err }
+  end
+end
+
+---@param response table|nil アダプターが on_done に渡す応答
+local function stub_vibing(response)
+  package.loaded["vibing"] = {
+    get_config = function()
+      return { permissions = { mode = "acceptEdits", allow = { "Read" }, deny = {} } }
+    end,
+    get_adapter = function()
+      return {
+        stream = function(_, _prompt, _opts, _on_chunk, on_done)
+          on_done(response)
+        end,
+      }
+    end,
+  }
+end
+
+---プロンプトの読み込みをスタブする。
+---
+---本物の `PromptLoader` は runtimepath から `vibing.nvim` で終わるディレクトリを探すため、
+---worktree（`.vibing/worktrees/<branch>`）でスイートを回すと必ず失敗する。ここの主題は
+---コールバックの契約であってプロンプトの中身ではないので、その依存ごと外す。
+---@param err string? 読み込み失敗を再現する場合のエラー文言
+local function stub_prompt_loader(err)
+  package.loaded["vibing.core.utils.prompt_loader"] = {
+    load = function()
+      if err then
+        return nil, err
+      end
+      return "<conversation>stubbed</conversation>"
+    end,
+  }
+end
+
+describe("generate_and_insert_summary on_done", function()
+  before_each(function()
+    stub_prompt_loader()
+  end)
+
+  after_each(function()
+    package.loaded["vibing"] = nil
+    package.loaded["vibing.core.utils.prompt_loader"] = nil
+  end)
+
+  it("reports failure when a response is streaming", function()
+    local calls, on_done = recorder()
+
+    use_case.generate_and_insert_summary(chat_buffer({ is_sending = true }), { on_done = on_done })
+
+    assert.equals(1, #calls)
+    assert.is_false(calls[1].ok)
+    assert.is_truthy(calls[1].err)
+  end)
+
+  it("reports failure when there is nothing to summarize", function()
+    local calls, on_done = recorder()
+
+    use_case.generate_and_insert_summary(chat_buffer({ conversation = {} }), { on_done = on_done })
+
+    assert.equals(1, #calls)
+    assert.is_false(calls[1].ok)
+  end)
+
+  it("reports failure when no adapter is configured", function()
+    package.loaded["vibing"] = {
+      get_config = function()
+        return { permissions = { mode = "acceptEdits", allow = {}, deny = {} } }
+      end,
+      get_adapter = function()
+        return nil
+      end,
+    }
+    local calls, on_done = recorder()
+
+    use_case.generate_and_insert_summary(chat_buffer(), { on_done = on_done })
+
+    assert.equals(1, #calls)
+    assert.is_false(calls[1].ok)
+  end)
+
+  it("reports failure when the prompt cannot be loaded", function()
+    stub_vibing({ content = "## summary\n\n- 決めたこと" })
+    stub_prompt_loader("Could not find vibing.nvim plugin directory")
+    local calls, on_done = recorder()
+
+    use_case.generate_and_insert_summary(chat_buffer(), { on_done = on_done })
+
+    assert.equals(1, #calls)
+    assert.is_false(calls[1].ok)
+    assert.is_truthy(calls[1].err:find("plugin directory", 1, true))
+  end)
+
+  it("passes the adapter's error through", function()
+    stub_vibing({ error = "usage limit reached" })
+    local calls, on_done = recorder()
+
+    use_case.generate_and_insert_summary(chat_buffer(), { on_done = on_done })
+
+    assert.equals(1, #calls)
+    assert.is_false(calls[1].ok)
+    assert.is_truthy(calls[1].err:find("usage limit reached", 1, true))
+  end)
+
+  it("reports failure when the summary cannot be inserted", function()
+    -- 応答は返っているが `## summary` で始まらないケース。挿入されていないので、
+    -- ここで ok=true を返すとタイトル生成が summary 抜きで走ってしまう。
+    stub_vibing({ content = "Here is a summary of the conversation." })
+    local calls, on_done = recorder()
+
+    use_case.generate_and_insert_summary(chat_buffer(), { on_done = on_done })
+
+    assert.equals(1, #calls)
+    assert.is_false(calls[1].ok)
+  end)
+
+  it("reports success once the summary is in the buffer", function()
+    stub_vibing({ content = "## summary\n\n- 決めたこと" })
+    local buffer = chat_buffer()
+    vim.api.nvim_buf_set_lines(buffer.buf, 0, -1, false, {
+      "---",
+      "vibing.nvim: true",
+      "---",
+      "",
+      "# Vibing Chat",
+      "",
+      "---",
+      "",
+      "## User",
+      "レイヤー構成を整理して",
+    })
+    local calls, on_done = recorder()
+
+    use_case.generate_and_insert_summary(buffer, { on_done = on_done })
+
+    assert.equals(1, #calls)
+    assert.is_true(calls[1].ok)
+    assert.is_nil(calls[1].err)
+
+    local SummaryInserter = require("vibing.presentation.chat.modules.summary_inserter")
+    assert.is_truthy(SummaryInserter.extract(buffer.buf))
+  end)
+
+  it("still works without an on_done callback", function()
+    stub_vibing({ content = "## summary\n\n- 決めたこと" })
+
+    assert.has_no.errors(function()
+      use_case.generate_and_insert_summary(chat_buffer())
+    end)
+  end)
+end)

--- a/tests/lua/presentation/chat/controller_summarize_spec.lua
+++ b/tests/lua/presentation/chat/controller_summarize_spec.lua
@@ -1,0 +1,125 @@
+-- `:VibingSummarize [--with-title]` の引数解釈と、タイトル生成への連鎖を固定する。
+--
+-- 連鎖で押さえたいのは「どのバッファに対して」タイトルを付けるか。要約は非同期なので、
+-- 完了時点のカレントバッファは別のチャット（あるいは非チャット）になっていることがある。
+-- そのため `M.handle_set_file_title()`（カレントを取り直す）ではなくハンドラを直接呼び、
+-- 要約開始時に掴んだバッファを渡している。ここを取り直す実装に戻すとテストが落ちる。
+
+local controller = require("vibing.presentation.chat.controller")
+
+describe("controller.handle_summarize", function()
+  local captured_opts
+  local titled_buffers
+  local summarized_buffers
+  local current_buffer
+
+  ---@param ok boolean 要約が成功したことにするか
+  local function stub_use_case(ok)
+    package.loaded["vibing.application.chat.use_case"] = {
+      generate_and_insert_summary = function(chat_buffer, opts)
+        table.insert(summarized_buffers, chat_buffer)
+        captured_opts = opts
+        if opts and opts.on_done then
+          opts.on_done(ok, ok and nil or "stubbed failure")
+        end
+      end,
+    }
+  end
+
+  before_each(function()
+    captured_opts = nil
+    titled_buffers = {}
+    summarized_buffers = {}
+    current_buffer = { name = "chat-a" }
+
+    package.loaded["vibing.presentation.chat.view"] = {
+      get_current = function()
+        return current_buffer
+      end,
+    }
+    package.loaded["vibing.application.chat.handlers.set_file_title"] = function(_, chat_buffer)
+      table.insert(titled_buffers, chat_buffer)
+      return true
+    end
+    stub_use_case(true)
+  end)
+
+  after_each(function()
+    package.loaded["vibing.presentation.chat.view"] = nil
+    package.loaded["vibing.application.chat.use_case"] = nil
+    package.loaded["vibing.application.chat.handlers.set_file_title"] = nil
+  end)
+
+  it("does not generate a title without the flag", function()
+    controller.handle_summarize("")
+
+    assert.equals(1, #summarized_buffers)
+    assert.is_nil(captured_opts and captured_opts.on_done)
+    assert.equals(0, #titled_buffers)
+  end)
+
+  it("treats a missing argument the same as an empty one", function()
+    controller.handle_summarize(nil)
+
+    assert.equals(1, #summarized_buffers)
+    assert.equals(0, #titled_buffers)
+  end)
+
+  it("generates a title after a successful summary with --with-title", function()
+    controller.handle_summarize("--with-title")
+
+    assert.equals(1, #titled_buffers)
+    assert.equals(current_buffer, titled_buffers[1])
+  end)
+
+  it("titles the buffer it started on, not whatever is current when the summary lands", function()
+    -- 要約中にユーザーが別のチャットへ移った状況。get_current が別のバッファを返すように
+    -- なっても、タイトルは要約したバッファに付かなければならない。
+    local started_on = current_buffer
+    package.loaded["vibing.application.chat.use_case"] = {
+      generate_and_insert_summary = function(chat_buffer, opts)
+        table.insert(summarized_buffers, chat_buffer)
+        current_buffer = { name = "chat-b" }
+        opts.on_done(true)
+      end,
+    }
+
+    controller.handle_summarize("--with-title")
+
+    assert.equals(1, #titled_buffers)
+    assert.equals(started_on, titled_buffers[1])
+  end)
+
+  it("skips title generation when the summary failed", function()
+    -- summary が無いまま走らせるとタイトル生成は抜粋にフォールバックし、ユーザーが
+    -- 頼んでいない API 呼び出しが1回余分に走る。
+    stub_use_case(false)
+
+    controller.handle_summarize("--with-title")
+
+    assert.equals(0, #titled_buffers)
+  end)
+
+  it("summarizes anyway when given an unknown argument", function()
+    controller.handle_summarize("--foo")
+
+    assert.equals(1, #summarized_buffers)
+    assert.is_nil(captured_opts and captured_opts.on_done)
+  end)
+
+  it("accepts --with-title alongside an unknown argument", function()
+    controller.handle_summarize("--foo --with-title")
+
+    assert.equals(1, #summarized_buffers)
+    assert.equals(1, #titled_buffers)
+  end)
+
+  it("does nothing outside a chat buffer", function()
+    current_buffer = nil
+
+    controller.handle_summarize("--with-title")
+
+    assert.equals(0, #summarized_buffers)
+    assert.equals(0, #titled_buffers)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

`:VibingSummarize` の完了を外から知る手段が無く、`:VibingSummarize` → `:VibingSetFileTitle` の連鎖を利用側で書くにはバッファ内容のポーリングが必要でした。タイトル生成は `## summary` があればそれを入力に使う実装なので、この2つには本質的な順序依存があります。

`generate_and_insert_summary` に完了コールバックを追加し、その上に合成コマンド `:VibingSummarize --with-title` を載せます。

## Changes

- `use_case.generate_and_insert_summary(chat_buffer, { on_done = fun(ok, err) })` を追加。**成否にかかわらず必ず1回だけ**呼ばれる
- `:VibingSummarize --with-title` を追加（`nargs`・補完つき）。要約成功後に `:VibingSetFileTitle` を実行する
- `doc/vibing.txt` / `doc/api-reference.md` / README（en/ja）/ `.claude/rules/commands-reference.md` を更新
- テスト16件を追加

## 設計判断

**`on_done` は同期的な早期リターン（ストリーミング中・会話が空・adapter 無し）でも呼ぶ。** 呼ばれない経路が1つでもあると、連鎖する呼び出し側は「まだ来ていない」と「もう来ない」を区別できず待ち続けます。ポーリングが存在していた理由そのものなので、ここは全経路（同期5・非同期6）を塞いでいます。

**挿入失敗は `ok=false`。** 応答は返っているがモデルが `## summary` で始めなかった場合がこれに当たります。`ok=true` にすると、バッファに summary が無いままタイトル生成が走ります。

**連鎖先には要約開始時に掴んだバッファを渡す。** `controller.handle_set_file_title()` はカレントバッファを取り直すため使っていません。要約は非同期で、完了時点のカレントバッファは別のチャット（あるいは非チャット）になっていることがあります。

**要約が失敗したらタイトル生成はしない。** summary が無い状態で走らせるとタイトル生成は抜粋にフォールバックし、ユーザーが頼んでいないリクエストが1回余分に走ります。失敗は通知済みなので `:VibingSetFileTitle` を手で叩けば済みます。

**未知の引数は警告して要約自体は続行。** `--unrenamed` の既存パターンに寄せています。黙って無視はしません。

`User VibingSummarizeDone` autocmd は採らず、既存のコールバック様式に揃えました。単一ケースのためにイベントバスを新設するより表面積が小さいためです。observer が増えた時点で足せます。

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test addition or update

## Testing

- [x] Tested locally in Neovim
- [x] Manual testing completed

新規テスト16件（`summary_completion_spec.lua` 8件 / `controller_summarize_spec.lua` 8件）はすべて green です。

`:VibingSummarize --with-title` の補完と `nargs="?"` の挙動は実 nvim で確認しました。`:VibingSummarize --foo --with-title` が1引数として届くこと、`getcompletion("VibingSummarize --w", "cmdline")` が `--with-title` を返すことを確認しています。

`check:doc` OK、`lint:md` は変更ファイルで指摘なしです。

### 既知の失敗（このPRとは無関係）

worktree 上でスイートを回すと以下が失敗しますが、**変更前と同一**であることを stash して確認済みです。

| 失敗 | 原因 |
| --- | --- |
| `summary_input_spec` (8), `summary_prompt_spec` (1) | `PromptLoader.get_plugin_root()` が runtimepath から `vibing.nvim` で終わるパスを探すため、`.vibing/worktrees/<branch>` では必ず nil になる |
| `dap_spec` (3), `view_spec` (1) | 変更前から同じ失敗 |

1つ目はテストだけの問題ではなく、**worktree で開いたチャットでは要約もタイトル生成も実際に動かない**ことを意味します。このPRのスコープ外なので別issueにすべきと考えています。

また `pnpm run check` と node の `lua-syntax-gate` はこの環境に `luac` が無いため元から失敗します。変更した Lua ファイルは `luajit -b` で構文検証済みです。

### Test Environment

- **Neovim version**: NVIM v0.13.0-dev-1403+g70958dae75-Homebrew
- **Operating System**: macOS 26.6.2
- **Node.js version**: v22.23.2

## Documentation

- [x] README.md updated (if applicable)
- [x] doc/vibing.txt updated (if applicable)
- [x] CLAUDE.md updated (if applicable)
- [x] Code comments added/updated (if applicable)

`doc/api-reference.md` には「Chat API」節を新設しました。このコールバックは利用側（dotfiles）から呼ばれる前提なので、「内部実装であり予告なく変わる」のままでは目的を果たさないためです。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes

## Related Issues

Fixes #615

## Additional Context

これが入れば、issueに書かれている利用側のポーリング + タイムアウト（約80行）を削除してキーマップ1行に置き換えられます。

```vim
:VibingSummarize --with-title
```

コールバックを直接使う場合:

```lua
local use_case = require("vibing.application.chat.use_case")
local chat_buffer = require("vibing.presentation.chat.view").get_current()

use_case.generate_and_insert_summary(chat_buffer, {
  on_done = function(ok, err)
    if not ok then
      return
    end
    require("vibing.application.chat.handlers.set_file_title")({}, chat_buffer)
  end,
})
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the optional `--with-title` flag to `:VibingSummarize`.
  - Successfully generated summaries can now automatically rename the chat using the summary.
  - Title generation is skipped when summarization fails.
  - Unknown command-line options now produce a warning.

- **Bug Fixes**
  - Improved completion handling so summary success and failure are reported consistently, including insertion errors.

- **Documentation**
  - Updated English and Japanese usage guides and API documentation with the new flag and summary workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->