### PR TITLE
feat: self-host the Claude Code plugin via --plugin-dir

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -354,9 +354,12 @@ injection an unreviewed `.claude/skills/` allows, and it is why Claude Code gate
 `.mcp.json` behind approval. The convenience was preferred; `agent.plugins.project_dir = false`
 is the opt-out.
 
-**A worktree falls back to the project root.** `.vibing/` is git-ignored, so a worktree checkout
-has no `.vibing/plugins` of its own — resolution reads the worktree's copy when present and the
-Neovim root's otherwise, mirroring `project_system_prompt.read_for_cwd`.
+**A worktree reads both its own `.vibing/plugins` and the project root's.** `.vibing/` is
+git-ignored, so a worktree checkout usually has none of its own. This is a union with per-name
+precedence, not the strict fallback `project_system_prompt.read_for_cwd` applies to
+`.vibing/system-prompt.md`: that one picks a single file and so has to choose, while a _set_ of
+plugins does not, and a worktree adding one experimental plugin should not lose every plugin the
+project already had. Reusing a root plugin's name is still how a worktree overrides it.
 
 **Accepted:** a plain `claude` session started outside Neovim no longer sees the `nvim_*` tools.
 Reaching a running Neovim was the entire point of them, so no opt-in was added.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -57,9 +57,9 @@ Granting everything would override the user's `settings.json` deny rules, which
 `--setting-sources user,project,local` still pulls in.
 
 Those MCP tools are the exception because `--allowedTools` cannot express them reliably: it takes
-literal prefixes, and the plugin-scoped one is `mcp__plugin_<marketplace>_vibing-nvim__`, a name
-fixed when `claude plugin marketplace add` ran. `can_use_tool.is_vibing_nvim_mcp_tool` matches on
-the suffix instead, so the grant survives a rename that `VIBING_NVIM_MCP_TOOL_PATTERNS` would not.
+literal prefixes, and the plugin-scoped one is `mcp__plugin_<plugin>_<server>__`, built from
+`claude-plugin/.claude-plugin/plugin.json`. `can_use_tool.is_vibing_nvim_mcp_tool` matches on the
+suffix instead, so the grant survives a rename that `VIBING_NVIM_MCP_TOOL_PATTERNS` would not.
 Before #564 every allowed call took the silent path, so under any mode but `bypassPermissions` the
 CLI refused those tools while vibing.nvim's own log said "allow".
 
@@ -283,6 +283,85 @@ Tests:
 - tests/*.test.mjs             - Node.js tests
 - tests/e2e/*.spec.lua         - E2E tests against a spawned Neovim instance
 ```
+
+## Self-Hosted Claude Code Plugin (`--plugin-dir`)
+
+vibing.nvim's own Claude Code plugin — the `vibing-nvim` MCP server, the bundled skills, the
+`nvim-navigator` agent — is **not installed**. `cli_command_builder` passes
+`--plugin-dir <path>` once per directory resolved by
+`infrastructure/plugins/plugin_dirs.lua`, which loads a plugin for that CLI invocation only and
+writes nothing to Claude Code's global state.
+
+The resolved list is `self` → `.vibing/plugins/*/` → `agent.plugins.extra`, and it is the single
+definition of "which plugin directories apply here": the argv, the skill completion provider and
+the agent completion provider all read it rather than each re-deriving the convention.
+
+**What this bought.** `build.sh` used to run `claude plugin marketplace add` and
+`claude plugin install ... --scope user`, which produced #480/#482 (hanging `claude plugin` calls
+needing a bespoke watchdog), #450, #557, and a standing marketplace-rename migration. It also
+copied `claude-plugin/` into a per-version cache, so ~90 lines of rsync plus a
+`mcp-server/{node_modules,dist}` symlink-back existed purely to keep that copy in step with the
+checkout. All of it is gone. The structural win is the third one: the MCP server no longer
+updates independently of the Neovim plugin it serves, so a worktree runs the server it contains
+rather than whatever the user last installed globally.
+
+**Measured against claude 2.1.231**, because none of it is documented:
+
+| Question                                 | Answer                                                                        |
+| ---------------------------------------- | ----------------------------------------------------------------------------- |
+| Tool name under `--plugin-dir`           | `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` — identical to the install      |
+| What decides that prefix                 | `plugin.json`'s `name` and the `mcpServers` key. **Not** the marketplace name |
+| Same-named plugin in two `--plugin-dir`s | The **earlier flag wins**; the later one's skills never load                  |
+| How many `--plugin-dir` flags            | No cap found: 30 loaded, all 30 skills visible to the model                   |
+| Broken / missing / absent manifest       | **Silently ignored**, exit 0, no warning                                      |
+| `--strict-mcp-config`                    | Blocks the plugin's MCP servers (0 connection log lines)                      |
+| Coexisting with a user-scope install     | Inline wins, no duplication, no error                                         |
+
+Two of those rows drive design decisions rather than being trivia.
+
+**First-wins is why the order is fixed at self → project → extra.** A `.vibing/plugins/` entry
+that names itself `vibing-nvim` cannot displace the real one. `plugin_dirs.resolve_entries`
+deduplicates by plugin name the same way, so the list it returns is what actually loads rather
+than what the CLI was offered — which is also what lets the completion providers reuse it.
+
+**Silent-ignore is why there is a manifest check at all.** `--plugin-dir` gives no signal
+whatsoever for a directory it declines, so "I dropped a plugin in and nothing happened" would
+have no explanation anywhere. `plugin_dirs` reads each candidate's `.claude-plugin/plugin.json`
+first and warns about the ones it drops. The per-cwd cache is what keeps that to one notification
+instead of one per request; a separate warned-once flag would be redundant with it, and would
+have to survive `clear_cache()` to mean anything — silencing the warning on exactly the
+`:VibingReloadCommands` the user runs after trying to fix the plugin.
+
+**Not passed on the lightweight path**, per `core/types.lua`. `--strict-mcp-config` already
+blocks the MCP servers there, but skill descriptions still cost prompt tokens on a call that has
+`--tools ""` and so nothing to invoke them with.
+
+**Completion needs the same list, and gets it by argv rather than by rediscovery.**
+`bin/list-commands.ts` only knew `~/.claude/plugins/installed_plugins.json`, where a
+`--plugin-dir` plugin cannot appear. Teaching it the `.vibing/plugins` convention would mean
+writing the same working-directory handling in Lua and TypeScript, so `skills.lua` appends the
+already-resolved paths to the `jobstart` argv and `resolveSessionPluginDirs` scans them. The
+agent provider (`completion/providers/agents.lua`) merges the same entries ahead of the installed
+ones — without it `nvim-navigator` would load in the CLI and never appear in completion.
+
+**`:VibingReloadCommands` clears `plugin_dirs` first**, before the provider caches: both
+re-resolve from it, so clearing it second would refill them from the list being discarded.
+
+**`.vibing/plugins/` is read by default, and that is a security decision, not an oversight.** A
+plugin may declare `mcpServers`, so a directory committed to a cloned repository can start a
+process on the user's machine on the first message. That is a stronger thing than the instruction
+injection an unreviewed `.claude/skills/` allows, and it is why Claude Code gates a project's own
+`.mcp.json` behind approval. The convenience was preferred; `agent.plugins.project_dir = false`
+is the opt-out.
+
+**A worktree falls back to the project root.** `.vibing/` is git-ignored, so a worktree checkout
+has no `.vibing/plugins` of its own — resolution reads the worktree's copy when present and the
+Neovim root's otherwise, mirroring `project_system_prompt.read_for_cwd`.
+
+**Accepted:** a plain `claude` session started outside Neovim no longer sees the `nvim_*` tools.
+Reaching a running Neovim was the entire point of them, so no opt-in was added.
+`.claude-plugin/marketplace.json` is kept — a manual `claude plugin install` still works, and
+deleting it can happen later.
 
 ## Startup Cost
 

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -24,6 +24,7 @@
 | `:VibingPendingResumes`               | List chats waiting on a usage limit reset or a scheduled send                                                                                                 |
 | `:VibingCancelResume [all]`           | Cancel the pending auto-resume/scheduled send for this chat (or every one with `all`); also clears the project's recorded usage limit for that chat's backend |
 | `:VibingReloadCommands`               | Reload custom slash commands                                                                                                                                  |
+| `:VibingCreatePlugin [name]`          | Scaffold a project-local Claude Code plugin under `.vibing/plugins/` and open its example skill                                                               |
 | `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                                                                                   |
 | `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                                                                               |
 | `:VibingDailySummaryAll [YYYY-MM-DD]` | Generate daily summary from all chat files (default: today)                                                                                                   |
@@ -77,6 +78,12 @@ requests backed by the `vibing-worktree-{list,create,attach,run,finish}` Claude 
 bundled with this plugin (`claude-plugin/skills/`), not by chat slash commands. See
 `claude-plugin/skills/vibing-worktree-list/SKILL.md` and its sibling `-create`, `-attach`,
 `-run`, `-finish` skills.
+
+`:VibingCreatePlugin` writes into `.vibing/plugins/<name>/`, the per-project plugin directory
+`--plugin-dir` loads (`architecture.md` → "Self-Hosted Claude Code Plugin"). Without an argument
+it prompts. A directory whose name starts with `_` is skipped by `plugin_dirs`, which is what
+keeps the seeded `_template/` out of both the request and the `/` picker, and what lets a plugin
+be parked by renaming rather than deleting.
 
 Running several tasks in parallel across worker chats is the same story: ask for it in natural
 language ("並行でやって"), and the bundled `vibing-orchestrate` skill

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -5,8 +5,9 @@ instance without deadlocks: an async RPC server (`lua/vibing/infrastructure/rpc/
 `vim.loop` TCP,
 `vim.schedule()` for safe API calls) is queried by the Node MCP server
 (`claude-plugin/mcp-server/`) acting as a TCP client, so both buffer reads and writes are possible.
-Installation is handled by `build.sh` (installs the `vibing-nvim` Claude Code plugin, user
-scope) — see
+Nothing is installed: `build.sh` builds the server, and the plugin that carries it is handed to
+the CLI per session with `--plugin-dir` (`architecture.md` → "Self-Hosted Claude Code Plugin").
+See
 `claude-plugin/mcp-server/README.md` and `handbook/lazy-setup-example.lua` for setup details;
 don't duplicate them here.
 
@@ -26,14 +27,21 @@ than restating the reasoning — a skill is loaded on its own, so a bare cross-r
 the rule unstated.
 
 **The prefix depends on how the server was registered.** `mcp__vibing-nvim__<tool>` for a plain
-user-level entry, `mcp__plugin_<marketplace>_vibing-nvim__<tool>` for a plugin install.
-`VIBING_NVIM_MCP_TOOL_PATTERNS` (`core/constants/tools.lua`) enumerates the prefixes for
-`--allowedTools`, which accepts nothing but literals — so it must be updated by hand on a
-marketplace rename. It silently went stale once when the marketplace became `vibing`;
-`tests/lua/core/constants/tools_spec.lua` now reads the name out of
-`.claude-plugin/marketplace.json` and fails if the matching entry is missing. The grant still
-works while that list is stale, because the hook's suffix match is what actually decides — which
-is exactly why nothing noticed.
+user-level entry, `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` when it arrives inside the plugin
+— which is the normal case, since vibing.nvim self-hosts that plugin with `--plugin-dir`.
+
+Note what builds that second form: the **plugin** name and the MCP server name, both from
+`claude-plugin/.claude-plugin/plugin.json`. The marketplace name never appears in it. This rule
+used to be written down as `mcp__plugin_<marketplace>_…`, and
+`tests/lua/core/constants/tools_spec.lua` read `marketplace.json` to enforce it — so after the
+marketplace was renamed to `vibing`, the list carried an `mcp__plugin_vibing_vibing-nvim__*` entry
+the CLI has never once emitted, and a test defended it. Both are gone; the spec reads `plugin.json`
+now.
+
+`VIBING_NVIM_MCP_TOOL_PATTERNS` (`core/constants/tools.lua`) still has to be maintained by hand,
+because `--allowedTools` accepts nothing but literals. A stale entry there does not break chats:
+the hook's suffix match is what actually decides, which is exactly why nothing noticed the dead
+one for so long.
 
 **The port has to be named explicitly**, and a subagent does not inherit the chat's. The system
 prompt therefore tells the model both to pass its own `rpc_port` and to forward it in any task

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,18 @@ jobs:
           test -d bin && echo "OK: bin/ directory exists"
           test -f lua/vibing/init.lua && echo "OK: lua/vibing/init.lua exists"
 
-      # Four files independently assert where the Claude Code plugin lives —
+      # Five files independently assert where the Claude Code plugin lives —
       # marketplace.json's `source`, build.sh's PLUGIN_SRC_DIR, install.lua's
-      # get_mcp_dir(), and plugin.json's ${CLAUDE_PLUGIN_ROOT}-relative args.
-      # They cannot share a constant (JSON / bash / Lua), and nothing else in CI
-      # runs build.sh or installs the plugin, so a rename that updates only some
-      # of them goes green here and surfaces as "MCP server directory not found"
-      # on a user's next build. Resolve `source` and check the rest against it.
+      # get_mcp_dir(), plugin_dirs.lua's `--plugin-dir` target, and plugin.json's
+      # ${CLAUDE_PLUGIN_ROOT}-relative args. They cannot share a constant
+      # (JSON / bash / Lua), and nothing else in CI runs build.sh or loads the
+      # plugin, so a rename that updates only some of them goes green here and
+      # surfaces as "MCP server directory not found" on a user's next build.
+      # Resolve `source` and check the rest against it.
+      #
+      # plugin_dirs.lua is the load-bearing one since #618: the plugin is handed
+      # to the CLI per session with `--plugin-dir` instead of being installed, so
+      # that path is what actually decides whether the MCP tools exist at all.
       - name: Check Claude Code plugin layout
         run: |
           SRC="$(node -e "
@@ -102,14 +107,11 @@ jobs:
             process.stdout.write(p.source.replace(/^\.\//, '').replace(/\/\$/, ''));
           ")"
           echo "marketplace.json source: $SRC"
-          # build.sh keeps its own copy of the marketplace *name*, which decides the plugin id it
-          # installs and updates. A rename that misses it leaves build.sh operating on a
-          # marketplace that no longer exists. (The matching copy in core/constants/tools.lua is
-          # checked by tests/lua/core/constants/tools_spec.lua, which reads the same manifest.)
-          NAME="$(node -e "process.stdout.write(require('./.claude-plugin/marketplace.json').name)")"
-          echo "marketplace.json name: $NAME"
-          grep -q "MARKETPLACE_NAME=\"$NAME\"" build.sh \
-            && echo "OK: build.sh MARKETPLACE_NAME matches"
+          # The marketplace name is deliberately not cross-checked against build.sh any more.
+          # build.sh no longer installs through a marketplace, and the MCP tool prefix never
+          # depended on that name in the first place — it is built from plugin.json's `name`,
+          # which tests/lua/core/constants/tools_spec.lua checks against
+          # core/constants/tools.lua.
           test -f "$SRC/.claude-plugin/plugin.json" && echo "OK: $SRC/.claude-plugin/plugin.json exists"
           test -d "$SRC/mcp-server" && echo "OK: $SRC/mcp-server/ exists"
           test -d "$SRC/agents" && echo "OK: $SRC/agents/ exists"
@@ -118,6 +120,8 @@ jobs:
             && echo "OK: build.sh PLUGIN_SRC_DIR matches"
           grep -q "\"/$SRC/mcp-server\"" lua/vibing/install.lua \
             && echo "OK: install.lua MCP dir matches"
+          grep -q "\"/$SRC\"" lua/vibing/infrastructure/plugins/plugin_dirs.lua \
+            && echo "OK: plugin_dirs.lua --plugin-dir target matches"
 
   format-and-lint:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,11 @@ Claude Code に配布されるものは**すべて `claude-plugin/` 配下**に�
 marketplace root（`.claude-plugin/marketplace.json` があるディレクトリ）で、plugin root は
 その1階層下という関係になっている。
 
+ただし通常の経路はもう marketplace ではない。`claude-plugin/` は
+`cli_command_builder` が `--plugin-dir` でセッションごとに CLI に渡す（#618、
+`.claude/rules/architecture.md` →「Self-Hosted Claude Code Plugin」）。marketplace.json は
+手動 `claude plugin install` のために残してあるだけ。
+
 | 場所                                       | 中身                                                   |
 | ------------------------------------------ | ------------------------------------------------------ |
 | `.claude-plugin/marketplace.json`          | marketplace 定義。`source` が `./claude-plugin` を指す |
@@ -90,7 +95,7 @@ marketplace root（`.claude-plugin/marketplace.json` があるディレクトリ
 | `claude-plugin/mcp-server/`                | 配布される MCP サーバー                                |
 | `.claude/{skills,commands,rules}/`         | **このリポジトリを開発するため**のもの。配布されない   |
 
-`claude-plugin/` に置いたものは `claude plugin install` でユーザーに届き、`.claude/` に置いた
+`claude-plugin/` に置いたものは `--plugin-dir` 経由でユーザーに届き、`.claude/` に置いた
 ものは届かない。スキルを追加するときはどちらの読者向けかで置き場所を決める。
 
 ディレクトリ名が `plugin/` でないのは Neovim の予約名だからで、`plugin/**/*.lua` は

--- a/README.ja.md
+++ b/README.ja.md
@@ -152,7 +152,7 @@ MCP ツールの接続先として、`mcp = { enabled = true }`(デフォルト)
 
 **プロジェクト固有のプラグイン。** `.vibing/plugins/<name>/`(`.claude-plugin/plugin.json`
 付き)に置いたものは同じ仕組みで読み込まれ、そのプロジェクトのチャットにだけ効きます。追加
-したら `:VibingReloadCommands` を実行してください。なお、プラグインは `mcpServers` を宣言
+したら `:VibingReloadCommands` を実行してください。雛形は `:VibingCreatePlugin <name>` で作れます。なお、プラグインは `mcpServers` を宣言
 できるため、クローンしたリポジトリに仕込まれたプラグインが手元でプロセスを起動しうる点には
 注意してください。信用できないリポジトリでは `agent.plugins.project_dir = false` にします。
 `agent.plugins` の詳細は [handbook/configuration.md](handbook/configuration.md) を参照。
@@ -192,6 +192,7 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 | `:VibingClearContext`                 | コンテキストを全クリア                                                                             |
 | `:VibingCancel`                       | 実行中のリクエストをキャンセル                                                                     |
 | `:VibingReloadCommands`               | カスタムスラッシュコマンドと補完候補を再読み込み                                                   |
+| `:VibingCreatePlugin [name]`          | `.vibing/plugins/` にプロジェクト固有のClaude Codeプラグインを作成                                 |
 | `:VibingCopyUnsentUserHeader`         | `## User <!-- unsent -->` をクリップボードにコピー                                                 |
 | `:VibingDailySummary [YYYY-MM-DD]`    | プロジェクトのチャットから日報を生成(デフォルト: 今日)                                             |
 | `:VibingDailySummaryAll [YYYY-MM-DD]` | すべてのチャットから日報を生成(デフォルト: 今日)                                                   |

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,7 +106,7 @@ vibing.nvim は補完プラグイン(Copilot、Codeium)や他のチャットプ�
   dependencies = {
     "stevearc/oil.nvim",  -- オプション: ファイルブラウザ統合
   },
-  build = "./build.sh",  -- MCP サーバーのビルドと Claude Code プラグインの登録
+  build = "./build.sh",  -- 同梱 MCP サーバーのビルド
   config = function()
     require("vibing").setup()
   end,
@@ -129,37 +129,40 @@ use {
 
 ### Claude Code プラグイン(MCP + スキル + エージェント)
 
-vibing.nvim は [Claude Code プラグイン](https://code.claude.com/docs/en/plugins)としても配布
-されており、`vibing-nvim` MCP サーバー・Neovim 対応スキル・読み取り専用ナビゲーション
-サブエージェントが同梱されます。`~/.claude.json` の手動編集は不要です。
+vibing.nvim は [Claude Code プラグイン](https://code.claude.com/docs/en/plugins)を同梱して
+おり、`vibing-nvim` MCP サーバー・Neovim 対応スキル・読み取り専用ナビゲーション
+サブエージェントが含まれます。
 
-**自動:** 上記のように `build = "./build.sh"` でインストールし、`claude` CLI が `PATH` に
-あれば、ビルドのたびに `build.sh` が `claude plugin marketplace add` +
-`claude plugin install ... --scope user` を実行します。追加作業はありません。
+**インストール作業はありません。** このプラグインは Claude Code のグローバル状態には一切
+登録されません。vibing.nvim が自分の `claude-plugin/` ディレクトリをセッションごとに
+`--plugin-dir` で CLI に渡すため、いま動いている checkout がそのまま使われます(worktree を
+含む)。`build.sh` がやるのは MCP サーバーのビルドと、旧バージョンのインストールが残っている
+場合の一度きりの後片付けだけです。
 
-**手動:** 自分でインストールする場合(`build.sh` を実行しない場合や別マシンなど):
+これにより `mcp__plugin_vibing-nvim_vibing-nvim__*` ツール(実行中の Neovim へのバッファ/
+ウィンドウ/カーソルアクセス・Ex コマンド・LSP クエリ)、同梱スキル(`nvim-context`、
+`nvim-lsp-navigation`、`vibing-chat-recall`、`vibing-chat-search`、および worktree
+ワークフローの `vibing-worktree-{list,create,attach,run,finish}`)、`nvim-navigator`
+サブエージェント(`@vibing-nvim:nvim-navigator` による読み取り専用コードナビゲーション)が
+利用できます。
 
-```text
-/plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing
-```
+MCP ツールの接続先として、`mcp = { enabled = true }`(デフォルト)の Neovim が起動している
+必要があります。引き換えに、Neovim の外で起動した素の `claude` セッションからはこれらの
+ツールが見えなくなります。もともと想定された使い方ではありません。
 
-いずれの方法でも、`vibing-nvim` MCP サーバー(実行中の Neovim へのバッファ/ウィンドウ/
-カーソルアクセス・Ex コマンド・LSP クエリを `mcp__vibing-nvim__*` ツールとして提供)、
-同梱スキル(`nvim-context`、`nvim-lsp-navigation`、`vibing-chat-recall`、
-`vibing-chat-search`、および worktree ワークフローの
-`vibing-worktree-{list,create,attach,run,finish}`)、`nvim-navigator` サブエージェント
-(`@vibing-nvim:nvim-navigator` による読み取り専用コードナビゲーション)が登録されます。
+**プロジェクト固有のプラグイン。** `.vibing/plugins/<name>/`(`.claude-plugin/plugin.json`
+付き)に置いたものは同じ仕組みで読み込まれ、そのプロジェクトのチャットにだけ効きます。追加
+したら `:VibingReloadCommands` を実行してください。なお、プラグインは `mcpServers` を宣言
+できるため、クローンしたリポジトリに仕込まれたプラグインが手元でプロセスを起動しうる点には
+注意してください。信用できないリポジトリでは `agent.plugins.project_dir = false` にします。
+`agent.plugins` の詳細は [handbook/configuration.md](handbook/configuration.md) を参照。
 
-同梱 MCP サーバーは初回起動時(およびソース変更時)に自動でビルドされるため、MCP サーバー
-自体の個別ビルドは不要です。MCP ツールの接続先として、`mcp = { enabled = true }`(デフォルト)
-の Neovim が起動している必要があります。
-
-**アンインストール:**
+**旧バージョンからの移行:** `build.sh` が user scope のインストールとマーケットプレイス
+登録を削除します。手動でやる場合:
 
 ```text
 /plugin uninstall vibing-nvim@vibing
-/plugin marketplace remove vibing-nvim
+/plugin marketplace remove vibing
 ```
 
 ## 🚀 クイックスタート

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ they compose well.
   dependencies = {
     "stevearc/oil.nvim",  -- Optional: file browser integration
   },
-  build = "./build.sh",  -- Builds the MCP server and registers the Claude Code plugin
+  build = "./build.sh",  -- Builds the bundled MCP server
   config = function()
     require("vibing").setup()
   end,
@@ -131,36 +131,37 @@ use {
 
 ### Claude Code Plugin (MCP + Skills + Agents)
 
-vibing.nvim is also distributed as a [Claude Code plugin](https://code.claude.com/docs/en/plugins),
-which bundles the `vibing-nvim` MCP server together with Neovim-aware skills and a read-only
-navigation subagent — no manual `~/.claude.json` editing required.
+vibing.nvim ships a [Claude Code plugin](https://code.claude.com/docs/en/plugins) that bundles the
+`vibing-nvim` MCP server together with Neovim-aware skills and a read-only navigation subagent.
 
-**Automatic:** if you install with `build = "./build.sh"` (as above) and have the `claude` CLI on
-your `PATH`, `build.sh` runs `claude plugin marketplace add` + `claude plugin install ... --scope
-user` for you on every build — nothing else to do.
+**Nothing to install.** The plugin is not registered into Claude Code's global state at all —
+vibing.nvim hands the CLI its own `claude-plugin/` directory per session with `--plugin-dir`, so
+whichever checkout is running is the one that serves you. `build.sh` only builds the MCP server
+(and, once, cleans up an install from an older version of vibing.nvim).
 
-**Manual:** to install it yourself (e.g. without running `build.sh`, or on a different machine):
-
-```text
-/plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing
-```
-
-Either way, this registers the `vibing-nvim` MCP server (buffer/window/cursor access, Ex commands,
-and LSP queries against the running Neovim instance, as `mcp__vibing-nvim__*` tools), the bundled
-skills (`nvim-context`, `nvim-lsp-navigation`, `vibing-chat-recall`, `vibing-chat-search`, and the
+That gives you `mcp__plugin_vibing-nvim_vibing-nvim__*` tools (buffer/window/cursor access, Ex
+commands, and LSP queries against the running Neovim instance), the bundled skills
+(`nvim-context`, `nvim-lsp-navigation`, `vibing-chat-recall`, `vibing-chat-search`, and the
 `vibing-worktree-{list,create,attach,run,finish}` worktree workflow), and the `nvim-navigator`
 subagent (read-only code navigation via `@vibing-nvim:nvim-navigator`).
 
-The bundled MCP server builds itself on first launch (and whenever its sources change), so no
-separate build step is needed for the MCP server itself. You still need Neovim running with
-`mcp = { enabled = true }` (the default) for the MCP tools to have anything to connect to.
+You still need Neovim running with `mcp = { enabled = true }` (the default) for the MCP tools to
+have anything to connect to. The one trade-off is that a plain `claude` session started outside
+Neovim no longer sees these tools; that was never a supported way to use them.
 
-**Uninstalling:**
+**Your own project plugins.** Anything you drop into `.vibing/plugins/<name>/` (with a
+`.claude-plugin/plugin.json`) is loaded the same way, for chats in that project only. Run
+`:VibingReloadCommands` after adding one. Note that a plugin may declare `mcpServers`, so a plugin
+in a repository you cloned can start a process on your machine — set
+`agent.plugins.project_dir = false` for repositories you do not trust. See
+[handbook/configuration.md](handbook/configuration.md) for `agent.plugins`.
+
+**Upgrading from an older vibing.nvim:** `build.sh` removes the user-scope install and its
+marketplace entry for you. To do it by hand:
 
 ```text
 /plugin uninstall vibing-nvim@vibing
-/plugin marketplace remove vibing-nvim
+/plugin marketplace remove vibing
 ```
 
 ## 🚀 Quick Start

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Neovim no longer sees these tools; that was never a supported way to use them.
 
 **Your own project plugins.** Anything you drop into `.vibing/plugins/<name>/` (with a
 `.claude-plugin/plugin.json`) is loaded the same way, for chats in that project only. Run
-`:VibingReloadCommands` after adding one. Note that a plugin may declare `mcpServers`, so a plugin
+`:VibingReloadCommands` after adding one, or `:VibingCreatePlugin <name>` to write a working
+skeleton in the first place. Note that a plugin may declare `mcpServers`, so a plugin
 in a repository you cloned can start a process on your machine — set
 `agent.plugins.project_dir = false` for repositories you do not trust. See
 [handbook/configuration.md](handbook/configuration.md) for `agent.plugins`.
@@ -199,6 +200,7 @@ help tags.
 | `:VibingPendingResumes`               | List chats waiting on a usage limit reset or a scheduled send                                                                         |
 | `:VibingCancelResume [all]`           | Cancel the pending auto-resume/scheduled send for this chat (or every one with `all`); also clears the project's recorded usage limit |
 | `:VibingReloadCommands`               | Reload custom slash commands and completion candidates                                                                                |
+| `:VibingCreatePlugin [name]`          | Create a project-local Claude Code plugin under `.vibing/plugins/`                                                                    |
 | `:VibingCopyUnsentUserHeader`         | Copy `## User <!-- unsent -->` to clipboard                                                                                           |
 | `:VibingDailySummary [YYYY-MM-DD]`    | Generate daily summary from project chat files (default: today)                                                                       |
 | `:VibingDailySummaryAll [YYYY-MM-DD]` | Generate daily summary from all chat files (default: today)                                                                           |

--- a/bin/lib/plugin-loader.ts
+++ b/bin/lib/plugin-loader.ts
@@ -234,3 +234,43 @@ export async function resolveInstalledPlugins(): Promise<ResolvedPlugin[]> {
 
   return plugins;
 }
+
+/**
+ * Resolve plugin directories that vibing.nvim self-hosts for the session via the `claude` CLI's
+ * `--plugin-dir` flag (its own `claude-plugin/`, plus anything under `.vibing/plugins/`).
+ *
+ * These never appear in installed_plugins.json — nothing was installed — so completion would
+ * otherwise be blind to skills the CLI itself loads perfectly well. The directories arrive
+ * already resolved from the Lua side (`infrastructure/plugins/plugin_dirs.lua`) rather than
+ * being rediscovered here: the convention depends on a chat's working directory, and writing
+ * that lookup in two languages is how the two copies drift apart.
+ *
+ * The id is the plugin's declared `name`, because that is what Claude Code namespaces its
+ * skills under — `<name>:<skill>` — regardless of the directory's own basename.
+ *
+ * @param dirs Absolute plugin directory paths.
+ * @returns Entries for directories carrying a readable `.claude-plugin/plugin.json`.
+ *   Anything else is skipped silently, mirroring the CLI's own handling of a broken plugin
+ *   directory (the Lua side is what warns about it, once per working directory).
+ */
+export async function resolveSessionPluginDirs(dirs: string[]): Promise<ResolvedPlugin[]> {
+  const resolved = await Promise.all(
+    dirs.map(async (dir): Promise<ResolvedPlugin | null> => {
+      try {
+        const manifest = JSON.parse(
+          await readFile(join(dir, '.claude-plugin', 'plugin.json'), 'utf8')
+        ) as { name?: unknown };
+        if (typeof manifest.name !== 'string' || manifest.name === '') {
+          debugLog(`Session plugin dir has no name: ${dir}`);
+          return null;
+        }
+        return { id: manifest.name, path: dir };
+      } catch (error) {
+        debugLog(`Could not read session plugin dir: ${dir}`, error);
+        return null;
+      }
+    })
+  );
+
+  return resolved.filter((plugin): plugin is ResolvedPlugin => plugin !== null);
+}

--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -128,11 +128,17 @@ async function listCommands() {
     const sessionPlugins = await resolveSessionPluginDirs(process.argv.slice(2));
     const installedPlugins = await resolveInstalledPlugins();
 
-    const seen = new Set(sessionPlugins.map((plugin) => pluginShortName(plugin.id)));
-    const plugins = [
-      ...sessionPlugins,
-      ...installedPlugins.filter((plugin) => !seen.has(pluginShortName(plugin.id))),
-    ];
+    // First occurrence of a plugin name wins, across both lists. The Lua side already
+    // deduplicates the directories it passes, but this is also a standalone binary taking a
+    // caller's argv, and listing a skill the CLI would not load offers a `/` entry that silently
+    // does nothing.
+    const seen = new Set<string>();
+    const plugins = [...sessionPlugins, ...installedPlugins].filter((plugin) => {
+      const name = pluginShortName(plugin.id);
+      if (seen.has(name)) return false;
+      seen.add(name);
+      return true;
+    });
 
     const pluginSkillLists = await Promise.all(
       plugins.map((plugin) => scanPluginSkills(plugin.path, pluginShortName(plugin.id)))

--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -14,7 +14,7 @@
 import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import { safeJsonStringify } from './lib/utils.js';
-import { resolveInstalledPlugins } from './lib/plugin-loader.js';
+import { resolveInstalledPlugins, resolveSessionPluginDirs } from './lib/plugin-loader.js';
 
 interface CommandEntry {
   name: string;
@@ -121,7 +121,18 @@ async function scanPluginSkills(pluginPath: string, pluginName: string): Promise
 
 async function listCommands() {
   try {
-    const plugins = await resolveInstalledPlugins();
+    // Argv is a list of absolute plugin directories vibing.nvim self-hosts for the session via
+    // the CLI's `--plugin-dir`, already resolved by the Lua side. They go first because that is
+    // the precedence the CLI itself applies to a duplicate plugin name: the earlier
+    // `--plugin-dir` wins, and an installed plugin of the same name never loads.
+    const sessionPlugins = await resolveSessionPluginDirs(process.argv.slice(2));
+    const installedPlugins = await resolveInstalledPlugins();
+
+    const seen = new Set(sessionPlugins.map((plugin) => pluginShortName(plugin.id)));
+    const plugins = [
+      ...sessionPlugins,
+      ...installedPlugins.filter((plugin) => !seen.has(pluginShortName(plugin.id))),
+    ];
 
     const pluginSkillLists = await Promise.all(
       plugins.map((plugin) => scanPluginSkills(plugin.path, pluginShortName(plugin.id)))

--- a/build.sh
+++ b/build.sh
@@ -14,9 +14,12 @@ MCP_DIR="${PLUGIN_SRC_DIR}/mcp-server"
 # Use VIBING_NODE_EXECUTABLE env var if set, otherwise default to "node"
 NODE_EXECUTABLE="${VIBING_NODE_EXECUTABLE:-node}"
 
-# Timeouts (seconds) for `claude` CLI calls in the plugin-registration block below.
-# `claude plugin list --json` only reads local state, so it gets a shorter budget
-# than the marketplace/plugin subcommands, which may hit the network.
+# Timeouts (seconds) for the `claude plugin ...` cleanup calls below. Kept even
+# though vibing.nvim no longer installs itself as a plugin: uninstalling one is
+# the same subcommand family that hangs (#480/#482), and the cleanup runs on
+# every build until the user's machine is clean. `claude plugin list --json`
+# only reads local state, so it gets a shorter budget than the subcommands that
+# may hit the network.
 readonly CLAUDE_CLI_LIST_TIMEOUT=30
 readonly CLAUDE_CLI_TIMEOUT=60
 
@@ -39,7 +42,7 @@ kill_tree() {
 
 # Run a command with a hard timeout. macOS doesn't ship GNU coreutils' `timeout`,
 # so this is implemented with a background watchdog instead of relying on it.
-# Needed because `claude plugin ...` invocations below can hang indefinitely on
+# Needed because `claude plugin ...` invocations can hang indefinitely on
 # a stalled network call, which otherwise wedges this script forever and gets
 # it killed by the caller's own timeout (e.g. lazy.nvim's build-step timeout),
 # skipping every step after it.
@@ -151,211 +154,61 @@ echo "[vibing.nvim] Building TypeScript..."
 npm run build --silent
 
 # Record the fingerprint run.mjs's self-build check compares against (same
-# algorithm, via bin/build-fingerprint.mjs), so the plugin cache's run.mjs
-# recognizes this build as fresh on first launch instead of running `npm ci`
-# over the node_modules symlink set up below and replacing it with a real
-# copy until the next build.sh run re-links it.
+# algorithm, via bin/build-fingerprint.mjs), so run.mjs recognizes this build as
+# fresh on first launch instead of spending a `npm ci` + `npm run build` on the
+# very tree that was just built.
 "$NODE_EXECUTABLE" bin/write-fingerprint.mjs
 
 # Verify build succeeded
 if [ -f "dist/index.js" ]; then
     echo "[vibing.nvim] ✓ MCP server built successfully"
 
-    # Register vibing-nvim with Claude Code exclusively as a proper Claude Code
-    # plugin (user scope) — this registers the MCP server *and* the bundled
-    # skills/agents in one step. There is intentionally no raw ~/.claude.json
-    # mcpServers fallback: that path can only ever hardcode a single default
-    # RPC port, so it silently targets the wrong Neovim instance whenever more
-    # than one is running (see cli_command_builder.lua's rpc_port handling).
+    # vibing.nvim is NOT installed into Claude Code's global state. Its plugin
+    # (claude-plugin/) is handed to the CLI per session with `--plugin-dir`,
+    # assembled in lua/vibing/infrastructure/plugins/plugin_dirs.lua. The MCP
+    # tool names are identical either way — the prefix comes from plugin.json's
+    # `name`, not from how the plugin was loaded (measured on claude 2.1.231).
+    #
+    # That removes three standing problems at once: `claude plugin ...` calls
+    # that hang and needed the watchdog above (#480/#482), a plugin cache that
+    # had to be rsync'd and symlinked back to this checkout on every build, and
+    # an MCP server that updated independently of the Neovim plugin it serves —
+    # so a worktree edited its own copy while a different one actually ran.
+    #
+    # What remains here is one-shot cleanup for machines that already have the
+    # old user-scope install. It is best-effort: an inline `--plugin-dir` plugin
+    # wins over an installed one of the same name (measured), so a leftover is
+    # inert rather than a conflict.
     cd "$SCRIPT_DIR"
-    MARKETPLACE_NAME="vibing"
-    PLUGIN_ID="vibing-nvim@${MARKETPLACE_NAME}"
-    # Pre-rename identifiers, kept only for the one-time migration cleanup below.
-    OLD_MARKETPLACE_NAME="vibing-nvim"
-    OLD_PLUGIN_ID="vibing-nvim@${OLD_MARKETPLACE_NAME}"
-    PLUGIN_INSTALL_HINT="claude plugin marketplace add $SCRIPT_DIR && claude plugin install ${PLUGIN_ID} --scope user"
     if command -v claude &> /dev/null; then
-        # Remove any legacy direct "vibing-nvim" mcpServers registration (e.g. from
-        # `claude mcp add` predating the plugin-based install above, or a leftover
-        # ~/.claude.json entry). That path hardcodes a single RPC port and silently
-        # targets the wrong Neovim instance whenever more than one is running, so it
-        # must not coexist with the plugin registration. Ignore failure: this is a
-        # no-op when no such entry exists.
+        # Legacy direct "vibing-nvim" mcpServers registration (e.g. from `claude
+        # mcp add`, predating the plugin install). That path hardcodes a single
+        # RPC port and silently targets the wrong Neovim instance whenever more
+        # than one is running. No-op when no such entry exists.
         claude mcp remove vibing-nvim --scope user &> /dev/null || true
 
-        # Fetch the installed-plugin list once up front and reuse it below for the
-        # migration-cleanup check, the already-installed check, and (after a
-        # refresh) the installPath lookup, instead of asking `claude` — slow on at
-        # least one real machine in this project's history — for the same data
-        # repeatedly. Re-fetched only after an operation that actually changes it
-        # (a fresh install, or the migration cleanup below).
+        # The user-scope plugin install and its marketplace, from before #618 —
+        # under the current name and the pre-rename one. These are historical
+        # identifiers to clean up, not configuration to follow, which is why they
+        # appear nowhere else in the repository any more.
+        #
+        # Gated on evidence rather than fired unconditionally: this runs on every
+        # build, forever, on machines that never had the install, and each
+        # `claude plugin ...` call is a process spawn under a 60s watchdog. One
+        # `list` answers for all four.
         PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
-
-        # Remove the pre-rename "vibing-nvim" marketplace/plugin registration (this
-        # marketplace was renamed to "vibing" so the plugin-scoped MCP tool prefix
-        # isn't mcp__plugin_vibing-nvim_vibing-nvim__* — see git history), but only
-        # when there's actual evidence of it in the plugin list. `claude plugin
-        # marketplace add` on the same directory does not migrate an existing
-        # registration to the new name on its own, so without this an upgrading
-        # user would end up with both the old and new marketplace/plugin registered
-        # side by side — reintroducing the very duplicate-tool-name problem this
-        # rename fixed, just under two names instead of one. Gating on the list
-        # (rather than running unconditionally) keeps this a one-time cost during
-        # the migration window instead of two extra `claude` CLI spawns on every
-        # future build forever.
-        if echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='${OLD_PLUGIN_ID}')?0:1)" 2>/dev/null; then
-            run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin uninstall "$OLD_PLUGIN_ID" &> /dev/null || true
-            run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace remove "$OLD_MARKETPLACE_NAME" &> /dev/null || true
-            PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
-        fi
-
-        # Capture output instead of streaming it directly so it can be printed
-        # below only on failure, keeping successful (repeat) runs quiet.
-        # `... || STATUS=$?` (rather than a bare `STATUS=$?` on the next line) is
-        # required under `set -e`: a plain `VAR="$(cmd)"` assignment fails the
-        # *script* the moment cmd's timeout/error trips a non-zero exit, before
-        # the "if $STATUS -ne 0" fallback below ever runs. A command is exempt
-        # from set -e only when it isn't the final element of a && / || list, so
-        # attaching the fallback via `||` on the same line keeps the assignment's
-        # own failure from aborting the script while still capturing its status.
-        MARKETPLACE_ADD_STATUS=0
-        MARKETPLACE_ADD_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace add "$SCRIPT_DIR" 2>&1)" || MARKETPLACE_ADD_STATUS=$?
-        if [ $MARKETPLACE_ADD_STATUS -ne 0 ]; then
-            echo "[vibing.nvim] ⚠ Warning: 'claude plugin marketplace add' failed"
-            echo "$MARKETPLACE_ADD_OUTPUT"
-            echo "[vibing.nvim] You can manually install by running: $PLUGIN_INSTALL_HINT"
-        # Query installed state as JSON rather than grepping the human-readable table
-        # (`claude plugin list`), whose "❯" marker/formatting is a display detail,
-        # not a stable contract to match against.
-        elif echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')||'[]').some(p=>p.id==='${PLUGIN_ID}')?0:1)" 2>/dev/null; then
-            # Already installed: `claude plugin install` is a no-op here, so on repeat
-            # runs (e.g. `:Lazy update` re-invoking this script) it won't pick up
-            # skill/agent changes on its own. Explicitly refresh the marketplace
-            # pointer and re-sync the cached plugin snapshot to the current commit.
-            echo "[vibing.nvim] vibing-nvim plugin already installed; refreshing cache..."
-            # See the MARKETPLACE_ADD_STATUS comment above for why the fallback is
-            # attached via `||` on the same line rather than a separate `STATUS=$?`.
-            MARKETPLACE_UPDATE_STATUS=0
-            MARKETPLACE_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace update "$MARKETPLACE_NAME" 2>&1)" || MARKETPLACE_UPDATE_STATUS=$?
-            PLUGIN_UPDATE_OUTPUT=""
-            PLUGIN_UPDATE_STATUS=1
-            if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ]; then
-                PLUGIN_UPDATE_STATUS=0
-                PLUGIN_UPDATE_OUTPUT="$(run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin update "$PLUGIN_ID" 2>&1)" || PLUGIN_UPDATE_STATUS=$?
-            fi
-            if [ $MARKETPLACE_UPDATE_STATUS -eq 0 ] && [ $PLUGIN_UPDATE_STATUS -eq 0 ]; then
-                echo "[vibing.nvim] ✓ Synced vibing-nvim plugin cache (restart Claude Code to apply)"
-            elif [ $MARKETPLACE_UPDATE_STATUS -ne 0 ]; then
-                echo "[vibing.nvim] ⚠ Warning: 'claude plugin marketplace update' failed"
-                echo "$MARKETPLACE_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update $MARKETPLACE_NAME && claude plugin update $PLUGIN_ID"
-            else
-                echo "[vibing.nvim] ⚠ Warning: 'claude plugin update' failed"
-                echo "$PLUGIN_UPDATE_OUTPUT"
-                echo "[vibing.nvim] You can manually sync by running: claude plugin marketplace update $MARKETPLACE_NAME && claude plugin update $PLUGIN_ID"
-            fi
-        else
-            echo "[vibing.nvim] Installing vibing-nvim as a Claude Code plugin (user scope)..."
-            if run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin install "$PLUGIN_ID" --scope user; then
-                echo "[vibing.nvim] ✓ Installed vibing-nvim Claude Code plugin (scope: user)"
-                # The snapshot above predates this install, so it won't have an
-                # installPath for $PLUGIN_ID yet — refetch before using it below.
-                PLUGIN_LIST_JSON="$(run_with_timeout "$CLAUDE_CLI_LIST_TIMEOUT" claude plugin list --json 2>/dev/null)" || true
-            else
-                echo "[vibing.nvim] ⚠ Warning: 'claude plugin install' failed"
-                echo "[vibing.nvim] You can manually install by running: $PLUGIN_INSTALL_HINT"
-            fi
-        fi
-
-        # `claude plugin update` treats a matching git commit SHA as "already up to
-        # date" and never re-copies — which, for a "directory"-source (dev-mode)
-        # plugin whose whole point is tracking uncommitted local edits, means it
-        # silently skips syncing on every single build.sh run where HEAD hasn't
-        # moved. So sync this checkout's plugin tree into the cache directly on
-        # every run, rather than only when detected as broken.
-        #
-        # This block predates the claude-plugin/ layout, when `source` was the
-        # repository root and the CLI's own copy step ran over ~700MB / ~26k files
-        # per snapshot — slow enough on a machine with real-time antivirus/EDR
-        # scanning (observed on a corporate-managed Mac) that it could stop partway
-        # while still updating its bookkeeping as if it finished. That copy is now
-        # ~60 files, so the incomplete-snapshot failure is largely retired; the
-        # SHA-skip above is what keeps this sync load-bearing.
-        #
-        # mcp-server/node_modules and mcp-server/dist are symlinked into the cache
-        # rather than copied, for two reasons: (1) rsync/cp copying node_modules'
-        # thousands of small files is exactly the kind of slow-on-this-machine
-        # operation that produced the incomplete snapshot in the first place, and
-        # doing it here would just as easily blow past lazy.nvim's own build-step
-        # timeout; (2) a symlink means a later `npm run build` here is reflected
-        # immediately without rerunning this sync.
-        PLUGIN_INSTALL_PATH="$(echo "$PLUGIN_LIST_JSON" | "$NODE_EXECUTABLE" -e "
-          const plugins = JSON.parse(require('fs').readFileSync(0, 'utf8') || '[]');
-          const p = plugins.find((p) => p.id === '${PLUGIN_ID}');
-          process.stdout.write(p && p.installPath ? p.installPath : '');
-        " 2>/dev/null)"
-
-        if [ -n "$PLUGIN_INSTALL_PATH" ]; then
-            echo "[vibing.nvim] Syncing plugin cache with this checkout..."
-            # A partial-copy failure here (permission errors, EDR/antivirus
-            # interference — the exact class of environment this sync exists
-            # to work around) must not abort the rest of build.sh under `set
-            # -e`, the way every other `claude plugin ...` call above already
-            # tolerates failure. Capture the status via `||` instead of
-            # letting a failing command be the tail of its own statement.
-            SYNC_STATUS=0
-            if command -v rsync &> /dev/null; then
-                rsync -a --delete --exclude='/mcp-server/node_modules' --exclude='/mcp-server/dist' "$PLUGIN_SRC_DIR/" "$PLUGIN_INSTALL_PATH/" || SYNC_STATUS=$?
-            else
-                # Portable fallback without rsync. Copy each top-level entry
-                # individually and skip the excluded ones outright, rather than
-                # `cp -R` the whole tree and `rm -rf` them after: on a repeat run,
-                # the destination's mcp-server/node_modules and mcp-server/dist are
-                # already symlinks back into this very checkout (from the symlink
-                # step below), and `cp -R` landing on an existing symlink follows it
-                # — copying this checkout's node_modules into itself through the
-                # link — instead of replacing it.
-                for entry in "$PLUGIN_SRC_DIR"/* "$PLUGIN_SRC_DIR"/.[!.]*; do
-                    [ -e "$entry" ] || continue
-                    [ "$entry" = "$MCP_DIR" ] && continue
-                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/" || SYNC_STATUS=$?
-                done
-                # Only this loop copies *into* the destination's mcp-server/, so it
-                # is the only one that needs the directory to exist first.
-                mkdir -p "$PLUGIN_INSTALL_PATH/mcp-server"
-                for entry in "$MCP_DIR"/* "$MCP_DIR"/.[!.]*; do
-                    [ -e "$entry" ] || continue
-                    name="${entry##*/}"
-                    [ "$name" = "node_modules" ] && continue
-                    [ "$name" = "dist" ] && continue
-                    cp -R "$entry" "$PLUGIN_INSTALL_PATH/mcp-server/" || SYNC_STATUS=$?
-                done
-            fi
-            if [ "$SYNC_STATUS" -ne 0 ]; then
-                echo "[vibing.nvim] ⚠ Warning: plugin cache sync failed (exit $SYNC_STATUS); cache may be incomplete"
-            fi
-
-            # Unconditionally (re)point node_modules/dist at this live checkout's own
-            # build output rather than only when missing: an earlier run of this
-            # script, or an earlier version of it, may have left a real (now stale)
-            # copy behind instead of a symlink, and `ln -sfn` is instant either way so
-            # there's no cost to always re-asserting it.
-            if [ -d "$PLUGIN_INSTALL_PATH/mcp-server" ]; then
-                [ -L "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" ] || rm -rf "$PLUGIN_INSTALL_PATH/mcp-server/node_modules"
-                [ -L "$PLUGIN_INSTALL_PATH/mcp-server/dist" ] || rm -rf "$PLUGIN_INSTALL_PATH/mcp-server/dist"
-                ln -sfn "$MCP_DIR/node_modules" "$PLUGIN_INSTALL_PATH/mcp-server/node_modules"
-                ln -sfn "$MCP_DIR/dist" "$PLUGIN_INSTALL_PATH/mcp-server/dist"
-            fi
-
-            if [ -f "$PLUGIN_INSTALL_PATH/mcp-server/bin/run.mjs" ] && [ -d "$PLUGIN_INSTALL_PATH/mcp-server/node_modules" ]; then
-                echo "[vibing.nvim] ✓ Plugin cache OK (restart Claude Code to apply any changes)"
-            else
-                echo "[vibing.nvim] ✗ Repair failed; mcp-server/ still incomplete under $PLUGIN_INSTALL_PATH"
-            fi
-        fi
-    else
-        echo "[vibing.nvim] ⚠ 'claude' CLI not found; skipping Claude Code plugin registration"
-        echo "[vibing.nvim] Install Claude Code, then run: $PLUGIN_INSTALL_HINT"
+        for legacy_marketplace in "vibing" "vibing-nvim"; do
+            # The closing quote is part of the pattern on purpose: "vibing-nvim@vibing" is a
+            # prefix of "vibing-nvim@vibing-nvim", so an unanchored match would report the
+            # pre-rename install as the current one and print a misleading line.
+            case "$PLUGIN_LIST_JSON" in
+                *"\"vibing-nvim@${legacy_marketplace}\""*)
+                    echo "[vibing.nvim] Removing the old user-scope plugin install (vibing-nvim@${legacy_marketplace})..."
+                    run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin uninstall "vibing-nvim@${legacy_marketplace}" &> /dev/null || true
+                    run_with_timeout "$CLAUDE_CLI_TIMEOUT" claude plugin marketplace remove "$legacy_marketplace" &> /dev/null || true
+                    ;;
+            esac
+        done
     fi
 
     MCP_SERVER_PATH="${MCP_DIR}/dist/index.js"

--- a/claude-plugin/agents/nvim-navigator.md
+++ b/claude-plugin/agents/nvim-navigator.md
@@ -18,7 +18,7 @@ prompt; whoever delegates to you is expected to pass it along. If it isn't there
 say which ones you found and ask rather than guessing.
 
 _Which prefix._ The tools below are written as `mcp__vibing-nvim__<tool>`, but a plugin-scoped
-install exposes them as `mcp__plugin_<marketplace>_vibing-nvim__<tool>` instead. If the plain
+plugin load exposes them as `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` instead. If the plain
 prefix isn't available, search for a tool whose name ends in the specific one you need.
 
 Given a navigation or analysis question:

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -29,28 +29,28 @@ This MCP server enables Claude Code to interact with a running Neovim instance t
 
 ## Installation
 
-### Option 0: Claude Code Plugin (recommended)
+### Option 0: vibing.nvim's own bundled plugin (the default — nothing to install)
 
-Install this MCP server, plus Neovim-aware skills and a `nvim-navigator` subagent, as a single
-[Claude Code plugin](https://code.claude.com/docs/en/plugins) — no manual `~/.claude.json` editing
-and no separate build step (the server builds itself on first launch).
+This MCP server ships inside vibing.nvim's [Claude Code plugin](https://code.claude.com/docs/en/plugins),
+alongside Neovim-aware skills and an `nvim-navigator` subagent. vibing.nvim hands the plugin
+directory to the `claude` CLI per session with `--plugin-dir`, so it is never installed into
+Claude Code's global state and never has to be kept in sync with anything: the server that runs
+is always the one in the checkout that spawned it — a git worktree included.
 
-`../../build.sh` does this automatically (`claude plugin marketplace add` + `claude plugin install
-... --scope user`) whenever the `claude` CLI is on `PATH`. To do it yourself instead:
+`../../build.sh` builds it; there is no registration step. The tools arrive as
+`mcp__plugin_vibing-nvim_vibing-nvim__*`, the same names a marketplace install produced, because
+the prefix comes from `../.claude-plugin/plugin.json`'s `name` rather than from how the plugin
+was loaded.
 
-```text
-/plugin marketplace add shabaraba/vibing.nvim
-/plugin install vibing-nvim@vibing
-```
+The consequence worth knowing: a `claude` session started outside Neovim does not get these
+tools. Reaching a running Neovim was always the point of them, so there is no opt-in for it.
 
-See the plugin manifest at `../.claude-plugin/plugin.json`. The manual steps below remain useful
-for development or if you need a non-default RPC port/timeout.
+The manual options below remain useful for development, for a non-default RPC port/timeout, or
+for a backend other than Claude (`codex mcp add` / `copilot mcp add`, which `build.sh` still
+does — those CLIs have no plugin system).
 
-**Trust note:** installing this as a "directory"-source plugin runs `npm ci`/`npm run build` from
-that checkout on first launch. Only add the marketplace from a source you trust (the official repo,
-or your own fork/clone).
-
-To uninstall:
+**Upgrading:** if an older vibing.nvim installed this as a user-scope plugin, `build.sh` removes
+it. By hand:
 
 ```text
 /plugin uninstall vibing-nvim@vibing

--- a/claude-plugin/skills/nvim-context/SKILL.md
+++ b/claude-plugin/skills/nvim-context/SKILL.md
@@ -17,10 +17,10 @@ Two things decide whether a `vibing-nvim` tool call reaches the editor the user 
 Both apply to every skill and subagent in this plugin, so they are stated once here.
 
 **Which name.** Tools are written below as `mcp__vibing-nvim__<tool>`, which is the plain
-user-level MCP server registration. A Claude Code plugin install exposes them as
-`mcp__plugin_<marketplace>_vibing-nvim__<tool>` instead, where `<marketplace>` is fixed at
-`claude plugin marketplace add` time. If the plain prefix is not available, look for a tool whose
-name **ends** in the one you need rather than assuming it is missing.
+user-level MCP server registration. Loaded as a Claude Code plugin — which is how vibing.nvim
+itself provides them, handing the CLI this directory with `--plugin-dir` — they appear as
+`mcp__plugin_vibing-nvim_vibing-nvim__<tool>` instead. If the plain prefix is not available, look
+for a tool whose name **ends** in the one you need rather than assuming it is missing.
 
 **Which instance.** Every tool takes an `rpc_port` naming the target Neovim.
 
@@ -28,9 +28,9 @@ name **ends** in the one you need rather than assuming it is missing.
   value on every call.
 - A subagent does **not** inherit it. Take it from your task prompt, and if it isn't there, call
   `nvim_list_instances` and use the port it reports.
-- Anywhere else (an ordinary Claude Code session — this MCP server installs at user scope, so it
-  is visible in sessions that have nothing to do with vibing.nvim), `nvim_list_instances` is the
-  only way to know. If it lists more than one, say which you found and ask rather than guessing.
+- Anywhere else (an ordinary Claude Code session that loaded this plugin some other way — a
+  `--plugin-dir` of your own, or a leftover install), `nvim_list_instances` is the only way to
+  know. If it lists more than one, say which you found and ask rather than guessing.
 
 Omitting `rpc_port` works only while exactly one Neovim is live: reads fall back to the instance
 registry, and writes refuse outright. Worktrees and concurrent chats make more than one the normal

--- a/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
+++ b/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
@@ -14,8 +14,8 @@ available and the target filetype has an LSP client attached, prefer LSP-backed 
 prompt inside a vibing.nvim chat, or from your task prompt if you are a subagent. Only when
 neither supplies one, call `nvim_list_instances`; if that reports more than one instance, say
 which you found and ask rather than picking one. And if the `mcp__vibing-nvim__` prefix below is
-unavailable, look for a tool name **ending** in the one you need — a plugin install registers them
-as `mcp__plugin_<marketplace>_vibing-nvim__<tool>`. The `nvim-context` skill explains both in full.
+unavailable, look for a tool name **ending** in the one you need — loaded as a plugin they are
+`mcp__plugin_vibing-nvim_vibing-nvim__<tool>`. The `nvim-context` skill explains both in full.
 
 ## Tool mapping
 

--- a/claude-plugin/skills/vibing-chat-recall/SKILL.md
+++ b/claude-plugin/skills/vibing-chat-recall/SKILL.md
@@ -43,7 +43,7 @@ Pass this turn's `rpc_port` (also in the system prompt) on both calls below — 
 inside a vibing.nvim chat, so the port is always there and `nvim_list_instances` is never the
 route. If the
 `mcp__vibing-nvim__` prefix is unavailable, look for a tool name **ending** in the one you need —
-a plugin install registers them as `mcp__plugin_<marketplace>_vibing-nvim__<tool>`. The
+loaded as a plugin they are `mcp__plugin_vibing-nvim_vibing-nvim__<tool>`. The
 `nvim-context` skill explains both in full.
 
 1. Call `mcp__vibing-nvim__nvim_get_buffer` with the `bufnr` from the system prompt to fetch the

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -78,12 +78,22 @@ Using packer.nvim: >lua
       end,
     }
 <
-`build.sh` builds the MCP server and, when the `claude` CLI is on your PATH,
-registers vibing.nvim as a Claude Code plugin (user scope). That plugin ships
-the `vibing-nvim` MCP server, the bundled skills and the `nvim-navigator`
-subagent. To install it by hand instead: >
-    /plugin marketplace add shabaraba/vibing.nvim
-    /plugin install vibing-nvim@vibing
+`build.sh` builds the bundled MCP server. There is no plugin to install:
+vibing.nvim hands the `claude` CLI its own `claude-plugin/` directory per
+session with `--plugin-dir`, so the MCP server, the bundled skills and the
+`nvim-navigator` subagent always come from the checkout that is running.
+
+Anything you put in `.vibing/plugins/<name>/` (carrying a
+`.claude-plugin/plugin.json`) is loaded the same way, for that project only;
+run |:VibingReloadCommands| after adding one. A plugin may declare
+`mcpServers`, so one committed to a repository you cloned can start a process
+on your machine — set `agent.plugins.project_dir = false` for repositories you
+do not trust.
+
+Upgrading from a version that installed itself into Claude Code's user scope:
+`build.sh` removes that install for you. By hand: >
+    /plugin uninstall vibing-nvim@vibing
+    /plugin marketplace remove vibing
 <
 ==============================================================================
 4. CONFIGURATION                                        *vibing-configuration*

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -85,10 +85,17 @@ session with `--plugin-dir`, so the MCP server, the bundled skills and the
 
 Anything you put in `.vibing/plugins/<name>/` (carrying a
 `.claude-plugin/plugin.json`) is loaded the same way, for that project only;
-run |:VibingReloadCommands| after adding one. A plugin may declare
-`mcpServers`, so one committed to a repository you cloned can start a process
-on your machine — set `agent.plugins.project_dir = false` for repositories you
-do not trust.
+run |:VibingReloadCommands| after adding one. Use |:VibingCreatePlugin| to
+write a working skeleton rather than assembling one by hand.
+
+The directory is created on the first chat in a project, holding an inactive
+`_template/` copy of that skeleton. Directories whose name starts with `_` are
+skipped, so the template costs no context and never reaches the `/` picker.
+Renaming a plugin to `_name` is also how you park one without deleting it.
+
+A plugin may declare `mcpServers`, so one committed to a repository you cloned
+can start a process on your machine — set `agent.plugins.project_dir = false`
+for repositories you do not trust.
 
 Upgrading from a version that installed itself into Claude Code's user scope:
 `build.sh` removes that install for you. By hand: >
@@ -237,6 +244,12 @@ Scheduled requests:~
                                                       *:VibingReloadCommands*
 :VibingReloadCommands
     Reload custom slash commands and completion candidates.
+
+                                                        *:VibingCreatePlugin*
+:VibingCreatePlugin [{name}]
+    Create a project-local Claude Code plugin in `.vibing/plugins/{name}/`
+    and open its example skill. Prompts for the name when given none. The
+    plugin applies to this project only and takes effect immediately.
 
                                                 *:VibingCopyUnsentUserHeader*
 :VibingCopyUnsentUserHeader

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -36,6 +36,7 @@ require("vibing").setup({
     auto_resume_on_limit = { enabled = false, max_retries = 1 },
     scheduled_requests = { enabled = true, max_retries = 3 },
     codex_provider_notice = { enabled = true },
+    plugins = { self = true, project_dir = ".vibing/plugins", extra = {} },
   },
   chat = {
     window = {
@@ -185,8 +186,66 @@ agent = {
                             -- off by default. Turn it off to stop the `codex doctor --json`
                             -- probe it needs. Codex backend only.
   },
+
+  plugins = {               -- Claude Code plugins loaded for the session with --plugin-dir.
+                            -- Claude backend only. See "Plugin Directories" below.
+    self = true,            -- vibing.nvim's own claude-plugin/ — the nvim_* MCP tools and
+                            -- every bundled skill. Turning this off removes all of them;
+                            -- it is a debugging escape hatch, not a normal setting.
+    project_dir = ".vibing/plugins",
+                            -- Directories under this (relative to the project) are each
+                            -- loaded as a plugin. false disables the whole convention.
+    extra = {},             -- Additional paths: absolute, ~-relative, or relative to the
+                            -- request's working directory.
+  },
 }
 ```
+
+### Plugin Directories
+
+vibing.nvim does not install anything into Claude Code's global state. Its own `claude-plugin/`
+— the `vibing-nvim` MCP server, the bundled skills, the `nvim-navigator` subagent — is handed to
+the CLI per request with `--plugin-dir`, which loads a plugin for that session only. So the MCP
+server is always the one belonging to the checkout that spawned it, worktrees included, and there
+is no install, update or uninstall step to keep in sync.
+
+The same flag carries your own project plugins. A directory under `.vibing/plugins/` that
+contains a `.claude-plugin/plugin.json` is loaded for chats in that project:
+
+```text
+.vibing/plugins/
+└── my-tooling/
+    ├── .claude-plugin/plugin.json   # { "name": "my-tooling", ... }
+    └── skills/
+        └── deploy/SKILL.md
+```
+
+Run `:VibingReloadCommands` after adding, removing or fixing one — resolution is cached per
+working directory, and that command is what drops the cache.
+
+**Order matters, and it is `self` → `project_dir` → `extra`.** When two directories declare the
+same plugin name the CLI keeps the first and ignores the rest, so a project plugin cannot shadow
+vibing.nvim's own by taking its name.
+
+**Worktrees fall back to the project root.** `.vibing/` is git-ignored, so a worktree checkout
+has no `.vibing/plugins` of its own; a chat whose `working_dir` is a worktree reads the worktree's
+copy if there is one and the root's otherwise, the same way `.vibing/system-prompt.md` resolves.
+
+**A broken plugin is reported.** `--plugin-dir` ignores a directory with no manifest, an
+unparseable manifest or a nonexistent path in complete silence, which makes "I put it there and
+nothing happened" impossible to diagnose. vibing.nvim checks first and warns once per working
+directory instead.
+
+**Lightweight calls get none of this.** Title generation, `/summarize` and the daily summary run
+with no tools and no project config; loading plugins there would only spend prompt tokens on
+skill descriptions nothing can invoke.
+
+> **Trust.** A plugin may declare `mcpServers`, so `.vibing/plugins/` in a repository you cloned
+> can start a process on your machine on the first message you send. This is a stronger thing
+> than the instructions an unreviewed `.claude/skills/` can inject, and it is the reason Claude
+> Code gates a project's own `.mcp.json` behind approval. vibing.nvim reads the directory by
+> default anyway, on convenience grounds — set `project_dir = false` for repositories you do not
+> trust.
 
 ### Codex Provider Notice
 

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -247,9 +247,10 @@ you.
 same plugin name the CLI keeps the first and ignores the rest, so a project plugin cannot shadow
 vibing.nvim's own by taking its name.
 
-**Worktrees fall back to the project root.** `.vibing/` is git-ignored, so a worktree checkout
-has no `.vibing/plugins` of its own; a chat whose `working_dir` is a worktree reads the worktree's
-copy if there is one and the root's otherwise, the same way `.vibing/system-prompt.md` resolves.
+**Worktrees read both locations.** `.vibing/` is git-ignored, so a worktree checkout usually has
+no `.vibing/plugins` of its own. A chat whose `working_dir` is a worktree gets the worktree's
+plugins _and_ the root's, with the worktree winning where both declare the same plugin name —
+so a worktree can add or override a plugin without losing the rest.
 
 **A broken plugin is reported.** `--plugin-dir` ignores a directory with no manifest, an
 unparseable manifest or a nonexistent path in complete silence, which makes "I put it there and

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -214,14 +214,34 @@ contains a `.claude-plugin/plugin.json` is loaded for chats in that project:
 
 ```text
 .vibing/plugins/
+├── _template/                      # inactive skeleton, written on the first chat
 └── my-tooling/
-    ├── .claude-plugin/plugin.json   # { "name": "my-tooling", ... }
-    └── skills/
-        └── deploy/SKILL.md
+    ├── .claude-plugin/plugin.json  # { "name": "my-tooling", ... }
+    ├── skills/
+    │   └── deploy/SKILL.md         # offered as `my-tooling:deploy` in the `/` picker
+    └── agents/
+        └── reviewer.md             # offered as a subagent
 ```
 
+`:VibingCreatePlugin my-tooling` writes that skeleton and opens its example skill. Without an
+argument it prompts for the name. Names are lowercase letters, digits, `-` and `_`, because a
+skill is namespaced as `<plugin>:<skill>` and the directory is passed to a shell-invoked CLI.
+
+The directory is created on the first chat in a project, holding `_template/` alone. That is a
+complete plugin, kept inactive because **a directory whose name starts with `_` is skipped**: an
+example skill that loaded by default would spend prompt tokens in every request of every project
+and sit in the `/` picker. Copy it to a plain name, or use the command, to turn it on.
+
+The same rule parks a plugin you are not using: rename `my-tooling` to `_my-tooling` and it stops
+loading without being deleted. Parked directories are skipped silently — unlike a broken manifest,
+they are inactive on purpose.
+
+Claude Code also honours `commands/` and `hooks/` inside a plugin. They work; they just do not
+appear in vibing.nvim's `/` completion, which lists skills and subagents.
+
 Run `:VibingReloadCommands` after adding, removing or fixing one — resolution is cached per
-working directory, and that command is what drops the cache.
+working directory, and that command is what drops the cache. `:VibingCreatePlugin` drops it for
+you.
 
 **Order matters, and it is `self` → `project_dir` → `extra`.** When two directories declare the
 same plugin name the CLI keeps the first and ignores the rest, so a project plugin cannot shadow

--- a/handbook/lazy-setup-example.lua
+++ b/handbook/lazy-setup-example.lua
@@ -1,11 +1,11 @@
 -- Lazy.nvim setup example for vibing.nvim
 -- Place this in ~/.config/nvim/lua/plugins/vibing.lua
 --
--- MCP server registration is exclusively via the Claude Code plugin marketplace
--- (`claude plugin install vibing-nvim@vibing`), which build.sh installs automatically.
--- There is no separate ~/.claude.json registration path: that route can only ever hardcode a
--- single default RPC port, so it silently targets the wrong Neovim instance whenever more than
--- one is running.
+-- The MCP server reaches Claude Code as part of vibing.nvim's own bundled plugin, which is
+-- handed to the CLI per session with `--plugin-dir` -- nothing is installed, and build.sh only
+-- builds it. There is no separate ~/.claude.json registration path: that route can only ever
+-- hardcode a single default RPC port, so it silently targets the wrong Neovim instance whenever
+-- more than one is running.
 
 return {
   {
@@ -14,7 +14,7 @@ return {
       -- Add any dependencies here
     },
 
-    -- Build the MCP server and install the Claude Code plugin on install/update
+    -- Build the bundled MCP server on install/update
     build = "./build.sh",
 
     -- Use a custom Node.js executable during build:

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -101,6 +101,18 @@
 ---@field auto_resume_on_limit Vibing.AutoResumeOnLimitConfig 使用量リミット自動継続設定
 ---@field scheduled_requests Vibing.ScheduledRequestsConfig 予約リクエスト設定
 ---@field codex_provider_notice Vibing.CodexProviderNoticeConfig codex軽量呼び出しのプロバイダ警告設定
+---@field plugins Vibing.PluginsConfig? `--plugin-dir`で読み込むClaude Codeプラグインの設定
+
+---@class Vibing.PluginsConfig
+---セッション限りで読み込むClaude Codeプラグインのディレクトリ設定（claudeバックエンドのみ）
+---`--plugin-dir`はユーザーのグローバル状態に何も書かずにプラグインを読む。vibing.nvim自身の
+---`claude-plugin/`もこれで渡すため、MCPサーバーとバンドルskillは常に「いま動いているcheckout」の
+---ものになる（worktreeを含む）。
+---@field self boolean? falseでvibing.nvim自身のclaude-plugin/を渡さなくなる。nvim_*のMCPツールと
+---  バンドルskillが全て消えるのでデバッグ用の逃げ道であり、通常は触らない（デフォルト: true）
+---@field project_dir string|false? プロジェクトルートからの相対パス。この直下の各ディレクトリを
+---  プラグインとして渡す。falseで無効化（デフォルト: ".vibing/plugins"）
+---@field extra string[]? 任意の追加パス。絶対パス、`~`始まり、またはリクエストのcwd相対（デフォルト: {}）
 
 ---@class Vibing.CodexProviderNoticeConfig
 ---codexの軽量呼び出し（タイトル生成・要約等）が設定済みプロバイダから外れることを警告するか
@@ -277,6 +289,20 @@ M.defaults = {
     -- フラグが無いためプロバイダへの到達性通信も付いてくる。それを避けたい場合はfalseにする。
     codex_provider_notice = {
       enabled = true,
+    },
+    -- `--plugin-dir` で読み込むプラグイン。self → project_dir → extra の順で渡す。
+    --
+    -- 順序は意味を持つ。同名プラグインを複数渡すと**先に渡した方が勝つ**（claude 2.1.231で実測）。
+    -- self を先頭に置いているので、プロジェクト側のプラグインが名前を合わせて vibing.nvim 自身を
+    -- 乗っ取ることはできない。
+    --
+    -- project_dir を既定で読むのは利便性を取った判断で、リスクは受容している。プラグインは
+    -- mcpServers を宣言できるため、クローンしたリポジトリに仕込まれた `.vibing/plugins/` は
+    -- 最初のチャット送信時に任意のプロセスを起動しうる。信用できないリポジトリでは false にする。
+    plugins = {
+      self = true,
+      project_dir = ".vibing/plugins",
+      extra = {},
     },
   },
   chat = {

--- a/lua/vibing/core/constants/tools.lua
+++ b/lua/vibing/core/constants/tools.lua
@@ -94,30 +94,32 @@ M.INTERNAL_TOOLS = {
 M.INTERNAL_TOOLS_MAP = to_map(M.INTERNAL_TOOLS)
 
 ---vibing-nvim自身が提供するMCPツールの許可パターン。プレーンなユーザーレベルMCPサーバー登録
----（mcp__vibing-nvim__*）と、Claude Codeプラグイン登録（mcp__plugin_<marketplace>_vibing-nvim__*）の
+---（mcp__vibing-nvim__*）と、Claude Codeプラグインとしての登録（mcp__plugin_<plugin>_<server>__*）の
 ---両方に対応する。
 ---
----プラグイン側の接頭辞は`mcp__plugin_<marketplace>_vibing-nvim__`で、マーケットプレイス名は
----`claude plugin marketplace add`が実際に登録した名前で決まる。現行は`vibing`
----（`claude plugin list --json`のidが`vibing-nvim@vibing`であることで確認済み）。`vibing-nvim`は
----改名前の名前で、build.shの移行処理を通していない既存インストールがまだそちらの接頭辞でツールを
----配るため残してある。
+---**プラグイン側の接頭辞を決めるのはプラグイン名であって、マーケットプレイス名ではない。**
+---plugin.jsonの`name`（vibing-nvim）とmcpServersのキー（vibing-nvim）が並ぶので
+---`mcp__plugin_vibing-nvim_vibing-nvim__`になる。マーケットプレイスが`vibing`に改名されても
+---ツール名は一度も変わっていない。以前ここには`mcp__plugin_vibing_vibing-nvim__*`も並んでいたが、
+---それは実際には一度も生成されないプレフィックスで、tools_spec.luaがmarketplace.jsonの`name`を
+---読んで存在を要求していたため、使われない経路をテストが守り続けていた。
+---
+---#618以降、プラグインはユーザースコープにインストールされず`--plugin-dir`でセッション限りに
+---読み込まれる。接頭辞はそれでも同一（claude 2.1.231で実測）。読み込み方ではなくplugin.jsonの
+---`name`で決まるため。
 ---
 ---**この列挙は手で追従させるしかない。** --allowedToolsは具体的なプレフィックスしか受け付けない。
----tools_spec.luaが.claude-plugin/marketplace.jsonの`name`を読んで対応する要素の存在を検証するので、
----次に改名する人はテストで気づく。build.shの`MARKETPLACE_NAME`も同じ名前を別に持っているので、
----そちらはCIの"Check Claude Code plugin layout"が突き合わせる。
+---tools_spec.luaがclaude-plugin/.claude-plugin/plugin.jsonの`name`とmcpServersのキーを読んで
+---対応する要素の存在を検証するので、次に改名する人はテストで気づく。
 ---
 ---**ただしここがずれても通常のチャットは止まらない。** PreToolUseフックが
----can_use_tool.M.is_vibing_nvim_mcp_tool（サフィックスマッチなのでマーケットプレイス名に依存しない）
----で明示的なallowを返し、CLIは自前のゲートをスキップするため。実際`vibing`への改名後もここは
----`vibing-nvim`のままだったが、誰も気づかないまま動いていた。この列挙が効くのはフックの手前、
+---can_use_tool.M.is_vibing_nvim_mcp_tool（サフィックスマッチなのでプラグイン名に依存しない）
+---で明示的なallowを返し、CLIは自前のゲートをスキップするため。この列挙が効くのはフックの手前、
 ---CLIが最初に見る関門としてであって、最終的な担保ではない。
 ---#564以前は逆で、フックが黙って通す実装だったためここのずれがそのまま拒否になっていた。
 ---@type string[]
 M.VIBING_NVIM_MCP_TOOL_PATTERNS = {
   "mcp__vibing-nvim__*",
-  "mcp__plugin_vibing_vibing-nvim__*",
   "mcp__plugin_vibing-nvim_vibing-nvim__*",
 }
 

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -9,6 +9,7 @@ local CLIEventProcessor = require("vibing.infrastructure.adapter.modules.cli_eve
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
 local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
 local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+local PluginScaffold = require("vibing.infrastructure.plugins.scaffold")
 local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
 
 ---@class Vibing.ClaudeCLIAdapter : Vibing.Adapter
@@ -70,6 +71,11 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   local cwd = opts.cwd or vim.fn.getcwd()
   local settings_path = nil
   if not opts.lightweight then
+    -- Seeding rides along with the hook settings because both are "this project is now using
+    -- vibing.nvim" side effects, and this is the one place a real request passes through. Doing
+    -- it in setup() would create `.vibing/` in every directory Neovim is ever started in.
+    pcall(PluginScaffold.ensure, cwd, self.config)
+
     local ok
     ok, settings_path = pcall(SettingsGenerator.ensure, cwd)
     if not ok then

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -4,6 +4,7 @@
 
 local tools_constants = require("vibing.core.constants.tools")
 local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
+local PluginDirs = require("vibing.infrastructure.plugins.plugin_dirs")
 local worktree_constants = require("vibing.core.constants.worktree")
 
 local M = {}
@@ -220,6 +221,21 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     local subagent = config.agent and config.agent.subagent
     if subagent and subagent.enabled then
       table.insert(cmd, "--forward-subagent-text")
+    end
+
+    -- vibing.nvim's own plugin (the nvim_* MCP tools and the bundled skills) is loaded for this
+    -- session only, from this checkout, instead of being installed into Claude Code's user
+    -- scope. That is what keeps the MCP server from drifting away from the Neovim plugin it
+    -- serves -- a worktree now runs its own copy rather than the globally installed one.
+    -- `.vibing/plugins/*/` rides along on the same flag.
+    --
+    -- Not passed on the lightweight path: `core/types.lua` obliges utility calls to load no
+    -- tools and no project config. `--strict-mcp-config` already blocks the MCP servers there
+    -- (verified: zero connection log lines), but a plugin's skill descriptions still cost prompt
+    -- tokens, and lightweight has no tools to invoke them with anyway.
+    for _, plugin_dir in ipairs(PluginDirs.resolve(opts.cwd, config)) do
+      table.insert(cmd, "--plugin-dir")
+      table.insert(cmd, plugin_dir)
     end
   end
 

--- a/lua/vibing/infrastructure/completion/providers/agents.lua
+++ b/lua/vibing/infrastructure/completion/providers/agents.lua
@@ -90,11 +90,45 @@ local function load_installed_plugins()
   return result
 end
 
+---Plugin directories vibing.nvim self-hosts via `--plugin-dir`, prepended to the installed ones.
+---
+---These are invisible to `installed_plugins.json` by construction — nothing was installed — so
+---without this the plugin's own bundled agents (`nvim-navigator`) would load in the CLI and yet
+---never appear in completion. Prepended rather than appended because the CLI resolves a
+---duplicate plugin name in favour of the first `--plugin-dir`, and the dedup below follows suit.
+---@return {plugin_name: string, install_path: string}[]
+local function load_self_hosted_plugins()
+  local ok, PluginDirs = pcall(require, "vibing.infrastructure.plugins.plugin_dirs")
+  if not ok then
+    return {}
+  end
+  local config_ok, Config = pcall(require, "vibing.config")
+  if not config_ok then
+    return {}
+  end
+
+  local result = {}
+  for _, entry in ipairs(PluginDirs.resolve_entries(nil, Config.get())) do
+    table.insert(result, { plugin_name = entry.name, install_path = entry.path })
+  end
+  return result
+end
+
 ---Scan all plugin directories for agents
 ---@return Vibing.CompletionItem[]
 local function scan_agents()
   local items = {}
-  local plugins = load_installed_plugins()
+  local plugins = load_self_hosted_plugins()
+  local seen = {}
+  for _, plugin in ipairs(plugins) do
+    seen[plugin.plugin_name] = true
+  end
+  for _, plugin in ipairs(load_installed_plugins()) do
+    if not seen[plugin.plugin_name] then
+      seen[plugin.plugin_name] = true
+      table.insert(plugins, plugin)
+    end
+  end
 
   for _, plugin in ipairs(plugins) do
     local agents_dir = plugin.install_path .. "/agents/"

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -156,6 +156,30 @@ local function resolve_list_commands()
   return executable, script_path
 end
 
+---Plugin directories vibing.nvim self-hosts via `--plugin-dir`, so their skills show up in
+---completion too. `list-commands` only knows about `~/.claude/plugins/installed_plugins.json`,
+---and teaching it the `.vibing/plugins` convention would mean writing the same cwd handling in
+---two languages; passing the already-resolved paths keeps the convention defined in one place.
+---
+---Resolved against the same global cwd the rest of this module keys on, not a chat's
+---`working_dir`: completion is a property of the editor, not of whichever chat buffer happens to
+---be focused. Passing it explicitly is what lets `_bundled_cache_cwd` stand in as this list's
+---staleness key too -- `plugin_dirs` caches per cwd, so with the cwd unchanged the list cannot
+---change underneath us except via `plugin_dirs.clear_cache()`, and the only caller of that
+---(`:VibingReloadCommands`) clears this module's cache in the same breath.
+---@return string[]
+local function resolve_plugin_dirs()
+  local ok, PluginDirs = pcall(require, "vibing.infrastructure.plugins.plugin_dirs")
+  if not ok then
+    return {}
+  end
+  local config_ok, Config = pcall(require, "vibing.config")
+  if not config_ok then
+    return {}
+  end
+  return PluginDirs.resolve(vim.fn.getcwd(-1, -1), Config.get())
+end
+
 ---Parse raw JSON output from list-commands into completion items
 ---@param stdout string
 ---@return Vibing.CompletionItem[]
@@ -221,6 +245,7 @@ local function start_async_load()
   end
 
   local cwd = vim.fn.getcwd(-1, -1)
+  local plugin_dirs = resolve_plugin_dirs()
   _loading = true
   _bundled_cache_cwd = cwd
   _bundled_cache_script_mtime = vim.fn.getftime(script_path)
@@ -232,7 +257,8 @@ local function start_async_load()
   -- Do NOT use stdout_buffered=true: Neovim caps its internal buffer at 65536 bytes,
   -- which truncates large outputs (e.g. >64KB plugin skill lists) and breaks JSON parsing.
   -- Instead, stream chunks and reconstruct lines manually.
-  local job_id = vim.fn.jobstart({ executable, script_path }, {
+  local job_id = vim.fn.jobstart(
+    vim.list_extend({ executable, script_path }, plugin_dirs), {
     cwd = cwd,
     on_stdout = function(_, data, _)
       if type(data) ~= "table" or #data == 0 then
@@ -283,7 +309,6 @@ local function invalidate_if_stale()
   local script_stale = script_path
     and _bundled_cache_script_mtime
     and vim.fn.getftime(script_path) ~= _bundled_cache_script_mtime
-
   if _bundled_cache_cwd == current_cwd and not script_stale then
     return
   end

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -257,8 +257,9 @@ local function start_async_load()
   -- Do NOT use stdout_buffered=true: Neovim caps its internal buffer at 65536 bytes,
   -- which truncates large outputs (e.g. >64KB plugin skill lists) and breaks JSON parsing.
   -- Instead, stream chunks and reconstruct lines manually.
-  local job_id = vim.fn.jobstart(
-    vim.list_extend({ executable, script_path }, plugin_dirs), {
+  local argv = vim.list_extend({ executable, script_path }, plugin_dirs)
+
+  local job_id = vim.fn.jobstart(argv, {
     cwd = cwd,
     on_stdout = function(_, data, _)
       if type(data) ~= "table" or #data == 0 then

--- a/lua/vibing/infrastructure/permissions/can_use_tool.lua
+++ b/lua/vibing/infrastructure/permissions/can_use_tool.lua
@@ -46,7 +46,7 @@ local ONCE_SUFFIX = ":once"
 ---
 --- The leading `_` is the whole reason this is not a bare suffix match. Both registration styles
 --- put a separator directly before the server name — `mcp__vibing-nvim__` and
---- `mcp__plugin_<marketplace>_vibing-nvim__` — so requiring one rejects a server whose name merely
+--- `mcp__plugin_<plugin>_vibing-nvim__` — so requiring one rejects a server whose name merely
 --- *ends* with it (`mcp__my-vibing-nvim__nvim_get_buffer`). What it cannot reject is a third-party
 --- server actually named `vibing-nvim` exposing `nvim_*` tools: nothing in the tool name says who
 --- registered it. That call is granted, which matters because this decision bypasses the CLI's own
@@ -245,11 +245,11 @@ function M.can_use_tool(tool_name, input, config)
       return allow(input)
     end
 
-    -- Handle vibing-nvim MCP tools. The vibing-nvim MCP server may be registered either as a
-    -- plain user-level MCP server (mcp__vibing-nvim__<tool>) or as a Claude Code plugin
-    -- (mcp__plugin_<marketplace>_<plugin>__<tool>, e.g. mcp__plugin_vibing_vibing-nvim__<tool>).
-    -- Match on suffix so both registration styles are recognized identically, regardless of
-    -- marketplace name.
+    -- Handle vibing-nvim MCP tools. The vibing-nvim MCP server may reach the CLI either as a
+    -- plain user-level MCP server (mcp__vibing-nvim__<tool>) or inside a Claude Code plugin
+    -- (mcp__plugin_<plugin>_<server>__<tool>, i.e. mcp__plugin_vibing-nvim_vibing-nvim__<tool>) --
+    -- which is the normal case, since vibing.nvim self-hosts that plugin with --plugin-dir.
+    -- Match on suffix so both are recognized identically, whatever the plugin is called.
     if M.is_vibing_nvim_mcp_tool(tool_name) then
       if config.mcp_enabled then
         return allow(input)

--- a/lua/vibing/infrastructure/plugins/plugin_dirs.lua
+++ b/lua/vibing/infrastructure/plugins/plugin_dirs.lua
@@ -138,8 +138,13 @@ local function candidates(cwd, nvim_root, plugins)
   if type(project_dir) == "string" and project_dir ~= "" then
     vim.list_extend(dirs, glob_plugin_dirs(cwd, project_dir))
     -- `.vibing/` is git-ignored, so a worktree checkout has no `.vibing/plugins` of its own.
-    -- Fall back to the root Neovim was started in, where the user actually puts them --
-    -- `project_system_prompt.read_for_cwd` resolves `.vibing/system-prompt.md` the same way.
+    -- Also offer the root Neovim was started in, where the user actually puts them.
+    --
+    -- This is a union with per-name precedence, not the strict fallback
+    -- `project_system_prompt.read_for_cwd` does for `.vibing/system-prompt.md`. That one picks a
+    -- single file so it has to choose; a *set* of plugins does not. A worktree adding one
+    -- experimental plugin should not lose every plugin the project already had, and the
+    -- deduplication below still lets it override one of them by reusing its name.
     if cwd ~= nvim_root then
       vim.list_extend(dirs, glob_plugin_dirs(nvim_root, project_dir))
     end
@@ -162,14 +167,25 @@ end
 --- @param config Vibing.Config
 --- @return Vibing.PluginDirEntry[]
 function M.resolve_entries(cwd, config)
-  local nvim_root = vim.fn.getcwd()
+  -- The *global* cwd, not `getcwd()`. "The root Neovim was started in" is a property of the
+  -- session, and `:lcd`/`:tcd` set a per-window view of it rather than a different project.
+  -- Reading the window-local one would also disagree with the completion providers, which key
+  -- their own caches on the global cwd: under `:lcd` the two would differ, `cwd ~= nvim_root`
+  -- would hold spuriously, and `.vibing/plugins` would be globbed twice for the same project.
+  local nvim_root = vim.fn.getcwd(-1, -1)
   local effective = (cwd and cwd ~= "") and cwd or nvim_root
 
   if cache[effective] then
     return cache[effective]
   end
 
-  local plugins = (config.agent and config.agent.plugins) or {}
+  -- A non-table `agent.plugins` reads as "unset" rather than reaching `candidates()`, where
+  -- `plugins.self` on a boolean or a string raises. The builder runs under `pcall`, so that
+  -- surfaced as an unexplained "failed to build command" instead of naming the bad config.
+  local plugins = config.agent and config.agent.plugins
+  if type(plugins) ~= "table" then
+    plugins = {}
+  end
   local entries = {}
   local seen_names = {}
   local seen_paths = {}

--- a/lua/vibing/infrastructure/plugins/plugin_dirs.lua
+++ b/lua/vibing/infrastructure/plugins/plugin_dirs.lua
@@ -76,6 +76,11 @@ local function read_manifest(dir)
 end
 
 --- Directories directly under `root .. "/" .. rel`, sorted, or `{}` when there are none.
+---
+--- A leading underscore means "present but not loaded". The scaffolded `_template` relies on it,
+--- and it doubles as the way to park a plugin: renaming `my-plugin` to `_my-plugin` takes it out
+--- of the session without deleting it. Since this resolution is what the skill and agent
+--- completion providers read, an excluded directory disappears from the `/` picker too.
 --- @param root string
 --- @param rel string
 --- @return string[]
@@ -88,7 +93,7 @@ local function glob_plugin_dirs(root, rel)
   local found = vim.fn.glob(base .. "/*", false, true)
   local dirs = {}
   for _, path in ipairs(found) do
-    if vim.fn.isdirectory(path) == 1 then
+    if vim.fn.isdirectory(path) == 1 and not vim.fs.basename(path):match("^_") then
       table.insert(dirs, path)
     end
   end

--- a/lua/vibing/infrastructure/plugins/plugin_dirs.lua
+++ b/lua/vibing/infrastructure/plugins/plugin_dirs.lua
@@ -1,0 +1,223 @@
+--- Claude Code plugin directories loaded for the session via `--plugin-dir`.
+---
+--- vibing.nvim hosts its own bundled plugin (`claude-plugin/`) this way rather than installing
+--- it into Claude Code's user scope, so the MCP server and the bundled skills always come from
+--- the checkout that is running -- a worktree included. The same mechanism doubles as a
+--- project-local personal plugin drop (`.vibing/plugins/*/`).
+---
+--- The resolved list is the single definition of "which plugin directories apply here": the CLI
+--- argv (`cli_command_builder`), the skill completion provider and the agent completion provider
+--- all read it, rather than each re-deriving the convention.
+--- @module vibing.infrastructure.plugins.plugin_dirs
+
+local Notify = require("vibing.core.utils.notify")
+
+local M = {}
+
+--- @class Vibing.PluginDirEntry
+--- @field name string plugin name, as declared by `.claude-plugin/plugin.json`
+--- @field path string absolute path handed to `--plugin-dir`
+
+--- Resolved entries per cwd. Keyed by the effective cwd, since `.vibing/plugins` is a
+--- project-relative convention and a chat's `working_dir` can be a worktree.
+---
+--- The `config` argument is deliberately **not** part of the key: `setup()` runs before any
+--- request, and every caller reads the same resolved config afterwards. A second `setup()` with
+--- different `agent.plugins` therefore needs `clear_cache()` to take effect, which is also what
+--- `:VibingReloadCommands` does.
+--- @type table<string, Vibing.PluginDirEntry[]>
+local cache = {}
+
+--- vibing.nvim's own bundled plugin: `<repo>/claude-plugin`.
+---
+--- Resolved by walking up from this file to the `package.json` that marks the repo root, the
+--- same way `completion/providers/skills.lua` finds `dist/`. The alternative in this codebase --
+--- `debug.getinfo` plus a hand-counted `:h` chain -- encodes this file's own depth and breaks
+--- silently if the module moves.
+--- @return string|nil
+local function self_plugin_dir()
+  local source = debug.getinfo(1, "S").source:sub(2)
+  local repo_root = vim.fs.root(source, "package.json")
+  if not repo_root then
+    return nil
+  end
+  return repo_root .. "/claude-plugin"
+end
+
+--- Read a candidate's plugin manifest.
+---
+--- `--plugin-dir` **silently ignores** a directory with no manifest, a malformed manifest, or a
+--- path that does not exist -- measured against claude 2.1.231: every one of those completes the
+--- turn with exit 0 and no warning. So a plugin that was dropped in and does not work leaves no
+--- trace at all unless this checks first.
+--- @param dir string
+--- @return string|nil name, string|nil problem
+local function read_manifest(dir)
+  local manifest = dir .. "/.claude-plugin/plugin.json"
+  if vim.fn.filereadable(manifest) ~= 1 then
+    return nil, "no .claude-plugin/plugin.json"
+  end
+
+  local ok, lines = pcall(vim.fn.readfile, manifest)
+  if not ok or type(lines) ~= "table" then
+    return nil, "unreadable .claude-plugin/plugin.json"
+  end
+
+  local decoded_ok, decoded = pcall(vim.json.decode, table.concat(lines, "\n"))
+  if not decoded_ok or type(decoded) ~= "table" then
+    return nil, "malformed .claude-plugin/plugin.json"
+  end
+
+  if type(decoded.name) ~= "string" or decoded.name == "" then
+    return nil, ".claude-plugin/plugin.json has no name"
+  end
+
+  return decoded.name, nil
+end
+
+--- Directories directly under `root .. "/" .. rel`, sorted, or `{}` when there are none.
+--- @param root string
+--- @param rel string
+--- @return string[]
+local function glob_plugin_dirs(root, rel)
+  local base = root .. "/" .. rel
+  if vim.fn.isdirectory(base) ~= 1 then
+    return {}
+  end
+
+  local found = vim.fn.glob(base .. "/*", false, true)
+  local dirs = {}
+  for _, path in ipairs(found) do
+    if vim.fn.isdirectory(path) == 1 then
+      table.insert(dirs, path)
+    end
+  end
+  table.sort(dirs)
+  return dirs
+end
+
+--- @param path string
+--- @param base string
+--- @return string
+local function absolutise(path, base)
+  if path:sub(1, 1) ~= "/" and not path:match("^~") then
+    path = base .. "/" .. path
+  end
+  -- Parenthesised: gsub returns a replacement count as its second value, and letting that
+  -- through turns the caller's `table.insert(dirs, absolutise(...))` into the three-argument
+  -- positional form, which then rejects the path as a non-numeric index.
+  return (vim.fn.fnamemodify(vim.fn.expand(path), ":p"):gsub("/$", ""))
+end
+
+--- Candidate directories in the order the CLI should see them.
+---
+--- **The order is load-bearing.** With two `--plugin-dir` paths declaring the same plugin name,
+--- the earlier flag wins -- measured against claude 2.1.231 by giving each copy of a same-named
+--- skill a different marker word and reading back which one the model saw. Putting `self` first
+--- therefore means a project-local plugin cannot shadow vibing.nvim's own by reusing its name.
+--- @param cwd string effective working directory of the request
+--- @param nvim_root string
+--- @param plugins table
+--- @return string[]
+local function candidates(cwd, nvim_root, plugins)
+  local dirs = {}
+
+  if plugins.self ~= false then
+    local own = self_plugin_dir()
+    if own then
+      table.insert(dirs, own)
+    end
+  end
+
+  local project_dir = plugins.project_dir
+  if type(project_dir) == "string" and project_dir ~= "" then
+    vim.list_extend(dirs, glob_plugin_dirs(cwd, project_dir))
+    -- `.vibing/` is git-ignored, so a worktree checkout has no `.vibing/plugins` of its own.
+    -- Fall back to the root Neovim was started in, where the user actually puts them --
+    -- `project_system_prompt.read_for_cwd` resolves `.vibing/system-prompt.md` the same way.
+    if cwd ~= nvim_root then
+      vim.list_extend(dirs, glob_plugin_dirs(nvim_root, project_dir))
+    end
+  end
+
+  for _, extra in ipairs(plugins.extra or {}) do
+    if type(extra) == "string" and extra ~= "" then
+      table.insert(dirs, absolutise(extra, cwd))
+    end
+  end
+
+  return dirs
+end
+
+--- Resolve the plugin directories that apply to a request running in `cwd`.
+---
+--- Entries are deduplicated by plugin name, first occurrence winning, so the returned list
+--- matches what the CLI actually loads rather than what it was offered.
+--- @param cwd string|nil the chat's `working_dir`; nil means Neovim's own cwd
+--- @param config Vibing.Config
+--- @return Vibing.PluginDirEntry[]
+function M.resolve_entries(cwd, config)
+  local nvim_root = vim.fn.getcwd()
+  local effective = (cwd and cwd ~= "") and cwd or nvim_root
+
+  if cache[effective] then
+    return cache[effective]
+  end
+
+  local plugins = (config.agent and config.agent.plugins) or {}
+  local entries = {}
+  local seen_names = {}
+  local seen_paths = {}
+  local problems = {}
+
+  for _, dir in ipairs(candidates(effective, nvim_root, plugins)) do
+    local path = vim.fn.fnamemodify(dir, ":p"):gsub("/$", "")
+    if not seen_paths[path] then
+      seen_paths[path] = true
+      local name, problem = read_manifest(path)
+      if not name then
+        table.insert(problems, string.format("%s (%s)", path, problem))
+      elseif not seen_names[name] then
+        seen_names[name] = true
+        table.insert(entries, { name = name, path = path })
+      end
+    end
+  end
+
+  -- The cache above is what keeps this to one notification per cwd: resolution runs on every
+  -- request, and warning each time would fire on every message. A separate warned-once flag
+  -- would be redundant with it, and worse -- it would have to survive `clear_cache()` to mean
+  -- anything, which would silence the warning on exactly the `:VibingReloadCommands` the user
+  -- runs after trying to fix the plugin.
+  if #problems > 0 then
+    Notify.warn(
+      "ignored by --plugin-dir, so their skills and MCP servers will not load: "
+        .. table.concat(problems, ", "),
+      "Plugins"
+    )
+  end
+
+  cache[effective] = entries
+  return entries
+end
+
+--- Absolute paths to pass to `--plugin-dir`, one flag each.
+--- @param cwd string|nil the chat's `working_dir`; nil means Neovim's own cwd
+--- @param config Vibing.Config
+--- @return string[]
+function M.resolve(cwd, config)
+  local paths = {}
+  for _, entry in ipairs(M.resolve_entries(cwd, config)) do
+    table.insert(paths, entry.path)
+  end
+  return paths
+end
+
+--- Drop the resolved lists and the warned-about flags. Reached from
+--- `:VibingReloadCommands`, which is how a newly dropped-in plugin becomes visible without
+--- restarting Neovim.
+function M.clear_cache()
+  cache = {}
+end
+
+return M

--- a/lua/vibing/infrastructure/plugins/scaffold.lua
+++ b/lua/vibing/infrastructure/plugins/scaffold.lua
@@ -1,0 +1,118 @@
+--- Create project-local Claude Code plugins under `.vibing/plugins/`.
+---
+--- The directory is seeded the first time a chat runs in a project, so the convention is
+--- discoverable without reading the docs, and `:VibingCreatePlugin` writes further ones on
+--- demand. What gets loaded is decided by `plugin_dirs`; this module only puts files on disk.
+--- @module vibing.infrastructure.plugins.scaffold
+
+local Config = require("vibing.config")
+local Fs = require("vibing.core.utils.fs")
+local Files = require("vibing.infrastructure.plugins.scaffold_files")
+
+local M = {}
+
+--- Claude Code namespaces skills as `<plugin>:<skill>` and vibing.nvim passes the directory
+--- straight to a shell-invoked CLI, so a name is restricted to what is safe in both.
+local NAME_PATTERN = "^[a-z0-9][a-z0-9%-_]*$"
+
+--- Where plugins live for this project. `agent.plugins.project_dir` is the single definition of
+--- the convention, so an unset config falls back to the resolved options rather than to a second
+--- copy of the default string.
+--- @param root string project root
+--- @param config Vibing.Config|nil
+--- @return string|nil absolute path to the plugins directory, nil when disabled
+local function plugins_dir(root, config)
+  local resolved = config or Config.get()
+  local plugins = (resolved.agent and resolved.agent.plugins) or {}
+  local rel = plugins.project_dir
+  if type(rel) ~= "string" or rel == "" then
+    return nil
+  end
+  return root .. "/" .. rel
+end
+
+--- @param dir string
+--- @param files table<string, string>
+local function write_files(dir, files)
+  for rel, contents in pairs(files) do
+    local path = dir .. "/" .. rel
+    Fs.ensure_dir(vim.fn.fnamemodify(path, ":h"))
+
+    local handle, err = io.open(path, "w")
+    if not handle then
+      error(string.format("could not write %s: %s", path, tostring(err)))
+    end
+    handle:write(contents)
+    handle:close()
+  end
+end
+
+--- @param name string
+--- @return boolean ok, string|nil problem
+function M.validate_name(name)
+  if type(name) ~= "string" or name == "" then
+    return false, "plugin name is required"
+  end
+  if not name:match(NAME_PATTERN) then
+    return false, string.format("%q must be lowercase letters, digits, '-' and '_'", name)
+  end
+  return true, nil
+end
+
+--- Seed `.vibing/plugins/` with the template plugin.
+---
+--- Called on the first request of a session per project. Only a missing plugins directory
+--- triggers this, so a user who deleted the template does not get it back on every chat.
+--- @param root string|nil project root; defaults to Neovim's cwd
+--- @param config Vibing.Config|nil
+--- @return boolean seeded whether anything was written
+function M.ensure(root, config)
+  root = (root and root ~= "") and root or vim.fn.getcwd()
+  local base = plugins_dir(root, config)
+  if not base or vim.fn.isdirectory(base) == 1 then
+    return false
+  end
+
+  Fs.ensure_dir(base)
+  write_files(base .. "/" .. Files.TEMPLATE_DIR, Files.plugin("example"))
+  return true
+end
+
+--- Write a new plugin directory.
+---
+--- Refuses to touch an existing directory: the point of the command is a starting skeleton, and
+--- overwriting a plugin someone has been editing is not recoverable from here.
+--- @param name string plugin name
+--- @param root string|nil project root; defaults to Neovim's cwd
+--- @param config Vibing.Config|nil
+--- @return string|nil path, string|nil problem
+function M.create(name, root, config)
+  local ok, problem = M.validate_name(name)
+  if not ok then
+    return nil, problem
+  end
+
+  root = (root and root ~= "") and root or vim.fn.getcwd()
+  local base = plugins_dir(root, config)
+  if not base then
+    return nil, "agent.plugins.project_dir is disabled"
+  end
+
+  local dir = base .. "/" .. name
+  if vim.fn.isdirectory(dir) == 1 then
+    return nil, string.format("%s already exists", dir)
+  end
+
+  -- A user who runs the command before ever sending a message would otherwise get a plugin
+  -- directory with no template next to it.
+  pcall(M.ensure, root, config)
+
+  local written, write_err = pcall(write_files, dir, Files.plugin(name))
+  if not written then
+    return nil, tostring(write_err)
+  end
+
+  return dir, nil
+end
+
+return M

--- a/lua/vibing/infrastructure/plugins/scaffold_files.lua
+++ b/lua/vibing/infrastructure/plugins/scaffold_files.lua
@@ -1,0 +1,125 @@
+--- File contents for a project-local Claude Code plugin.
+---
+--- Kept apart from `scaffold.lua` so the writer stays about paths and failure handling while
+--- this stays about what a correct plugin looks like.
+--- @module vibing.infrastructure.plugins.scaffold_files
+
+local M = {}
+
+--- Name of the template directory under `.vibing/plugins/`.
+---
+--- The leading underscore is load-bearing: `plugin_dirs` skips those, so the template ships a
+--- complete example without its skill description riding along in every request's system prompt
+--- and without showing up in the `/` picker. Copy it to a plain name to turn it on.
+M.TEMPLATE_DIR = "_template"
+
+--- Written by hand rather than through `vim.json.encode`, which emits one unindented line with
+--- the keys in table order. This file is meant to be edited.
+--- @param name string plugin name
+--- @return string
+local function plugin_json(name)
+  return table.concat({
+    "{",
+    string.format('  "name": %s,', vim.json.encode(name)),
+    string.format('  "description": %s,', vim.json.encode("Project-local plugin: " .. name .. ".")),
+    '  "version": "0.1.0"',
+    "}",
+    "",
+  }, "\n")
+end
+
+--- @param name string
+--- @return string
+local function skill(name)
+  return table.concat({
+    "---",
+    "name: example",
+    "description: Use when you need a worked example of a project-local skill. Replace this"
+      .. " description with the situation that should pull the skill in - Claude reads only"
+      .. " this line when deciding whether to load the body, so name the trigger, not the topic.",
+    "---",
+    "",
+    "# Example skill",
+    "",
+    string.format("This file lives in `.vibing/plugins/%s/skills/example/SKILL.md`.", name),
+    "",
+    "Everything below the frontmatter is loaded only once the description above matches what the",
+    "user is doing. Put the actual instructions here: the steps to follow, the commands to run,",
+    "the conventions of this repository that Claude cannot infer from the code.",
+    "",
+    "## Replace this",
+    "",
+    "1. Rewrite `description` so it states *when* to use the skill.",
+    "2. Rewrite this body with the procedure worth repeating.",
+    "3. Run `:VibingReloadCommands` and type `/` in a chat - the skill appears as",
+    string.format("   `%s:example`.", name),
+    "",
+  }, "\n")
+end
+
+--- @param name string
+--- @return string
+local function agent(name)
+  return table.concat({
+    "---",
+    "name: example-agent",
+    "description: Use when a task should run in its own context window with a narrower brief than"
+      .. " the main conversation. Replace this with the kind of work this agent should be handed.",
+    "model: sonnet",
+    "---",
+    "",
+    "You are a subagent defined by a project-local plugin.",
+    "",
+    string.format("This file lives in `.vibing/plugins/%s/agents/example-agent.md`.", name),
+    "",
+    "Describe here what the agent should do, what it must not do, and what its final message",
+    "should contain - that message is the only thing the caller receives.",
+    "",
+  }, "\n")
+end
+
+--- @param name string
+--- @return string
+local function readme(name)
+  return table.concat({
+    string.format("# %s", name),
+    "",
+    "A project-local Claude Code plugin, loaded by vibing.nvim through `--plugin-dir`.",
+    "",
+    "```",
+    string.format("%s/", name),
+    "├── .claude-plugin/plugin.json   required - a directory without it is silently ignored",
+    "├── skills/<skill>/SKILL.md      shows up in the chat's `/` completion",
+    "└── agents/<agent>.md            shows up as a subagent",
+    "```",
+    "",
+    "Also honoured by Claude Code, though vibing.nvim's `/` completion does not list them:",
+    "`commands/`, `hooks/`, and an `mcpServers` block in `plugin.json`.",
+    "",
+    "## After editing",
+    "",
+    "Run `:VibingReloadCommands`. Directory contents are read per request, but the resolved",
+    "plugin list and the completion cache are not.",
+    "",
+    "## Troubleshooting",
+    "",
+    "`--plugin-dir` ignores a broken plugin without saying so, so vibing.nvim checks the manifest",
+    "itself and warns. If a change seems to have no effect, check that `plugin.json` still parses",
+    "and still has a `name`.",
+    "",
+  }, "\n")
+end
+
+--- Files that make up one plugin, relative to the plugin directory.
+--- @param name string plugin name
+--- @return table<string, string> relative path -> contents
+function M.plugin(name)
+  return {
+    [".claude-plugin/plugin.json"] = plugin_json(name),
+    ["README.md"] = readme(name),
+    ["skills/example/SKILL.md"] = skill(name),
+    ["agents/example-agent.md"] = agent(name),
+  }
+end
+
+return M

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -154,7 +154,12 @@ function M.create_plugin(name)
   require("vibing.application.completion").clear_cache()
 
   notify.info(string.format("created %s", path), "CreatePlugin")
-  vim.cmd.edit(vim.fn.fnameescape(path .. "/skills/example/SKILL.md"))
+
+  -- 雛形はすでにディスク上にあるので、`:edit`の失敗（壊れたShaDa、autocmdのエラー）で作成を失敗扱いにしない
+  local ok, err = pcall(vim.cmd.edit, vim.fn.fnameescape(path .. "/skills/example/SKILL.md"))
+  if not ok then
+    notify.warn(string.format("could not open the example skill: %s", err), "CreatePlugin")
+  end
 end
 
 ---Neovimユーザーコマンドを登録

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -138,6 +138,25 @@ local function complete_positions(arg_lead)
   return matches
 end
 
+---プロジェクト固有のClaude Codeプラグインの雛形を作成する
+---作成後は`--plugin-dir`の解決結果を捨てて、再起動なしで読み込めるようにする
+---@param name string プラグイン名
+function M.create_plugin(name)
+  local scaffold = require("vibing.infrastructure.plugins.scaffold")
+  local path, problem = scaffold.create(name)
+
+  if not path then
+    notify.error(problem or "failed to create plugin", "CreatePlugin")
+    return
+  end
+
+  require("vibing.infrastructure.plugins.plugin_dirs").clear_cache()
+  require("vibing.application.completion").clear_cache()
+
+  notify.info(string.format("created %s", path), "CreatePlugin")
+  vim.cmd.edit(vim.fn.fnameescape(path .. "/skills/example/SKILL.md"))
+end
+
 ---Neovimユーザーコマンドを登録
 ---VibingChat, VibingContext等の全コマンドを登録
 ---チャット操作、コンテキスト管理を含む
@@ -493,6 +512,22 @@ function M._register_commands()
 
     notify.info("Commands and completions reloading...")
   end, { desc = "Reload custom slash commands and completion candidates" })
+
+  vim.api.nvim_create_user_command("VibingCreatePlugin", function(opts)
+    local name = vim.trim(opts.args)
+    if name == "" then
+      vim.ui.input({ prompt = "Plugin name: " }, function(input)
+        if input and vim.trim(input) ~= "" then
+          M.create_plugin(vim.trim(input))
+        end
+      end)
+      return
+    end
+    M.create_plugin(name)
+  end, {
+    nargs = "?",
+    desc = "Create a project-local Claude Code plugin under .vibing/plugins/",
+  })
 
   vim.api.nvim_create_user_command("VibingCopyUnsentUserHeader", function()
     local timestamp = require("vibing.core.utils.timestamp")

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -479,8 +479,14 @@ function M._register_commands()
     local commands = require("vibing.application.chat.commands")
     local completion = require("vibing.application.completion")
     local skills = require("vibing.infrastructure.completion.providers.skills")
+    local plugin_dirs = require("vibing.infrastructure.plugins.plugin_dirs")
 
     commands.reload_custom()
+
+    -- Before the provider caches, not after: the skill and agent providers both re-resolve
+    -- from this one, so clearing it second would refill them from the list being discarded.
+    -- This is also what makes a plugin newly dropped into `.vibing/plugins` take effect.
+    plugin_dirs.clear_cache()
 
     completion.clear_cache()
     skills.preload()

--- a/lua/vibing/install.lua
+++ b/lua/vibing/install.lua
@@ -32,13 +32,16 @@ local function get_node_executable()
   return node_cmd
 end
 
----Build the message guiding the user to register vibing-nvim as a Claude Code plugin
----@param plugin_root string
+---What to tell the user once the MCP server is built.
+---
+---There is nothing left for them to run: since #618 vibing.nvim hands its own `claude-plugin/`
+---to the CLI per session with `--plugin-dir` rather than installing it into Claude Code's user
+---scope, so the MCP tools and the bundled skills are available as soon as the build lands. This
+---used to print a `claude plugin marketplace add ... && claude plugin install ...` hint.
 ---@return string
-local function plugin_install_message(plugin_root)
-  return "Register vibing-nvim as a Claude Code plugin by running: claude plugin marketplace add "
-    .. plugin_root
-    .. " && claude plugin install vibing-nvim@vibing --scope user"
+local function plugin_ready_message()
+  return "The vibing-nvim Claude Code plugin is loaded per session from this checkout; "
+    .. "no `claude plugin install` step is needed."
 end
 
 ---Check if command exists
@@ -85,7 +88,6 @@ end
 ---Build MCP server (synchronous)
 ---@return boolean success
 function M.build()
-  local plugin_root = get_plugin_root()
   local mcp_dir = get_mcp_dir()
 
   print_build("Building MCP server...")
@@ -141,7 +143,7 @@ function M.build()
   local dist_index = get_dist_entry()
   if vim.fn.filereadable(dist_index) == 1 then
     print_build("✓ MCP server built successfully")
-    print_build(plugin_install_message(plugin_root))
+    print_build(plugin_ready_message())
 
     return true
   else
@@ -153,7 +155,6 @@ end
 ---Build MCP server (async with callback)
 ---@param callback? function Callback function called with success status
 function M.build_async(callback)
-  local plugin_root = get_plugin_root()
   local mcp_dir = get_mcp_dir()
 
   print_build("Building MCP server...")
@@ -200,7 +201,7 @@ function M.build_async(callback)
         if vim.fn.filereadable(dist_index) == 1 then
           vim.schedule(function()
             print_build("✓ MCP server built successfully")
-            print_build(plugin_install_message(plugin_root))
+            print_build(plugin_ready_message())
             if callback then
               callback(true)
             end

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "node scripts/build.mjs",
     "build:watch": "node scripts/build.mjs --watch",
     "test": "npm run test:lua && npm run test:node",
-    "test:node": "find tests -name '*.test.mjs' -exec node --test {} +",
+    "test:node": "npm run build && find tests -name '*.test.mjs' -exec node --test {} +",
     "test:lua": "nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/ { minimal_init = 'tests/minimal_init.lua' }\"",
     "test:e2e": "VIBING_E2E=1 nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/e2e/ { minimal_init = 'tests/minimal_init.lua' }\"",
     "test:eval": "nvim --headless -u tests/minimal_init.lua -l tests/evals/run.lua",

--- a/tests/e2e/plugin_dir_spec.lua
+++ b/tests/e2e/plugin_dir_spec.lua
@@ -1,0 +1,97 @@
+-- E2E: a plugin dropped into `.vibing/plugins/` reaches the model.
+--
+-- The unit specs cover the two halves separately: plugin_dirs_spec proves the directory is
+-- resolved, cli_command_builder_spec proves `--plugin-dir` lands in the argv. Neither can show
+-- that the CLI then actually loads it, and that is the part with no error path — a `--plugin-dir`
+-- the CLI declines to use is ignored in silence (exit 0, no warning), so a mistake here looks
+-- exactly like everything working.
+local helper = require("vibing.testing.e2e_helper")
+
+-- tests/e2e is swept by `test:lua` too, and this spec sends a real request to the CLI.
+-- Only `test:e2e` sets VIBING_E2E=1; everything else skips rather than quietly spending tokens.
+if not helper.should_run() then
+  return
+end
+
+local TIMEOUTS = {
+  CHAT_CREATION = 2000,
+  BUFFER_READY = 5000,
+  -- A single short turn, but the plugin's skills are loaded before the first token.
+  ASSISTANT_RESPONSE = 60000,
+}
+
+-- The marker has to be something the model cannot produce from the prompt alone, or the spec
+-- passes without the skill ever having loaded.
+local MARKER = "ZQXPLUMB"
+local PLUGIN_NAME = "vibing-e2e-probe"
+local SKILL_NAME = "marker-probe"
+
+describe("E2E: .vibing/plugins is loaded via --plugin-dir", function()
+  local nvim_instance
+  local project_root
+
+  before_each(function()
+    -- A throwaway project directory, not the repository's own: a plugin written into the
+    -- developer's real `.vibing/plugins/` would be picked up by every other chat they have open.
+    project_root = vim.fn.tempname()
+    local skill_dir = project_root .. "/.vibing/plugins/" .. PLUGIN_NAME .. "/skills/" .. SKILL_NAME
+    vim.fn.mkdir(skill_dir, "p")
+    vim.fn.mkdir(project_root .. "/.vibing/plugins/" .. PLUGIN_NAME .. "/.claude-plugin", "p")
+    vim.fn.writefile(
+      { vim.json.encode({ name = PLUGIN_NAME, description = "vibing.nvim E2E probe", version = "0.0.1" }) },
+      project_root .. "/.vibing/plugins/" .. PLUGIN_NAME .. "/.claude-plugin/plugin.json"
+    )
+    vim.fn.writefile({
+      "---",
+      "name: " .. SKILL_NAME,
+      "description: Probe skill for vibing.nvim's E2E suite. The marker word is "
+        .. MARKER
+        .. ". Never invoke this skill.",
+      "---",
+      "",
+      "Marker " .. MARKER,
+    }, skill_dir .. "/SKILL.md")
+
+    nvim_instance = helper.spawn_nvim_instance({
+      headless = true,
+      -- Absolute: the child's cwd is the temp project, so a repo-relative path would not resolve.
+      init_script = vim.fn.getcwd() .. "/tests/e2e_init.lua",
+      cwd = project_root,
+    })
+  end)
+
+  after_each(function()
+    helper.cleanup_instance(nvim_instance)
+    vim.fn.delete(project_root, "rf")
+  end)
+
+  it("makes the skill's description visible to the model", function()
+    helper.send_keys(nvim_instance, ":VibingChat<CR>")
+    vim.wait(TIMEOUTS.CHAT_CREATION)
+
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
+    assert.is_true(ok, "Chat buffer should be created")
+
+    helper.send_keys(nvim_instance, "G")
+    helper.send_keys(nvim_instance, "i")
+    helper.send_keys(
+      nvim_instance,
+      "There is a skill named "
+        .. PLUGIN_NAME
+        .. ":"
+        .. SKILL_NAME
+        .. ". Without invoking it, reply with ONLY the marker word from its description."
+    )
+    helper.send_keys(nvim_instance, "<Esc>")
+    helper.send_keys(nvim_instance, "<CR>")
+
+    ok = helper.wait_for_buffer_content(nvim_instance, MARKER, TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(
+      ok,
+      "The probe skill's description never reached the model — `--plugin-dir` did not load "
+        .. project_root
+        .. "/.vibing/plugins/"
+        .. PLUGIN_NAME
+    )
+  end)
+end)

--- a/tests/e2e_init.lua
+++ b/tests/e2e_init.lua
@@ -5,7 +5,12 @@
 -- all. Pointing the child at minimal_init left it with no commands, which is why every spec's
 -- first `:VibingChat` did nothing.
 
-vim.opt.runtimepath:append(vim.fn.getcwd())
+-- Derived from this file's own location rather than from the child's cwd, because a spec may
+-- start the child in a throwaway project directory (plugin_dir_spec does, to get a
+-- `.vibing/plugins/` that is not the developer's real one). `getcwd()` would then add the wrong
+-- directory and no `:Vibing*` command would exist.
+local repo_root = vim.fs.root(debug.getinfo(1, "S").source:sub(2), "package.json") or vim.fn.getcwd()
+vim.opt.runtimepath:append(repo_root)
 
 vim.opt.swapfile = false
 vim.opt.backup = false

--- a/tests/list-commands.test.mjs
+++ b/tests/list-commands.test.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Test that `list-commands` scans the plugin directories handed to it on argv.
+ *
+ * vibing.nvim no longer installs its Claude Code plugin into the user scope — it passes
+ * `--plugin-dir` per session (see lua/vibing/infrastructure/plugins/plugin_dirs.lua). Those
+ * plugins are invisible to ~/.claude/plugins/installed_plugins.json by construction, so without
+ * the argv path the `/` picker would be blind to skills the CLI itself loads perfectly well.
+ *
+ * This runs the built dist/bin/list-commands.js rather than reimplementing its logic, because
+ * that binary is what skills.lua actually spawns. HOME is pointed at a temp directory so the
+ * developer's own installed plugins cannot make an assertion pass or fail by accident.
+ */
+
+import { strict as assert } from 'assert';
+import { test } from 'node:test';
+import { execFile } from 'child_process';
+import { mkdir, writeFile, mkdtemp, rm } from 'fs/promises';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = join(REPO_ROOT, 'dist', 'bin', 'list-commands.js');
+
+/** Create a plugin directory declaring `name` and carrying one skill. */
+async function writePlugin(dir, name, skillName, description) {
+  await mkdir(join(dir, '.claude-plugin'), { recursive: true });
+  await writeFile(join(dir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name }));
+  await mkdir(join(dir, 'skills', skillName), { recursive: true });
+  await writeFile(
+    join(dir, 'skills', skillName, 'SKILL.md'),
+    `---\nname: ${skillName}\ndescription: ${description}\n---\n\nBody.\n`
+  );
+}
+
+/** Run the built script with `dirs` as argv and a throwaway HOME. */
+async function listCommands(home, dirs) {
+  const { stdout } = await execFileAsync(process.execPath, [SCRIPT, ...dirs], {
+    env: { ...process.env, HOME: home },
+    cwd: home,
+  });
+  return JSON.parse(stdout);
+}
+
+test('list-commands surfaces skills from a directory passed on argv', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
+  try {
+    const home = join(root, 'home');
+    await mkdir(home, { recursive: true });
+    const plugin = join(root, 'my-plugin');
+    await writePlugin(plugin, 'my-plugin', 'do-a-thing', 'Does a thing.');
+
+    const commands = await listCommands(home, [plugin]);
+    const entry = commands.find((c) => c.name === 'my-plugin:do-a-thing');
+
+    assert.ok(entry, 'skill from the argv plugin directory is missing');
+    assert.equal(entry.description, 'Does a thing.');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('list-commands namespaces by the manifest name, not the directory name', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
+  try {
+    const home = join(root, 'home');
+    await mkdir(home, { recursive: true });
+    // Claude Code namespaces a skill as `<plugin.json name>:<skill>` regardless of where the
+    // directory sits, which matters most for vibing.nvim itself: the directory is
+    // `claude-plugin/` and the plugin is `vibing-nvim`.
+    const plugin = join(root, 'some-checkout-dir');
+    await writePlugin(plugin, 'declared-name', 'a-skill', 'Desc.');
+
+    const commands = await listCommands(home, [plugin]);
+
+    assert.ok(commands.some((c) => c.name === 'declared-name:a-skill'));
+    assert.ok(!commands.some((c) => c.name === 'some-checkout-dir:a-skill'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('list-commands skips an argv directory with no readable manifest', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
+  try {
+    const home = join(root, 'home');
+    await mkdir(home, { recursive: true });
+
+    const noManifest = join(root, 'no-manifest');
+    await mkdir(join(noManifest, 'skills', 'orphan'), { recursive: true });
+    await writeFile(
+      join(noManifest, 'skills', 'orphan', 'SKILL.md'),
+      '---\nname: orphan\ndescription: Orphaned.\n---\n'
+    );
+
+    const broken = join(root, 'broken');
+    await mkdir(join(broken, '.claude-plugin'), { recursive: true });
+    await writeFile(join(broken, '.claude-plugin', 'plugin.json'), '{ not json');
+
+    // A directory that does not exist at all must not take the process down either — the CLI
+    // itself ignores one silently, so completion refusing to produce any list would be worse.
+    const commands = await listCommands(home, [noManifest, broken, join(root, 'absent')]);
+
+    assert.ok(!commands.some((c) => c.name.includes('orphan')));
+    assert.ok(
+      commands.some((c) => c.name === 'compact'),
+      'built-in commands still listed'
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('an argv plugin wins over an installed one of the same name', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
+  try {
+    const home = join(root, 'home');
+    const installed = join(root, 'installed');
+    await writePlugin(installed, 'dup', 'from-installed', 'Installed copy.');
+    await mkdir(join(home, '.claude', 'plugins'), { recursive: true });
+    await writeFile(
+      join(home, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 1,
+        plugins: {
+          'dup@somewhere': [
+            {
+              scope: 'user',
+              installPath: installed,
+              version: '1.0.0',
+              installedAt: '2026-01-01T00:00:00Z',
+              lastUpdated: '2026-01-01T00:00:00Z',
+              gitCommitSha: 'abc',
+            },
+          ],
+        },
+      })
+    );
+
+    const session = join(root, 'session');
+    await writePlugin(session, 'dup', 'from-session', 'Session copy.');
+
+    // This mirrors the CLI, where the earlier --plugin-dir wins outright and the loser's skills
+    // never load. Listing both would offer a `/dup:from-installed` that cannot be invoked.
+    const commands = await listCommands(home, [session]);
+
+    assert.ok(commands.some((c) => c.name === 'dup:from-session'));
+    assert.ok(!commands.some((c) => c.name === 'dup:from-installed'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('with no argv directories, installed plugins are still scanned', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
+  try {
+    const home = join(root, 'home');
+    const installed = join(root, 'installed');
+    await writePlugin(installed, 'legacy', 'still-here', 'Installed skill.');
+    await mkdir(join(home, '.claude', 'plugins'), { recursive: true });
+    await writeFile(
+      join(home, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 1,
+        plugins: {
+          'legacy@market': [
+            {
+              scope: 'user',
+              installPath: installed,
+              version: '1.0.0',
+              installedAt: '2026-01-01T00:00:00Z',
+              lastUpdated: '2026-01-01T00:00:00Z',
+              gitCommitSha: 'abc',
+            },
+          ],
+        },
+      })
+    );
+
+    const commands = await listCommands(home, []);
+
+    assert.ok(commands.some((c) => c.name === 'legacy:still-here'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tests/lua/core/constants/tools_spec.lua
+++ b/tests/lua/core/constants/tools_spec.lua
@@ -1,29 +1,37 @@
 local Tools = require("vibing.core.constants.tools")
 
----Read the marketplace name the plugin is actually published under.
----@return string
-local function marketplace_name()
+---Read the bundled plugin's own manifest — the one `--plugin-dir` loads.
+---@return table
+local function plugin_manifest()
   local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h:h:h:h")
-  local path = root .. "/.claude-plugin/marketplace.json"
-  assert.equals(1, vim.fn.filereadable(path), "marketplace.json not found at " .. path)
-  local manifest = vim.json.decode(table.concat(vim.fn.readfile(path), "\n"))
-  assert.is_string(manifest.name)
-  return manifest.name
+  local path = root .. "/claude-plugin/.claude-plugin/plugin.json"
+  assert.equals(1, vim.fn.filereadable(path), "plugin.json not found at " .. path)
+  return vim.json.decode(table.concat(vim.fn.readfile(path), "\n"))
 end
 
 describe("tools constants", function()
   describe("VIBING_NVIM_MCP_TOOL_PATTERNS", function()
-    -- `--allowedTools` takes literal prefixes, so this list cannot be derived from the
-    -- marketplace name at runtime — it has to be maintained by hand. It fell out of date
-    -- exactly once already: marketplace.json was renamed to "vibing" and this list kept
-    -- saying "vibing-nvim", so the pre-approval silently matched nothing. Nothing caught it,
-    -- because the PreToolUse hook's suffix match kept ordinary chats working.
-    it("covers the marketplace name the plugin is currently published under", function()
-      local expected = ("mcp__plugin_%s_vibing-nvim__*"):format(marketplace_name())
-      assert.is_true(
-        vim.tbl_contains(Tools.VIBING_NVIM_MCP_TOOL_PATTERNS, expected),
-        ("%s is missing; add it when renaming the marketplace"):format(expected)
-      )
+    -- `--allowedTools` takes literal prefixes, so this list cannot be derived from the plugin
+    -- manifest at runtime — it has to be maintained by hand, and this is what catches a rename.
+    --
+    -- It reads plugin.json, not marketplace.json, because the prefix is built from the *plugin*
+    -- name and the MCP server name; the marketplace name never appears in it. This spec used to
+    -- assert the marketplace form (`mcp__plugin_vibing_vibing-nvim__*`) and so guarded a prefix
+    -- the CLI has never once emitted. Since #618 the plugin is not installed through a
+    -- marketplace at all — it is loaded per session with `--plugin-dir` — and the prefix is
+    -- unchanged, because how the plugin is loaded was never what decided it.
+    it("covers the prefix built from the bundled plugin's name and MCP server name", function()
+      local manifest = plugin_manifest()
+      assert.is_string(manifest.name)
+      assert.is_table(manifest.mcpServers)
+
+      for server_name in pairs(manifest.mcpServers) do
+        local expected = ("mcp__plugin_%s_%s__*"):format(manifest.name, server_name)
+        assert.is_true(
+          vim.tbl_contains(Tools.VIBING_NVIM_MCP_TOOL_PATTERNS, expected),
+          ("%s is missing; add it when renaming the plugin or its MCP server"):format(expected)
+        )
+      end
     end)
 
     it("covers the plain user-level MCP server registration", function()

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -1,10 +1,13 @@
 local cli_command_builder = require("vibing.infrastructure.adapter.modules.cli_command_builder")
+local PluginDirs = require("vibing.infrastructure.plugins.plugin_dirs")
 
 describe("cli_command_builder", function()
   local original_exepath
 
   before_each(function()
     cli_command_builder._reset_path_cache()
+    -- Keyed by cwd, and several describe blocks below stub getcwd to a fresh tempdir.
+    PluginDirs.clear_cache()
     original_exepath = vim.fn.exepath
     vim.fn.exepath = function(name)
       if name == "claude" then
@@ -17,6 +20,7 @@ describe("cli_command_builder", function()
   after_each(function()
     vim.fn.exepath = original_exepath
     cli_command_builder._reset_path_cache()
+    PluginDirs.clear_cache()
   end)
 
   local function find_flag(cmd, flag)
@@ -499,6 +503,58 @@ describe("cli_command_builder", function()
       local config = { agent = { subagent = { enabled = true } } }
       local cmd = cli_command_builder.build("hello", { lightweight = true }, nil, config, nil)
       assert.is_nil(find_flag(cmd, "--forward-subagent-text"))
+    end)
+  end)
+
+  describe("--plugin-dir", function()
+    local function plugin_dirs(cmd)
+      local dirs = {}
+      for i, arg in ipairs(cmd) do
+        if arg == "--plugin-dir" then
+          table.insert(dirs, cmd[i + 1])
+        end
+      end
+      return dirs
+    end
+
+    -- This is what makes the nvim_* MCP tools and the bundled skills exist at all, now that the
+    -- plugin is no longer installed into Claude Code's user scope.
+    it("passes vibing.nvim's own claude-plugin/ on an ordinary request", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      local dirs = plugin_dirs(cmd)
+
+      assert.equals(1, #dirs)
+      assert.is_true(dirs[1]:find("/claude-plugin", 1, true) ~= nil)
+      assert.equals(1, vim.fn.filereadable(dirs[1] .. "/.claude-plugin/plugin.json"))
+    end)
+
+    -- `core/types.lua` obliges a lightweight call to load no tools and no project config. The MCP
+    -- servers are already blocked there by --strict-mcp-config, but a plugin's skill descriptions
+    -- still cost prompt tokens on a call that has no tools to invoke them with.
+    it("passes none on a lightweight call", function()
+      local cmd = cli_command_builder.build("hello", { lightweight = true }, nil, {}, nil)
+      assert.same({}, plugin_dirs(cmd))
+    end)
+
+    it("passes one flag per directory", function()
+      local project_root = vim.fn.tempname()
+      vim.fn.mkdir(project_root .. "/plugins/extra1/.claude-plugin", "p")
+      vim.fn.writefile(
+        { vim.json.encode({ name = "extra1" }) },
+        project_root .. "/plugins/extra1/.claude-plugin/plugin.json"
+      )
+
+      local config = { agent = { plugins = { extra = { project_root .. "/plugins/extra1" } } } }
+      local dirs = plugin_dirs(cli_command_builder.build("hello", {}, nil, config, nil))
+
+      assert.equals(2, #dirs)
+      assert.equals(project_root .. "/plugins/extra1", dirs[2])
+      vim.fn.delete(project_root, "rf")
+    end)
+
+    it("passes none when the whole feature is turned off", function()
+      local config = { agent = { plugins = { self = false, project_dir = false } } }
+      assert.same({}, plugin_dirs(cli_command_builder.build("hello", {}, nil, config, nil)))
     end)
   end)
 end)

--- a/tests/lua/infrastructure/plugins/plugin_dirs_spec.lua
+++ b/tests/lua/infrastructure/plugins/plugin_dirs_spec.lua
@@ -225,6 +225,29 @@ describe("plugin_dirs", function()
   -- claude 2.1.231 by giving two same-named copies of a skill different marker words and reading
   -- back which one the model saw). Deduplicating the same way means the returned list is what
   -- actually loads, and that a project plugin cannot shadow vibing.nvim's own by taking its name.
+  describe("underscore-prefixed directories", function()
+    it("are not loaded, which is what parks a plugin without deleting it", function()
+      write_plugin(project_root .. "/.vibing/plugins/_template", "template")
+      write_plugin(project_root .. "/.vibing/plugins/live", "live")
+
+      local dirs = PluginDirs.resolve(nil, {
+        agent = { plugins = { self = false, project_dir = ".vibing/plugins" } },
+      })
+
+      assert.same({ project_root .. "/.vibing/plugins/live" }, dirs)
+    end)
+
+    it("are skipped silently, since they are parked on purpose", function()
+      vim.fn.mkdir(project_root .. "/.vibing/plugins/_broken", "p")
+
+      PluginDirs.resolve(nil, {
+        agent = { plugins = { self = false, project_dir = ".vibing/plugins" } },
+      })
+
+      assert.same({}, notifications)
+    end)
+  end)
+
   describe("duplicate plugin names", function()
     it("keeps the first and drops the rest", function()
       write_plugin(project_root .. "/.vibing/plugins/impostor", "vibing-nvim")

--- a/tests/lua/infrastructure/plugins/plugin_dirs_spec.lua
+++ b/tests/lua/infrastructure/plugins/plugin_dirs_spec.lua
@@ -189,6 +189,20 @@ describe("plugin_dirs", function()
       assert.equals(project_root .. "/.vibing/plugins/shared", dirs[2])
     end)
 
+    -- Deliberately a union, not the strict fallback `.vibing/system-prompt.md` gets: a worktree
+    -- that adds one plugin should not lose the ones the project already had.
+    it("keeps both when the worktree and the root declare different plugins", function()
+      write_plugin(project_root .. "/.vibing/plugins/from-root", "from-root")
+      local worktree = project_root .. "/.vibing/worktrees/feature"
+      write_plugin(worktree .. "/.vibing/plugins/from-worktree", "from-worktree")
+
+      local dirs = PluginDirs.resolve(worktree, config)
+
+      assert.equals(3, #dirs)
+      assert.equals(worktree .. "/.vibing/plugins/from-worktree", dirs[2])
+      assert.equals(project_root .. "/.vibing/plugins/from-root", dirs[3])
+    end)
+
     it("prefers the worktree's own copy when both declare the same plugin name", function()
       write_plugin(project_root .. "/.vibing/plugins/shared", "shared")
       local worktree = project_root .. "/.vibing/worktrees/feature"
@@ -245,6 +259,19 @@ describe("plugin_dirs", function()
       })
 
       assert.same({}, notifications)
+    end)
+  end)
+
+  describe("malformed config", function()
+    -- `candidates()` indexes `plugins.self`, so a truthy non-table raised. The builder runs under
+    -- pcall, which turned a config typo into an unexplained "failed to build command".
+    it("treats a non-table agent.plugins as unset instead of raising", function()
+      for _, bad in ipairs({ true, "yes", 42 }) do
+        local ok, dirs = pcall(PluginDirs.resolve, nil, { agent = { plugins = bad } })
+        PluginDirs.clear_cache()
+        assert.is_true(ok, vim.inspect(bad))
+        assert.same({ own_plugin_dir() }, dirs)
+      end
     end)
   end)
 

--- a/tests/lua/infrastructure/plugins/plugin_dirs_spec.lua
+++ b/tests/lua/infrastructure/plugins/plugin_dirs_spec.lua
@@ -1,0 +1,237 @@
+local PluginDirs = require("vibing.infrastructure.plugins.plugin_dirs")
+
+describe("plugin_dirs", function()
+  local project_root
+  local original_getcwd
+  local original_notify
+  local notifications
+
+  ---Create a plugin directory with a manifest declaring `name`.
+  ---@param dir string
+  ---@param name string
+  local function write_plugin(dir, name)
+    vim.fn.mkdir(dir .. "/.claude-plugin", "p")
+    vim.fn.writefile({ vim.json.encode({ name = name }) }, dir .. "/.claude-plugin/plugin.json")
+  end
+
+  ---The repo's own claude-plugin/, which `self` resolves to.
+  local function own_plugin_dir()
+    local root = vim.fs.root(debug.getinfo(1, "S").source:sub(2), "package.json")
+    return root .. "/claude-plugin"
+  end
+
+  before_each(function()
+    PluginDirs.clear_cache()
+    project_root = vim.fn.tempname()
+    vim.fn.mkdir(project_root, "p")
+    original_getcwd = vim.fn.getcwd
+    vim.fn.getcwd = function()
+      return project_root
+    end
+    notifications = {}
+    original_notify = vim.notify
+    vim.notify = function(msg, level)
+      table.insert(notifications, { msg = msg, level = level })
+    end
+  end)
+
+  after_each(function()
+    vim.notify = original_notify
+    vim.fn.getcwd = original_getcwd
+    vim.fn.delete(project_root, "rf")
+    PluginDirs.clear_cache()
+  end)
+
+  describe("self", function()
+    it("resolves vibing.nvim's own claude-plugin/ by default", function()
+      local dirs = PluginDirs.resolve(nil, {})
+      assert.same({ own_plugin_dir() }, dirs)
+    end)
+
+    it("reports it under the name declared in its manifest, not its directory name", function()
+      local entries = PluginDirs.resolve_entries(nil, {})
+      assert.equals("vibing-nvim", entries[1].name)
+    end)
+
+    it("is omitted when agent.plugins.self is false", function()
+      local dirs = PluginDirs.resolve(nil, { agent = { plugins = { self = false } } })
+      assert.same({}, dirs)
+    end)
+  end)
+
+  describe("project_dir", function()
+    local config = { agent = { plugins = { project_dir = ".vibing/plugins" } } }
+
+    it("picks up every directory under it that carries a manifest", function()
+      write_plugin(project_root .. "/.vibing/plugins/alpha", "alpha")
+      write_plugin(project_root .. "/.vibing/plugins/beta", "beta")
+
+      local dirs = PluginDirs.resolve(nil, config)
+
+      assert.equals(3, #dirs)
+      assert.equals(own_plugin_dir(), dirs[1])
+      assert.equals(project_root .. "/.vibing/plugins/alpha", dirs[2])
+      assert.equals(project_root .. "/.vibing/plugins/beta", dirs[3])
+    end)
+
+    it("adds nothing when the directory does not exist", function()
+      assert.same({ own_plugin_dir() }, PluginDirs.resolve(nil, config))
+    end)
+
+    it("is skipped entirely when set to false", function()
+      write_plugin(project_root .. "/.vibing/plugins/alpha", "alpha")
+      local dirs = PluginDirs.resolve(nil, { agent = { plugins = { project_dir = false } } })
+      assert.same({ own_plugin_dir() }, dirs)
+    end)
+  end)
+
+  describe("broken candidates", function()
+    local config = { agent = { plugins = { project_dir = ".vibing/plugins" } } }
+
+    -- `--plugin-dir` ignores these without a word (measured on claude 2.1.231: exit 0, no
+    -- warning, turn completes), so "I dropped a plugin in and nothing happened" would otherwise
+    -- have no explanation anywhere.
+    it("drops a directory with no manifest and says so", function()
+      vim.fn.mkdir(project_root .. "/.vibing/plugins/nomanifest", "p")
+
+      local dirs = PluginDirs.resolve(nil, config)
+
+      assert.same({ own_plugin_dir() }, dirs)
+      assert.equals(1, #notifications)
+      assert.is_true(notifications[1].msg:find("nomanifest", 1, true) ~= nil)
+      assert.equals(vim.log.levels.WARN, notifications[1].level)
+    end)
+
+    it("drops a directory whose manifest is not valid JSON", function()
+      vim.fn.mkdir(project_root .. "/.vibing/plugins/broken/.claude-plugin", "p")
+      vim.fn.writefile({ "{ not json" }, project_root .. "/.vibing/plugins/broken/.claude-plugin/plugin.json")
+
+      assert.same({ own_plugin_dir() }, PluginDirs.resolve(nil, config))
+      assert.equals(1, #notifications)
+      assert.is_true(notifications[1].msg:find("malformed", 1, true) ~= nil)
+    end)
+
+    it("drops a manifest with no name", function()
+      vim.fn.mkdir(project_root .. "/.vibing/plugins/anon/.claude-plugin", "p")
+      vim.fn.writefile(
+        { vim.json.encode({ description = "no name here" }) },
+        project_root .. "/.vibing/plugins/anon/.claude-plugin/plugin.json"
+      )
+
+      assert.same({ own_plugin_dir() }, PluginDirs.resolve(nil, config))
+      assert.equals(1, #notifications)
+    end)
+
+    -- Resolution happens on every request, so a per-call warning would notify on every message.
+    it("warns once per cwd, not once per call", function()
+      vim.fn.mkdir(project_root .. "/.vibing/plugins/nomanifest", "p")
+
+      PluginDirs.resolve(nil, config)
+      PluginDirs.resolve(nil, config)
+      PluginDirs.resolve(nil, config)
+
+      assert.equals(1, #notifications)
+    end)
+
+    -- An explicit reload is the user saying "I changed something, look again" -- typically right
+    -- after trying to fix the manifest. Staying quiet there would report a still-broken plugin
+    -- as fixed.
+    it("warns again after an explicit cache clear", function()
+      vim.fn.mkdir(project_root .. "/.vibing/plugins/nomanifest", "p")
+
+      PluginDirs.resolve(nil, config)
+      PluginDirs.clear_cache()
+      PluginDirs.resolve(nil, config)
+
+      assert.equals(2, #notifications)
+    end)
+  end)
+
+  describe("caching", function()
+    local config = { agent = { plugins = { project_dir = ".vibing/plugins" } } }
+
+    it("does not re-scan until the cache is cleared", function()
+      assert.same({ own_plugin_dir() }, PluginDirs.resolve(nil, config))
+
+      write_plugin(project_root .. "/.vibing/plugins/late", "late")
+      assert.same({ own_plugin_dir() }, PluginDirs.resolve(nil, config))
+
+      PluginDirs.clear_cache()
+      assert.equals(2, #PluginDirs.resolve(nil, config))
+    end)
+
+    it("keys on the request's cwd, so a worktree does not read the root's cached list", function()
+      local worktree = project_root .. "/.vibing/worktrees/feature"
+      write_plugin(worktree .. "/.vibing/plugins/only-here", "only-here")
+
+      assert.same({ own_plugin_dir() }, PluginDirs.resolve(nil, config))
+
+      local from_worktree = PluginDirs.resolve(worktree, config)
+      assert.equals(2, #from_worktree)
+      assert.equals(worktree .. "/.vibing/plugins/only-here", from_worktree[2])
+    end)
+  end)
+
+  describe("worktree fallback", function()
+    local config = { agent = { plugins = { project_dir = ".vibing/plugins" } } }
+
+    -- `.vibing/` is git-ignored, so a worktree checkout starts with no `.vibing/plugins` of its
+    -- own. Without the fallback, moving a chat into a worktree would silently drop every
+    -- project plugin the user had set up.
+    it("falls back to the Neovim root when the worktree has no plugins of its own", function()
+      write_plugin(project_root .. "/.vibing/plugins/shared", "shared")
+      local worktree = project_root .. "/.vibing/worktrees/feature"
+      vim.fn.mkdir(worktree, "p")
+
+      local dirs = PluginDirs.resolve(worktree, config)
+
+      assert.equals(2, #dirs)
+      assert.equals(project_root .. "/.vibing/plugins/shared", dirs[2])
+    end)
+
+    it("prefers the worktree's own copy when both declare the same plugin name", function()
+      write_plugin(project_root .. "/.vibing/plugins/shared", "shared")
+      local worktree = project_root .. "/.vibing/worktrees/feature"
+      write_plugin(worktree .. "/.vibing/plugins/shared", "shared")
+
+      local dirs = PluginDirs.resolve(worktree, config)
+
+      assert.equals(2, #dirs)
+      assert.equals(worktree .. "/.vibing/plugins/shared", dirs[2])
+    end)
+  end)
+
+  describe("extra", function()
+    it("accepts an absolute path", function()
+      local elsewhere = vim.fn.tempname()
+      write_plugin(elsewhere, "elsewhere")
+
+      local dirs = PluginDirs.resolve(nil, { agent = { plugins = { extra = { elsewhere } } } })
+
+      assert.same({ own_plugin_dir(), elsewhere }, dirs)
+      vim.fn.delete(elsewhere, "rf")
+    end)
+
+    it("resolves a relative path against the request's cwd", function()
+      write_plugin(project_root .. "/tools/my-plugin", "my-plugin")
+
+      local dirs = PluginDirs.resolve(nil, { agent = { plugins = { extra = { "tools/my-plugin" } } } })
+
+      assert.same({ own_plugin_dir(), project_root .. "/tools/my-plugin" }, dirs)
+    end)
+  end)
+
+  -- The CLI resolves a duplicate plugin name in favour of the earlier --plugin-dir (measured on
+  -- claude 2.1.231 by giving two same-named copies of a skill different marker words and reading
+  -- back which one the model saw). Deduplicating the same way means the returned list is what
+  -- actually loads, and that a project plugin cannot shadow vibing.nvim's own by taking its name.
+  describe("duplicate plugin names", function()
+    it("keeps the first and drops the rest", function()
+      write_plugin(project_root .. "/.vibing/plugins/impostor", "vibing-nvim")
+
+      local dirs = PluginDirs.resolve(nil, { agent = { plugins = { project_dir = ".vibing/plugins" } } })
+
+      assert.same({ own_plugin_dir() }, dirs)
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/plugins/scaffold_spec.lua
+++ b/tests/lua/infrastructure/plugins/scaffold_spec.lua
@@ -1,0 +1,128 @@
+local PluginDirs = require("vibing.infrastructure.plugins.plugin_dirs")
+local Scaffold = require("vibing.infrastructure.plugins.scaffold")
+local ScaffoldFiles = require("vibing.infrastructure.plugins.scaffold_files")
+
+describe("plugins scaffold", function()
+  local project_root
+  local original_getcwd
+
+  local function plugins_dir()
+    return project_root .. "/.vibing/plugins"
+  end
+
+  --- An empty table means "no agent.plugins at all", which disables project_dir. Real callers
+  --- always pass a resolved config, so the tests spell the relevant part out.
+  --- @param overrides table|nil
+  local function config(overrides)
+    return {
+      agent = {
+        plugins = vim.tbl_extend(
+          "force",
+          { self = false, project_dir = ".vibing/plugins" },
+          overrides or {}
+        ),
+      },
+    }
+  end
+
+  before_each(function()
+    PluginDirs.clear_cache()
+    project_root = vim.fn.tempname()
+    vim.fn.mkdir(project_root, "p")
+    original_getcwd = vim.fn.getcwd
+    vim.fn.getcwd = function()
+      return project_root
+    end
+  end)
+
+  after_each(function()
+    vim.fn.getcwd = original_getcwd
+    vim.fn.delete(project_root, "rf")
+    PluginDirs.clear_cache()
+  end)
+
+  describe("ensure", function()
+    it("seeds the plugins directory with the template plugin", function()
+      assert.is_true(Scaffold.ensure(project_root, config()))
+
+      assert.equals(
+        1,
+        vim.fn.filereadable(
+          plugins_dir() .. "/" .. ScaffoldFiles.TEMPLATE_DIR .. "/.claude-plugin/plugin.json"
+        )
+      )
+    end)
+
+    it("leaves the template inactive so it costs no context", function()
+      Scaffold.ensure(project_root, config())
+
+      -- The underscore prefix is what keeps it out of the glob; if the name ever loses it,
+      -- every project would start shipping the example skill's description on every request
+      -- and listing it in the `/` picker.
+      assert.same({}, PluginDirs.resolve(project_root, config()))
+    end)
+
+    it("does not run again once the directory exists", function()
+      Scaffold.ensure(project_root, config())
+      local template = plugins_dir() .. "/" .. ScaffoldFiles.TEMPLATE_DIR
+      vim.fn.delete(template, "rf")
+
+      assert.is_false(Scaffold.ensure(project_root, config()))
+      assert.equals(0, vim.fn.isdirectory(template))
+    end)
+
+    it("does nothing when project_dir is disabled", function()
+      assert.is_false(Scaffold.ensure(project_root, config({ project_dir = false })))
+      assert.equals(0, vim.fn.isdirectory(plugins_dir()))
+    end)
+  end)
+
+  describe("create", function()
+    it("writes a plugin that --plugin-dir actually loads", function()
+      local path, problem = Scaffold.create("my-plugin", project_root, config())
+
+      assert.is_nil(problem)
+      assert.equals(plugins_dir() .. "/my-plugin", path)
+      assert.same({ plugins_dir() .. "/my-plugin" }, PluginDirs.resolve(project_root, config()))
+    end)
+
+    it("names the plugin in its manifest after the directory", function()
+      Scaffold.create("my-plugin", project_root, config())
+
+      local entries = PluginDirs.resolve_entries(project_root, config())
+      assert.equals("my-plugin", entries[1].name)
+    end)
+
+    it("ships a skill and an agent", function()
+      local path = Scaffold.create("my-plugin", project_root, config())
+
+      assert.equals(1, vim.fn.filereadable(path .. "/skills/example/SKILL.md"))
+      assert.equals(1, vim.fn.filereadable(path .. "/agents/example-agent.md"))
+    end)
+
+    it("seeds the template too, for a first run that skipped the chat", function()
+      Scaffold.create("my-plugin", project_root, config())
+
+      assert.equals(
+        1,
+        vim.fn.isdirectory(plugins_dir() .. "/" .. ScaffoldFiles.TEMPLATE_DIR)
+      )
+    end)
+
+    it("refuses to overwrite an existing plugin", function()
+      Scaffold.create("my-plugin", project_root, config())
+      local path, problem = Scaffold.create("my-plugin", project_root, config())
+
+      assert.is_nil(path)
+      assert.is_truthy(problem:match("already exists"))
+    end)
+
+    it("rejects names that would break skill namespacing or the shell", function()
+      for _, name in ipairs({ "", "My Plugin", "../escape", "plugin:name" }) do
+        local path, problem = Scaffold.create(name, project_root, config())
+        assert.is_nil(path, name)
+        assert.is_truthy(problem)
+      end
+    end)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

`claude` CLI の `--plugin-dir` を使い、vibing-nvim プラグインの user scope インストールを廃止する。あわせてプロジェクト固有のプラグイン置き場 `.vibing/plugins/` を導入する。

`build.sh` が `claude plugin marketplace add` / `install --scope user` でグローバル状態に書き込む方式は、#480 / #482（`claude plugin` の無限ハングと専用タイムアウトラッパー）、#450、#557、旧マーケットプレイス名からの移行処理を繰り返し生んできた。さらに構造的な問題として、**MCP サーバーが Neovim プラグイン本体と独立に更新される**（worktree で MCP サーバーを直しても、実際に動くのは user scope 側の別コード）。

`--plugin-dir <path>` はそのセッション限りでディレクトリからプラグインを読むフラグで、グローバル状態に何も書かずに同じ結果が得られる。

## Changes

- **新規 `lua/vibing/infrastructure/plugins/plugin_dirs.lua`** — `self` → `.vibing/plugins/*/` → `agent.plugins.extra` の順に解決。cwd をキーにキャッシュし、`.claude-plugin/plugin.json` を検証して駄目なものは落として警告する。「どのプラグインディレクトリが効くか」の唯一の定義元で、argv・skill 補完・agent 補完がすべてここを読む
- **`cli_command_builder`** — non-lightweight のときだけ 1 パスにつき 1 つ `--plugin-dir` を積む
- **`config.agent.plugins`** — `{ self = true, project_dir = ".vibing/plugins", extra = {} }`
- **補完** — `skills.lua` は解決済みパスを `list-commands` の argv に渡し、`agents.lua` は installed plugins の手前にマージする（これが無いと `nvim-navigator` は CLI でロードされるのに補完に出ない）
- **`bin/list-commands.ts` / `plugin-loader.ts`** — `process.argv` で受けたディレクトリを `resolveSessionPluginDirs` でスキャン。cwd の解釈を 2 言語で書くのを避けるため、探索の定義元は Lua 側に残す
- **`build.sh` を 409 → 250 行** — marketplace 登録・旧名移行・プラグインキャッシュへの rsync/symlink（約 90 行）を削除。残すのは `.node-path`、依存インストールとビルド、fingerprint、そして**証拠がある場合だけ走る**旧インストールの後片付け
- **`tools.lua`** — `mcp__plugin_vibing_vibing-nvim__*` を削除
- **CI** — plugin layout チェックを `MARKETPLACE_NAME` から `plugin_dirs.lua` の `--plugin-dir` 対象に張り替え

### `mcp__plugin_vibing_vibing-nvim__*` について

このエントリは**実際には一度も生成されたことがない**。プラグイン側の接頭辞を決めるのは plugin.json の `name`（`vibing-nvim`）であって、マーケットプレイス名（`vibing`）ではない。`tools_spec.lua` が `marketplace.json` の `name` を読んでこのエントリの存在を要求していたため、使われない経路をテストが守り続けていた。テストは `claude-plugin/.claude-plugin/plugin.json` 基準に張り替えた。

チャットが止まらなかったのは、PreToolUse フックのサフィックスマッチが実際の判定をしているため（`architecture.md` に記載のとおり）。

## 実測（claude 2.1.231）

issue に「実装時に確かめる」として残っていた 2 点を含め、実機で確認した。

| 確認項目 | 結果 |
| --- | --- |
| `--plugin-dir` でのツール名 | `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` — user scope インストール版と同一 |
| **同名プラグインが複数の `--plugin-dir` にある場合** | **先に渡した方が勝つ**。同名スキルに別のマーカー語を仕込み、モデルがどちらを見たかで判定（A→B で `MARKERALPHA`、B→A で `MARKERBRAVO`） |
| **`--plugin-dir` の個数上限** | **観測されず**。30 個渡して `Loaded 30 session-only plugins`、スキャン 30 件すべてモデルから可視 |
| user scope インストールとの併用 | inline 側が勝つ。12 installed が居る状態で `Found 1 plugins`、skill は worktree の `claude-plugin/skills` から 11 件ロード |
| 壊れた / manifest 無し / 存在しないパス | **黙って無視され exit 0**。警告もエラーも出ない |

先勝ちの実測が 2 つの設計判断を決めている。

1. **順序を self → project → extra に固定する理由。** `.vibing/plugins/` に `vibing-nvim` を名乗るものを置いても本物を乗っ取れない。`plugin_dirs` も同じ規則で名前重複を除くので、返るリストは「CLI に渡した候補」ではなく「実際にロードされるもの」になる
2. **manifest 検証を入れる理由。** `--plugin-dir` は断ったディレクトリについて一切シグナルを出さないため、これが無いと「置いたのに効かない」の説明がどこにも残らない

### `.vibing/plugins/` の雛形と `:VibingCreatePlugin`（2コミット目）

`.vibing/plugins/` は規約だけがあって実体が無く、`.claude-plugin/plugin.json` の構成を知らないと何も読み込まれない状態だった。`--plugin-dir` は断ったディレクトリについて一切シグナルを出さないので、間違えても気づけない。

- **プロジェクト初回の non-lightweight リクエスト時**に `.vibing/plugins/` を作り、完全な `_template/`（manifest + skill + subagent）を置く。`setup()` ではなく `claude_cli:stream` の hook settings 生成の隣に置いたのは、Neovim を起動したすべてのディレクトリに `.vibing/` を作らないため
- **`:VibingCreatePlugin [name]`** — 同じ雛形を実名で書き、example skill を開く。引数なしなら `vim.ui.input` で聞く。作成後に `plugin_dirs` と補完のキャッシュを落とすので再起動は不要
- **`plugin_dirs` が `_` 始まりのディレクトリを除外する。** これが雛形をロードさせない仕組み。有効なままだと example skill の description が全プロジェクト・全リクエストのシステムプロンプトに載り、`/` 補完にも並ぶ。副次的に、**使っていないプラグインを `my-tooling` → `_my-tooling` にリネームすれば消さずに止められる**規約になる。壊れた manifest と違い意図的な無効化なので警告は出さない

除外は `glob_plugin_dirs` の1箇所だけ。ここは argv・skill 補完・agent 補完・`list-commands` がすべて通る唯一の入り口なので、1箇所で全経路から消える。

実機確認（headless）:

```
:VibingCreatePlugin my-tooling
  → .vibing/plugins/{_template,my-tooling}/ が生成
plugin_dirs.resolve → { ".../plugins/my-tooling" }      ← _template は載らない
list-commands       → ['my-tooling:example']            ← 補完に出る
```

テストは `scaffold_spec.lua` 10件（seeding、二度目は走らない、`project_dir = false`、生成物が実際に解決される、上書き拒否、名前バリデーション）と `plugin_dirs_spec` に2件追加（`_` 始まりが解決されない・警告も出ない）。

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Code refactoring
- [x] Documentation update
- [x] Test addition or update
- [x] CI/CD update

## Testing

- [x] Tested locally in Neovim
- [x] Ran `pnpm run check` / `check:doc` / `lint` / `lint:md` / `format:check`
- [x] Manual testing completed

**E2E: 12/12 green**（`pnpm run test:e2e`、exit 0）。新規 `tests/e2e/plugin_dir_spec.lua` は、使い捨ての一時プロジェクトに `.vibing/plugins/` を作り、そのスキルの説明文がモデルまで届くことを子 Neovim 経由で確認する。`--plugin-dir` の失敗は無音なので、ユニットテストだけでは「argv に載った」までしか言えない。

**Lua**: 新規 `plugin_dirs_spec.lua` 20 件、`scaffold_spec.lua` 10 件、`cli_command_builder_spec` に 4 件追加、すべて green。既存の `summary_input_spec` 8 件は落ちるが、これは **main でも同様に落ちる既存の失敗**（`prompt_loader` が runtimepath から `vibing.nvim` を見つけられない）で、本 PR とは無関係。

**Node**: 43/43。新規 `tests/list-commands.test.mjs` は、ビルド済み `dist/bin/list-commands.js` を `HOME` を一時ディレクトリに向けて実行し、実装の再実装ではなく実物を検証する。

### 未自動化（手動確認が要る箇所）

`build.sh` の後片付けは自動テスト対象外。クリーン環境でのビルド、既存インストールがある環境での移行、`claude plugin list` に残らないことは手動で確認してほしい。

### Test Environment

- **Neovim version**: NVIM v0.13.0-dev-937+g089662d318-Homebrew
- **Operating System**: macOS 26.5
- **Node.js version**: v22.21.1

## Documentation

- [x] README.md / README.ja.md updated
- [x] doc/vibing.txt updated（`:VibingCreatePlugin` と `_` 規約を含む）
- [x] CLAUDE.md updated
- [x] Code comments added/updated
- [x] `.claude/rules/architecture.md` に「Self-Hosted Claude Code Plugin (`--plugin-dir`)」節を追加、`mcp-integration.md` の接頭辞の記述を訂正
- [x] `handbook/configuration.md` に `agent.plugins` と "Plugin Directories" 節、`.claude/rules/commands-reference.md` に `:VibingCreatePlugin`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally with my changes

## Related Issues

Fixes #618

## Additional Context

### 受容したリスク

- **Neovim 外の素の `claude` から `nvim_*` ツールが使えなくなる。** 実行中の Neovim に届くことがこれらのツールの存在理由なので、オプトインの逃げ道は用意していない
- **`.vibing/plugins/` は既定で読み込む。** プラグインは `mcpServers` を宣言できるため、クローンしたリポジトリに仕込まれたものが最初の送信時に任意のプロセスを起動しうる。`.claude/skills/` の無承認ロードが「指示の注入」であるのに対し、これは「コード実行」であり、Claude Code 自身がプロジェクトの `.mcp.json` を承認制にしている理由でもある。利便性を優先して受容し、`agent.plugins.project_dir = false` を逃げ道とした
- `.claude-plugin/marketplace.json` は残した。手動 `claude plugin install` の経路を積極的に壊す理由がなく、削除は後からでもできる

### worktree でのフォールバック

`.vibing/` は gitignore されるので worktree の checkout には `.vibing/plugins` が無い。`working_dir` が worktree のチャットは、worktree 側にあればそれを、無ければ Neovim のルートを読む（`project_system_prompt.read_for_cwd` と同じ解決）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code plugins now load per session without global installation.
  * Added bundled, project-local, and additional plugin directories with validation, precedence, worktree support, and reload updates.
  * Added `:VibingCreatePlugin` to scaffold project-local plugins with example skills and agents.
  * Completion now includes skills and agents from loaded plugins.
  * Lightweight sessions exclude plugin loading.

* **Documentation**
  * Updated installation, configuration, migration, MCP tool naming, and security guidance.
  * Added Japanese documentation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
