### PR TITLE
feat: link related chat buffers via frontmatter and keep the links in sync on rename

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -406,6 +406,10 @@ Chat files are saved as Markdown with YAML frontmatter:
 vibing.nvim: true
 session_id: <cli-session-id>
 created_at: 2024-01-01T12:00:00
+orchestrated: # Optional: chats this one drives (see "Multi-Agent Orchestration")
+  - .vibing/chat/worker-auth.md
+orchestrated_by: # Optional: the chat driving this one
+  - .vibing/chat/orchestrator.md
 working_dir: .vibing/worktrees/fix-auth-session # Optional: relative path from git root for working directory
 model: sonnet # sonnet, opus, haiku, or fable (from config.agent.default_model)
 effort: xhigh # Optional: low, medium, high, xhigh, max (from config.agent.default_effort)
@@ -848,6 +852,46 @@ Node side accepts either shape.
 `idle` means "no request in flight", not "succeeded": a worker that failed, that is waiting on a
 tool-approval prompt, or that asked a question is idle too. The skill says so, because the
 distinction is not something the status can carry.
+
+**The relationship is recorded in frontmatter, not in the transcript.** `orchestrated` on the
+orchestrator, `orchestrated_by` on the worker, both git-root-relative path lists written by
+`application/chat/orchestration_link.lua` when `nvim_chat_create` or `nvim_chat_send_message` is
+given an optional `from_bufnr`. `infrastructure/link/orchestration_chat_scanner.lua` keeps them in
+step through `:VibingSetFileTitle`, alongside `ForkedChatScanner`.
+
+Before this, the only record was prose the skill told the orchestrator to write into its own
+reply, and it decayed two ways: **bufnrs are per-session** (a restart makes the number point at
+some unrelated buffer) and **file paths get renamed out from under it** by `:VibingSetFileTitle`.
+Frontmatter plus a rename scanner is how `forked_from` already solves exactly this, so the shape
+is borrowed rather than invented.
+
+Four details are load-bearing:
+
+- **`from_bufnr` is optional, in both directions of version skew.** The wire format carries no
+  protocol version, so an older Neovim ignores the extra key and an older MCP server never sends
+  it. Requiring it would turn a forgotten argument into a refused send — a worse failure than a
+  missing link, and one that would break every existing caller at once.
+- **The link is written before the message is sent.** `update_frontmatter_list` edits the buffer
+  directly, so writing after the worker's reply starts would race its streaming.
+- **`update_frontmatter_list` writes to the buffer, not to disk**, and the rename scanner reads
+  disk. So `orchestration_link` saves both files itself. The sender is the one that needs it:
+  `:VibingChat` holds the first write until the first response, so an orchestrator that dispatches
+  on its opening turn has no file for a scanner to find.
+- **One scanner reads both keys.** Splitting it per direction would double the full-file reads and
+  the `git rev-parse` calls over the same directory, and a rename has to update whichever side
+  names the old path anyway.
+
+Copying `ForkedChatScanner` wholesale is the trap here. `forked_from` is a scalar, so its
+`update_link` hands the whole key to `Frontmatter.update`; doing that to a list drops every other
+element. `OrchestrationChatScanner` replaces the matching element and dedupes afterwards, since a
+rename can collide with an entry the list already had. Two parser behaviours bite the same way: an
+empty list parses to a **truthy** `{}`, and a hand-written `orchestrated: path.md` parses to a
+**string** rather than a list.
+
+A one-sided write warns rather than failing the send: the link is a record, and rename sync still
+works from whichever side did get written. Fork and subagent chats do **not** inherit these fields
+— `inherited_frontmatter.from_source` is an explicit whitelist, and a fork claiming its parent's
+relationships would be claiming work it was never given.
 
 **Out of scope, deliberately:** workers cannot message the orchestrator back, there is no
 event-driven completion notification, and the orchestrator does not poll inside its own turn — it

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -99,10 +99,16 @@ at roughly the right place beats refusing to point.
 
 ## Orchestration
 
-`nvim_chat_create({ rpc_port, position?, working_dir? })` creates a chat buffer and returns
-`{ bufnr, file_path, working_dir, position, saved }` as JSON, so one chat can spawn worker chats,
-brief each with `nvim_chat_send_message`, and poll them with `nvim_get_buffer` — which reports a
-chat buffer's `responding` / `idle` status as a second content block.
+`nvim_chat_create({ rpc_port, position?, working_dir?, from_bufnr? })` creates a chat buffer and
+returns `{ bufnr, file_path, working_dir, position, saved }` as JSON, so one chat can spawn worker
+chats, brief each with `nvim_chat_send_message`, and poll them with `nvim_get_buffer` — which
+reports a chat buffer's `responding` / `idle` status as a second content block.
+
+Both tools take an optional `from_bufnr`, the caller's own chat buffer number, which records the
+relationship in both chat files' frontmatter (`orchestrated` / `orchestrated_by`) instead of
+leaving it in prose that a rename or a restart invalidates. Why it stays optional, why the write
+happens before the send, and why the list field needs its own scanner: `architecture.md` →
+"Multi-Agent Orchestration".
 
 The workflow is the bundled `vibing-orchestrate` skill. Why `position` defaults to `back`, why the
 chat file is written at creation, why the status is a field rather than a text heuristic, and what

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -218,10 +218,19 @@ The MCP server exposes the following tools to Claude:
 
 ### Chat
 
+- **nvim_chat_create** - Create a worker chat buffer and return its `bufnr` and `file_path`
+  - `position` (optional): Window position, defaults to `back` (buffer only, no window)
+  - `working_dir` (optional): Git-root-relative directory the chat runs in; must already exist
+  - `from_bufnr` (optional): The calling chat's buffer number, recorded as this chat's
+    orchestrator in both files' frontmatter
+
 - **nvim_chat_send_message** - Send a message to a chat buffer and start an AI request
   - `bufnr` (required): Chat buffer number
   - `message` (required): Message text
   - `sender` (optional): Sender label, defaults to "User"
+  - `from_bufnr` (optional): The calling chat's buffer number. Records the orchestration
+    relationship in both chat files' frontmatter (`orchestrated` / `orchestrated_by`), so it
+    outlives the buffer numbers and file names it was built from
 
 - **nvim_ask_user_question** - Render a multiple-choice question in the chat buffer. This cancels
   the in-flight turn; the user's answer arrives as the next turn's message

--- a/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
@@ -122,6 +122,66 @@ describe('chat tools (worktree redesign)', () => {
     expect(inputSchema.required).toContain('rpc_port');
   });
 
+  it('offers from_bufnr on both chat tools but never requires it', () => {
+    for (const name of ['nvim_chat_send_message', 'nvim_chat_create']) {
+      const tool = allTools.find((t) => t.name === name);
+      const inputSchema = tool?.inputSchema as {
+        required?: string[];
+        properties: Record<string, unknown>;
+      };
+      expect(inputSchema.properties.from_bufnr).toBeDefined();
+      // Requiring it would break every existing caller that omits it, and the failure would be a
+      // refused send rather than a missing link.
+      expect(inputSchema.required).not.toContain('from_bufnr');
+    }
+  });
+
+  it('nvim_chat_send_message forwards from_bufnr so Neovim can record the link', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true, bufnr: 14 });
+
+    await handlers.nvim_chat_send_message({
+      rpc_port: 9878,
+      bufnr: 14,
+      message: 'do the thing',
+      from_bufnr: 12,
+    });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'send_message',
+      { bufnr: 14, message: 'do the thing', sender: undefined, from_bufnr: 12 },
+      9878
+    );
+  });
+
+  it('nvim_chat_send_message still sends when from_bufnr is omitted', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true, bufnr: 14 });
+
+    const result = await handlers.nvim_chat_send_message({
+      rpc_port: 9878,
+      bufnr: 14,
+      message: 'do the thing',
+    });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'send_message',
+      { bufnr: 14, message: 'do the thing', sender: undefined, from_bufnr: undefined },
+      9878
+    );
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('nvim_chat_create forwards from_bufnr so a worker is linked at creation', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ bufnr: 14, file_path: '/tmp/worker.md' });
+
+    await handlers.nvim_chat_create({ rpc_port: 9878, from_bufnr: 12 });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'create_chat',
+      { position: undefined, working_dir: undefined, from_bufnr: 12 },
+      9878
+    );
+  });
+
   it('has a handler for nvim_ask_user_question', () => {
     expect(handlers.nvim_ask_user_question).toBeDefined();
     expect(typeof handlers.nvim_ask_user_question).toBe('function');

--- a/claude-plugin/mcp-server/src/handlers/chat.ts
+++ b/claude-plugin/mcp-server/src/handlers/chat.ts
@@ -5,6 +5,7 @@ import { CHAT_POSITIONS } from '../tools/chat.js';
 const chatCreateArgsSchema = z.object({
   position: z.enum(CHAT_POSITIONS).optional(),
   working_dir: z.string().optional(),
+  from_bufnr: z.number().optional(),
   rpc_port: z.number(),
 });
 
@@ -18,11 +19,16 @@ const chatCreateArgsSchema = z.object({
  * The chat file is written to disk by the Lua handler at creation time, so `file_path` names a
  * file that actually exists; `saved: false` means that write failed and the chat lives only in
  * the buffer.
+ *
+ * `from_bufnr` is optional and records the caller as this chat's orchestrator in both chat files'
+ * frontmatter. It stays optional deliberately: making it required would break every existing
+ * caller that omits it, and there is no protocol version on the wire — an older Neovim simply
+ * ignores the extra key, and an older server never sends it.
  */
 export async function handleChatCreate(args: any): Promise<any> {
-  const { position, working_dir, rpc_port } = chatCreateArgsSchema.parse(args);
+  const { position, working_dir, from_bufnr, rpc_port } = chatCreateArgsSchema.parse(args);
 
-  const result = await callNeovim('create_chat', { position, working_dir }, rpc_port);
+  const result = await callNeovim('create_chat', { position, working_dir, from_bufnr }, rpc_port);
 
   return {
     content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
@@ -35,18 +41,24 @@ const chatSendMessageArgsSchema = z.object({
   bufnr: z.number(),
   message: z.string(),
   sender: z.string().optional(),
+  from_bufnr: z.number().optional(),
   rpc_port: z.number(),
 });
 
 /**
  * Handler for nvim_chat_send_message
  * Programmatically sends a message to a chat buffer and triggers AI request
+ *
+ * `from_bufnr` names the calling chat and records the orchestration relationship in both chat
+ * files' frontmatter, so it outlives the buffer numbers and the file names it was built from.
+ * It is optional for compatibility in both directions of Lua/Node version skew: an older Neovim
+ * ignores the extra key, an older server never sends it, and neither breaks the send.
  */
 export async function handleChatSendMessage(args: any): Promise<any> {
   // Zod schema already validates required fields and types
-  const { bufnr, message, sender, rpc_port } = chatSendMessageArgsSchema.parse(args);
+  const { bufnr, message, sender, from_bufnr, rpc_port } = chatSendMessageArgsSchema.parse(args);
 
-  await callNeovim('send_message', { bufnr, message, sender }, rpc_port);
+  await callNeovim('send_message', { bufnr, message, sender, from_bufnr }, rpc_port);
 
   return {
     content: [{ type: 'text', text: 'Message sent and AI request initiated in chat buffer' }],

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -40,6 +40,13 @@ export const chatTools: Tool[] = [
             '(e.g. ".vibing/worktrees/fix-auth"). Must already exist. Omit to use the ' +
             "Neovim instance's own working directory.",
         },
+        from_bufnr: {
+          type: 'number',
+          description:
+            'Your own chat: the exact "Current vibing.nvim chat buffer number" from your ' +
+            'system prompt. Pass it whenever you create a worker — it records the ' +
+            'relationship in both chat files, which survives renames and restarts.',
+        },
       }),
       required: requireRpcPort([]),
     },
@@ -64,6 +71,13 @@ export const chatTools: Tool[] = [
           type: 'string',
           description:
             'Optional sender identifier (default: "User"). Future: supports "Alpha", "Bravo", etc.',
+        },
+        from_bufnr: {
+          type: 'number',
+          description:
+            'Your own chat: the exact "Current vibing.nvim chat buffer number" from your ' +
+            'system prompt. Pass it whenever you drive another chat — it records the ' +
+            'relationship in both chat files, which survives renames and restarts.',
         },
       }),
       required: requireRpcPort(['bufnr', 'message']),

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -26,22 +26,39 @@ five chats for a job that was really one is expensive and the user has to clean 
 ## 2. Create one worker chat per task
 
 ```text
-nvim_chat_create({ rpc_port, position: "back" })
-nvim_chat_create({ rpc_port, position: "back", working_dir: ".vibing/worktrees/fix-auth" })
+nvim_chat_create({ rpc_port, position: "back", from_bufnr: <this chat's bufnr> })
+nvim_chat_create({
+  rpc_port,
+  position: "back",
+  from_bufnr: <this chat's bufnr>,
+  working_dir: ".vibing/worktrees/fix-auth",
+})
 ```
 
 - `position: "back"` (the default) creates the buffer without opening a window, so the user's
   layout is untouched. Don't use a split position for workers unless the user asked to watch them.
 - `working_dir` is relative to the git root and must already exist — create the worktree first.
+- **Always pass `from_bufnr`**: the exact "Current vibing.nvim chat buffer number" from your
+  system prompt. It records the relationship in both chat files' frontmatter (`orchestrated` here,
+  `orchestrated_by` on the worker), which is what makes it survive a rename or a restart.
 - Keep the returned `bufnr` **and** `file_path` for every worker, and write them into your reply
-  in this chat. That list is the only record of which worker owns which task; if the conversation
-  is resumed later, the transcript is where you will read it back from.
+  in this chat. `from_bufnr` records the relationship, but not which worker owns which task — that
+  mapping only exists in what you write here, and the transcript is where you read it back from if
+  the conversation is resumed later.
 
 ## 3. Send each worker a self-contained brief
 
 ```text
-nvim_chat_send_message({ rpc_port, bufnr: <worker bufnr>, message: "<the whole task>" })
+nvim_chat_send_message({
+  rpc_port,
+  bufnr: <worker bufnr>,
+  from_bufnr: <this chat's bufnr>,
+  message: "<the whole task>",
+})
 ```
+
+Pass `from_bufnr` here too. It is the same value as in step 2, and sending is what registers the
+relationship for a worker you did not create yourself.
 
 A worker chat starts empty. It has none of this conversation's context: not the user's original
 request, not the files already discussed, not the decisions already made. Write the brief as if to

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -323,6 +323,10 @@ with YAML frontmatter: >
     vibing.nvim: true
     session_id: <cli-session-id>
     created_at: 2026-01-01T12:00:00
+    orchestrated:                            # optional: chats this drives
+      - .vibing/chat/worker-auth.md
+    orchestrated_by:                         # optional: who drives this
+      - .vibing/chat/orchestrator.md
     working_dir: .vibing/worktrees/fix-auth   # optional, relative to git root
     agent: claude
     mode: code                                # code | plan | explore
@@ -341,6 +345,13 @@ with YAML frontmatter: >
 Note the singular `permission_mode`; the permissions lists are plural. Reopen
 a chat with |:VibingChat| {file} or plain |:edit| — the session resumes from
 `session_id`, and `working_dir` decides where the CLI runs.
+
+`orchestrated` and `orchestrated_by` record which chat drove which. They are
+written when one chat creates or messages another through the vibing-nvim MCP
+tools, as git-root-relative paths, and are rewritten on both sides when
+|:VibingSetFileTitle| renames a chat file. Buffer numbers do not survive a
+restart and file names do not survive a rename, so the frontmatter is the only
+place the relationship keeps meaning.
 
 ==============================================================================
 9. BACKENDS                                                  *vibing-backends*

--- a/lua/vibing/application/chat/handlers/set_file_title.lua
+++ b/lua/vibing/application/chat/handlers/set_file_title.lua
@@ -5,6 +5,7 @@ local FileManager = require("vibing.presentation.chat.modules.file_manager")
 local SyncManager = require("vibing.application.link.sync_manager")
 local DailySummaryScanner = require("vibing.infrastructure.link.daily_summary_scanner")
 local ForkedChatScanner = require("vibing.infrastructure.link.forked_chat_scanner")
+local OrchestrationChatScanner = require("vibing.infrastructure.link.orchestration_chat_scanner")
 local SummaryInserter = require("vibing.presentation.chat.modules.summary_inserter")
 local Fs = require("vibing.core.utils.fs")
 
@@ -214,13 +215,17 @@ return function(_, chat_buffer)
         old_file_path, new_file_path, { DailySummaryScanner.new() }, daily_base_dir
       )
 
-      -- フォーク元リンクの更新（チャット保存ディレクトリを検索）
-      local fork_result = SyncManager.sync_links(
-        old_file_path, new_file_path, { ForkedChatScanner.new() }, save_dir
+      -- チャット間リンクの更新（チャット保存ディレクトリを検索）。
+      -- daily summary と違ってベースディレクトリが同じなので、1回の呼び出しにまとめられる
+      local chat_result = SyncManager.sync_links(
+        old_file_path,
+        new_file_path,
+        { ForkedChatScanner.new(), OrchestrationChatScanner.new() },
+        save_dir
       )
 
-      local total_updated = daily_result.updated + fork_result.updated
-      local total_failed = daily_result.failed + fork_result.failed
+      local total_updated = daily_result.updated + chat_result.updated
+      local total_failed = daily_result.failed + chat_result.failed
 
       if total_updated > 0 then
         notify.info(string.format("Updated %d linked file(s)", total_updated), "Link Sync")

--- a/lua/vibing/application/chat/inherited_frontmatter.lua
+++ b/lua/vibing/application/chat/inherited_frontmatter.lua
@@ -2,7 +2,12 @@
 ---親チャットから新しいチャットへ引き継ぐfrontmatterの共通部分。
 ---forkとsubagent chatはここが完全に一致し、違うのは出自を示す1フィールド
 ---（`forked_from` / `subagent_id`）だけなので、引き継ぎ範囲は片方に足してもう片方に
----足し忘れないようここに一本化する
+---足し忘れないようここに一本化する。
+---
+---`orchestrated` / `orchestrated_by` は**意図的に**含めない。ここは明示的なホワイトリスト
+---なので既に落ちているが、足してはいけないことを記録しておく: forkもsubagent chatも自分では
+---誰とも関係を結んでいないのに、親の関係を自分のものとして主張することになる
+---（`SubagentMarker.strip` がforkでマーカーを剥がすのと同じ理由）
 local M = {}
 
 local Modes = require("vibing.core.constants.modes")

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -1,0 +1,69 @@
+---@class Vibing.Application.Chat.OrchestrationLink
+---チャット同士のオーケストレーション関係を、双方の frontmatter に記録する。
+---
+---関係の唯一の記録がトランスクリプトの地の文だったのが元の状態で、それは二重に壊れる。
+---bufnr は Neovim を再起動すれば別のバッファを指し、`:VibingSetFileTitle` はチャット
+---ファイルを改名するので、書き残したパスは黙って腐る。`forked_from` が frontmatter +
+---`ForkedChatScanner` で既に解いている問題なので、同じ形に揃える。
+---
+---方向を `orchestrated` / `orchestrated_by` の2フィールドに分けているのは、ワーカー側が
+---「自分に指示を出したのは誰か」を答えられる必要があるため。隣のワーカーと区別のつかない
+---フラットな集合では、そこに答えられない。
+local M = {}
+
+local Git = require("vibing.core.utils.git")
+local FileManager = require("vibing.presentation.chat.modules.file_manager")
+
+---@param bufnr number
+---@return table? chat_buf
+local function resolve_chat(bufnr)
+  if type(bufnr) ~= "number" or not vim.api.nvim_buf_is_valid(bufnr) then
+    return nil
+  end
+  return require("vibing.presentation.chat.view").get_chat_buffer(bufnr)
+end
+
+---A が B に指示を出した関係を両者の frontmatter に書く
+---
+---呼び出しは `ProgrammaticSender.send` より**前**に済ませること。
+---`update_frontmatter_list` はバッファを直接編集するので、B の応答が始まってから書くと
+---ストリーミングと競合する。
+---@param from_bufnr number 送信元（オーケストレーター側）
+---@param to_bufnr number 送信先（ワーカー側）
+---@return boolean success
+---@return string? error
+function M.link(from_bufnr, to_bufnr)
+  if from_bufnr == to_bufnr then
+    return false, "A chat cannot orchestrate itself"
+  end
+
+  local from_chat = resolve_chat(from_bufnr)
+  local to_chat = resolve_chat(to_bufnr)
+  if not from_chat or not to_chat then
+    return false, "Both buffers must be vibing chat buffers"
+  end
+
+  local from_path = vim.api.nvim_buf_get_name(from_bufnr)
+  local to_path = vim.api.nvim_buf_get_name(to_bufnr)
+  if from_path == "" or to_path == "" then
+    return false, "Both chats must have a file name"
+  end
+
+  from_chat:update_frontmatter_list("orchestrated", Git.to_display_path(to_path), "add")
+  to_chat:update_frontmatter_list("orchestrated_by", Git.to_display_path(from_path), "add")
+
+  -- `update_frontmatter_list` はバッファにしか書かない。リネーム同期はディスクを読むので、
+  -- ここで保存しないとリンクは「次に何かの理由で保存されるまで」存在しないことになる。
+  -- 送信元は `:VibingChat` の性質上まだ一度も保存されていないことがあり、その窓がいちばん
+  -- 長い（＝1ターン目に投げた相手が改名されるとリンクが片方向に腐る）
+  local saved_from = FileManager.save_buffer(from_bufnr)
+  local saved_to = FileManager.save_buffer(to_bufnr)
+
+  if not (saved_from and saved_to) then
+    return false, "Wrote the orchestration link but could not save both chat files"
+  end
+
+  return true, nil
+end
+
+return M

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -49,8 +49,11 @@ function M.link(from_bufnr, to_bufnr)
     return false, "Both chats must have a file name"
   end
 
-  from_chat:update_frontmatter_list("orchestrated", Git.to_display_path(to_path), "add")
-  to_chat:update_frontmatter_list("orchestrated_by", Git.to_display_path(from_path), "add")
+  -- 戻り値を捨ててはいけない。`update_frontmatter_list` は frontmatter の閉じ `---` が
+  -- 先頭100行に収まらないと false を返す（長い permission 配列を持つチャットで現実に起きる）。
+  -- 捨てると、このモジュールが防ぐために存在している「黙って関係が残らない」がそのまま起きる
+  local wrote_forward = from_chat:update_frontmatter_list("orchestrated", Git.to_display_path(to_path), "add")
+  local wrote_back = to_chat:update_frontmatter_list("orchestrated_by", Git.to_display_path(from_path), "add")
 
   -- `update_frontmatter_list` はバッファにしか書かない。リネーム同期はディスクを読むので、
   -- ここで保存しないとリンクは「次に何かの理由で保存されるまで」存在しないことになる。
@@ -59,6 +62,9 @@ function M.link(from_bufnr, to_bufnr)
   local saved_from = FileManager.save_buffer(from_bufnr)
   local saved_to = FileManager.save_buffer(to_bufnr)
 
+  if not (wrote_forward and wrote_back) then
+    return false, "Could not write the orchestration link into both chats' frontmatter"
+  end
   if not (saved_from and saved_to) then
     return false, "Wrote the orchestration link but could not save both chat files"
   end

--- a/lua/vibing/infrastructure/link/forked_chat_scanner.lua
+++ b/lua/vibing/infrastructure/link/forked_chat_scanner.lua
@@ -81,16 +81,11 @@ function ForkedChatScanner:update_link(file_path, old_path, new_path)
 
   local new_forked_from = Git.to_display_path(new_path)
 
-  -- frontmatterを更新
-  local updated_text = Frontmatter.update(text, { forked_from = new_forked_from })
-  local updated_lines = vim.split(updated_text, "\n", { plain = true })
-
-  local result = vim.fn.writefile(updated_lines, file_path)
-  if result ~= 0 then
-    return false, string.format("Failed to write file: %s", vim.v.errmsg or "unknown")
-  end
-
-  return true, nil
+  -- 開かれているバッファがあればそちら経由で書く。ディスクを直接書くと、そのバッファの
+  -- 次の保存が同期した内容を巻き戻すか、確認プロンプトでNeovimを止める
+  -- （infrastructure/storage/frontmatter_file.lua のコメント参照）
+  local FrontmatterFile = require("vibing.infrastructure.storage.frontmatter_file")
+  return FrontmatterFile.update(file_path, { forked_from = new_forked_from })
 end
 
 return ForkedChatScanner

--- a/lua/vibing/infrastructure/link/orchestration_chat_scanner.lua
+++ b/lua/vibing/infrastructure/link/orchestration_chat_scanner.lua
@@ -10,6 +10,7 @@ OrchestrationChatScanner.__index = OrchestrationChatScanner
 
 local Scanner = require("vibing.infrastructure.link.scanner")
 local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+local FrontmatterFile = require("vibing.infrastructure.storage.frontmatter_file")
 local Git = require("vibing.core.utils.git")
 
 setmetatable(OrchestrationChatScanner, { __index = Scanner })
@@ -166,13 +167,9 @@ function OrchestrationChatScanner:update_link(file_path, old_path, new_path)
     return false, "No orchestration link to update"
   end
 
-  local updated_text = Frontmatter.update(text, updates)
-  local result = vim.fn.writefile(vim.split(updated_text, "\n", { plain = true }), file_path)
-  if result ~= 0 then
-    return false, string.format("Failed to write file: %s", vim.v.errmsg or "unknown")
-  end
-
-  return true, nil
+  -- ディスクに直接書かない。オーケストレーションのリンクはbufnr起点で張られるので、相手側の
+  -- チャットはほぼ必ず開いている（FrontmatterFile のコメント参照）
+  return FrontmatterFile.update(file_path, updates)
 end
 
 return OrchestrationChatScanner

--- a/lua/vibing/infrastructure/link/orchestration_chat_scanner.lua
+++ b/lua/vibing/infrastructure/link/orchestration_chat_scanner.lua
@@ -1,0 +1,178 @@
+---@class Vibing.Infrastructure.Link.OrchestrationChatScanner : Vibing.Infrastructure.Link.Scanner
+---オーケストレーションで結ばれたチャットの `orchestrated` / `orchestrated_by` を
+---ファイル名の変更に追従させるスキャナー。
+---
+---`ForkedChatScanner` が雛形だが、そのままコピーはできない。`forked_from` はスカラーなので
+---`Frontmatter.update` にキーごと渡して丸ごと差し替えられるのに対し、こちらはリストなので
+---同じことをすると他の要素が全部消える。該当する1要素だけを差し替える。
+local OrchestrationChatScanner = {}
+OrchestrationChatScanner.__index = OrchestrationChatScanner
+
+local Scanner = require("vibing.infrastructure.link.scanner")
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+local Git = require("vibing.core.utils.git")
+
+setmetatable(OrchestrationChatScanner, { __index = Scanner })
+
+---両方向を1本のスキャナーで見る。リネームされたのが A でも B でも、相手側のファイルは
+---この2キーのどちらかに old_path を持っているので、スキャナーを分ける理由がない。
+---分ければ全ファイルの読み込みと `git rev-parse` が二重になるだけになる
+local LINK_KEYS = { "orchestrated", "orchestrated_by" }
+
+---@return Vibing.Infrastructure.Link.OrchestrationChatScanner
+function OrchestrationChatScanner.new()
+  return setmetatable({}, OrchestrationChatScanner)
+end
+
+---`Git.get_root()` は毎回 `git rev-parse` を起動する。1ファイルにつきリンク要素の数だけ
+---呼ぶことになるので、スキャナーインスタンスの生存期間（＝1回の同期）だけキャッシュする。
+---見つからなかったことも `false` として覚え、毎回引き直さない
+---@return string?
+function OrchestrationChatScanner:_git_root()
+  if self._git_root_cache == nil then
+    self._git_root_cache = Git.get_root() or false
+  end
+  return self._git_root_cache or nil
+end
+
+---frontmatter に書かれた表示パスを絶対パスに正規化する
+---@param value string
+---@return string
+function OrchestrationChatScanner:_to_absolute(value)
+  local git_root = self:_git_root()
+  if git_root and not value:match("^[/~]") then
+    return vim.fs.joinpath(git_root, value)
+  end
+  return vim.fn.fnamemodify(vim.fn.expand(value), ":p")
+end
+
+---リンクフィールドを配列として読む。
+---
+---2つの落とし穴を吸収する。空リストは `{}` という**真値の table** としてパースされるので
+---`if not value` では弾けない。そして手で `orchestrated: path.md` と1行で書かれていれば
+---table ではなく**文字列**として返ってくる
+---@param frontmatter table
+---@param key string
+---@return string[]
+local function read_link_list(frontmatter, key)
+  local value = frontmatter[key]
+  if type(value) == "string" and value ~= "" then
+    return { value }
+  end
+  if type(value) ~= "table" then
+    return {}
+  end
+  return value
+end
+
+---@param file_path string
+---@return table?
+local function read_frontmatter(file_path)
+  local ok, content = pcall(vim.fn.readfile, file_path)
+  if not ok or not content or #content == 0 then
+    return nil
+  end
+
+  local frontmatter = Frontmatter.parse(table.concat(content, "\n"))
+  -- チャット保存ディレクトリには手書きのメモが置かれていることがある。リンクキーの
+  -- 有無だけで判定すると、たまたま同名のキーを持つ `.md` を書き換えてしまう
+  if not frontmatter or frontmatter["vibing.nvim"] ~= true then
+    return nil
+  end
+  return frontmatter
+end
+
+---@param base_dir string
+---@return string[]
+function OrchestrationChatScanner:find_target_files(base_dir)
+  if vim.fn.isdirectory(base_dir) == 0 then
+    return {}
+  end
+
+  local md_files = vim.fn.glob(base_dir .. "**/*.md", false, true)
+  local vibing_files = vim.fn.glob(base_dir .. "**/*.vibing", false, true)
+
+  return vim.list_extend(md_files, vibing_files)
+end
+
+---@param file_path string
+---@param target_path string
+---@return boolean
+function OrchestrationChatScanner:contains_link(file_path, target_path)
+  local frontmatter = read_frontmatter(file_path)
+  if not frontmatter then
+    return false
+  end
+
+  local target_abs = vim.fn.fnamemodify(target_path, ":p")
+
+  for _, key in ipairs(LINK_KEYS) do
+    for _, item in ipairs(read_link_list(frontmatter, key)) do
+      if self:_to_absolute(item) == target_abs then
+        return true
+      end
+    end
+  end
+
+  return false
+end
+
+---@param file_path string
+---@param old_path string
+---@param new_path string
+---@return boolean success
+---@return string? error
+function OrchestrationChatScanner:update_link(file_path, old_path, new_path)
+  local ok, lines = pcall(vim.fn.readfile, file_path)
+  if not ok or not lines then
+    return false, string.format("Failed to read file: %s", lines or "unknown")
+  end
+
+  local text = table.concat(lines, "\n")
+  local frontmatter = Frontmatter.parse(text)
+  if not frontmatter then
+    return false, "No frontmatter"
+  end
+
+  local old_abs = vim.fn.fnamemodify(old_path, ":p")
+  local new_display = Git.to_display_path(new_path)
+
+  local updates = {}
+  for _, key in ipairs(LINK_KEYS) do
+    local replaced = false
+    local seen = {}
+    local next_items = {}
+
+    for _, item in ipairs(read_link_list(frontmatter, key)) do
+      local value = item
+      if self:_to_absolute(item) == old_abs then
+        value = new_display
+        replaced = true
+      end
+      -- リネーム先が既にリストに載っていることがある（A が B と C の両方を指していて、
+      -- B が C の名前に改名された場合）。差し替えたあとに重複を落とす
+      if not seen[value] then
+        seen[value] = true
+        table.insert(next_items, value)
+      end
+    end
+
+    if replaced then
+      updates[key] = next_items
+    end
+  end
+
+  if not next(updates) then
+    return false, "No orchestration link to update"
+  end
+
+  local updated_text = Frontmatter.update(text, updates)
+  local result = vim.fn.writefile(vim.split(updated_text, "\n", { plain = true }), file_path)
+  if result ~= 0 then
+    return false, string.format("Failed to write file: %s", vim.v.errmsg or "unknown")
+  end
+
+  return true, nil
+end
+
+return OrchestrationChatScanner

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -3,23 +3,10 @@
 local M = {}
 
 local ChatConstants = require("vibing.core.constants.chat")
-
----作成したチャットをその場でディスクに書き出す
----`:VibingChat`は最初の応答が返るまでファイルを書かない（buffer.lua:update_session_id）。
----呼び出し元にファイルパスを返す以上、そのパスが存在しないのは嘘なので、forkと同じく
----作成時点で保存する
----@param bufnr number
----@return boolean saved
-local function save_now(bufnr)
-  local ok = pcall(vim.api.nvim_buf_call, bufnr, function()
-    vim.cmd("silent write")
-  end)
-  -- `write`はエラーを黙って飲むことがあるので、pcallの成否だけでなくmodifiedも確認する
-  return ok and not vim.bo[bufnr].modified
-end
+local FileManager = require("vibing.presentation.chat.modules.file_manager")
 
 ---新しいチャットバッファを作成する
----@param params {position?: string, working_dir?: string}
+---@param params {position?: string, working_dir?: string, from_bufnr?: number}
 ---@return {bufnr: number, file_path: string, working_dir: string?, position: string, saved: boolean}
 function M.create_chat(params)
   params = params or {}
@@ -42,12 +29,29 @@ function M.create_chat(params)
   -- （:VibingCancel などのフォールバック先）を奪わない
   local chat_buf = require("vibing.presentation.chat.view").render(session, position, { background = true })
 
+  -- `:VibingChat`は最初の応答が返るまでファイルを書かない（buffer.lua:update_session_id）。
+  -- 呼び出し元にファイルパスを返す以上、そのパスが存在しないのは嘘なので、forkと同じく
+  -- 作成時点で保存する
+  local saved = FileManager.save_buffer(chat_buf.buf)
+
+  -- 作成した時点でリンクを張る。送信を待つ形でも記録はできるが、`from_bufnr` の渡し忘れが
+  -- 「黙って関係が残らない」失敗になるので、関係が確定する最も早い時点で書く
+  if params.from_bufnr then
+    local ok, err = require("vibing.application.chat.orchestration_link").link(params.from_bufnr, chat_buf.buf)
+    if not ok then
+      require("vibing.core.utils.notify").warn(
+        string.format("Created chat %d but could not link it: %s", chat_buf.buf, err or "unknown"),
+        "Orchestration"
+      )
+    end
+  end
+
   return {
     bufnr = chat_buf.buf,
     file_path = chat_buf.file_path,
     working_dir = session.working_dir,
     position = position,
-    saved = save_now(chat_buf.buf),
+    saved = saved,
   }
 end
 

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -32,7 +32,7 @@ function M.create_chat(params)
   -- `:VibingChat`は最初の応答が返るまでファイルを書かない（buffer.lua:update_session_id）。
   -- 呼び出し元にファイルパスを返す以上、そのパスが存在しないのは嘘なので、forkと同じく
   -- 作成時点で保存する
-  local saved = FileManager.save_buffer(chat_buf.buf)
+  FileManager.save_buffer(chat_buf.buf)
 
   -- 作成した時点でリンクを張る。送信を待つ形でも記録はできるが、`from_bufnr` の渡し忘れが
   -- 「黙って関係が残らない」失敗になるので、関係が確定する最も早い時点で書く
@@ -51,7 +51,9 @@ function M.create_chat(params)
     file_path = chat_buf.file_path,
     working_dir = session.working_dir,
     position = position,
-    saved = saved,
+    -- リンク書き込みはバッファを変更して保存し直すので、`saved` はその**後**に見る。
+    -- 先にスナップショットすると、リンクの無いディスク上のコピーに対して true を返しうる
+    saved = not vim.bo[chat_buf.buf].modified,
   }
 end
 

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -5,11 +5,27 @@ local M = {}
 local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
 
 ---Send message to chat buffer
----@param params {bufnr: number, message: string, sender?: string}
+---@param params {bufnr: number, message: string, sender?: string, from_bufnr?: number}
 ---@return {success: boolean, bufnr: number}
 function M.send_message(params)
   if not params then
     error("Missing parameters")
+  end
+
+  -- `from_bufnr` は任意。必須にすると渡し忘れで送信そのものが失敗し、既存の
+  -- オーケストレーション経路が壊れる。渡されなければリンクを張らないだけ（＝従来の動作）
+  if params.from_bufnr then
+    -- 送信より前に書く。`update_frontmatter_list` はバッファを直接触るので、宛先の応答が
+    -- 始まってから書くとストリーミングと競合する
+    local ok, err = require("vibing.application.chat.orchestration_link").link(params.from_bufnr, params.bufnr)
+    -- リンクは記録であって、失敗が送信を止める理由にはならない。片方だけ書けた状態でも
+    -- リネーム同期は残った側で動く
+    if not ok then
+      require("vibing.core.utils.notify").warn(
+        string.format("Could not link chats %d -> %d: %s", params.from_bufnr, params.bufnr, err or "unknown"),
+        "Orchestration"
+      )
+    end
   end
 
   -- ProgrammaticSender.send already validates parameters
@@ -17,4 +33,3 @@ function M.send_message(params)
 end
 
 return M
-

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -15,8 +15,11 @@ function M.send_message(params)
   -- `from_bufnr` は任意。必須にすると渡し忘れで送信そのものが失敗し、既存の
   -- オーケストレーション経路が壊れる。渡されなければリンクを張らないだけ（＝従来の動作）
   if params.from_bufnr then
-    -- 送信より前に書く。`update_frontmatter_list` はバッファを直接触るので、宛先の応答が
-    -- 始まってから書くとストリーミングと競合する
+    -- リンクは送信より前に書く必要がある（`update_frontmatter_list` はバッファを直接触るので、
+    -- 宛先の応答が始まってから書くとストリーミングと競合する）。ただし送信が弾かれると
+    -- 行われなかったやり取りの関係だけが永久に残るので、先に送信可能かを確かめる
+    ProgrammaticSender.validate(params.bufnr, params.message)
+
     local ok, err = require("vibing.application.chat.orchestration_link").link(params.from_bufnr, params.bufnr)
     -- リンクは記録であって、失敗が送信を止める理由にはならない。片方だけ書けた状態でも
     -- リネーム同期は残った側で動く

--- a/lua/vibing/infrastructure/storage/frontmatter.lua
+++ b/lua/vibing/infrastructure/storage/frontmatter.lua
@@ -154,15 +154,19 @@ local function get_sorted_keys(tbl)
     created_at = 3,
     forked_from = 4,
     subagent_id = 5,
-    working_dir = 6,
-    agent = 7,
-    model = 8,
-    effort = 9,
-    permission_mode = 10,
-    permissions_allow = 11,
-    permissions_deny = 12,
-    permissions_ask = 13,
-    language = 14,
+    -- 出自を示すフィールド(forked_from / subagent_id)の直後。どれも「このチャットが
+    -- 他のどのチャットと繋がっているか」を答えるものなので、まとめて先頭側に置く
+    orchestrated = 6,
+    orchestrated_by = 7,
+    working_dir = 8,
+    agent = 9,
+    model = 10,
+    effort = 11,
+    permission_mode = 12,
+    permissions_allow = 13,
+    permissions_deny = 14,
+    permissions_ask = 15,
+    language = 16,
   }
 
   table.sort(keys, function(a, b)

--- a/lua/vibing/infrastructure/storage/frontmatter_file.lua
+++ b/lua/vibing/infrastructure/storage/frontmatter_file.lua
@@ -1,0 +1,114 @@
+---@class Vibing.Infrastructure.Storage.FrontmatterFile
+---チャットファイルのfrontmatterを、そのファイルが**開かれている場合はバッファ経由で**更新する。
+---
+---リンクのリネーム同期はディスクを直接書いていたが、同期対象は原理的に開かれていることが多い
+---（オーケストレーションのリンクはbufnr起点で張られるので、相手は常にロード済み）。開いている
+---バッファを迂回して書くと2通りに壊れる:
+---
+---  1. そのバッファの次の保存が、書いた内容をそのまま巻き戻す（`write!`はVimの
+---     「読み込み後にファイルが変わった」ガードを黙って踏み越える）
+---  2. ガードが効く保存だと `Do you really want to write to it (y/n)?` のプロンプトが出る。
+---     チャットの保存は `vim.schedule` の中から走るので、そこでNeovimが止まる
+---
+---ロードされていなければ従来通りディスクに書く。
+local M = {}
+
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+
+---比較は両側ともシンボリックリンクを解決した形で行う。`nvim_buf_get_name` は解決済みの
+---パスを返すので（macOSでは `/var/...` が `/private/var/...` になる）、`:p` を付けただけの
+---候補と突き合わせると、同じファイルなのに一致しない
+---@param path string
+---@return string
+local function physical(path)
+  return vim.fn.resolve(vim.fn.fnamemodify(path, ":p"))
+end
+
+---@param file_path string
+---@return number? bufnr
+local function loaded_buffer(file_path)
+  local target = physical(file_path)
+
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      local name = vim.api.nvim_buf_get_name(bufnr)
+      if name ~= "" and physical(name) == target then
+        return bufnr
+      end
+    end
+  end
+
+  return nil
+end
+
+---frontmatterブロックだけを差し替える。本文には触れない
+---（ストリーミング中のバッファを丸ごと書き換えると応答を壊す）
+---@param bufnr number
+---@param updates table
+---@return boolean success
+---@return string? error
+local function update_buffer(bufnr, updates)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  if lines[1] ~= "---" then
+    return false, "Buffer has no frontmatter"
+  end
+
+  local close = nil
+  for i = 2, #lines do
+    if lines[i] == "---" then
+      close = i
+      break
+    end
+  end
+  if not close then
+    return false, "Buffer frontmatter is not terminated"
+  end
+
+  local block = table.concat(vim.list_slice(lines, 1, close), "\n")
+  local updated = Frontmatter.update(block, updates)
+  vim.api.nvim_buf_set_lines(bufnr, 0, close, false, vim.split(updated, "\n", { plain = true }))
+
+  -- ここで保存しないと、同期したと報告した内容がディスクに無いままになる。
+  -- バッファ側を真として書いているので、`write!` でガードを踏み越えても失うものはない
+  local ok = pcall(vim.api.nvim_buf_call, bufnr, function()
+    vim.cmd.write({ bang = true })
+  end)
+  if not ok or vim.bo[bufnr].modified then
+    return false, "Updated the buffer but could not save it"
+  end
+
+  return true, nil
+end
+
+---@param file_path string
+---@param updates table
+---@return boolean success
+---@return string? error
+local function update_file(file_path, updates)
+  local ok, lines = pcall(vim.fn.readfile, file_path)
+  if not ok or not lines then
+    return false, string.format("Failed to read file: %s", lines or "unknown")
+  end
+
+  local updated = Frontmatter.update(table.concat(lines, "\n"), updates)
+  if vim.fn.writefile(vim.split(updated, "\n", { plain = true }), file_path) ~= 0 then
+    return false, string.format("Failed to write file: %s", vim.v.errmsg or "unknown")
+  end
+
+  return true, nil
+end
+
+---frontmatterのキーを更新する。開かれていればバッファ経由、なければディスクへ
+---@param file_path string
+---@param updates table
+---@return boolean success
+---@return string? error
+function M.update(file_path, updates)
+  local bufnr = loaded_buffer(file_path)
+  if bufnr then
+    return update_buffer(bufnr, updates)
+  end
+  return update_file(file_path, updates)
+end
+
+return M

--- a/lua/vibing/presentation/chat/modules/file_manager.lua
+++ b/lua/vibing/presentation/chat/modules/file_manager.lua
@@ -57,6 +57,26 @@ function M.load_from_file(buf, file_path)
   return true
 end
 
+---チャットバッファをその場でディスクに書き出す
+---
+---`:VibingChat`は最初の応答が返るまでファイルを書かない（buffer.lua:update_session_id）ので、
+---ディスク上のファイルを前提にする処理（呼び出し元へのパス返却、リンクのリネーム同期）は
+---自分で保存を済ませる必要がある。
+---`write`はエラーを黙って飲むことがあるので、pcallの成否だけでなくmodifiedも確認する
+---@param buf number バッファ番号
+---@return boolean saved
+function M.save_buffer(buf)
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then
+    return false
+  end
+
+  local ok = pcall(vim.api.nvim_buf_call, buf, function()
+    vim.cmd.write({ bang = true })
+  end)
+
+  return ok and not vim.bo[buf].modified
+end
+
 ---メッセージからファイル名を更新
 ---@param buf number バッファ番号
 ---@param current_path string? 現在のファイルパス

--- a/lua/vibing/presentation/chat/modules/programmatic_sender.lua
+++ b/lua/vibing/presentation/chat/modules/programmatic_sender.lua
@@ -13,29 +13,43 @@ local _send_locks = {}
 ---@param message string Message content to send
 ---@param sender? string Sender identifier (default: "User", future: "Alpha", "Bravo", etc.)
 ---@return {success: boolean, bufnr: number}
-function M.send(bufnr, message, sender)
-  sender = sender or "User"
-
-  -- Validate buffer
+---送信できる状態かを確かめ、対象のChatBufferを返す（送れないなら error）
+---
+---`send`から切り出してあるのは、送信の前に別の副作用を済ませたい呼び出し元があるため。
+---`nvim_chat_send_message`はfrontmatterへのリンク書き込みを送信より前に行う必要がある
+---（バッファを直接触るので、応答が始まってから書くとストリーミングと競合する）ので、
+---「書いたあとに送信が弾かれ、行われなかったやり取りの関係だけが残る」のを避けるには
+---先にここを通す必要がある
+---@param bufnr number
+---@param message string
+---@return table chat_buf
+function M.validate(bufnr, message)
   if not vim.api.nvim_buf_is_valid(bufnr) then
     error("Invalid buffer number")
   end
 
-  -- Validate message content
   if not message or vim.trim(message) == "" then
     error("Empty message")
   end
 
-  -- Get ChatBuffer instance via public API
   local chat_buf = view.get_chat_buffer(bufnr)
   if not chat_buf then
     error("Buffer is not a vibing chat buffer")
   end
 
-  -- Acquire lock to prevent concurrent sends
   if _send_locks[bufnr] then
     error("Another send operation is in progress for this buffer")
   end
+
+  return chat_buf
+end
+
+function M.send(bufnr, message, sender)
+  sender = sender or "User"
+
+  local chat_buf = M.validate(bufnr, message)
+
+  -- Acquire lock to prevent concurrent sends
   _send_locks[bufnr] = true
 
   local success, err = pcall(function()

--- a/tests/lua/application/link/sync_manager_spec.lua
+++ b/tests/lua/application/link/sync_manager_spec.lua
@@ -1,0 +1,85 @@
+local SyncManager = require("vibing.application.link.sync_manager")
+
+---3メソッドだけのスキャナーを組み立てる。実ファイルを触らないので、`sync_links` 自身の
+---走査・集計・エラー処理だけを見られる
+---@param files string[]
+---@param matches table<string, boolean>
+---@param failures table<string, string>?
+---@return table
+local function fake_scanner(files, matches, failures)
+  return {
+    updated = {},
+    find_target_files = function()
+      return files
+    end,
+    contains_link = function(_, file)
+      return matches[file] == true
+    end,
+    update_link = function(self, file, _, new_path)
+      if failures and failures[file] then
+        return false, failures[file]
+      end
+      table.insert(self.updated, { file = file, new_path = new_path })
+      return true, nil
+    end,
+  }
+end
+
+describe("SyncManager.sync_links", function()
+  it("updates only the files that contain the link", function()
+    local scanner = fake_scanner({ "a.md", "b.md", "c.md" }, { ["b.md"] = true })
+
+    local result = SyncManager.sync_links("/old.md", "/new.md", { scanner }, "/base/")
+
+    assert.equals(1, result.updated)
+    assert.equals(0, result.failed)
+    assert.same({ { file = "b.md", new_path = "/new.md" } }, scanner.updated)
+  end)
+
+  it("reports total as the number of files scanned, not matched", function()
+    -- 「N件更新しました」の分母ではないので、ユーザー向けの文言に使ってはいけない
+    local scanner = fake_scanner({ "a.md", "b.md", "c.md" }, { ["a.md"] = true })
+
+    local result = SyncManager.sync_links("/old.md", "/new.md", { scanner }, "/base/")
+
+    assert.equals(3, result.total)
+    assert.equals(1, result.updated)
+  end)
+
+  it("counts a failed update without aborting the rest of the sweep", function()
+    local scanner = fake_scanner({ "a.md", "b.md" }, { ["a.md"] = true, ["b.md"] = true }, { ["a.md"] = "boom" })
+
+    local result = SyncManager.sync_links("/old.md", "/new.md", { scanner }, "/base/")
+
+    assert.equals(1, result.updated)
+    assert.equals(1, result.failed)
+    assert.same({ { file = "b.md", new_path = "/new.md" } }, scanner.updated)
+  end)
+
+  it("runs every scanner it is given over the same base directory", function()
+    local first = fake_scanner({ "a.md" }, { ["a.md"] = true })
+    local second = fake_scanner({ "b.md" }, { ["b.md"] = true })
+
+    local result = SyncManager.sync_links("/old.md", "/new.md", { first, second }, "/base/")
+
+    assert.equals(2, result.updated)
+    assert.equals(2, result.total)
+  end)
+
+  it("counts a file twice when two scanners both match it", function()
+    -- forked と orchestration の両方のリンクを持つチャットは2回数えられる。ユーザーに出る
+    -- 「Updated N linked file(s)」がファイル数ではなくリンク数であることの根拠
+    local first = fake_scanner({ "a.md" }, { ["a.md"] = true })
+    local second = fake_scanner({ "a.md" }, { ["a.md"] = true })
+
+    local result = SyncManager.sync_links("/old.md", "/new.md", { first, second }, "/base/")
+
+    assert.equals(2, result.updated)
+  end)
+
+  it("returns zeros when no scanner finds anything", function()
+    local result = SyncManager.sync_links("/old.md", "/new.md", { fake_scanner({}, {}) }, "/base/")
+
+    assert.same({ total = 0, updated = 0, failed = 0 }, result)
+  end)
+end)

--- a/tests/lua/infrastructure/link/forked_chat_scanner_spec.lua
+++ b/tests/lua/infrastructure/link/forked_chat_scanner_spec.lua
@@ -1,0 +1,96 @@
+local ForkedChatScanner = require("vibing.infrastructure.link.forked_chat_scanner")
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+local Git = require("vibing.core.utils.git")
+
+---@param dir string
+---@param name string
+---@param frontmatter table
+---@return string path
+local function write_chat(dir, name, frontmatter)
+  local path = dir .. "/" .. name
+  local defaults = { ["vibing.nvim"] = true, session_id = "session-" .. name }
+  for k, v in pairs(frontmatter) do
+    defaults[k] = v
+  end
+  vim.fn.writefile(vim.split(Frontmatter.serialize(defaults, "## User\n"), "\n", { plain = true }), path)
+  return path
+end
+
+---@param path string
+---@return table
+local function read_frontmatter(path)
+  return (Frontmatter.parse(table.concat(vim.fn.readfile(path), "\n")))
+end
+
+describe("ForkedChatScanner", function()
+  local dir
+  local original_get_root
+
+  before_each(function()
+    dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, "p")
+    original_get_root = Git.get_root
+    Git.get_root = function()
+      return dir
+    end
+  end)
+
+  after_each(function()
+    Git.get_root = original_get_root
+    vim.fn.delete(dir, "rf")
+  end)
+
+  it("finds a fork that points at the renamed source", function()
+    local source = dir .. "/source.md"
+    local fork = write_chat(dir, "fork.md", { forked_from = "source.md" })
+
+    assert.is_true(ForkedChatScanner.new():contains_link(fork, source))
+  end)
+
+  it("ignores a chat with no forked_from", function()
+    local other = write_chat(dir, "other.md", {})
+
+    assert.is_false(ForkedChatScanner.new():contains_link(other, dir .. "/source.md"))
+  end)
+
+  it("ignores a fork that points somewhere else", function()
+    local fork = write_chat(dir, "fork.md", { forked_from = "elsewhere.md" })
+
+    assert.is_false(ForkedChatScanner.new():contains_link(fork, dir .. "/source.md"))
+  end)
+
+  it("rewrites forked_from to the new display path", function()
+    local fork = write_chat(dir, "fork.md", { forked_from = "source.md" })
+
+    local ok = ForkedChatScanner.new():update_link(fork, dir .. "/source.md", dir .. "/renamed.md")
+
+    assert.is_true(ok)
+    assert.equals("renamed.md", read_frontmatter(fork).forked_from)
+  end)
+
+  it("replaces the whole key, which is why a list field needs its own scanner", function()
+    -- `forked_from` はスカラーなので `Frontmatter.update` にキーごと渡して問題ない。
+    -- 同じ実装をリスト（orchestrated / orchestrated_by）に流用すると他の要素が消えるため、
+    -- `OrchestrationChatScanner` は要素単位で書き換えている
+    local fork = write_chat(dir, "fork.md", { forked_from = "source.md" })
+
+    ForkedChatScanner.new():update_link(fork, dir .. "/source.md", dir .. "/renamed.md")
+
+    local frontmatter = read_frontmatter(fork)
+    assert.equals("renamed.md", frontmatter.forked_from)
+    assert.is_true(frontmatter["vibing.nvim"])
+  end)
+
+  it("reports a failure when there is no forked_from to update", function()
+    local other = write_chat(dir, "other.md", {})
+
+    local ok, err = ForkedChatScanner.new():update_link(other, dir .. "/source.md", dir .. "/renamed.md")
+
+    assert.is_false(ok)
+    assert.equals("No forked_from field", err)
+  end)
+
+  it("returns nothing for a directory that does not exist", function()
+    assert.same({}, ForkedChatScanner.new():find_target_files(dir .. "/missing/"))
+  end)
+end)

--- a/tests/lua/infrastructure/link/orchestration_chat_scanner_spec.lua
+++ b/tests/lua/infrastructure/link/orchestration_chat_scanner_spec.lua
@@ -1,0 +1,185 @@
+local OrchestrationChatScanner = require("vibing.infrastructure.link.orchestration_chat_scanner")
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+local Git = require("vibing.core.utils.git")
+
+---@param dir string
+---@param name string
+---@param frontmatter table
+---@return string path
+local function write_chat(dir, name, frontmatter)
+  local path = dir .. "/" .. name
+  local defaults = { ["vibing.nvim"] = true, session_id = "session-" .. name }
+  for k, v in pairs(frontmatter) do
+    defaults[k] = v
+  end
+  vim.fn.writefile(vim.split(Frontmatter.serialize(defaults, "## User\n"), "\n", { plain = true }), path)
+  return path
+end
+
+---@param path string
+---@return table
+local function read_frontmatter(path)
+  return (Frontmatter.parse(table.concat(vim.fn.readfile(path), "\n")))
+end
+
+describe("OrchestrationChatScanner", function()
+  local dir
+  local original_get_root
+
+  before_each(function()
+    dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, "p")
+    original_get_root = Git.get_root
+    -- 実際のリポジトリではなく一時ディレクトリをgitルートに見せる。こうすると
+    -- `to_display_path` がそこからの相対パスを書き、スキャナーが同じルートで解決するので、
+    -- git相対の経路をそのまま踏める
+    Git.get_root = function()
+      return dir
+    end
+  end)
+
+  after_each(function()
+    Git.get_root = original_get_root
+    vim.fn.delete(dir, "rf")
+  end)
+
+  describe("contains_link", function()
+    it("finds a chat that names the renamed file in orchestrated", function()
+      local worker = dir .. "/worker.md"
+      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = { "worker.md" } })
+
+      assert.is_true(OrchestrationChatScanner.new():contains_link(orchestrator, worker))
+    end)
+
+    it("finds a chat that names the renamed file in orchestrated_by", function()
+      local orchestrator = dir .. "/orchestrator.md"
+      local worker = write_chat(dir, "worker.md", { orchestrated_by = { "orchestrator.md" } })
+
+      assert.is_true(OrchestrationChatScanner.new():contains_link(worker, orchestrator))
+    end)
+
+    it("normalizes a ~-shortened path the same way it normalizes a git-relative one", function()
+      -- gitルートの外にあるチャット（`save_location_type = "user"` 等）は `to_display_path` が
+      -- `~/...` の形で書く。$HOME を差し替えても `expand()` には効かない（Vimは起動時に
+      -- ホームディレクトリを確定する）ので、実ホーム配下に置いて経路をそのまま踏む
+      Git.get_root = function()
+        return nil
+      end
+
+      local home_dir = vim.fn.expand("~") .. "/.vibing-orchestration-spec-" .. vim.fn.getpid()
+      vim.fn.mkdir(home_dir, "p")
+      local worker = home_dir .. "/worker.md"
+      local orchestrator = write_chat(home_dir, "orchestrator.md", {
+        orchestrated = { vim.fn.fnamemodify(worker, ":~") },
+      })
+
+      local found = OrchestrationChatScanner.new():contains_link(orchestrator, worker)
+      vim.fn.delete(home_dir, "rf")
+
+      assert.is_true(found)
+    end)
+
+    it("reads a hand-written scalar link instead of erroring on it", function()
+      -- `orchestrated: worker.md` と1行で書かれると table ではなく文字列でパースされる
+      local worker = dir .. "/worker.md"
+      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = "worker.md" })
+
+      assert.is_true(OrchestrationChatScanner.new():contains_link(orchestrator, worker))
+    end)
+
+    it("ignores a chat with no orchestration links", function()
+      local other = write_chat(dir, "other.md", { forked_from = "worker.md" })
+
+      assert.is_false(OrchestrationChatScanner.new():contains_link(other, dir .. "/worker.md"))
+    end)
+
+    it("ignores an empty link list rather than treating it as a match", function()
+      -- 空リストは真値の table としてパースされるので、存在チェックだけでは弾けない
+      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = {} })
+
+      assert.is_false(OrchestrationChatScanner.new():contains_link(orchestrator, dir .. "/worker.md"))
+    end)
+
+    it("ignores a markdown file that is not a vibing chat", function()
+      local note = dir .. "/note.md"
+      vim.fn.writefile({ "---", "orchestrated:", "  - worker.md", "---", "just a note" }, note)
+
+      assert.is_false(OrchestrationChatScanner.new():contains_link(note, dir .. "/worker.md"))
+    end)
+  end)
+
+  describe("update_link", function()
+    it("replaces only the matching element and keeps the rest of the list", function()
+      -- `ForkedChatScanner` をそのままコピーすると落ちる箇所。`forked_from` はスカラーなので
+      -- キーごと差し替えられるが、リストで同じことをすると他の要素が消える
+      local orchestrator = write_chat(dir, "orchestrator.md", {
+        orchestrated = { "alpha.md", "worker.md", "bravo.md" },
+      })
+
+      local ok = OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
+
+      assert.is_true(ok)
+      assert.same({ "alpha.md", "renamed.md", "bravo.md" }, read_frontmatter(orchestrator).orchestrated)
+    end)
+
+    it("updates orchestrated_by as well as orchestrated", function()
+      local worker = write_chat(dir, "worker.md", { orchestrated_by = { "orchestrator.md" } })
+
+      local ok =
+        OrchestrationChatScanner.new():update_link(worker, dir .. "/orchestrator.md", dir .. "/renamed.md")
+
+      assert.is_true(ok)
+      assert.same({ "renamed.md" }, read_frontmatter(worker).orchestrated_by)
+    end)
+
+    it("does not leave a duplicate when the new name is already in the list", function()
+      local orchestrator = write_chat(dir, "orchestrator.md", {
+        orchestrated = { "worker.md", "renamed.md" },
+      })
+
+      local ok = OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
+
+      assert.is_true(ok)
+      assert.same({ "renamed.md" }, read_frontmatter(orchestrator).orchestrated)
+    end)
+
+    it("leaves other frontmatter keys untouched", function()
+      local orchestrator = write_chat(dir, "orchestrator.md", {
+        orchestrated = { "worker.md" },
+        permissions_allow = { "Read", "Edit" },
+        model = "sonnet",
+      })
+
+      OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
+
+      local frontmatter = read_frontmatter(orchestrator)
+      assert.same({ "Read", "Edit" }, frontmatter.permissions_allow)
+      assert.equals("sonnet", frontmatter.model)
+      assert.is_true(frontmatter["vibing.nvim"])
+    end)
+
+    it("reports a failure when the file has no matching link", function()
+      local other = write_chat(dir, "other.md", { orchestrated = { "alpha.md" } })
+
+      local ok, err = OrchestrationChatScanner.new():update_link(other, dir .. "/worker.md", dir .. "/renamed.md")
+
+      assert.is_false(ok)
+      assert.is_string(err)
+    end)
+  end)
+
+  describe("find_target_files", function()
+    it("returns nothing for a directory that does not exist", function()
+      assert.same({}, OrchestrationChatScanner.new():find_target_files(dir .. "/missing/"))
+    end)
+
+    it("finds both .md and .vibing chat files", function()
+      write_chat(dir, "a.md", {})
+      write_chat(dir, "b.vibing", {})
+
+      local files = OrchestrationChatScanner.new():find_target_files(dir .. "/")
+
+      assert.equals(2, #files)
+    end)
+  end)
+end)

--- a/tests/lua/infrastructure/link/orchestration_chat_scanner_spec.lua
+++ b/tests/lua/infrastructure/link/orchestration_chat_scanner_spec.lua
@@ -158,6 +158,51 @@ describe("OrchestrationChatScanner", function()
       assert.is_true(frontmatter["vibing.nvim"])
     end)
 
+    it("writes through a loaded buffer instead of behind its back", function()
+      -- オーケストレーションのリンクはbufnr起点で張られるので、同期の相手は常に開いている。
+      -- ディスクを直接書くと、そのバッファの次の保存が同期内容を巻き戻すか、
+      -- 「読み込み後にファイルが変わった」プロンプトでNeovimを止める
+      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = { "worker.md" } })
+      local bufnr = vim.fn.bufadd(orchestrator)
+      vim.fn.bufload(bufnr)
+
+      local ok = OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
+
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local modified = vim.bo[bufnr].modified
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+
+      assert.is_true(ok)
+      assert.is_truthy(table.concat(lines, "\n"):find("renamed.md", 1, true), "buffer should carry the new link")
+      assert.is_false(modified, "the buffer should be saved, not left dirty")
+      -- ディスク側も追随している
+      assert.same({ "renamed.md" }, read_frontmatter(orchestrator).orchestrated)
+    end)
+
+    it("leaves the body of a loaded buffer alone", function()
+      -- ストリーミング中のチャットを丸ごと書き換えると応答が壊れる。触るのはfrontmatterだけ
+      local orchestrator = dir .. "/orchestrator.md"
+      local body = "## User\n\nhello\n\n## Assistant\n\npartial reply"
+      vim.fn.writefile(
+        vim.split(
+          Frontmatter.serialize({ ["vibing.nvim"] = true, orchestrated = { "worker.md" } }, body),
+          "\n",
+          { plain = true }
+        ),
+        orchestrator
+      )
+      local bufnr = vim.fn.bufadd(orchestrator)
+      vim.fn.bufload(bufnr)
+
+      OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
+
+      local text = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+
+      assert.is_truthy(text:find("partial reply", 1, true), "the body must survive")
+      assert.is_truthy(text:find("renamed.md", 1, true))
+    end)
+
     it("reports a failure when the file has no matching link", function()
       local other = write_chat(dir, "other.md", { orchestrated = { "alpha.md" } })
 

--- a/tests/lua/infrastructure/storage/frontmatter_spec.lua
+++ b/tests/lua/infrastructure/storage/frontmatter_spec.lua
@@ -111,6 +111,44 @@ session_id: abc
       end
       assert.same({ "session_id", "permission_mode", "permissions_allow", "language" }, order)
     end)
+
+    it("should serialize the orchestration links beside the other origin fields", function()
+      -- `forked_from` / `subagent_id` と同じく「このチャットが他のどれと繋がっているか」を
+      -- 答えるフィールドなので、設定値より前にまとまって並ぶ
+      local serialized = frontmatter.serialize({
+        language = "ja",
+        orchestrated_by = { "chat/a.md" },
+        working_dir = ".vibing/worktrees/x",
+        orchestrated = { "chat/b.md" },
+        forked_from = "chat/c.md",
+        session_id = "abc",
+      })
+      local order = {}
+      for _, line in ipairs(vim.split(serialized, "\n", { plain = true })) do
+        local key = line:match("^([%w_%.]+):")
+        if key then
+          table.insert(order, key)
+        end
+      end
+      assert.same({
+        "session_id",
+        "forked_from",
+        "orchestrated",
+        "orchestrated_by",
+        "working_dir",
+        "language",
+      }, order)
+    end)
+
+    it("should round-trip an empty list as a truthy but empty table", function()
+      -- 空リストは値なしの `orchestrated:` 行になり、パースすると `{}` に戻る。真値なので
+      -- `if not value` では弾けず、読む側は `#value == 0` を見る必要がある
+      local serialized = frontmatter.serialize({ ["vibing.nvim"] = true, orchestrated = {} })
+      local parsed = frontmatter.parse(serialized)
+
+      assert.is_table(parsed.orchestrated)
+      assert.equals(0, #parsed.orchestrated)
+    end)
   end)
 
   describe("handle invalid YAML (UT-FM-003)", function()

--- a/tests/lua/presentation/chat/modules/frontmatter_handler_spec.lua
+++ b/tests/lua/presentation/chat/modules/frontmatter_handler_spec.lua
@@ -63,3 +63,102 @@ describe("frontmatter_handler.update_field", function()
     assert.same({ "permission_mode: plan" }, frontmatter_lines())
   end)
 end)
+
+describe("frontmatter_handler.update_list", function()
+  local buf
+
+  ---@param lines string[]
+  local function open(lines)
+    buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    return buf
+  end
+
+  ---frontmatter の中身から `updated_at` を除いて返す。update_list は毎回それを打つので、
+  ---どのアサーションにも現れて本題を隠してしまう
+  ---@return string[]
+  local function frontmatter_lines()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local out = {}
+    for i = 2, #lines do
+      if lines[i] == "---" then
+        break
+      end
+      if not lines[i]:match("^updated_at:") then
+        table.insert(out, lines[i])
+      end
+    end
+    return out
+  end
+
+  after_each(function()
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
+  it("creates the key block when the frontmatter does not have it yet", function()
+    open({ "---", "session_id: abc", "---", "" })
+
+    assert.is_true(handler.update_list(buf, "orchestrated", "chat/worker.md", "add"))
+    assert.same({ "session_id: abc", "orchestrated:", "  - chat/worker.md" }, frontmatter_lines())
+  end)
+
+  it("appends to an existing list", function()
+    open({ "---", "orchestrated:", "  - chat/a.md", "---", "" })
+
+    assert.is_true(handler.update_list(buf, "orchestrated", "chat/b.md", "add"))
+    assert.same({ "orchestrated:", "  - chat/a.md", "  - chat/b.md" }, frontmatter_lines())
+  end)
+
+  it("does not add a value the list already carries", function()
+    open({ "---", "orchestrated:", "  - chat/a.md", "---", "" })
+
+    assert.is_true(handler.update_list(buf, "orchestrated", "chat/a.md", "add"))
+    assert.same({ "orchestrated:", "  - chat/a.md" }, frontmatter_lines())
+  end)
+
+  it("dedupes on the exact string only", function()
+    -- 同じファイルを git 相対と ~ 短縮の両方で書くと、両方が残る。書き込む側が
+    -- `Git.to_display_path` に一本化している前提の上に成り立っている
+    open({ "---", "orchestrated:", "  - chat/a.md", "---", "" })
+
+    handler.update_list(buf, "orchestrated", "~/proj/chat/a.md", "add")
+    assert.same({ "orchestrated:", "  - chat/a.md", "  - ~/proj/chat/a.md" }, frontmatter_lines())
+  end)
+
+  it("removes one item and keeps the others", function()
+    open({ "---", "orchestrated:", "  - chat/a.md", "  - chat/b.md", "---", "" })
+
+    assert.is_true(handler.update_list(buf, "orchestrated", "chat/a.md", "remove"))
+    assert.same({ "orchestrated:", "  - chat/b.md" }, frontmatter_lines())
+  end)
+
+  it("drops the key entirely when the last item is removed", function()
+    open({ "---", "session_id: abc", "orchestrated:", "  - chat/a.md", "---", "" })
+
+    assert.is_true(handler.update_list(buf, "orchestrated", "chat/a.md", "remove"))
+    assert.same({ "session_id: abc" }, frontmatter_lines())
+  end)
+
+  it("keeps a neighbouring key intact when the list is rewritten", function()
+    open({ "---", "orchestrated:", "  - chat/a.md", "model: sonnet", "---", "" })
+
+    assert.is_true(handler.update_list(buf, "orchestrated", "chat/b.md", "add"))
+    assert.same({ "orchestrated:", "  - chat/a.md", "  - chat/b.md", "model: sonnet" }, frontmatter_lines())
+  end)
+
+  it("refuses an empty key or value instead of writing a malformed line", function()
+    open({ "---", "session_id: abc", "---", "" })
+
+    assert.is_false(handler.update_list(buf, "orchestrated", "", "add"))
+    assert.is_false(handler.update_list(buf, "", "chat/a.md", "add"))
+    assert.same({ "session_id: abc" }, frontmatter_lines())
+  end)
+
+  it("returns false when the frontmatter has no closing delimiter", function()
+    open({ "---", "session_id: abc", "" })
+
+    assert.is_false(handler.update_list(buf, "orchestrated", "chat/a.md", "add"))
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

オーケストレーションで結ばれたチャット同士の関係を、frontmatter の `orchestrated` / `orchestrated_by` に記録する。

これまで関係の唯一の記録はトランスクリプトの地の文（`vibing-orchestrate` SKILL.md §2 が「bufnr と file_path を返信に書き残せ」と指示している箇所）だったが、これは二重に腐る。**bufnr はセッションを跨がない**（Neovim を再起動すると同じ番号が無関係なバッファを指す）し、**file_path は `:VibingSetFileTitle` が改名する**。`forked_from` が frontmatter + `ForkedChatScanner` で既に解いている問題なので、同じ形を借りた。

**stacked PR の下段。** 上段の #627（完了通知）は `from_bufnr` の上に乗るので、こちらを先にマージする必要がある。

## Changes

- `orchestrated` / `orchestrated_by` を frontmatter に追加。git ルート相対パスのリスト。`get_sorted_keys` では `forked_from` / `subagent_id` の直後（＝出自を示すフィールド群）に並ぶ
- `nvim_chat_create` / `nvim_chat_send_message` に任意引数 `from_bufnr` を追加。渡されたときだけ双方の frontmatter にリンクを書く
- `lua/vibing/application/chat/orchestration_link.lua`（新規）— 双方向の書き込みと保存
- `lua/vibing/infrastructure/link/orchestration_chat_scanner.lua`（新規）— リネーム追従。`set_file_title.lua` の既存の同期呼び出しに合流させた
- `file_manager.save_buffer` を切り出し、`rpc/handlers/chat.lua` のローカル `save_now` と共用

## 設計上の判断

**`from_bufnr` は任意。** ワイヤにプロトコル版が無いので、古い Neovim は未知キーを無視し、古い MCP サーバーは送らない。両方向の skew がこれで吸収される。必須にすると渡し忘れが「リンクが無い」ではなく「送信が失敗する」になり、既存の呼び出し側が一斉に壊れる。

**`ForkedChatScanner` をコピーしていない。** `forked_from` はスカラーなので `update_link` が `Frontmatter.update` にキーごと渡しているが、リストで同じことをすると**他の要素が全部消える**。該当する1要素だけを差し替え、そのあと重複排除する（`a.md → b.md` のリネーム先が既にリストにいる場合がある）。

リスト化で新たに踏むパーサの癖が2つあり、どちらもガードした:

- **空リストは真値**。`serialize({})` は値なしの `orchestrated:` 行を吐き、パースすると `{}` に戻る。`if not value` では弾けない
- **手書きのスカラーは文字列**。`orchestrated: path.md` と1行で書かれると table にならない

**書き込みは送信より前。** `update_frontmatter_list` はバッファを直接触るので、宛先の応答が始まってから書くとストリーミングと競合する。

**`update_frontmatter_list` はバッファにしか書かない**が、リネーム同期はディスクを読む。そのため `orchestration_link` が自分で保存する。効くのは送信元側で、`:VibingChat` は最初の応答までファイルを書かないので、1ターン目に投げたオーケストレーターにはスキャナーが見つけるファイルが存在しない。

**片肺リンクは警告に留める。** リンクは記録であって、失敗が送信を止める理由にならない。リネーム同期は書けた側から動く。

**fork / subagent chat は継承しない。** `inherited_frontmatter.from_source` が明示ホワイトリストなので既に落ちるが、意図であることをコメントに残した。fork が親の関係を自分のものとして主張することになる。

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test addition or update
- [x] Documentation update

## Testing

- [x] Ran `npm run test:lua`（135 spec ファイル。このPRで追加・変更した分はすべて green）
  - 既存の失敗が2ファイル残る: `summary_input_spec.lua` 8件 / `summary_prompt_spec.lua` 1件。
    いずれも `Could not find vibing.nvim plugin directory` で、**`main` で同一に再現する**
    ためこのPRとは無関係（別途対応が要る）
- [x] Ran mcp-server の `vitest run`（12 files / 127 tests、全 green）
- [x] Ran `npm run check` / `npm run check:doc` / `npm run lint` / `npm run format:check`
- [x] `npm run lint:md`: 指摘5件はいずれも main に同一で存在する既存分（行番号がずれただけ）で、新規はゼロ

無テストだったスキャナー / 同期レイヤに土台を張った:

- `tests/lua/infrastructure/link/orchestration_chat_scanner_spec.lua`（新規 14 件）— 両方向の検出、1要素だけの差し替え、重複排除、空リスト、手書きスカラー、`vibing.nvim: true` を持たない `.md` の除外、`~` 展開
- `tests/lua/infrastructure/link/forked_chat_scanner_spec.lua`（新規 7 件）— 既存挙動の固定。「キーごと差し替える」ことを明示的に pin して、リスト側が別実装である理由を残した
- `tests/lua/application/link/sync_manager_spec.lua`（新規 6 件）— `total` が走査数であること、2スキャナーが同じファイルを二重に数えることを含む
- `frontmatter_handler.update_list`（新規 9 件）と `frontmatter_spec`（新規 2 件）

`~` 展開のテストは実ホーム配下の一時ディレクトリを使っている。Vim はホームディレクトリを**起動時に確定する**ので、`$HOME` を差し替えても `expand()` には効かない。

### Test Environment

- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js**: pnpm 10.28.0 / vitest 4.1.11

## Documentation

- [x] doc/vibing.txt updated
- [x] CLAUDE.md updated（`.claude/rules/architecture.md`, `.claude/rules/mcp-integration.md`）
- [x] Code comments added/updated
- [x] `claude-plugin/skills/vibing-orchestrate/SKILL.md` に `from_bufnr` を追加
- [x] `claude-plugin/mcp-server/README.md` に `nvim_chat_create`（従来まるごと未記載だった）と `from_bufnr` を追加

## Related Issues

Fixes #628

## Additional Context

#628 の未決事項のうち、このPRで決めたもの:

- **フィールド名**: `related_to` / `related_from` ではなく `orchestrated` / `orchestrated_by`。関係の意味が名前に出る
- **エッジを張るタイミング**: 送信時だけでなく `nvim_chat_create` でも張る。`from_bufnr` の渡し忘れに強く、ワーカー作成時点で関係が確定する
- **送信元の未保存ファイル**: 保存する。リンクを書く以上、同期がそのファイルを見つけられないと片方向に腐る

**path → bufnr の解決（#628 の A/B/C）は #627 側に入れる。** ワーカーの `orchestrated_by` を解決してシステムプロンプトに出す案（A）を採るが、`chat_notifications.enabled` に紐づくので上段の PR に置く。

**残した未決事項**: 要素数の上限（ワーカー20個で20行）、`:VibingDeleteChats` による dangling リンクの掃除（`forked_from` も同じ問題を抱えているので別イシューが筋）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat orchestration relationships are now recorded in chat metadata when one chat creates or messages another.
  * Relationships remain synchronized when chat files are renamed.
  * Chat creation and messaging tools now support an optional source chat reference.

* **Documentation**
  * Added guidance for orchestration metadata and the new tool parameter.

* **Tests**
  * Added coverage for relationship creation, persistence, renaming, metadata handling, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
