### PR TITLE
fix: read a block scalar description in skill and agent completion

### DIFF
--- a/bin/list-commands.ts
+++ b/bin/list-commands.ts
@@ -52,6 +52,39 @@ const BUILTIN_COMMANDS: CommandEntry[] = [
   },
 ];
 
+/** A YAML block scalar header: `|` or `>` plus an optional indent and chomping indicator. */
+const BLOCK_SCALAR_HEADER = /^[|>](?:\d[-+]?|[-+]\d?)?$/;
+
+/**
+ * Read one top-level frontmatter key, following a YAML block scalar onto its indented
+ * continuation lines.
+ *
+ * A line-anchored `^key:\s*(.+)$` captures the block scalar's own header, so a skill written
+ * with `description: >-` had ">-" as its entire description in the `/` picker. Continuation
+ * lines are joined with a space for `|` as well as `>`, because the one consumer of this value
+ * is a completion menu — `omnifunc`'s `menu` field is a single line, so a literal block's
+ * newlines have nowhere to go.
+ *
+ * @returns the value, or null when the key is absent.
+ */
+function readFrontmatterScalar(lines: string[], key: string): string | null {
+  const prefix = `${key}:`;
+  const index = lines.findIndex((line) => line.startsWith(prefix));
+  if (index === -1) return null;
+
+  const inline = lines[index].slice(prefix.length).trim();
+  if (!BLOCK_SCALAR_HEADER.test(inline)) return inline;
+
+  const continued: string[] = [];
+  for (const line of lines.slice(index + 1)) {
+    if (line.trim() === '') continue;
+    // Back at column 0 is the next top-level key, which ends the block.
+    if (!/^\s/.test(line)) break;
+    continued.push(line.trim());
+  }
+  return continued.join(' ');
+}
+
 /** Parse a SKILL.md file's YAML frontmatter for name/description/user-invocable. */
 async function parseSkillFrontmatter(
   skillMdPath: string
@@ -66,17 +99,17 @@ async function parseSkillFrontmatter(
   const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
   if (!frontmatterMatch) return null;
 
-  const nameMatch = frontmatterMatch[1].match(/^name:\s*(.+)$/m);
-  if (!nameMatch) return null;
-  const descMatch = frontmatterMatch[1].match(/^description:\s*(.+)$/m);
+  const lines = frontmatterMatch[1].split('\n');
+  const name = readFrontmatterScalar(lines, 'name');
+  if (!name) return null;
   // Default true, matching Claude Code CLI's own opt-out convention: skills are
   // visible in the slash menu unless they explicitly declare `user-invocable: false`.
-  const userInvocableMatch = frontmatterMatch[1].match(/^user-invocable:\s*(.+)$/m);
+  const userInvocable = readFrontmatterScalar(lines, 'user-invocable');
 
   return {
-    name: nameMatch[1].trim(),
-    description: descMatch ? descMatch[1].trim() : '',
-    userInvocable: userInvocableMatch ? userInvocableMatch[1].trim() !== 'false' : true,
+    name,
+    description: readFrontmatterScalar(lines, 'description') ?? '',
+    userInvocable: userInvocable === null ? true : userInvocable !== 'false',
   };
 }
 

--- a/lua/vibing/core/utils/yaml_frontmatter.lua
+++ b/lua/vibing/core/utils/yaml_frontmatter.lua
@@ -1,0 +1,66 @@
+---@class Vibing.YamlFrontmatter
+---Reads single top-level scalars out of a markdown file's YAML frontmatter.
+---
+---Deliberately not a YAML parser: the callers (skill and agent completion) want two or three
+---known keys out of a handful of lines, and pulling in a real parser to read `description:`
+---would cost more than it explains. What it does handle is the one construct a line-anchored
+---`^key:%s*(.+)$` gets wrong -- block scalars. `description: >-` matches that pattern and
+---captures ">-", so a skill that wraps a long description across lines had ">-" as its entire
+---description in the `/` picker.
+---@module "vibing.core.utils.yaml_frontmatter"
+local M = {}
+
+---A block scalar header: `|` or `>` plus an optional indent and chomping indicator, in either
+---order (`>`, `>-`, `|2`, `>-2`).
+---@param value string
+---@return boolean
+local function is_block_header(value)
+  return value:match("^[|>]%d?[-+]?$") ~= nil or value:match("^[|>][-+]%d?$") ~= nil
+end
+
+---Read one top-level frontmatter key.
+---
+---Continuation lines are joined with a space for `|` as well as `>`, because every consumer of
+---this puts the value in a completion item's `description`, and `omnifunc`'s `menu` field is a
+---single line -- a literal block's newlines have nowhere to go.
+---@param lines string[] whole-file lines; the frontmatter must open on the first one
+---@param key string
+---@return string? value, or nil when there is no frontmatter, the key is absent, or it is empty
+function M.read(lines, key)
+  if not lines or lines[1] ~= "---" then
+    return nil
+  end
+
+  local value = nil
+  local collecting = false
+
+  for i = 2, #lines do
+    local line = lines[i]
+    if line == "---" then
+      break
+    end
+
+    local found_key, inline = line:match("^([%w%-_]+):%s*(.*)$")
+    if found_key then
+      -- Column 0 is the next top-level key, which ends the block we were collecting.
+      if collecting then
+        break
+      end
+      if found_key == key then
+        if is_block_header(inline) then
+          value, collecting = "", true
+        else
+          value = inline
+          break
+        end
+      end
+    elseif collecting and line:match("^%s+%S") then
+      local continued = vim.trim(line)
+      value = value == "" and continued or (value .. " " .. continued)
+    end
+  end
+
+  return value ~= "" and value or nil
+end
+
+return M

--- a/lua/vibing/infrastructure/completion/providers/agents.lua
+++ b/lua/vibing/infrastructure/completion/providers/agents.lua
@@ -3,6 +3,8 @@
 ---@module "vibing.infrastructure.completion.providers.agents"
 local M = {}
 
+local YamlFrontmatter = require("vibing.core.utils.yaml_frontmatter")
+
 ---@type Vibing.CompletionItem[]?
 local _cache = nil
 
@@ -20,38 +22,21 @@ local function parse_agent(file_path, plugin_name)
     return nil
   end
 
-  -- Check for YAML frontmatter
-  if lines[1] ~= "---" then
-    return nil
-  end
-
-  local name = nil
-  local description = nil
-
-  for i = 2, #lines do
-    local line = lines[i]
-    if line == "---" then
-      break
-    end
-
-    local key, value = line:match("^(%w+):%s*(.+)$")
-    if key == "name" then
-      name = value
-    elseif key == "description" then
-      description = value
-    end
-  end
-
+  local name = YamlFrontmatter.read(lines, "name")
   if not name then
     return nil
   end
 
   return {
     name = name,
-    description = description or name,
+    description = YamlFrontmatter.read(lines, "description") or name,
     full_name = plugin_name .. ":" .. name,
   }
 end
+
+---Exposed for tests: everything above this reads a real plugin tree out of `installed_plugins.json`
+---or `plugin_dirs`, so the frontmatter parsing has no other reachable seam.
+M._parse_agent = parse_agent
 
 ---Load installed plugins from ~/.claude/plugins/installed_plugins.json
 ---@return {plugin_name: string, install_path: string}[]

--- a/lua/vibing/infrastructure/completion/providers/skills.lua
+++ b/lua/vibing/infrastructure/completion/providers/skills.lua
@@ -3,6 +3,8 @@
 ---@module "vibing.infrastructure.completion.providers.skills"
 local M = {}
 
+local YamlFrontmatter = require("vibing.core.utils.yaml_frontmatter")
+
 ---@type Vibing.CompletionItem[]?
 local _cache = nil
 
@@ -21,29 +23,13 @@ local _bundled_cache_cwd = nil
 ---@type number?
 local _bundled_cache_script_mtime = nil
 
----Check if SKILL.md frontmatter opts out of slash-menu visibility via `user-invocable: false`.
----Matches Claude Code CLI's own convention: skills are visible in the `/` menu by default.
----@param lines string[]
----@return boolean
-local function is_user_invocable(lines)
-  local in_frontmatter = false
-  for _, line in ipairs(lines) do
-    if line == "---" then
-      if in_frontmatter then
-        break
-      end
-      in_frontmatter = true
-    elseif in_frontmatter then
-      local value = line:match("^user%-invocable:%s*(%S+)")
-      if value == "false" then
-        return false
-      end
-    end
-  end
-  return true
-end
-
 ---Parse SKILL.md to extract name and description
+---
+---The description comes from frontmatter, the same key `list-commands` reads for plugin skills.
+---This used to take the body's first `# heading` instead, which meant one `/` menu showed two
+---different things depending only on where a skill happened to live -- and no amount of editing
+---`description:` changed what a local skill displayed. The heading survives as a fallback for a
+---skill that declares no description at all.
 ---@param file_path string
 ---@return {name: string, description: string}?
 local function parse_skill(file_path)
@@ -56,23 +42,30 @@ local function parse_skill(file_path)
     return nil
   end
 
-  if not is_user_invocable(lines) then
+  -- Skills are visible in the `/` menu unless they opt out, matching the CLI's own convention.
+  if YamlFrontmatter.read(lines, "user-invocable") == "false" then
     return nil
   end
 
   local dir_name = vim.fn.fnamemodify(vim.fn.fnamemodify(file_path, ":h"), ":t")
-  local description = dir_name
+  local description = YamlFrontmatter.read(lines, "description")
 
-  for _, line in ipairs(lines) do
-    local match = line:match("^#%s+(.+)$")
-    if match then
-      description = match
-      break
+  if not description then
+    for _, line in ipairs(lines) do
+      local heading = line:match("^#%s+(.+)$")
+      if heading then
+        description = heading
+        break
+      end
     end
   end
 
-  return { name = dir_name, description = description }
+  return { name = dir_name, description = description or dir_name }
 end
+
+---Exposed for tests: the callers above it walk real skill directories, so the parsing has no
+---other reachable seam.
+M._parse_skill = parse_skill
 
 ---Get hardcoded bundled skills (Claude Code built-in skills)
 ---These are not available via supportedCommands() API

--- a/tests/list-commands.test.mjs
+++ b/tests/list-commands.test.mjs
@@ -63,6 +63,73 @@ test('list-commands surfaces skills from a directory passed on argv', async () =
   }
 });
 
+test('a block scalar description is read, not its `>-` header', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
+  try {
+    const home = join(root, 'home');
+    await mkdir(home, { recursive: true });
+    const plugin = join(root, 'my-plugin');
+    await mkdir(join(plugin, '.claude-plugin'), { recursive: true });
+    await writeFile(join(plugin, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'p' }));
+    await mkdir(join(plugin, 'skills', 'folded'), { recursive: true });
+    // Wrapping a long description in a folded block is ordinary YAML, and reading the line the
+    // key is on gave ">-" as the whole description in the `/` picker.
+    await writeFile(
+      join(plugin, 'skills', 'folded', 'SKILL.md'),
+      [
+        '---',
+        'name: folded',
+        'description: >-',
+        '  First line of the description.',
+        '  TRIGGER: second line.',
+        'user-invocable: true',
+        '---',
+        '',
+        'Body.',
+        '',
+      ].join('\n')
+    );
+
+    const commands = await listCommands(home, [plugin]);
+    const entry = commands.find((c) => c.name === 'p:folded');
+
+    assert.ok(entry, 'skill with a folded description is missing');
+    assert.equal(entry.description, 'First line of the description. TRIGGER: second line.');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('a block scalar does not swallow the keys after it', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
+  try {
+    const home = join(root, 'home');
+    await mkdir(home, { recursive: true });
+    const plugin = join(root, 'my-plugin');
+    await mkdir(join(plugin, '.claude-plugin'), { recursive: true });
+    await writeFile(join(plugin, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'p' }));
+    await mkdir(join(plugin, 'skills', 'hidden'), { recursive: true });
+    await writeFile(
+      join(plugin, 'skills', 'hidden', 'SKILL.md'),
+      [
+        '---',
+        'description: |',
+        '  Literal block.',
+        'user-invocable: false',
+        'name: hidden',
+        '---',
+        '',
+      ].join('\n')
+    );
+
+    const commands = await listCommands(home, [plugin]);
+
+    assert.ok(!commands.some((c) => c.name === 'p:hidden'), 'user-invocable: false was not seen');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('list-commands namespaces by the manifest name, not the directory name', async () => {
   const root = await mkdtemp(join(tmpdir(), 'vibing-list-commands-'));
   try {

--- a/tests/lua/core/utils/yaml_frontmatter_spec.lua
+++ b/tests/lua/core/utils/yaml_frontmatter_spec.lua
@@ -1,0 +1,70 @@
+local YamlFrontmatter = require("vibing.core.utils.yaml_frontmatter")
+
+describe("yaml_frontmatter", function()
+  it("reads a plain scalar", function()
+    local lines = { "---", "name: plain", "description: Does a thing.", "---", "", "# Body" }
+
+    assert.are.equal("plain", YamlFrontmatter.read(lines, "name"))
+    assert.are.equal("Does a thing.", YamlFrontmatter.read(lines, "description"))
+  end)
+
+  it("folds a block scalar instead of returning its header", function()
+    local lines = {
+      "---",
+      "description: >-",
+      "  First line of the description.",
+      "  TRIGGER: second line.",
+      "---",
+    }
+
+    assert.are.equal(
+      "First line of the description. TRIGGER: second line.",
+      YamlFrontmatter.read(lines, "description")
+    )
+  end)
+
+  it("accepts every block header form", function()
+    for _, header in ipairs({ "|", ">", "|-", ">-", "|+", ">2", ">-2", "|2-" }) do
+      local lines = { "---", "description: " .. header, "  Text.", "---" }
+      assert.are.equal("Text.", YamlFrontmatter.read(lines, "description"), header)
+    end
+  end)
+
+  it("ends a block at the next top-level key", function()
+    local lines = {
+      "---",
+      "description: |",
+      "  Literal block.",
+      "model: sonnet",
+      "---",
+    }
+
+    assert.are.equal("Literal block.", YamlFrontmatter.read(lines, "description"))
+    assert.are.equal("sonnet", YamlFrontmatter.read(lines, "model"))
+  end)
+
+  it("reads a dashed key", function()
+    local lines = { "---", "user-invocable: false", "---" }
+
+    assert.are.equal("false", YamlFrontmatter.read(lines, "user-invocable"))
+  end)
+
+  it("ignores a key nested under another one", function()
+    local lines = { "---", "metadata:", "  description: nested", "---" }
+
+    assert.is_nil(YamlFrontmatter.read(lines, "description"))
+  end)
+
+  it("stops at the closing delimiter", function()
+    local lines = { "---", "name: real", "---", "", "description: in the body" }
+
+    assert.is_nil(YamlFrontmatter.read(lines, "description"))
+  end)
+
+  it("returns nil for an absent key, an empty value, or no frontmatter", function()
+    assert.is_nil(YamlFrontmatter.read({ "---", "name: x", "---" }, "description"))
+    assert.is_nil(YamlFrontmatter.read({ "---", "description:", "---" }, "description"))
+    assert.is_nil(YamlFrontmatter.read({ "# Just a heading" }, "description"))
+    assert.is_nil(YamlFrontmatter.read({}, "description"))
+  end)
+end)

--- a/tests/lua/infrastructure/completion/agents_spec.lua
+++ b/tests/lua/infrastructure/completion/agents_spec.lua
@@ -1,0 +1,76 @@
+local Agents = require("vibing.infrastructure.completion.providers.agents")
+
+describe("agents provider frontmatter", function()
+  local dir
+
+  ---@param lines string[]
+  ---@return string
+  local function write_agent(lines)
+    local path = dir .. "/agent.md"
+    vim.fn.writefile(lines, path)
+    return path
+  end
+
+  before_each(function()
+    dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, "p")
+  end)
+
+  after_each(function()
+    vim.fn.delete(dir, "rf")
+  end)
+
+  it("reads a folded block scalar description instead of its header", function()
+    local path = write_agent({
+      "---",
+      "name: boundary-review",
+      "description: >-",
+      "  First line of the description.",
+      "  TRIGGER: second line.",
+      "---",
+      "",
+      "Body.",
+    })
+
+    local agent = Agents._parse_agent(path, "my-plugin")
+
+    assert.are.equal("boundary-review", agent.name)
+    assert.are.equal("First line of the description. TRIGGER: second line.", agent.description)
+  end)
+
+  it("stops a block scalar at the next top-level key", function()
+    local path = write_agent({
+      "---",
+      "description: |",
+      "  Literal block.",
+      "model: sonnet",
+      "name: after-block",
+      "---",
+    })
+
+    local agent = Agents._parse_agent(path, "my-plugin")
+
+    assert.are.equal("after-block", agent.name)
+    assert.are.equal("Literal block.", agent.description)
+  end)
+
+  it("still reads a plain single-line description", function()
+    local path = write_agent({
+      "---",
+      "name: plain",
+      "description: Does a thing.",
+      "---",
+    })
+
+    local agent = Agents._parse_agent(path, "my-plugin")
+
+    assert.are.equal("Does a thing.", agent.description)
+    assert.are.equal("my-plugin:plain", agent.full_name)
+  end)
+
+  it("falls back to the name when the description is missing", function()
+    local path = write_agent({ "---", "name: bare", "---" })
+
+    assert.are.equal("bare", Agents._parse_agent(path, "my-plugin").description)
+  end)
+end)

--- a/tests/lua/infrastructure/completion/skills_spec.lua
+++ b/tests/lua/infrastructure/completion/skills_spec.lua
@@ -1,0 +1,75 @@
+local Skills = require("vibing.infrastructure.completion.providers.skills")
+
+describe("skills provider frontmatter", function()
+  local root
+
+  ---Write `lines` as `<root>/<skill_name>/SKILL.md` and return its path.
+  ---@param skill_name string
+  ---@param lines string[]
+  ---@return string
+  local function write_skill(skill_name, lines)
+    local dir = root .. "/" .. skill_name
+    vim.fn.mkdir(dir, "p")
+    local path = dir .. "/SKILL.md"
+    vim.fn.writefile(lines, path)
+    return path
+  end
+
+  before_each(function()
+    root = vim.fn.tempname()
+    vim.fn.mkdir(root, "p")
+  end)
+
+  after_each(function()
+    vim.fn.delete(root, "rf")
+  end)
+
+  it("describes a local skill by its frontmatter, not the body heading", function()
+    -- The `/` picker used to show "思考整理" here while `list-commands` showed the frontmatter
+    -- for a plugin skill, so the same menu described two skills from two different sources.
+    local path = write_skill("thought-clarification", {
+      "---",
+      "name: thought-clarification",
+      "description: >-",
+      "  漠然とした課題感を言語化する。",
+      "  TRIGGER: 「モヤモヤを整理したい」。",
+      "---",
+      "",
+      "# 思考整理（Thought Clarification）",
+    })
+
+    local skill = Skills._parse_skill(path)
+
+    assert.are.equal("thought-clarification", skill.name)
+    assert.are.equal("漠然とした課題感を言語化する。 TRIGGER: 「モヤモヤを整理したい」。", skill.description)
+  end)
+
+  it("falls back to the body heading when no description is declared", function()
+    local path = write_skill("headed", { "---", "name: headed", "---", "", "# A Heading" })
+
+    assert.are.equal("A Heading", Skills._parse_skill(path).description)
+  end)
+
+  it("falls back to the directory name when there is neither", function()
+    local path = write_skill("bare", { "Body with no frontmatter and no heading." })
+
+    assert.are.equal("bare", Skills._parse_skill(path).description)
+  end)
+
+  it("still honours user-invocable: false", function()
+    local path = write_skill("hidden", {
+      "---",
+      "name: hidden",
+      "description: |",
+      "  Literal block.",
+      "user-invocable: false",
+      "---",
+    })
+
+    assert.is_nil(Skills._parse_skill(path))
+  end)
+
+  it("returns nil for a missing file", function()
+    assert.is_nil(Skills._parse_skill(root .. "/absent/SKILL.md"))
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

補完メニューに出るスキル／エージェントの description が、YAML のブロックスカラー（`>-` / `>` / `|` / `|-` …）で書かれていると `>-` という文字列だけになっていた問題を修正します。

```yaml
---
name: boundary-review
description: >-
  差分を領域の症状で検査する。
  TRIGGER: 「この差分、領域として問題ないか」。
---
```

これが `/` の補完で `>-` と表示されていました。原因は frontmatter を「キーがある行だけ」の正規表現で読んでいたためで、ブロックスカラーではインジケータ自体が値として捕まっていました。

- `bin/list-commands.ts` — `/^description:\s*(.+)$/m`（プラグインのスキル）
- `lua/vibing/infrastructure/completion/providers/agents.lua` — `^(%w+):%s*(.+)$`（`@agent:` 補完も同じ欠陥）

## Changes

- **ブロックスカラー対応**: ヘッダ（`|` / `>` + 任意のインデント/チョッピング指示子）を検出したら、インデントされた継続行を集めて値にする。列0の次のキーで終了するので、`description: >-` の後ろの `user-invocable: false` などが呑まれることもない
- **Lua 側の共通化**: `lua/vibing/core/utils/yaml_frontmatter.lua` を新設。`agents.lua` と `skills.lua` が同じ解析を各自持つのを避けた。YAML パーサではなく「frontmatter からトップレベルのスカラーを1つ読む」だけのもの
- **ローカルスキルの description 元を統一**: `.claude/skills/` 配下のスキルは frontmatter を一切見ず、本文の最初の `# 見出し` を description にしていた。同じ `/` メニューがスキルの置き場所だけで2つの異なる情報源を表示しており、`description:` を何に書き換えても表示は変わらなかった。frontmatter を読むように揃え、見出しは description を書いていないスキル向けのフォールバックとして残した

継続行は `|` でも空白で連結して1行にしている。この値の消費先は補完メニューで、`omnifunc` の `menu` フィールドは単一行のため、リテラルブロックの改行に行き場がないため。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Tested locally in Neovim
- [x] Ran `pnpm run test:lua` / `pnpm run test:node`
- [x] Ran `pnpm run lint`
- [x] Ran `pnpm run format:check`
- [x] Manual testing completed

追加したテスト:

| ファイル | 件数 | 内容 |
| --- | --- | --- |
| `tests/lua/core/utils/yaml_frontmatter_spec.lua` | 8（新規） | 全ブロックヘッダ形式（`\|` `>` `\|-` `>-` `\|+` `>2` `>-2` `\|2-`）、ネストしたキーを拾わない、閉じ `---` で止まる、空値/frontmatter なしで nil |
| `tests/lua/infrastructure/completion/skills_spec.lua` | 5（新規） | frontmatter が本文 H1 に勝つ、フォールバック2段、`user-invocable: false` の維持 |
| `tests/lua/infrastructure/completion/agents_spec.lua` | 4（新規） | エージェント frontmatter の折り畳み、ブロックの終端、name フォールバック |
| `tests/list-commands.test.mjs` | +2 | 折り畳み description が読めること、ブロックの後続キーが呑まれないこと |

`pnpm run test:lua` は exit 0、`test:node` は 44 pass。実際のプラグイン（`domain-architect:boundary-review`）と実際のローカルスキル（`thought-clarification`）に対して、走っている Neovim で表示を確認済み。

### Test Environment

- **Neovim version**: NVIM v0.12
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: v22

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [x] Code comments added/updated (if applicable)

ユーザー向けドキュメントに補完の description の出どころを書いた箇所はないため、理由はコード側のコメントに置いています。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Context

ローカルスキルの description が frontmatter 由来になることで、表示が長くなるスキルがあります（`boundary-review` のように TRIGGER/SKIP まで含むもの）。切り詰めは今回入れていませんが、必要になれば `YamlFrontmatter.read` の呼び出し側1箇所で対応できます。

TypeScript 側と Lua 側で解析が2つあるのは、言語をまたぐため統合できないことによるものです（`skills.lua` の既存コメントが同じ理由で cwd 解決の重複を許容しているのと同じ扱い）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of multi-line skill and agent descriptions in YAML frontmatter.
  * Correctly preserves visibility settings such as `user-invocable: false`.
  * Added reliable fallbacks for missing skill and agent descriptions.
  * Improved handling of malformed, missing, or empty frontmatter values.

* **Tests**
  * Added coverage for folded and literal YAML descriptions, metadata boundaries, visibility rules, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->