### PR TITLE
fix: split multi-line values before writing chat buffer lines

### DIFF
--- a/lua/vibing/presentation/chat/modules/renderer.lua
+++ b/lua/vibing/presentation/chat/modules/renderer.lua
@@ -3,6 +3,23 @@ local Context = require("vibing.application.context.manager")
 
 local M = {}
 
+---nvim_buf_set_lines は改行を含む要素を拒否するため、行配列を1行1要素に平坦化する
+---@param entries string[]
+---@return string[]
+local function flatten_lines(entries)
+  local result = {}
+  for _, entry in ipairs(entries) do
+    if entry:find("[\r\n]") then
+      for _, line in ipairs(vim.split(entry, "\r?\n", { trimempty = false })) do
+        table.insert(result, (line:gsub("\r", "")))
+      end
+    else
+      table.insert(result, entry)
+    end
+  end
+  return result
+end
+
 ---バッファを初期化（フロントマター + 初期コンテンツ）
 ---@param buf number バッファ番号
 ---@param session? Vibing.ChatSession セッション（指定時はそのfrontmatterを使用）
@@ -164,7 +181,7 @@ function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_mes
   end
 
   table.insert(newLines, "")
-  vim.api.nvim_buf_set_lines(buf, #lines, #lines, false, newLines)
+  vim.api.nvim_buf_set_lines(buf, #lines, #lines, false, flatten_lines(newLines))
 
   if pendingChoices then
     local choiceLines = {}
@@ -199,7 +216,7 @@ function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_mes
 
     local currentLines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
     local insertPos = #currentLines
-    vim.api.nvim_buf_set_lines(buf, insertPos, insertPos, false, choiceLines)
+    vim.api.nvim_buf_set_lines(buf, insertPos, insertPos, false, flatten_lines(choiceLines))
   end
 
   if pendingApproval then
@@ -247,7 +264,7 @@ function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_mes
 
     local currentLines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
     local insertPos = #currentLines
-    vim.api.nvim_buf_set_lines(buf, insertPos, insertPos, false, approvalLines)
+    vim.api.nvim_buf_set_lines(buf, insertPos, insertPos, false, flatten_lines(approvalLines))
   end
 
   if win and vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_buf(win) == buf then

--- a/tests/renderer_spec.lua
+++ b/tests/renderer_spec.lua
@@ -221,6 +221,32 @@ describe("vibing.presentation.chat.modules.renderer", function()
       end)
     end)
 
+    describe("with pendingApproval", function()
+      it("should split a multi-line command into separate lines", function()
+        local pendingApproval = {
+          tool = "Bash",
+          input = { command = "cat <<'EOF' > f.txt\nline1\nline2\nEOF" },
+          options = { { label = "allow_once" }, { label = "deny_once" } },
+        }
+
+        Renderer.addUserSection(mock_buf, mock_win, nil, pendingApproval)
+
+        local lines = vim.api.nvim_buf_get_lines(mock_buf, 0, -1, false)
+        local joined = table.concat(lines, "\n")
+
+        assert.is_truthy(joined:find("Command: cat <<'EOF' > f.txt", 1, true))
+        for _, line in ipairs(lines) do
+          assert.is_nil(line:find("\n", 1, true), "No buffer line may contain a newline")
+        end
+
+        local hasLine2 = false
+        for _, line in ipairs(lines) do
+          if line == "line2" then hasLine2 = true end
+        end
+        assert.is_true(hasLine2, "Continuation lines should be rendered as their own lines")
+      end)
+    end)
+
     describe("without pendingChoices", function()
       it("should create user section without choices", function()
         -- Execute


### PR DESCRIPTION
# Pull Request

## Summary

複数行のコマンドを含むツール承認 UI を描画しようとすると、`nvim_buf_set_lines` が
`'replacement string' item contains newlines` で例外を投げ、`add_user_section` が失敗して
チャットが次の `## User` セクションを生成できなくなる不具合を修正する。

```
Error  msg_show.lua_error vim.schedule callback: renderer.lua:250: 'replacement string' item contains newlines
stack traceback:
	[C]: in function 'nvim_buf_set_lines'
	renderer.lua:250: in function 'addUserSection'
	buffer.lua:671: in function 'add_user_section'
	send_message.lua:489: in function '_handle_response'
```

原因は、承認 UI の `Command: ` 行などを値そのままで連結していたこと。ヒアドキュメントのような
複数行 Bash コマンドが来ると 1 要素に `\n` が混ざり、Neovim API に拒否される。

同じ穴は選択肢 UI（`question` / `label` / `description`）にもあった。

## Changes

- `renderer.lua` に `flatten_lines()` を追加し、行配列を「1 行 1 要素」に正規化する（`\r\n` / `\r` も除去）
- `nvim_buf_set_lines` に渡す 3 箇所すべてに適用（承認 UI・選択肢 UI・ユーザーセクション本体）
- `tests/renderer_spec.lua` に、複数行コマンドを持つ `pendingApproval` の描画ケースを追加

値ごとに個別サニタイズするのではなく出力直前で平坦化しているため、今後フィールドを増やしても
同じバグは再発しない。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Tested locally in Neovim
- [ ] Ran `npm run validate`
- [ ] Ran `npm run lint`
- [ ] Ran `npm run format:check`
- [ ] Tested with multiple configurations
- [x] Manual testing completed

`tests/renderer_spec.lua` は 7 件すべて成功。

`pnpm run test:lua` 全体では dap（3 件）・view（1 件）・win_open_file（2 件）が失敗するが、
`git stash` して main の状態でも同じく失敗する**既存の不具合**であることを確認済み
（win_open_file は spec 実行自体がハングするため未確認だが、本変更とは無関係）。

`pnpm run check` は環境に `luac` が無いため未実行。

### Test Environment

- **Operating System**: macOS (Darwin 25.6.0)

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [ ] Code comments added/updated (if applicable)

ユーザー向けの挙動変更ではないためドキュメント更新は不要。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

なし

## Additional Context

`flatten_lines()` は複数行の値を「先頭行にラベルを付け、続く行はそのまま独立した行にする」形で
描画する。承認 UI としては元のコマンドの見た目がそのまま残るため、ユーザーが何を承認しようと
しているか判断しやすい。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat rendering for multi-line content, including commands, choices, user sections, and approval prompts.
  * Prevented embedded newline characters from appearing within individual buffer lines.
  * Removed carriage returns for cleaner display across line endings.

* **Tests**
  * Added coverage verifying multi-line approval commands render correctly with separate continuation lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->