### PR TITLE
fix: schedule a continuation prompt when a limit interrupts a turn mid-flight

### DIFF
--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -367,10 +367,10 @@ resumes with `:VibingPendingResumes` and `:VibingCancelResume`.
 ### Scheduled Requests
 
 Any chat message can be parked to send later as a **scheduled request** — unlike auto-resume's
-fixed continuation prompt, it resends the chat's own message, unedited, at the chosen time. This
-is not limited to usage-limit recovery: `:VibingSchedule 18:30` works with no limit ever having
-been hit. Two of the three ways a scheduled request gets created, described below, are
-specifically about usage limits.
+fixed continuation prompt, it usually resends the chat's own message, unedited, at the chosen time
+(the exception is a turn the limit interrupted mid-flight; see below). This is not limited to
+usage-limit recovery: `:VibingSchedule 18:30` works with no limit ever having been hit. Two of the
+three ways a scheduled request gets created, described below, are specifically about usage limits.
 
 ```lua
 require("vibing").setup({
@@ -391,6 +391,20 @@ active, unless the message is a slash command or a reply to a pending approval p
 always send immediately); and a turn the limit actually rejected, whose message is written back
 into a fresh unsent `## User` section instead of being discarded. `:VibingSchedule` always works;
 the other two are governed by `scheduled_requests.enabled`.
+
+**A rejected turn that got somewhere parks a continuation, not its own message.** The first two
+routes park a message that never ran, so the message is what should be sent. The third does not:
+a limit can land part-way through a turn, after the model has already answered, edited files, or
+run tools. Both that work and the request that asked for it are in the resumed session's
+transcript, so re-sending the same text hands the model the same request a second time and invites
+it to redo what it already did. When the rejected turn produced any output, vibing.nvim therefore
+parks `auto_resume_on_limit.prompt` (default `"Continue from where you left off."`) instead — the
+same sentence auto-resume uses, since it means the same thing. A turn the limit rejected at the
+door, with nothing streamed and no file touched, still parks its own message unchanged. The
+sentence lands in the unsent `## User` section like any other scheduled body, so it is visible and
+editable while parked; the original request stays in the transcript above it. Note that
+`auto_resume_on_limit.prompt` is read for its value alone — this works whether or not
+`auto_resume_on_limit.enabled` is set.
 
 **Where the body lives.** The scheduled message is never copied into the pending-resume store — it
 stays in the chat buffer's unsent `## User` section, visible and editable while parked. Deleting

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -328,7 +328,8 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
 
   -- 使用量リミットで弾かれた場合の扱い:
   --   1. プロジェクト単位のリセット時刻を記録し、次の送信を事前に予約へ回せるようにする
-  --   2. 弾かれた本文を未送信Userセクションとして書き戻し、リセット後に再送する予約を張る
+  --   2. 弾かれたターンの本文（何も出力せず弾かれた場合）か継続文言（途中まで進んでいた場合）を
+  --      未送信Userセクションとして書き戻し、リセット後に送る予約を張る
   --   3. 予約に回せなかった場合だけ、従来の auto_resume（固定プロンプト）にフォールバックする
   -- リミット以外で正常終了したときはリトライ budget とリセット時刻の記録をクリアする。
   local AutoResume = require("vibing.application.chat.auto_resume")
@@ -348,7 +349,8 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
       chat_file_path,
       response._rate_limit_info,
       message,
-      config
+      config,
+      M._turn_progressed(response, modified_file_paths)
     )
     if ok then
       rescheduled = result
@@ -493,6 +495,26 @@ function M._handle_response(response, callbacks, adapter, config, mote_configs, 
   -- 次のsend_message()時にkillすることで、ゾンビプロセス対策になる
 end
 
+---弾かれたターンが途中まで進んでいたか
+---
+---進んでいたなら、そのユーザーメッセージも部分的な作業もセッションのtranscriptに残っている。
+---同じ本文を送り直すとモデルは同じ依頼を2回受け取り、済んだ作業をやり直しかねないので、
+---呼び出し側はここがtrueのときだけ継続文言に切り替える。
+---
+---判定は「モデルが何か出力したか」だけを見る。content にはテキストdeltaとツール結果の表示が
+---入る（cli_event_processor）ので、非空ならAPI呼び出しは通っている。空ならリミットは
+---ターンの入口で弾いたということなので、本文を送り直す従来の挙動が正しい。
+---@param response table
+---@param modified_file_paths table<string, boolean>|nil
+---@return boolean
+function M._turn_progressed(response, modified_file_paths)
+  if next(modified_file_paths or {}) ~= nil then
+    return true
+  end
+  local content = response and response.content
+  return type(content) == "string" and vim.trim(content) ~= ""
+end
+
 ---リミットで弾かれたメッセージを、リセット後に再送する予約に切り替える
 ---
 ---本文はバッファの未送信Userセクションが唯一の置き場所なので、ここではJSONに複製せず
@@ -504,8 +526,9 @@ end
 ---@param info Vibing.RateLimitInfo
 ---@param message string|nil 弾かれたユーザーメッセージ
 ---@param config table
+---@param progressed boolean|nil 弾かれたターンが途中まで進んでいたか（M._turn_progressed）
 ---@return boolean rescheduled 予約に切り替えられたか
-function M._reschedule_rejected_message(callbacks, chat_file_path, info, message, config)
+function M._reschedule_rejected_message(callbacks, chat_file_path, info, message, config, progressed)
   local opts = (config.agent and config.agent.scheduled_requests) or {}
   if not opts.enabled then
     return false
@@ -560,8 +583,25 @@ function M._reschedule_rejected_message(callbacks, chat_file_path, info, message
     return false
   end
 
-  callbacks.set_pending_user_text(message)
+  callbacks.set_pending_user_text(progressed and M._continuation_prompt(config) or message)
   return true
+end
+
+---途中まで進んだターンを再開させる一言
+---
+---auto_resume_on_limit.prompt を流用する。意味が「リミット後にセッションを続けるための一言」で
+---同じであり、既定値の置き場所を1つに保つため。auto_resume が無効でも値そのものは読める。
+---@param config table
+---@return string
+function M._continuation_prompt(config)
+  local prompt = config
+    and config.agent
+    and config.agent.auto_resume_on_limit
+    and config.agent.auto_resume_on_limit.prompt
+  if type(prompt) == "string" and vim.trim(prompt) ~= "" then
+    return prompt
+  end
+  return "Continue from where you left off."
 end
 
 ---moteの変更ファイル結果とツールイベントのパスを絶対パスに正規化して統合する

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -78,13 +78,14 @@
 ---使用量リミットで応答が弾かれたとき、リセット時刻を待って自動で継続リクエストを送る
 ---@field enabled boolean リミット時に自動で継続リクエストを送るか（デフォルト: false、無人でトークンを消費するため）
 ---@field max_retries number 1回のリミットヒットにつき許可する自動再送の回数（再送がまたリミットに当たった時点で打ち切り）
----@field prompt string 再送する継続プロンプト（セッションはresumeされるので文脈の再説明は不要）
+---@field prompt string 再送する継続プロンプト（セッションはresumeされるので文脈の再説明は不要）。予約リクエスト（Vibing.ScheduledRequestsConfig）が途中まで進んだターンを再開するときも同じ文言を使う
 ---@field fallback_delay_sec number リセット時刻が取得できなかった場合の待ち時間（秒）
 ---@field grace_sec number リセット時刻からの上乗せ秒数（境界ぴったりで再送して弾かれるのを防ぐ）
 
 ---@class Vibing.ScheduledRequestsConfig
 ---予約リクエスト設定
 ---使用量リミット中に送信しようとしたリクエストを、リセット後に送る予約に切り替える
+---途中まで進んだターンが弾かれた場合だけは本文ではなく継続文言（auto_resume_on_limit.prompt）を予約する
 ---@field enabled boolean リミット中のリクエストを予約に切り替えるか（デフォルト: true、リミット中のリクエストはどのみち失敗するため）
 ---@field max_retries number 予約したリクエストがまた弾かれたときに許可する再予約の回数
 
@@ -265,6 +266,7 @@ M.defaults = {
       -- 再送がまたリミットに当たった時点で打ち切られる。
       max_retries = 1,
       -- 再送する継続プロンプト。セッションはresumeされるので文脈の再説明は不要。
+      -- scheduled_requests 側も、途中まで進んだターンを再開するときはこの文言を使う。
       prompt = "Continue from where you left off.",
       -- リセット時刻が取得できなかった場合の待ち時間（秒）。
       fallback_delay_sec = 300,
@@ -274,6 +276,10 @@ M.defaults = {
     -- 使用量リミット中に送信しようとしたリクエストを、リセット後に送る予約に切り替える。
     -- リミット中のリクエストはどのみち失敗するため既定で有効。
     -- :VibingSchedule による明示的な予約はこのフラグに関係なく常に動く。
+    --
+    -- 予約する本文は、弾かれたターンが何も出力せず終わったなら元の本文、途中まで進んでいたなら
+    -- auto_resume_on_limit.prompt。進んでいた分はセッションのtranscriptに残っているので、
+    -- 同じ依頼を送り直すと済んだ作業をやり直させることになる。
     scheduled_requests = {
       enabled = true,
       -- 予約したリクエストがまた弾かれたときに許可する再予約の回数。

--- a/tests/lua/application/chat/reschedule_rejected_message_spec.lua
+++ b/tests/lua/application/chat/reschedule_rejected_message_spec.lua
@@ -168,6 +168,41 @@ describe("send_message._reschedule_rejected_message", function()
     assert.equals("auto_resume", PendingResume.get(chat_path, tmp_root).kind)
   end)
 
+  it("schedules the continuation prompt instead when the rejected turn had already progressed", function()
+    -- The turn's own user message and its partial work are both in the session transcript, so
+    -- re-sending the same body would hand the model the same request twice.
+    local captured = {}
+    local config = make_config(true, 3)
+    config.agent.auto_resume_on_limit = { prompt = "Keep going." }
+
+    local ok = SendMessage._reschedule_rejected_message(
+      make_callbacks(captured),
+      chat_path,
+      { resets_at = os.time() + 3600, limit_type = "five_hour" },
+      "refactor the whole permission layer",
+      config,
+      true
+    )
+
+    assert.is_true(ok)
+    assert.equals("Keep going.", captured.text)
+  end)
+
+  it("falls back to the built-in continuation prompt when none is configured", function()
+    local captured = {}
+    local ok = SendMessage._reschedule_rejected_message(
+      make_callbacks(captured),
+      chat_path,
+      { resets_at = os.time() + 3600, limit_type = "five_hour" },
+      "refactor the whole permission layer",
+      make_config(true, 3),
+      true
+    )
+
+    assert.is_true(ok)
+    assert.equals("Continue from where you left off.", captured.text)
+  end)
+
   it("still re-schedules a scheduled request that was rejected again", function()
     -- The documented fire -> rejected -> re-schedule loop, which the guard above must not break.
     local PendingResume = require("vibing.infrastructure.storage.pending_resume")
@@ -190,5 +225,23 @@ describe("send_message._reschedule_rejected_message", function()
 
     assert.is_true(ok)
     assert.equals("my own message", captured.text)
+  end)
+end)
+
+describe("send_message._turn_progressed", function()
+  it("is false for a turn that produced nothing", function()
+    assert.is_false(SendMessage._turn_progressed({ content = "", error = "usage limit" }, {}))
+    assert.is_false(SendMessage._turn_progressed({ content = "  \n " }, nil))
+    assert.is_false(SendMessage._turn_progressed({}, {}))
+  end)
+
+  it("is true once the model has emitted text or a tool result", function()
+    assert.is_true(SendMessage._turn_progressed({ content = "Looking at the file..." }, {}))
+  end)
+
+  it("is true when a file was modified even with no streamed text", function()
+    -- Belt and braces: `content` is the primary signal, but a turn that only wrote files must
+    -- never be mistaken for one the limit rejected at the door.
+    assert.is_true(SendMessage._turn_progressed({ content = "" }, { ["/tmp/a.lua"] = true }))
   end)
 end)


### PR DESCRIPTION
# Pull Request

## Summary

使用量リミットがターンの途中で弾いた場合、これまでは弾かれた本文をそのまま未送信 `## User` セクションに書き戻して予約していた。だがそのターンのユーザーメッセージも、そこまでに行われた作業（応答テキスト・ツール実行・ファイル編集）も、resume されるセッションの transcript に残っている。同じ本文を送り直すとモデルは同じ依頼を2回受け取ることになり、済んだ作業をやり直そうとする。

弾かれたターンが何か出力していた場合だけ、本文ではなく継続文言（`agent.auto_resume_on_limit.prompt`、既定 `"Continue from where you left off."`）を予約するようにした。

## Changes

- `send_message._turn_progressed(response, modified_file_paths)` を追加。`response.content`（`cli_event_processor` がテキスト delta とツール結果表示を詰める）が非空、またはファイルが変更されていれば「進んだ」と判定する
- `_reschedule_rejected_message` に `progressed` 引数を追加し、true のときだけ `set_pending_user_text` へ継続文言を渡す
- 継続文言は `agent.auto_resume_on_limit.prompt` を流用。意味が「リミット後にセッションを続けるための一言」で同じであり、既定値の置き場所を1箇所に保てるため。auto_resume が無効でも値そのものは読める
- `handbook/configuration.md` と `config.lua` に挙動と理由を追記

## 設計判断

**なぜ「進捗があったターンのみ」か。** 判定は「モデルが何か出力したか」だけを見ている。`content` が空ならリミットはターンの入口で弾いたということで、その場合は本文を送り直す従来の挙動が正しい。誤判定しても現状に戻るだけで、新しい害はない。

**影響しない経路。** `<CR>` 時点でリミット中だった場合（そもそも走っていない）と `:VibingSchedule` は、これまでどおり本文をそのまま送る。auto_resume の継続リクエスト自体が弾かれたときのガード（`kind == "auto_resume"` かつ `in_flight` なら `on_rate_limited` に返す）も変わっていない。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Ran `pnpm run test:lua`（exit 0）
- [x] Ran `pnpm run check`
- [x] Ran `pnpm run format:check`

`tests/lua/application/chat/reschedule_rejected_message_spec.lua` に5ケース追加:

- 進捗ありのターン → 設定した継続文言が予約される
- 設定なし → 既定文言にフォールバックする
- `_turn_progressed`: 出力なし → false / テキストあり → true / ファイル変更のみ → true

既存の7ケース（`progressed` を渡さない = false）はそのまま通る。

## Documentation

- [x] Code comments added/updated
- [x] `handbook/configuration.md` の "Scheduled Requests" に節を追加
- [ ] `.claude/rules/features.md` — 同じ説明を入れたいが、このセッションでは書き込み許可が下りなかったため未反映

## Related Issues

なし（チャット中の指摘から）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled request recovery after usage-limit interruptions.
  * Partially completed requests now resume with a continuation prompt instead of repeating completed work.
  * Requests rejected before producing output continue to resend the original message.

* **Documentation**
  * Clarified scheduled request behavior and continuation prompt configuration.

* **Tests**
  * Added coverage for resuming partially completed requests and detecting meaningful progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->