### PR TITLE
feat: notify the sender chat when a chat it messaged finishes responding

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1133,10 +1133,67 @@ works from whichever side did get written. Fork and subagent chats do **not** in
 — `inherited_frontmatter.from_source` is an explicit whitelist, and a fork claiming its parent's
 relationships would be claiming work it was never given.
 
-**Out of scope, deliberately:** workers cannot message the orchestrator back, there is no
-event-driven completion notification, and the orchestrator does not poll inside its own turn — it
-hands control back to the user and reports when asked. All three would need a channel that does
-not exist yet; the MVP is "distribute, observe, report".
+**Completion is pushed, not polled** — `agent.chat_notifications.enabled`, default `false` because
+it spends tokens unattended. The whole mechanism is that **the send is the subscription**: when
+`nvim_chat_create` / `nvim_chat_send_message` receive `from_bufnr`, `completion_notifier.subscribe`
+records an A←B edge, and when B's turn ends A is given a new turn saying "B stopped, go read it".
+A worker asking its orchestrator a question is the same path in reverse — it just calls
+`nvim_chat_send_message` itself.
+
+There is no waiting anywhere, and there cannot be: the CLI process dies when its turn ends, so the
+only way to deliver anything to a chat is to _start a new turn on it_.
+
+The completion event fires from the `callbacks.add_user_section` wrapper in `buffer.lua`, and
+every word of that placement is load-bearing:
+
+- **The four completion paths in `_handle_response`** (session corruption, mote `finalize`,
+  no-file-change, git patch `finalize` — two of them inside `vim.schedule`) all converge on that
+  one callback. Nothing else does.
+- **Not `ChatBuffer:add_user_section()` itself**, which the slash-command path also calls — that
+  would report a completion for a turn the model never ran.
+- **Not next to `clear_sending()`**, which under `diff.tool = "mote"` runs before `finalize()`
+  writes `### Modified Files`. A reader woken there would see an unfinished transcript, the same
+  window `chat_status` documents.
+- **After the handle_id mismatch guard**, so a cancelled turn completing late fires nothing.
+
+It goes out as a `User VibingResponseDone` autocmd rather than a direct call so a user's own config
+can hook it too — before this there was no `nvim_exec_autocmds` anywhere in `lua/`.
+
+**Delivery refuses a busy buffer, and that is the sharpest edge in the feature.**
+`ChatBuffer:send_message()` cancels the in-flight request before starting a new one, so delivering
+into a responding chat would kill the turn it is in the middle of; and its `_is_sending` guard
+returns _silently_, so `ProgrammaticSender` used to report success for a message it never sent —
+leaving an orphan `## User` section that became the body of the user's next `<CR>`. A dispatched
+chat normally keeps working after dispatching, so the shorter the worker's task the more likely
+this window is. So `ProgrammaticSender` now refuses before appending (rather than appending and
+rolling back), and the notifier queues instead, flushing on the recipient's own completion event.
+Queued notifications coalesce into one message: three workers finishing while the orchestrator is
+busy is one turn, not three.
+
+Two smaller rules. Edges are **one-shot** — delivering consumes them, so a worker completing again
+without a fresh send is silent, and A messaging B three times still notifies once. And the chain is
+bounded by **hops, not cycle detection**: A→B→A→B is a legitimate question-and-answer, so
+`max_hops` (default 8) counts how many times a chat has been woken without a human `<CR>`, and
+exceeding it warns rather than declining in silence. The reset lives in the `<CR>` keymap callback
+rather than in `send_message()`, because delivery itself goes through `send_message()` — resetting
+there would zero the counter on every hop and disable the limit entirely.
+
+**The notification says "stopped", never "succeeded".** `idle` is also what a failed turn, a
+pending tool approval, and an `nvim_ask_user_question` look like, so judging outcomes from the
+event would repeat `chat_status`'s mistake. The message carries the bufnr and an instruction to
+read the transcript's tail — not the worker's text, which would pull B's context into A for no
+reason.
+
+A worker learns its orchestrator's bufnr from a system-prompt line built by resolving its
+`orchestrated_by` frontmatter to live buffers. Only that direction is exposed: a worker's list is
+written once at creation and stays byte-stable across turns (#469), while an orchestrator's
+`orchestrated` grows with each dispatch and would move the cached prefix mid-conversation.
+
+**Out of scope, deliberately:** the orchestrator still does not poll inside its own turn, and
+nothing is persisted — the subscription table and the delivery queue are in memory only, since
+Neovim dying takes the worker chats with it. Backends other than claude can be _notified_ (the
+event is backend-agnostic) but cannot _subscribe_: `nvim_chat_send_message` is an MCP tool, and
+codex/grok reach no MCP server, the same constraint `features.md` records for AskUserQuestion.
 
 ## Key Patterns
 

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -65,23 +65,29 @@ request, not the files already discussed, not the decisions already made. Write 
 someone who just walked in — goal, the files or directories involved, the constraints, and what
 "done" looks like. A brief that says "do the refactor we discussed" produces nothing useful.
 
-Say in the brief that the worker should report its result in its own chat and stop; workers cannot
-message you back.
+Say in the brief that the worker should report its result in its own chat and stop. Add that if it
+gets stuck or the brief turns out to be ambiguous, it should ask you rather than guess — a worker
+you passed `from_bufnr` to is told your buffer number and can call `nvim_chat_send_message` back.
+A question costs one turn; a worker guessing wrong costs the whole task.
 
-## 4. Hand control back to the user
+## 4. End your turn — you will be woken
 
 Do **not** loop on `nvim_get_buffer` waiting for workers to finish. A turn spent polling burns
 tokens, blocks this chat, and will hit the turn limit long before a real task completes.
 
-Once every brief is sent, end the turn with the worker list and an explicit handle:
+Once every brief is sent, end the turn with the worker list:
 
-> 3件のワーカーチャットにタスクを配りました（bufnr 12 / 14 / 16）。進捗を見たいときは「進捗は?」
-> と聞いてください。
+> 3件のワーカーチャットにタスクを配りました（bufnr 12 / 14 / 16）。終わり次第ここに戻ります。
 
-## 5. Report progress when asked
+If completion notifications are enabled (`agent.chat_notifications.enabled`), each worker you
+messaged wakes this chat with a new turn when it stops, naming the buffer to read. If they are
+not, nothing wakes you — say "進捗は?と聞いてください" instead and wait for the user.
 
-When the user asks, read each worker with `nvim_get_buffer({ rpc_port, bufnr })`. Alongside the
-transcript the result carries a chat-status line:
+## 5. Read the chat the notification named
+
+A notification tells you which buffer(s) stopped. Read those with
+`nvim_get_buffer({ rpc_port, bufnr })` — not every worker. Alongside the transcript the result
+carries a chat-status line:
 
 - `status: responding` — a reply is still being streamed in. Whatever you just read is partial;
   report it as in progress and do not summarize its conclusion.
@@ -92,8 +98,17 @@ Note that `idle` means "not currently running", not "succeeded" — a worker tha
 stopped to ask the user something, or that is waiting on a tool approval prompt is also idle. Read
 the tail of the transcript before calling a task done.
 
-Report per worker: task, state, and the one-line outcome. Then either hand control back again
-(some still running) or move to aggregation.
+**One notification is one turn, so three workers wake you three times.** If workers you dispatched
+are still running, do not start aggregating: say in one or two lines what this one produced, and
+end the turn. Aggregate only on the last one. An orchestrator that writes a full summary each time
+produces three contradictory summaries and pays for all of them.
+
+Track which workers are still outstanding by writing the list into your reply each time — that
+text is the only place the count survives between turns.
+
+A worker may also message you directly with a question instead of finishing. Answer it with
+`nvim_chat_send_message` (passing `from_bufnr` again, so its reply comes back to you) and end the
+turn.
 
 ## 6. Aggregate and clean up
 

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -172,6 +172,14 @@ agent = {
     grace_sec = 10,         -- Added to the reset time to avoid firing on the boundary
   },
 
+  chat_notifications = {    -- Tell a chat when a chat it messaged finishes responding
+    enabled = false,        -- Opt-in: the notification arrives as a new turn, so it spends
+                            -- tokens with nobody watching
+    max_hops = 8,           -- How many times a chat may be woken without a manual <CR>.
+                            -- A→B→A→B is legitimate (B asks, A answers), so the chain is
+                            -- bounded by depth rather than refused as a cycle
+  },
+
   codex_provider_notice = {
     enabled = true,         -- Warn when a Codex lightweight call leaves your model_provider.
                             -- On by default, unlike the toggles above: it spends no tokens,

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -155,6 +155,16 @@ function M.subscribe(from_bufnr, to_bufnr)
     return false
   end
 
+  edges[to_bufnr] = edges[to_bufnr] or {}
+
+  -- 同じ (A, B) への複数送信は1本に畳む。A が B に3回送っても通知は1回。
+  -- この判定を hop 上限より**前**に置く: 既に張ってあるエッジは生きていて通知も届くのに、
+  -- 上限に当たったという理由で「購読しなかった」と警告するのは事実に反する。
+  -- 同じワーカーに複数回ブリーフを送るのは `vibing-orchestrate` の通常の手順
+  if edges[to_bufnr][from_bufnr] ~= nil then
+    return true
+  end
+
   local current = depth[from_bufnr] or 0
   local max_hops = cfg.max_hops or DEFAULT_MAX_HOPS
   if current >= max_hops then
@@ -173,11 +183,7 @@ function M.subscribe(from_bufnr, to_bufnr)
     return false
   end
 
-  edges[to_bufnr] = edges[to_bufnr] or {}
-  -- 同じ (A, B) への複数送信は1本に畳む。A が B に3回送っても通知は1回
-  if edges[to_bufnr][from_bufnr] == nil then
-    edges[to_bufnr][from_bufnr] = current
-  end
+  edges[to_bufnr][from_bufnr] = current
 
   return true
 end

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -1,0 +1,269 @@
+---@class Vibing.Application.CompletionNotifier
+---A が B にリクエストを送ったという事実そのものを購読の登録として扱い、B が応答を終えたら
+---A に「B が止まった、読みに行け」とだけ伝える。
+---
+---エージェント（CLIプロセス）はターンが終われば死ぬので、待ち受けはできない。受け取り方は
+---「A に新しいターンを起こす」しかなく、それがこの設計。B から A への質問も、B が A に
+---`nvim_chat_send_message` を呼ぶだけで同じ経路に乗る。
+---
+---購読テーブルもキューも**インメモリのみ**。Neovim が落ちればワーカーチャットも道連れなので、
+---`pending-resume.json` のような永続化に意味がない。
+local M = {}
+
+local notify = require("vibing.core.utils.notify")
+
+local AUGROUP = "VibingCompletionNotifier"
+local DEFAULT_MAX_HOPS = 8
+
+---edges[to_bufnr][from_bufnr] = 購読を張った時点の深さ。
+---「to_bufnr が終わったら from_bufnr に知らせる」を表す
+---@type table<number, table<number, number>>
+local edges = {}
+
+---配達先が応答中だったために積んだ通知。from_bufnr 自身の完了で流す
+---@type table<number, {bufnr: number, depth: number}[]>
+local pending = {}
+
+---通知チェーンで何回起こされたか。手動送信で 0 に戻る
+---@type table<number, number>
+local depth = {}
+
+---@return {enabled: boolean, max_hops: number?}
+local function settings()
+  local config = require("vibing.config").get()
+  return (config.agent and config.agent.chat_notifications) or { enabled = false }
+end
+
+---@param queue {bufnr: number, depth: number}[]
+---@return string
+local function build_message(queue)
+  local lines = {}
+  for _, item in ipairs(queue) do
+    local name = vim.api.nvim_buf_is_valid(item.bufnr) and vim.api.nvim_buf_get_name(item.bufnr) or ""
+    -- frontmatter の `orchestrated` と同じ表示形式にする。モデルが読みに行く先を、
+    -- 記録と別の形で名指ししない
+    local display = name ~= "" and require("vibing.core.utils.git").to_display_path(name) or "unnamed"
+    table.insert(lines, string.format("- chat buffer %d (%s)", item.bufnr, display))
+  end
+
+  return table.concat({
+    "The following chat(s) you sent a message to have finished responding:",
+    "",
+    table.concat(lines, "\n"),
+    "",
+    "Read each one with nvim_get_buffer({ rpc_port, bufnr }) and decide what to do next.",
+    "",
+    '"Finished" only means no request is in flight. A chat may have failed, stopped to ask the',
+    "user something, or be waiting on a tool approval. Read the tail of the transcript before",
+    "treating its task as done.",
+    "",
+    "If other chats you dispatched are still running, do not start aggregating yet — say what",
+    "this one produced and end the turn. You will be woken again when the next one finishes.",
+  }, "\n")
+end
+
+---@param from_bufnr number
+---@param done_bufnr number
+---@param edge_depth number
+local function enqueue(from_bufnr, done_bufnr, edge_depth)
+  local queue = pending[from_bufnr] or {}
+  for _, item in ipairs(queue) do
+    if item.bufnr == done_bufnr then
+      return
+    end
+  end
+  table.insert(queue, { bufnr = done_bufnr, depth = edge_depth })
+  pending[from_bufnr] = queue
+end
+
+---積まれた通知を1通にまとめて配達する
+---
+---相手が応答中なら**何もしない**。応答中のバッファに送ると `ChatBuffer:send_message()` が
+---進行中のターンを kill する（buffer.lua の「前のリクエストが実行中ならキャンセル」）。
+---A が B に投げたあと A 自身のターンが続くのは普通なので、短いタスクほどこの窓に入る。
+---積んだままにしておけば、A 自身の VibingResponseDone でここが呼び直される。
+---@param from_bufnr number
+local function flush(from_bufnr)
+  local queue = pending[from_bufnr]
+  if not queue or #queue == 0 then
+    return
+  end
+
+  if not vim.api.nvim_buf_is_valid(from_bufnr) then
+    pending[from_bufnr] = nil
+    return
+  end
+
+  local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(from_bufnr)
+  if not chat_buf then
+    pending[from_bufnr] = nil
+    return
+  end
+
+  if chat_buf:is_responding() then
+    return
+  end
+
+  -- ユーザーが書きかけの `## User` を残しているなら触らない。配達は新しいセクションを足すので、
+  -- 下書きは送られないまま宙に浮き、次の<CR>は空のヘッダを読んで「No message to send」になる。
+  -- auto_resume が未送信セクションを上書きしないのと同じ扱い。
+  -- ユーザーがその下書きを送れば、そのターンの完了でここが呼び直されるので取りこぼさない
+  if chat_buf.extract_user_message then
+    local draft = chat_buf:extract_user_message()
+    if draft and vim.trim(draft) ~= "" then
+      return
+    end
+  end
+
+  local deepest = 0
+  for _, item in ipairs(queue) do
+    deepest = math.max(deepest, item.depth)
+  end
+
+  local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+  local ok, result = pcall(ProgrammaticSender.send, from_bufnr, build_message(queue))
+
+  -- 配達できて初めてキューを空ける。エッジは既に消費済みなので、先に捨てると失敗した通知は
+  -- 二度と再現しない。残しておけば次の完了イベントで作り直しなしに再試行できる
+  if ok and result and result.success then
+    pending[from_bufnr] = nil
+    -- 下げてはいけない。深く連鎖したチャットが、浅い時点で張られたエッジの配達を受けたときに
+    -- カウンタが戻ると、max_hops が連鎖を止められなくなる
+    depth[from_bufnr] = math.max(depth[from_bufnr] or 0, deepest + 1)
+  else
+    notify.warn(
+      string.format("Could not notify chat %d: %s", from_bufnr, ok and "the chat refused the message" or tostring(result)),
+      "Chat Notifications"
+    )
+  end
+end
+
+---A が B に送ったことを購読として記録する
+---@param from_bufnr number 送信元（通知を受け取る側）
+---@param to_bufnr number 送信先（完了を監視される側）
+---@return boolean subscribed 深さ上限などで張らなかった場合 false
+function M.subscribe(from_bufnr, to_bufnr)
+  local cfg = settings()
+  if not cfg.enabled then
+    return false
+  end
+
+  if type(from_bufnr) ~= "number" or type(to_bufnr) ~= "number" or from_bufnr == to_bufnr then
+    return false
+  end
+  if not (vim.api.nvim_buf_is_valid(from_bufnr) and vim.api.nvim_buf_is_valid(to_bufnr)) then
+    return false
+  end
+
+  local current = depth[from_bufnr] or 0
+  local max_hops = cfg.max_hops or DEFAULT_MAX_HOPS
+  if current >= max_hops then
+    -- 黙って張らないと、通知が来ない理由がどこにも残らない。A→B→A→B の往復自体は
+    -- 正当なユースケース（Bの質問にAが答える）なので、循環検出ではなく深さで止めている
+    notify.warn(
+      string.format(
+        "Chat %d has already been woken %d times without a manual send; not subscribing to chat %d. "
+          .. "Send a message in that chat yourself to reset the chain.",
+        from_bufnr,
+        current,
+        to_bufnr
+      ),
+      "Chat Notifications"
+    )
+    return false
+  end
+
+  edges[to_bufnr] = edges[to_bufnr] or {}
+  -- 同じ (A, B) への複数送信は1本に畳む。A が B に3回送っても通知は1回
+  if edges[to_bufnr][from_bufnr] == nil then
+    edges[to_bufnr][from_bufnr] = current
+  end
+
+  return true
+end
+
+---応答完了。購読者への配達と、自分宛キューの drain を行う
+---@param bufnr number
+function M.on_response_done(bufnr)
+  if not settings().enabled then
+    return
+  end
+
+  -- 購読者への配達が先。自分のキューを先に流すと bufnr が新しいターンを始めてしまい、
+  -- 「bufnr は終わった、読め」という通知を、走り出した直後の bufnr について配ることになる
+  local subscribers = edges[bufnr]
+  if subscribers then
+    -- 配達した時点で購読は消える（one-shot）。B が次に完了しても、A が改めて送っていなければ
+    -- 通知は飛ばない
+    edges[bufnr] = nil
+    for from_bufnr, edge_depth in pairs(subscribers) do
+      if vim.api.nvim_buf_is_valid(from_bufnr) then
+        enqueue(from_bufnr, bufnr, edge_depth)
+      end
+    end
+    for from_bufnr in pairs(subscribers) do
+      flush(from_bufnr)
+    end
+  end
+
+  flush(bufnr)
+end
+
+---ユーザーが手動送信したので通知チェーンの深さをリセットする
+---@param bufnr number
+function M.reset_depth(bufnr)
+  depth[bufnr] = nil
+end
+
+---バッファが消えたので関連する購読・キューを捨てる
+---@param bufnr number
+function M.forget(bufnr)
+  -- autocmdはパターン無しで登録しているので、エディタ内のどのバッファを閉じても走る。
+  -- 既定（無効）では状態が空のまま、全テーブルの走査だけが通常の編集操作ごとに起きる
+  if not (next(edges) or next(pending) or next(depth)) then
+    return
+  end
+
+  edges[bufnr] = nil
+  pending[bufnr] = nil
+  depth[bufnr] = nil
+
+  for _, subscribers in pairs(edges) do
+    subscribers[bufnr] = nil
+  end
+  for _, queue in pairs(pending) do
+    for i = #queue, 1, -1 do
+      if queue[i].bufnr == bufnr then
+        table.remove(queue, i)
+      end
+    end
+  end
+end
+
+---autocmdを登録する
+---
+---`enabled` はここでは見ない。イベント自体は設定に関わらず発火するので、購読側でだけ判定して
+---おけば、実行中に設定を変えた場合も追従する。無効時のコストは1ターンにつき空振り1回
+function M.setup()
+  local group = vim.api.nvim_create_augroup(AUGROUP, { clear = true })
+
+  vim.api.nvim_create_autocmd("User", {
+    group = group,
+    pattern = "VibingResponseDone",
+    callback = function(event)
+      local bufnr = event.data and event.data.bufnr
+      if type(bufnr) == "number" then
+        M.on_response_done(bufnr)
+      end
+    end,
+  })
+
+  vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+    group = group,
+    callback = function(event)
+      M.forget(event.buf)
+    end,
+  })
+end
+
+return M

--- a/lua/vibing/application/chat/handlers/set_file_title.lua
+++ b/lua/vibing/application/chat/handlers/set_file_title.lua
@@ -52,18 +52,6 @@ local function first_user_line(conversation)
   return nil
 end
 
----@param buf number
----@return boolean ok
----@return string? error
-local function save_buffer(buf)
-  local ok, err = pcall(function()
-    vim.api.nvim_buf_call(buf, function()
-      vim.cmd.write({ bang = true })  -- Force overwrite with :write!
-    end)
-  end)
-  return ok, err
-end
-
 ---@param _ string[]
 ---@param chat_buffer Vibing.ChatBuffer
 ---@return boolean
@@ -143,7 +131,7 @@ return function(_, chat_buffer)
     local new_file_path = get_unique_file_path(save_dir, new_filename)
 
     if is_existing_file then
-      local ok, save_err = save_buffer(chat_buffer.buf)
+      local ok, save_err = FileManager.save_buffer(chat_buffer.buf)
       if not ok then
         notify.error(string.format("Failed to save: %s", save_err))
         return
@@ -192,7 +180,7 @@ return function(_, chat_buffer)
     end
 
     if not is_existing_file then
-      local ok, save_err = save_buffer(chat_buffer.buf)
+      local ok, save_err = FileManager.save_buffer(chat_buffer.buf)
       if not ok then
         notify.error(string.format("Failed to save: %s", save_err))
         return

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -94,19 +94,28 @@ function M.link(from_bufnr, to_bufnr)
   -- 戻り値を捨ててはいけない。`update_frontmatter_list` は frontmatter の閉じ `---` が
   -- 先頭100行に収まらないと false を返す（長い permission 配列を持つチャットで現実に起きる）。
   -- 捨てると、このモジュールが防ぐために存在している「黙って関係が残らない」がそのまま起きる
-  if not from_chat:update_frontmatter_list("orchestrated", forward, "add") then
-    return false, "Could not record the worker in the orchestrator's frontmatter"
-  end
-  if not to_chat:update_frontmatter_list("orchestrated_by", backward, "add") then
-    return false, "Could not record the orchestrator in the worker's frontmatter"
-  end
+  local wrote_forward = from_chat:update_frontmatter_list("orchestrated", forward, "add")
+  local wrote_back = to_chat:update_frontmatter_list("orchestrated_by", backward, "add")
 
   -- `update_frontmatter_list` はバッファにしか書かない。リネーム同期はディスクを読むので、
   -- ここで保存しないとリンクは「次に何かの理由で保存されるまで」存在しないことになる。
   -- 送信元は `:VibingChat` の性質上まだ一度も保存されていないことがあり、その窓がいちばん
   -- 長い（＝1ターン目に投げた相手が改名されるとリンクが片方向に腐る）
+  -- 保存は書き込みの成否を見る**前**に、無条件で行う。片方だけ書けた状態でも、書けた側は
+  -- ディスクに残さなければならない（片肺でもリネーム同期は残った側で動く、というのが
+  -- このモジュールの設計方針）。成否チェックで先に return すると、書き込みに成功した
+  -- バッファが modified のまま一度も保存されず、呼び出し元は警告するだけで続行するので
+  -- 誰も気づかない
   local saved_from = FileManager.save_buffer(from_bufnr)
   local saved_to = FileManager.save_buffer(to_bufnr)
+
+  if not (wrote_forward and wrote_back) then
+    return false,
+      string.format(
+        "Could not record the orchestration link (%s side)",
+        not wrote_forward and "orchestrator" or "worker"
+      )
+  end
   if not (saved_from and saved_to) then
     return false, "Wrote the orchestration link but could not save both chat files"
   end

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -14,6 +14,22 @@ local M = {}
 local Git = require("vibing.core.utils.git")
 local FileManager = require("vibing.presentation.chat.modules.file_manager")
 
+---`Git.get_root()` はキャッシュを持たず、毎回 `vim.system():wait()` で同期的に
+---`git rev-parse` を起動する。`resolve_bufnrs` はワーカーチャットの**送信のたび**に呼ばれるので、
+---そのままではユーザーの `<CR>` の前でメインスレッドがプロセス起動1回分ブロックする。
+---値はcwdごとに固定なので、cwdをキーに覚える
+---@type table<string, string|false>
+local git_root_by_cwd = {}
+
+---@return string|false
+local function cached_git_root()
+  local cwd = vim.fn.getcwd()
+  if git_root_by_cwd[cwd] == nil then
+    git_root_by_cwd[cwd] = Git.get_root() or false
+  end
+  return git_root_by_cwd[cwd]
+end
+
 ---@param bufnr number
 ---@return table? chat_buf
 local function resolve_chat(bufnr)
@@ -49,11 +65,28 @@ function M.link(from_bufnr, to_bufnr)
     return false, "Both chats must have a file name"
   end
 
+  local forward = Git.to_display_path(to_path)
+  local backward = Git.to_display_path(from_path)
+
+  -- スキルは `nvim_chat_create` と続く `nvim_chat_send_message` の両方に `from_bufnr` を渡すので、
+  -- 同じリンクが2回書かれる。`update_frontmatter_list` は要素としては重複を弾くが、行の書き換えと
+  -- `updated_at` の更新でバッファを modified にするため、そのあと両チャットの全文が書き直される
+  if
+    vim.tbl_contains(from_chat:get_frontmatter_list("orchestrated"), forward)
+    and vim.tbl_contains(to_chat:get_frontmatter_list("orchestrated_by"), backward)
+  then
+    return true, nil
+  end
+
   -- 戻り値を捨ててはいけない。`update_frontmatter_list` は frontmatter の閉じ `---` が
   -- 先頭100行に収まらないと false を返す（長い permission 配列を持つチャットで現実に起きる）。
   -- 捨てると、このモジュールが防ぐために存在している「黙って関係が残らない」がそのまま起きる
-  local wrote_forward = from_chat:update_frontmatter_list("orchestrated", Git.to_display_path(to_path), "add")
-  local wrote_back = to_chat:update_frontmatter_list("orchestrated_by", Git.to_display_path(from_path), "add")
+  if not from_chat:update_frontmatter_list("orchestrated", forward, "add") then
+    return false, "Could not record the worker in the orchestrator's frontmatter"
+  end
+  if not to_chat:update_frontmatter_list("orchestrated_by", backward, "add") then
+    return false, "Could not record the orchestrator in the worker's frontmatter"
+  end
 
   -- `update_frontmatter_list` はバッファにしか書かない。リネーム同期はディスクを読むので、
   -- ここで保存しないとリンクは「次に何かの理由で保存されるまで」存在しないことになる。
@@ -61,15 +94,53 @@ function M.link(from_bufnr, to_bufnr)
   -- 長い（＝1ターン目に投げた相手が改名されるとリンクが片方向に腐る）
   local saved_from = FileManager.save_buffer(from_bufnr)
   local saved_to = FileManager.save_buffer(to_bufnr)
-
-  if not (wrote_forward and wrote_back) then
-    return false, "Could not write the orchestration link into both chats' frontmatter"
-  end
   if not (saved_from and saved_to) then
     return false, "Wrote the orchestration link but could not save both chat files"
   end
 
   return true, nil
+end
+
+---frontmatter に記録された表示パスを、いま開いているチャットバッファ番号に解決する
+---
+---frontmatter がパスを持つのはそれが唯一セッションを越えて意味を保つ形だからだが、
+---`nvim_chat_send_message` が受け取るのは bufnr なので、モデルに渡すにはここで引き直す
+---必要がある。開かれていないチャットは番号を持たないので単に落ちる
+---@param display_paths string[]?
+---@return number[]
+function M.resolve_bufnrs(display_paths)
+  -- 手で `orchestrated_by: path.md` と1行で書かれると文字列としてパースされる形も含めて、
+  -- リストフィールドの3つの形は `Frontmatter.as_list` が吸収する
+  local paths = require("vibing.infrastructure.storage.frontmatter").as_list(display_paths)
+  if #paths == 0 then
+    return {}
+  end
+
+  -- 比較は両側ともシンボリックリンクを解決した形で行う。`nvim_buf_get_name` は解決済みの
+  -- パスを返すので（macOSでは `/var/...` が `/private/var/...` になる）、`:p` だけでは
+  -- 同じファイルが一致しない
+  local PathSanitizer = require("vibing.domain.security.path_sanitizer")
+
+  local git_root = cached_git_root()
+  local wanted = {}
+  for _, path in ipairs(paths) do
+    if type(path) == "string" and path ~= "" then
+      wanted[PathSanitizer.normalize(Git.from_display_path(path, git_root))] = true
+    end
+  end
+
+  local resolved = {}
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      local name = vim.api.nvim_buf_get_name(bufnr)
+      if name ~= "" and wanted[PathSanitizer.normalize(name)] then
+        table.insert(resolved, bufnr)
+      end
+    end
+  end
+
+  table.sort(resolved)
+  return resolved
 end
 
 return M

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -18,16 +18,29 @@ local FileManager = require("vibing.presentation.chat.modules.file_manager")
 ---`git rev-parse` を起動する。`resolve_bufnrs` はワーカーチャットの**送信のたび**に呼ばれるので、
 ---そのままではユーザーの `<CR>` の前でメインスレッドがプロセス起動1回分ブロックする。
 ---値はcwdごとに固定なので、cwdをキーに覚える
----@type table<string, string|false>
+---@type table<string, string>
 local git_root_by_cwd = {}
 
+---**成功だけを覚える。** 「gitリポジトリではない」を覚えると、あとから `git init` された
+---（あるいはworktreeが生えた）ディレクトリが、そのNeovimが生きている限り誤判定のままになる。
+---外したときのコストは fail-fast な `rev-parse` 1回だけ。
+---`core/utils/git_snapshot.lua` の `root_cache` と同じ方針で、architecture.md にも明文化がある。
+---
+---`infrastructure/link/scanner.lua` の `git_root()` が `false` をキャッシュしてよいのは、
+---あちらのインスタンス寿命が1回の同期スイープに限られるため。こちらはモジュールレベルで
+---セッションを通して生きるので、同じ形には見えても扱いが違う
 ---@return string|false
 local function cached_git_root()
   local cwd = vim.fn.getcwd()
-  if git_root_by_cwd[cwd] == nil then
-    git_root_by_cwd[cwd] = Git.get_root() or false
+  if git_root_by_cwd[cwd] then
+    return git_root_by_cwd[cwd]
   end
-  return git_root_by_cwd[cwd]
+
+  local root = Git.get_root()
+  if root then
+    git_root_by_cwd[cwd] = root
+  end
+  return root or false
 end
 
 ---@param bufnr number

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -150,10 +150,29 @@ function M.execute(adapter, callbacks, message, config)
   -- レスポンス中にWrite/Editで変更されたファイルパスを追跡
   local modified_file_paths = {}
 
+  -- このチャットに指示を出したチャットのバッファ番号。frontmatter がパスを持つのは
+  -- それが唯一セッションを越えて意味を保つ形だからだが、`nvim_chat_send_message` が取るのは
+  -- bufnr なので、モデルに渡すにはここで引き直す必要がある。
+  --
+  -- 通知が無効なら解決自体を行わない。ワーカーがオーケストレーターに話しかけられても
+  -- 相手を起こす経路が無いので、プロンプトのトークンを払う理由がない。
+  local orchestrator_bufnrs = nil
+  local chat_notifications = config.agent and config.agent.chat_notifications
+  if chat_notifications and chat_notifications.enabled then
+    local ok, resolved = pcall(
+      require("vibing.application.chat.orchestration_link").resolve_bufnrs,
+      frontmatter.orchestrated_by
+    )
+    if ok and #resolved > 0 then
+      orchestrator_bufnrs = resolved
+    end
+  end
+
   local opts = {
     streaming = true,
     action_type = "chat",
     chat_bufnr = vim.api.nvim_buf_is_valid(bufnr) and bufnr or nil,
+    orchestrator_bufnrs = orchestrator_bufnrs,
     mode = M._validate_frontmatter_mode(frontmatter.mode),
     model = frontmatter.model,
     effort = frontmatter.effort,

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -83,6 +83,13 @@
 ---@field enabled boolean リミット中のリクエストを予約に切り替えるか（デフォルト: true、リミット中のリクエストはどのみち失敗するため）
 ---@field max_retries number 予約したリクエストがまた弾かれたときに許可する再予約の回数
 
+---@class Vibing.ChatNotificationsConfig
+---チャット間の完了通知設定
+---別チャットに送ったリクエストの完了を、送信元のチャットに通知する
+---通知は送信元の新しいターンとして届くため、無人でトークンを消費する
+---@field enabled boolean 完了通知を配達するか（デフォルト: false、無人でトークンを消費するため）
+---@field max_hops number 通知が連鎖して自走するのを止める上限。手動送信（<CR>）でリセットされる
+
 ---@class Vibing.AgentConfig
 ---エージェント設定
 ---Claudeのモード（code/plan/explore）とモデル（sonnet/opus/haiku/fable）を指定
@@ -95,6 +102,7 @@
 ---@field subagent Vibing.SubagentConfig? subagent（Task/Agentツール）の出力表示設定
 ---@field auto_resume_on_limit Vibing.AutoResumeOnLimitConfig 使用量リミット自動継続設定
 ---@field scheduled_requests Vibing.ScheduledRequestsConfig 予約リクエスト設定
+---@field chat_notifications Vibing.ChatNotificationsConfig チャット間の完了通知設定
 ---@field codex_provider_notice Vibing.CodexProviderNoticeConfig codex軽量呼び出しのプロバイダ警告設定
 ---@field plugins Vibing.PluginsConfig? `--plugin-dir`で読み込むClaude Codeプラグインの設定
 
@@ -277,6 +285,20 @@ M.defaults = {
       -- 予約したリクエストがまた弾かれたときに許可する再予約の回数。
       -- これがループの唯一の歯止めなので 0 未満にはしない。
       max_retries = 3,
+    },
+    -- 別チャットに送ったリクエストの完了を、送信元のチャットに通知する。
+    -- 通知は送信元の新しいターンとして届くため無人でトークンを消費する。既定は無効で、
+    -- これは subagent / auto_resume_on_limit / dap と同じ基準（トークンを使う機能は既定で切る）。
+    -- scheduled_requests や codex_provider_notice が既定で有効なのはトークンを使わないからで、
+    -- こちらには当てはまらない。
+    --
+    -- 無効でも `orchestrated` / `orchestrated_by` の記録自体は行われる。止まるのは通知の配達と、
+    -- ワーカーに「誰に報告すればいいか」を伝えるシステムプロンプトの1行だけ。
+    chat_notifications = {
+      enabled = false,
+      -- 通知が連鎖して自走するのを止める上限。A→B→A→B の往復は正当なユースケース
+      -- （Bの質問にAが答える）なので循環検出ではなく深さで止める。<CR>による手動送信で0に戻る。
+      max_hops = 8,
     },
     -- codexの軽量呼び出しは --ignore-user-config で走るので、ユーザーの model_provider が落ちて
     -- 既定のOpenAIエンドポイントに向く。それを1セッション1回だけ警告する。

--- a/lua/vibing/core/utils/git.lua
+++ b/lua/vibing/core/utils/git.lua
@@ -257,4 +257,29 @@ function M.to_display_path(abs_path)
   return abs_path
 end
 
+---`to_display_path` の逆。frontmatter に記録された表示パスを絶対パスへ戻す
+---
+---`git_root` を渡せるのは、多数のファイルを走査する呼び出し元（リンクスキャナー）が
+---`get_root()` の `git rev-parse` を1回に抑えられるようにするため。
+---
+---3値であることに意味がある: `nil` は「渡されていない（引き直せ）」、`false` は
+---「gitリポジトリの外だと分かっている」。`false` を `nil` に潰すと、リポジトリ外では
+---キャッシュが一切効かず、1ファイルのリンク要素ごとに `git rev-parse` が起動する
+---@param value string
+---@param git_root string|false|nil 解決済みのgitルート / 不在が確定 / 未指定
+---@return string
+function M.from_display_path(value, git_root)
+  if git_root == nil then
+    git_root = M.get_root()
+  end
+
+  -- `~` と絶対パスは、gitルートの外にあるチャット（`save_location_type = "user"` 等）が
+  -- 取る形。gitルート相対と取り違えるとルート配下の存在しないパスになる
+  if git_root and not value:match("^[/~]") then
+    return vim.fs.joinpath(git_root, value)
+  end
+
+  return vim.fn.fnamemodify(vim.fn.expand(value), ":p")
+end
+
 return M

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -324,6 +324,26 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
       table.insert(system_prompt_lines, "Current vibing.nvim chat buffer number: " .. tostring(opts.chat_bufnr))
     end
 
+    -- Which chat dispatched this one, resolved from the `orchestrated_by` frontmatter list.
+    -- Only a worker gets this, and the frontmatter it comes from is written once at creation, so
+    -- in the ordinary case the line stays byte-stable across turns and the cached system prefix
+    -- (#469) survives. It is not a guarantee: the value is a *resolution* of that frontmatter to
+    -- currently-open buffers, so closing and reopening the orchestrator, or toggling
+    -- `chat_notifications.enabled` mid-session, changes the line and costs one cache miss.
+    -- `orchestrated` is deliberately not exposed: an orchestrator's list grows with every
+    -- dispatch, so it would move the prefix on a normal turn rather than an unusual one — and the
+    -- completion notification already names the buffer it wants read.
+    if opts.orchestrator_bufnrs and #opts.orchestrator_bufnrs > 0 then
+      table.insert(
+        system_prompt_lines,
+        "This chat was started by vibing.nvim chat buffer "
+          .. table.concat(vim.tbl_map(tostring, opts.orchestrator_bufnrs), ", ")
+          .. ". If you need to ask it something, or want to report back before you finish, call "
+          .. "nvim_chat_send_message with that bufnr and your own chat buffer number as from_bufnr. "
+          .. "Otherwise just do the work and report in this chat — it is told when you stop."
+      )
+    end
+
     -- Project-local instructions from .vibing/system-prompt.md. Read fresh on every
     -- request, so an edit takes effect from the next message onward; that edit is also
     -- the only thing that invalidates the cached system prefix (see #469 note above).

--- a/lua/vibing/infrastructure/link/forked_chat_scanner.lua
+++ b/lua/vibing/infrastructure/link/forked_chat_scanner.lua
@@ -4,6 +4,9 @@ local ForkedChatScanner = {}
 ForkedChatScanner.__index = ForkedChatScanner
 
 local Scanner = require("vibing.infrastructure.link.scanner")
+local FrontmatterFile = require("vibing.infrastructure.storage.frontmatter_file")
+local Git = require("vibing.core.utils.git")
+
 setmetatable(ForkedChatScanner, { __index = Scanner })
 
 ---@return Vibing.Infrastructure.Link.ForkedChatScanner
@@ -11,51 +14,17 @@ function ForkedChatScanner.new()
   return setmetatable({}, ForkedChatScanner)
 end
 
----@param base_dir string
----@return string[]
-function ForkedChatScanner:find_target_files(base_dir)
-  if vim.fn.isdirectory(base_dir) == 0 then
-    return {}
-  end
-
-  -- Search for both .vibing and .md files (chat buffers use .md extension)
-  local md_files = vim.fn.glob(base_dir .. "**/*.md", false, true)
-  local vibing_files = vim.fn.glob(base_dir .. "**/*.vibing", false, true)
-
-  return vim.list_extend(md_files, vibing_files)
-end
-
 ---@param file_path string
 ---@param target_path string
 ---@return boolean
 function ForkedChatScanner:contains_link(file_path, target_path)
-  local ok, content = pcall(vim.fn.readfile, file_path)
-  if not ok or not content or #content == 0 then
+  local frontmatter = self:read_frontmatter(file_path)
+  if not frontmatter or type(frontmatter.forked_from) ~= "string" then
     return false
   end
 
-  -- frontmatterからforked_fromを抽出
-  local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
-  local text = table.concat(content, "\n")
-  local frontmatter = Frontmatter.parse(text)
-
-  if not frontmatter or not frontmatter.forked_from then
-    return false
-  end
-
-  -- forked_fromの正規化（Git相対パスまたはチルダ展開パス→絶対パス）
-  local Git = require("vibing.core.utils.git")
-  local forked_from_abs
-  local git_root = Git.get_root()
-  if git_root and not frontmatter.forked_from:match("^[/~]") then
-    forked_from_abs = vim.fs.joinpath(git_root, frontmatter.forked_from)
-  else
-    forked_from_abs = vim.fn.fnamemodify(vim.fn.expand(frontmatter.forked_from), ":p")
-  end
-
-  local target_abs = vim.fn.fnamemodify(target_path, ":p")
-
-  return forked_from_abs == target_abs
+  return Git.from_display_path(frontmatter.forked_from, self:git_root())
+    == vim.fn.fnamemodify(target_path, ":p")
 end
 
 ---@param file_path string
@@ -64,28 +33,17 @@ end
 ---@return boolean success
 ---@return string? error
 function ForkedChatScanner:update_link(file_path, old_path, new_path)
-  local ok, lines = pcall(vim.fn.readfile, file_path)
-  if not ok or not lines then
-    return false, string.format("Failed to read file: %s", lines or "unknown")
-  end
-
-  local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
-  local Git = require("vibing.core.utils.git")
-
-  local text = table.concat(lines, "\n")
-  local frontmatter = Frontmatter.parse(text)
-
+  -- `SyncManager` 経由なら `contains_link` が直前に確認しているが、単独で呼ばれたときに
+  -- `forked_from` を持たないファイルへキーを**新設**してしまうので、ここでも確かめる
+  local frontmatter = self:read_frontmatter(file_path)
   if not frontmatter or not frontmatter.forked_from then
     return false, "No forked_from field"
   end
 
-  local new_forked_from = Git.to_display_path(new_path)
-
   -- 開かれているバッファがあればそちら経由で書く。ディスクを直接書くと、そのバッファの
   -- 次の保存が同期した内容を巻き戻すか、確認プロンプトでNeovimを止める
   -- （infrastructure/storage/frontmatter_file.lua のコメント参照）
-  local FrontmatterFile = require("vibing.infrastructure.storage.frontmatter_file")
-  return FrontmatterFile.update(file_path, { forked_from = new_forked_from })
+  return FrontmatterFile.update(file_path, { forked_from = Git.to_display_path(new_path) })
 end
 
 return ForkedChatScanner

--- a/lua/vibing/infrastructure/link/orchestration_chat_scanner.lua
+++ b/lua/vibing/infrastructure/link/orchestration_chat_scanner.lua
@@ -25,82 +25,32 @@ function OrchestrationChatScanner.new()
   return setmetatable({}, OrchestrationChatScanner)
 end
 
----`Git.get_root()` は毎回 `git rev-parse` を起動する。1ファイルにつきリンク要素の数だけ
----呼ぶことになるので、スキャナーインスタンスの生存期間（＝1回の同期）だけキャッシュする。
----見つからなかったことも `false` として覚え、毎回引き直さない
----@return string?
-function OrchestrationChatScanner:_git_root()
-  if self._git_root_cache == nil then
-    self._git_root_cache = Git.get_root() or false
-  end
-  return self._git_root_cache or nil
-end
-
 ---frontmatter に書かれた表示パスを絶対パスに正規化する
 ---@param value string
 ---@return string
 function OrchestrationChatScanner:_to_absolute(value)
-  local git_root = self:_git_root()
-  if git_root and not value:match("^[/~]") then
-    return vim.fs.joinpath(git_root, value)
-  end
-  return vim.fn.fnamemodify(vim.fn.expand(value), ":p")
+  return Git.from_display_path(value, self:git_root())
 end
 
----リンクフィールドを配列として読む。
+---チャットファイルの frontmatter を読む
 ---
----2つの落とし穴を吸収する。空リストは `{}` という**真値の table** としてパースされるので
----`if not value` では弾けない。そして手で `orchestrated: path.md` と1行で書かれていれば
----table ではなく**文字列**として返ってくる
----@param frontmatter table
----@param key string
----@return string[]
-local function read_link_list(frontmatter, key)
-  local value = frontmatter[key]
-  if type(value) == "string" and value ~= "" then
-    return { value }
-  end
-  if type(value) ~= "table" then
-    return {}
-  end
-  return value
-end
-
+---チャット保存ディレクトリには手書きのメモが置かれていることがある。リンクキーの有無だけで
+---判定すると、たまたま同名のキーを持つ `.md` を書き換えてしまう
 ---@param file_path string
 ---@return table?
-local function read_frontmatter(file_path)
-  local ok, content = pcall(vim.fn.readfile, file_path)
-  if not ok or not content or #content == 0 then
-    return nil
-  end
-
-  local frontmatter = Frontmatter.parse(table.concat(content, "\n"))
-  -- チャット保存ディレクトリには手書きのメモが置かれていることがある。リンクキーの
-  -- 有無だけで判定すると、たまたま同名のキーを持つ `.md` を書き換えてしまう
+function OrchestrationChatScanner:_read_chat(file_path)
+  local frontmatter = self:read_frontmatter(file_path)
   if not frontmatter or frontmatter["vibing.nvim"] ~= true then
     return nil
   end
   return frontmatter
 end
 
----@param base_dir string
----@return string[]
-function OrchestrationChatScanner:find_target_files(base_dir)
-  if vim.fn.isdirectory(base_dir) == 0 then
-    return {}
-  end
-
-  local md_files = vim.fn.glob(base_dir .. "**/*.md", false, true)
-  local vibing_files = vim.fn.glob(base_dir .. "**/*.vibing", false, true)
-
-  return vim.list_extend(md_files, vibing_files)
-end
-
 ---@param file_path string
 ---@param target_path string
 ---@return boolean
 function OrchestrationChatScanner:contains_link(file_path, target_path)
-  local frontmatter = read_frontmatter(file_path)
+  local frontmatter = self:_read_chat(file_path)
   if not frontmatter then
     return false
   end
@@ -108,7 +58,7 @@ function OrchestrationChatScanner:contains_link(file_path, target_path)
   local target_abs = vim.fn.fnamemodify(target_path, ":p")
 
   for _, key in ipairs(LINK_KEYS) do
-    for _, item in ipairs(read_link_list(frontmatter, key)) do
+    for _, item in ipairs(Frontmatter.as_list(frontmatter[key])) do
       if self:_to_absolute(item) == target_abs then
         return true
       end
@@ -124,15 +74,9 @@ end
 ---@return boolean success
 ---@return string? error
 function OrchestrationChatScanner:update_link(file_path, old_path, new_path)
-  local ok, lines = pcall(vim.fn.readfile, file_path)
-  if not ok or not lines then
-    return false, string.format("Failed to read file: %s", lines or "unknown")
-  end
-
-  local text = table.concat(lines, "\n")
-  local frontmatter = Frontmatter.parse(text)
+  local frontmatter = self:_read_chat(file_path)
   if not frontmatter then
-    return false, "No frontmatter"
+    return false, "Not a vibing chat file"
   end
 
   local old_abs = vim.fn.fnamemodify(old_path, ":p")
@@ -144,14 +88,14 @@ function OrchestrationChatScanner:update_link(file_path, old_path, new_path)
     local seen = {}
     local next_items = {}
 
-    for _, item in ipairs(read_link_list(frontmatter, key)) do
+    for _, item in ipairs(Frontmatter.as_list(frontmatter[key])) do
       local value = item
       if self:_to_absolute(item) == old_abs then
         value = new_display
         replaced = true
       end
-      -- リネーム先が既にリストに載っていることがある（A が B と C の両方を指していて、
-      -- B が C の名前に改名された場合）。差し替えたあとに重複を落とす
+      -- 差し替え先が既にリストに載っていれば重複になる。リネーム先の衝突は
+      -- `set_file_title` が避けるが、このメソッド自体は任意の new_path で呼べる
       if not seen[value] then
         seen[value] = true
         table.insert(next_items, value)

--- a/lua/vibing/infrastructure/link/scanner.lua
+++ b/lua/vibing/infrastructure/link/scanner.lua
@@ -1,11 +1,69 @@
 ---@class Vibing.Infrastructure.Link.Scanner
+---リンク同期スキャナーの基底。
+---
+---走査そのもの（どのファイルを見るか、それを読む・gitルートを引く）は全スキャナーで同じなので
+---ここに集約し、サブクラスはリンクの解釈だけを持つ。キャッシュはインスタンス単位＝1回の同期の
+---生存期間で、`SyncManager` が毎回 `new()` するのでスキャン間に持ち越さない。
 local Scanner = {}
 Scanner.__index = Scanner
 
----@param base_dir string
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+
+---走査対象のチャットファイルを集める
+---
+---「どの拡張子がチャットファイルか」は個々のスキャナーの関心ではないので、ここが唯一の定義。
+---別の集め方をするスキャナー（daily summaryなど）だけが上書きする
+---@param base_dir string 末尾に "/" が必要（そのまま連結する）
 ---@return string[]
 function Scanner:find_target_files(base_dir)
-  error("Must be implemented by subclass")
+  if vim.fn.isdirectory(base_dir) == 0 then
+    return {}
+  end
+
+  -- チャットバッファは .md、保存形式としては .vibing もありうる
+  local md_files = vim.fn.glob(base_dir .. "**/*.md", false, true)
+  local vibing_files = vim.fn.glob(base_dir .. "**/*.vibing", false, true)
+
+  return vim.list_extend(md_files, vibing_files)
+end
+
+---ファイルのfrontmatterを読む
+---
+---`SyncManager` は同じファイルに対して `contains_link` の直後に `update_link` を呼ぶので、
+---キャッシュしないとチャットの全文を続けて2回読むことになる。チャットのtranscriptは
+---このリポジトリで最も大きいファイル群なので、これは実測できる差になる
+---@param file_path string
+---@return table?
+function Scanner:read_frontmatter(file_path)
+  self._frontmatter_cache = self._frontmatter_cache or {}
+
+  local cached = self._frontmatter_cache[file_path]
+  if cached ~= nil then
+    return cached or nil
+  end
+
+  local ok, content = pcall(vim.fn.readfile, file_path)
+  if not ok or not content or #content == 0 then
+    self._frontmatter_cache[file_path] = false
+    return nil
+  end
+
+  local frontmatter = Frontmatter.parse(table.concat(content, "\n"))
+  self._frontmatter_cache[file_path] = frontmatter or false
+  return frontmatter
+end
+
+---gitルートを引く
+---
+---`Git.get_root()` はキャッシュを持たず毎回 `git rev-parse` を起動する。走査は1ファイルにつき
+---リンク要素の数だけ正規化を行うので、キャッシュしないと数百のサブプロセスが同期的に走る。
+---不在は `false` のまま返す（`nil` に潰すと `Git.from_display_path` が「未指定」と読んで引き直す）
+---@return string|false
+function Scanner:git_root()
+  if self._git_root_cache == nil then
+    self._git_root_cache = require("vibing.core.utils.git").get_root() or false
+  end
+  return self._git_root_cache
 end
 
 ---@param file_path string

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -47,7 +47,12 @@ function M.create_chat(params)
 
     -- 作成でも購読を張る。送信だけを登録にすると、ブリーフに `from_bufnr` を渡し忘れたときに
     -- 「黙って通知が来ない」で終わる。作ってメッセージを送らないケースは無いので、
-    -- 早い方に寄せておくほうが渡し忘れに強い
+    -- 早い方に寄せておくほうが渡し忘れに強い。
+    --
+    -- リンクの書き込みが失敗しても購読は張る（意図的な非対称）。frontmatter が書けないと
+    -- ワーカーは「誰に報告すればいいか」の行を得られない（`send_message` が
+    -- `orchestrated_by` を読むため）が、オーケストレーター側が完了を知る手段まで一緒に
+    -- 失う理由はない。通知はインメモリで、frontmatter を必要としない
     require("vibing.application.chat.completion_notifier").subscribe(params.from_bufnr, chat_buf.buf)
   end
 

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -44,6 +44,11 @@ function M.create_chat(params)
         "Orchestration"
       )
     end
+
+    -- 作成でも購読を張る。送信だけを登録にすると、ブリーフに `from_bufnr` を渡し忘れたときに
+    -- 「黙って通知が来ない」で終わる。作ってメッセージを送らないケースは無いので、
+    -- 早い方に寄せておくほうが渡し忘れに強い
+    require("vibing.application.chat.completion_notifier").subscribe(params.from_bufnr, chat_buf.buf)
   end
 
   return {

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -32,7 +32,23 @@ function M.send_message(params)
   end
 
   -- ProgrammaticSender.send already validates parameters
-  return ProgrammaticSender.send(params.bufnr, params.message, params.sender)
+  local result = ProgrammaticSender.send(params.bufnr, params.message, params.sender)
+
+  -- 送ったという事実そのものを購読の登録として扱う。宛先が応答を終えたら送信元に
+  -- 「読みに行け」とだけ伝わる（application/chat/completion_notifier.lua）。
+  --
+  -- 送信の**後**に張るのが要点。上の `validate` は「応答中」を弾くが、その判定とここの間には
+  -- リンク書き込み（バッファ編集と2ファイルの保存）が挟まるので状態は変わりうるし、
+  -- `send_message()` が false を返す経路もある。先に張ると、送っていないメッセージについて
+  -- 「相手が終わった、読みに行け」だけが後から届く。
+  --
+  -- 遅すぎることはない: CLIの起動は非同期で、宛先の完了は `vim.schedule` 経由なので
+  -- この関数が返るより先には走らない
+  if params.from_bufnr and result and result.success then
+    require("vibing.application.chat.completion_notifier").subscribe(params.from_bufnr, params.bufnr)
+  end
+
+  return result
 end
 
 return M

--- a/lua/vibing/infrastructure/storage/frontmatter.lua
+++ b/lua/vibing/infrastructure/storage/frontmatter.lua
@@ -132,6 +132,23 @@ function M.parse(content)
   return parsed, body
 end
 
+---リストフィールドの値を配列として読む
+---
+---パーサが同じフィールドに対して3つの形を返しうるので、その規則はパーサの隣に置く。
+---値なしの `key:` は**真値の空table**（`if not value` では弾けない）、手書きの
+---`key: path.md` は**文字列**、通常のブロックリストだけが配列になる
+---@param value any
+---@return string[]
+function M.as_list(value)
+  if type(value) == "string" and value ~= "" then
+    return { value }
+  end
+  if type(value) ~= "table" then
+    return {}
+  end
+  return value
+end
+
 local function serialize_value(value)
   if type(value) == "boolean" then
     return value and "true" or "false"
@@ -142,32 +159,41 @@ local function serialize_value(value)
   end
 end
 
+---frontmatterに書き出すキーの順序。**並びそのもの**が定義なので、キーを挿入するときは
+---この配列の狙った位置に足すだけでよい（連番を振り直す必要がなく、番号の重複も表現できない）。
+---ここに無いキーは後ろにまとめてアルファベット順で並ぶ。
+---
+---`forked_from` / `subagent_id` / `orchestrated*` が設定値より前にあるのは、どれも
+---「このチャットが他のどのチャットと繋がっているか」を答えるフィールドだから。
+local KEY_ORDER = {
+  "vibing.nvim",
+  "session_id",
+  "created_at",
+  "forked_from",
+  "subagent_id",
+  "orchestrated",
+  "orchestrated_by",
+  "working_dir",
+  "agent",
+  "model",
+  "effort",
+  "permission_mode",
+  "permissions_allow",
+  "permissions_deny",
+  "permissions_ask",
+  "language",
+}
+
+local priority = {}
+for index, key in ipairs(KEY_ORDER) do
+  priority[key] = index
+end
+
 local function get_sorted_keys(tbl)
   local keys = {}
   for k in pairs(tbl) do
     table.insert(keys, k)
   end
-
-  local priority = {
-    ["vibing.nvim"] = 1,
-    session_id = 2,
-    created_at = 3,
-    forked_from = 4,
-    subagent_id = 5,
-    -- 出自を示すフィールド(forked_from / subagent_id)の直後。どれも「このチャットが
-    -- 他のどのチャットと繋がっているか」を答えるものなので、まとめて先頭側に置く
-    orchestrated = 6,
-    orchestrated_by = 7,
-    working_dir = 8,
-    agent = 9,
-    model = 10,
-    effort = 11,
-    permission_mode = 12,
-    permissions_allow = 13,
-    permissions_deny = 14,
-    permissions_ask = 15,
-    language = 16,
-  }
 
   table.sort(keys, function(a, b)
     local pa = priority[a] or 100

--- a/lua/vibing/infrastructure/storage/frontmatter_file.lua
+++ b/lua/vibing/infrastructure/storage/frontmatter_file.lua
@@ -14,25 +14,23 @@
 local M = {}
 
 local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
-
----比較は両側ともシンボリックリンクを解決した形で行う。`nvim_buf_get_name` は解決済みの
----パスを返すので（macOSでは `/var/...` が `/private/var/...` になる）、`:p` を付けただけの
----候補と突き合わせると、同じファイルなのに一致しない
----@param path string
----@return string
-local function physical(path)
-  return vim.fn.resolve(vim.fn.fnamemodify(path, ":p"))
-end
+local PathSanitizer = require("vibing.domain.security.path_sanitizer")
 
 ---@param file_path string
 ---@return number? bufnr
 local function loaded_buffer(file_path)
-  local target = physical(file_path)
+  -- 比較は両側ともシンボリックリンクを解決した形で行う。`nvim_buf_get_name` は解決済みの
+  -- パスを返すので（macOSでは `/var/...` が `/private/var/...` になる）、`:p` だけでは
+  -- 同じファイルが一致しない。`PathSanitizer.normalize` が expand→`:p`→resolve をまとめている
+  local target = PathSanitizer.normalize(file_path)
+  if not target then
+    return nil
+  end
 
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_loaded(bufnr) then
       local name = vim.api.nvim_buf_get_name(bufnr)
-      if name ~= "" and physical(name) == target then
+      if name ~= "" and PathSanitizer.normalize(name) == target then
         return bufnr
       end
     end
@@ -70,10 +68,7 @@ local function update_buffer(bufnr, updates)
 
   -- ここで保存しないと、同期したと報告した内容がディスクに無いままになる。
   -- バッファ側を真として書いているので、`write!` でガードを踏み越えても失うものはない
-  local ok = pcall(vim.api.nvim_buf_call, bufnr, function()
-    vim.cmd.write({ bang = true })
-  end)
-  if not ok or vim.bo[bufnr].modified then
+  if not require("vibing.presentation.chat.modules.file_manager").save_buffer(bufnr) then
     return false, "Updated the buffer but could not save it"
   end
 

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -86,6 +86,14 @@ function M.setup(opts)
     end)
   end)
 
+  -- チャット間の完了通知のautocmdを張る（設定に関わらず張る理由は completion_notifier.setup()
+  -- のコメント参照）。最初のリクエストまで何も発火しないので、起動パスから外す
+  vim.schedule(function()
+    pcall(function()
+      require("vibing.application.chat.completion_notifier").setup()
+    end)
+  end)
+
   -- 使用量リミット待ちのチャットのタイマーを張り直す。
   -- 5時間/週次リミットのリセットはNeovimの再起動を跨ぐことが多いため、
   -- .vibing/pending-resume.json から復元する。VimEnter後に遅延させて起動を妨げない。

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -207,6 +207,11 @@ function ChatBuffer:_setup_keymaps()
 
   local callbacks = {
     send_message = function()
+      -- 手動送信は通知チェーンの起点なので、ここで深さをリセットする。
+      -- `ChatBuffer:send_message()` 本体ではなくこのキーマップ側に置くのは、通知の配達自身が
+      -- `ProgrammaticSender` 経由で同じ関数を通るため。本体でリセットすると配達のたびに 0 に
+      -- 戻り、`max_hops` が一切効かなくなる
+      require("vibing.application.chat.completion_notifier").reset_depth(self.buf)
       self:send_message()
     end,
     cancel = function()
@@ -391,10 +396,15 @@ function ChatBuffer:_try_schedule_instead_of_send(message)
 end
 
 ---メッセージを送信
+---
+---戻り値は「このメッセージがリクエストとして扱われたか」。予約に回った場合も、未送信Userとして
+---残りリセット後に送られるのでtrueを返す。falseは黙って何もしなかったことを意味し、
+---`ProgrammaticSender` はこれを見て呼び出し元に成否を返す
+---@return boolean handled
 function ChatBuffer:send_message()
   -- 送信処理中はEnter連打による重複送信を無視する
   if self._is_sending then
-    return
+    return false
   end
 
   -- 前のリクエストが実行中ならキャンセル（ゾンビプロセス対策）
@@ -432,14 +442,14 @@ function ChatBuffer:send_message()
   if not message then
     vim.notify("[vibing] No message to send", vim.log.levels.WARN)
     self._is_sending = false
-    return
+    return false
   end
 
   -- リミット中と分かっているならコミットせずに予約へ回す。commit_user_message を通さないので
   -- `## User <!-- unsent -->` がそのまま残り、それが発火時に送られる本文になる。
   if self:_try_schedule_instead_of_send(message) then
     self._is_sending = false
-    return
+    return true
   end
 
   ConversationExtractor.commit_user_message(self.buf)
@@ -453,7 +463,7 @@ function ChatBuffer:send_message()
       else
         self:add_user_section()
         self._is_sending = false
-        return
+        return false
       end
     end
   end
@@ -475,7 +485,7 @@ function ChatBuffer:send_message()
           vim.log.levels.ERROR
         )
         self._is_sending = false
-        return
+        return false
       end
 
       -- Hook-based approval: update session state, then fall through to normal message flow
@@ -528,7 +538,7 @@ function ChatBuffer:send_message()
         vim.log.levels.WARN
       )
       self._is_sending = false
-      return
+      return false
     end
   end
 
@@ -560,7 +570,21 @@ function ChatBuffer:send_message()
       return self:update_session_id(session_id)
     end,
     add_user_section = function()
-      return self:add_user_section()
+      self:add_user_section()
+      -- 応答が完全に終わった唯一の合流点。`_handle_response` の完了経路は4つある
+      -- （セッション破損 / mote finalize / ファイル変更なし / git patch finalize、うち2つは
+      -- `vim.schedule` の中）が、すべてこのコールバックに合流する。しかも handle_id 不一致
+      -- による早期returnより後なので、キャンセル済みの古いターンが遅れて完了しても飛ばない。
+      --
+      -- `ChatBuffer:add_user_section()` 本体に置いてはいけない: そちらはスラッシュコマンド
+      -- 経路からも呼ばれるので、AIターンが1回も走っていないのに完了が飛ぶ。
+      --
+      -- autocmd を挟むのは、ユーザーが自分の設定からも拾えるようにするため。
+      -- `CompletionNotifier` 自身もこの経路で購読している
+      vim.api.nvim_exec_autocmds("User", {
+        pattern = "VibingResponseDone",
+        data = { bufnr = self.buf },
+      })
     end,
     get_bufnr = function()
       return self.buf
@@ -610,6 +634,8 @@ function ChatBuffer:send_message()
   if self:is_open() then
     Renderer.moveCursorToEnd(self.win, self.buf)
   end
+
+  return true
 end
 
 ---アシスタントの応答を追加開始

--- a/lua/vibing/presentation/chat/modules/file_manager.lua
+++ b/lua/vibing/presentation/chat/modules/file_manager.lua
@@ -65,16 +65,23 @@ end
 ---`write`はエラーを黙って飲むことがあるので、pcallの成否だけでなくmodifiedも確認する
 ---@param buf number バッファ番号
 ---@return boolean saved
+---@return string? error
 function M.save_buffer(buf)
   if not buf or not vim.api.nvim_buf_is_valid(buf) then
-    return false
+    return false, "Invalid buffer"
   end
 
-  local ok = pcall(vim.api.nvim_buf_call, buf, function()
+  local ok, err = pcall(vim.api.nvim_buf_call, buf, function()
     vim.cmd.write({ bang = true })
   end)
+  if not ok then
+    return false, tostring(err)
+  end
+  if vim.bo[buf].modified then
+    return false, "Buffer is still modified after writing"
+  end
 
-  return ok and not vim.bo[buf].modified
+  return true, nil
 end
 
 ---メッセージからファイル名を更新

--- a/lua/vibing/presentation/chat/modules/programmatic_sender.lua
+++ b/lua/vibing/presentation/chat/modules/programmatic_sender.lua
@@ -8,11 +8,6 @@ local Renderer = require("vibing.presentation.chat.modules.renderer")
 -- Per-buffer send locks to prevent concurrent sends
 local _send_locks = {}
 
----Programmatically send a message to a chat buffer
----@param bufnr number Buffer number
----@param message string Message content to send
----@param sender? string Sender identifier (default: "User", future: "Alpha", "Bravo", etc.)
----@return {success: boolean, bufnr: number}
 ---送信できる状態かを確かめ、対象のChatBufferを返す（送れないなら error）
 ---
 ---`send`から切り出してあるのは、送信の前に別の副作用を済ませたい呼び出し元があるため。
@@ -37,6 +32,17 @@ function M.validate(bufnr, message)
     error("Buffer is not a vibing chat buffer")
   end
 
+  -- 応答中のバッファには積まない。`ChatBuffer:send_message()` は `_is_sending` を見て
+  -- **黙って return** するので、先に `addUserSection` してしまうと送られない `## User`
+  -- セクションがバッファに残り、次にユーザーが<CR>したときの本文に化ける。さらにその手前で
+  -- 「前のリクエストが実行中ならキャンセル」が走るため、進行中のターンごと殺しうる。
+  -- 追加してから巻き戻すのではなく、追加する前に断る。
+  --
+  -- `send` 本体ではなくここに置くことで、リンク書き込みの前に呼ぶ事前検証でも同じ判定が効く
+  if chat_buf:is_responding() then
+    error("Chat buffer is already responding")
+  end
+
   if _send_locks[bufnr] then
     error("Another send operation is in progress for this buffer")
   end
@@ -52,6 +58,7 @@ function M.send(bufnr, message, sender)
   -- Acquire lock to prevent concurrent sends
   _send_locks[bufnr] = true
 
+  local sent = false
   local success, err = pcall(function()
     -- Save and restore cursor position
     local saved_win = vim.api.nvim_get_current_win()
@@ -61,7 +68,7 @@ function M.send(bufnr, message, sender)
 
     -- Add user section and send
     Renderer.addUserSection(bufnr, nil, nil, nil, message)
-    chat_buf:send_message()
+    sent = chat_buf:send_message()
 
     -- Restore cursor
     if saved_cursor and vim.api.nvim_win_is_valid(saved_win) then
@@ -76,7 +83,7 @@ function M.send(bufnr, message, sender)
     error(string.format("Failed to send message: %s", tostring(err)))
   end
 
-  return { success = true, bufnr = bufnr }
+  return { success = sent, bufnr = bufnr }
 end
 
 return M

--- a/tests/e2e/chat_completion_notification_spec.lua
+++ b/tests/e2e/chat_completion_notification_spec.lua
@@ -1,0 +1,80 @@
+-- E2E Tests for cross-chat completion notifications (#627)
+local helper = require("vibing.testing.e2e_helper")
+
+-- tests/e2e is swept by `test:lua` too, and this spec drives real CLI turns (the worker's, then
+-- the orchestrator's woken one). Only `test:e2e` sets VIBING_E2E=1.
+if not helper.should_run() then
+  return
+end
+
+local TIMEOUTS = {
+  SETUP = 800,
+  WORKER_TURN = 90000, -- worker's own turn plus the orchestrator turn the notification starts
+  POLL = 500,
+}
+
+describe("E2E: chat completion notification", function()
+  local nvim_instance
+
+  ---@param code string
+  ---@return any
+  local function exec(code)
+    return vim.fn.rpcrequest(nvim_instance.job_id, "nvim_exec_lua", code, {})
+  end
+
+  before_each(function()
+    nvim_instance = helper.spawn_nvim_instance({
+      headless = true,
+      init_script = "tests/e2e_init.lua",
+    })
+    vim.wait(TIMEOUTS.SETUP)
+    exec("require('vibing').setup({ agent = { chat_notifications = { enabled = true } } })")
+  end)
+
+  after_each(function()
+    helper.cleanup_instance(nvim_instance)
+  end)
+
+  it("wakes the sending chat with a new turn once the chat it messaged stops", function()
+    local bufnrs = exec([[
+      local chat = require('vibing.infrastructure.rpc.handlers.chat')
+      local a = chat.create_chat({ position = 'back' })
+      local b = chat.create_chat({ position = 'back', from_bufnr = a.bufnr })
+      return { a.bufnr, b.bufnr }
+    ]])
+    local orchestrator, worker = bufnrs[1], bufnrs[2]
+
+    assert.is_true(orchestrator > 0 and worker > 0, "both chats should be created")
+
+    -- 作成時点で双方向のリンクが frontmatter に書かれている（#628）
+    local worker_frontmatter = exec(
+      string.format("return table.concat(vim.api.nvim_buf_get_lines(%d, 0, 40, false), '\\n')", worker)
+    )
+    assert.is_truthy(worker_frontmatter:find("orchestrated_by", 1, true), "worker should record its orchestrator")
+
+    exec(string.format(
+      [[
+        require('vibing.infrastructure.rpc.handlers.message').send_message({
+          bufnr = %d,
+          from_bufnr = %d,
+          message = 'Reply with exactly the word: done. Do not use any tools.',
+        })
+      ]],
+      worker,
+      orchestrator
+    ))
+
+    -- ワーカーが止まると、オーケストレーター側に新しい `## User` として通知が届く
+    local deadline = vim.loop.now() + TIMEOUTS.WORKER_TURN
+    local notified = false
+    while vim.loop.now() < deadline and not notified do
+      vim.wait(TIMEOUTS.POLL)
+      local text = exec(
+        string.format("return table.concat(vim.api.nvim_buf_get_lines(%d, 0, -1, false), '\\n')", orchestrator)
+      )
+      notified = text:find("finished responding", 1, true) ~= nil
+    end
+
+    assert.is_true(notified, "orchestrator should be told the worker stopped")
+  end)
+end)

--- a/tests/evals/tasks.lua
+++ b/tests/evals/tasks.lua
@@ -8,6 +8,10 @@
 local Harness = require("vibing.testing.eval_harness")
 local Worktree = require("vibing.core.constants.worktree")
 
+--- from_bufnr のタスクで system prompt に載せる chat_bufnr。実在しないバッファ番号でよく、
+--- 「system promptに書かれた番号をそのまま写したか」だけを見るための固定値
+local ORCHESTRATOR_BUFNR = 4242
+
 ---@param record Vibing.Eval.Record
 ---@param substring string
 ---@return string? command 部分文字列を含む最初のBashコマンド
@@ -54,6 +58,36 @@ return {
       end
       if tonumber(input.rpc_port) ~= expected then
         return false, string.format("passed rpc_port=%s, expected %s", tostring(input.rpc_port), tostring(expected))
+      end
+      return true
+    end,
+  },
+
+  {
+    id = "orchestrate/passes_from_bufnr",
+    description = "ワーカーを作るとき from_bufnr に自分のchat_bufnrを渡す（渡し忘れは"
+      .. "「黙って関係が残らない・通知が来ない」で終わるので、表明が効いているかを測る）",
+    prompt = "Create one worker chat with the vibing.nvim chat tool so I can hand it a task later. "
+      .. "Just create it; do not send it anything yet.",
+    -- system prompt の "Current vibing.nvim chat buffer number" がこの値で入るので、
+    -- モデルがそれをそのまま from_bufnr に写したかを厳密に見られる。
+    -- 副作用として実際にワーカーチャットが1つ作られる（`back` なのでウィンドウは開かない）。
+    opts = { chat_bufnr = ORCHESTRATOR_BUFNR },
+    check = function(record)
+      local input = Harness.find_mcp_call(record, "nvim_chat_create")
+      if not input then
+        return false, "no nvim_chat_create call to inspect"
+      end
+      if not input.from_bufnr then
+        return false, "omitted from_bufnr, so nothing records which chat owns this worker"
+      end
+      if tonumber(input.from_bufnr) ~= ORCHESTRATOR_BUFNR then
+        return false,
+          string.format(
+            "passed from_bufnr=%s, expected %d (the chat buffer number in its own system prompt)",
+            tostring(input.from_bufnr),
+            ORCHESTRATOR_BUFNR
+          )
       end
       return true
     end,

--- a/tests/helpers/chat_files.lua
+++ b/tests/helpers/chat_files.lua
@@ -1,0 +1,40 @@
+--- Test seam for specs that need chat files on disk.
+---
+--- Writing a chat fixture means knowing the frontmatter keys a chat is required to carry
+--- (`vibing.nvim: true`, a `session_id`) and the shape `Frontmatter.serialize` produces. Four
+--- specs had already open-coded that pair; shared rather than pasted so a change to the
+--- serializer or the required-key set is repaired once instead of breaking specs independently.
+--- @module tests.helpers.chat_files
+
+local M = {}
+
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+
+--- Write a chat file with the given frontmatter merged over the required defaults.
+--- @param dir string directory the file goes in (no trailing slash)
+--- @param name string file name, e.g. "worker.md"
+--- @param frontmatter table? keys to set or override
+--- @param body string? body after the frontmatter (defaults to an empty User section)
+--- @return string path
+function M.write(dir, name, frontmatter, body)
+  local path = dir .. "/" .. name
+
+  local data = { ["vibing.nvim"] = true, session_id = "session-" .. name }
+  for key, value in pairs(frontmatter or {}) do
+    data[key] = value
+  end
+
+  local text = Frontmatter.serialize(data, body or "## User\n")
+  vim.fn.writefile(vim.split(text, "\n", { plain = true }), path)
+
+  return path
+end
+
+--- Parse the frontmatter back out of a chat file.
+--- @param path string
+--- @return table
+function M.read_frontmatter(path)
+  return (Frontmatter.parse(table.concat(vim.fn.readfile(path), "\n")))
+end
+
+return M

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -214,6 +214,24 @@ describe("CompletionNotifier", function()
     assert.equals("Chat Notifications", warnings[1].title)
   end)
 
+  it("does not warn about an edge it already holds when at the hop limit", function()
+    -- 同じワーカーに複数回ブリーフを送るのは通常の手順。既に張ってあるエッジは生きていて
+    -- 通知も届くので、上限に当たったからといって「購読しなかった」と警告するのは事実に反する
+    configure({ max_hops = 0 })
+    local a, b = make_chat(), make_chat()
+
+    -- 上限0でも、既存エッジがあれば黙って成功を返す
+    Notifier.subscribe(a, b)
+    assert.equals(1, #warnings, "the first subscribe is genuinely refused")
+
+    configure({ max_hops = 8 })
+    assert.is_true(Notifier.subscribe(a, b))
+    configure({ max_hops = 0 })
+
+    assert.is_true(Notifier.subscribe(a, b))
+    assert.equals(1, #warnings, "re-sending to an already-subscribed chat must not warn")
+  end)
+
   it("resets the hop count on a manual send", function()
     configure({ max_hops = 1 })
     local a, b = make_chat(), make_chat()

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -1,0 +1,341 @@
+local Config = require("vibing.config")
+local view = require("vibing.presentation.chat.view")
+local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+local notify = require("vibing.core.utils.notify")
+
+describe("CompletionNotifier", function()
+  ---モジュールレベルの購読テーブルはspec間で共有されるので、毎回requireし直して捨てる。
+  ---本番側にリセット用のAPIを生やすより、追加した状態が自動的にリセット対象になる
+  local Notifier
+  local originals = {}
+  local buffers = {}
+  local responding = {}
+  local drafts = {}
+  local sends = {}
+  local warnings = {}
+  local send_result = { success = true }
+
+  ---チャットバッファに見える実バッファを1つ作る
+  ---@return number bufnr
+  local function make_chat()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  ---@param opts table?
+  local function configure(opts)
+    Config.get = function()
+      return { agent = { chat_notifications = vim.tbl_extend("force", { enabled = true, max_hops = 8 }, opts or {}) } }
+    end
+  end
+
+  before_each(function()
+    originals.get = Config.get
+    originals.get_chat_buffer = view.get_chat_buffer
+    originals.send = ProgrammaticSender.send
+    originals.warn = notify.warn
+
+    buffers, responding, drafts, sends, warnings = {}, {}, {}, {}, {}
+    send_result = { success = true }
+
+    view.get_chat_buffer = function(bufnr)
+      if not vim.api.nvim_buf_is_valid(bufnr) then
+        return nil
+      end
+      return {
+        is_responding = function()
+          return responding[bufnr] == true
+        end,
+        extract_user_message = function()
+          return drafts[bufnr]
+        end,
+      }
+    end
+    ProgrammaticSender.send = function(bufnr, message)
+      table.insert(sends, { bufnr = bufnr, message = message })
+      if send_result.throws then
+        error("boom")
+      end
+      return { success = send_result.success, bufnr = bufnr }
+    end
+    notify.warn = function(message, title)
+      table.insert(warnings, { message = message, title = title })
+    end
+
+    configure()
+
+    package.loaded["vibing.application.chat.completion_notifier"] = nil
+    Notifier = require("vibing.application.chat.completion_notifier")
+  end)
+
+  after_each(function()
+    Config.get = originals.get
+    view.get_chat_buffer = originals.get_chat_buffer
+    ProgrammaticSender.send = originals.send
+    notify.warn = originals.warn
+
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end)
+
+  it("delivers to the sender when the chat it messaged finishes", function()
+    local a, b = make_chat(), make_chat()
+
+    assert.is_true(Notifier.subscribe(a, b))
+    Notifier.on_response_done(b)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+    assert.is_truthy(sends[1].message:find("chat buffer " .. b, 1, true))
+  end)
+
+  it("does not deliver into a chat that is still responding", function()
+    -- 本改修で一番壊れやすい箇所。応答中のバッファに送ると ChatBuffer:send_message() が
+    -- 「前のリクエストが実行中ならキャンセル」で進行中のターンを kill する
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    assert.equals(0, #sends)
+  end)
+
+  it("drains a queued notification when the sender itself finishes", function()
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+    assert.equals(0, #sends)
+
+    responding[a] = false
+    Notifier.on_response_done(a)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+  end)
+
+  it("coalesces several queued notifications into one message", function()
+    local a, b, c = make_chat(), make_chat(), make_chat()
+    responding[a] = true
+
+    Notifier.subscribe(a, b)
+    Notifier.subscribe(a, c)
+    Notifier.on_response_done(b)
+    Notifier.on_response_done(c)
+
+    responding[a] = false
+    Notifier.on_response_done(a)
+
+    assert.equals(1, #sends)
+    assert.is_truthy(sends[1].message:find("chat buffer " .. b, 1, true))
+    assert.is_truthy(sends[1].message:find("chat buffer " .. c, 1, true))
+  end)
+
+  it("consumes the edge on delivery so a second completion is silent", function()
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+    Notifier.on_response_done(b)
+
+    assert.equals(1, #sends)
+  end)
+
+  it("notifies once even when the sender messaged the same chat repeatedly", function()
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.subscribe(a, b)
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    assert.equals(1, #sends)
+  end)
+
+  it("delivers to every chat subscribed to the same worker", function()
+    local a1, a2, b = make_chat(), make_chat(), make_chat()
+
+    Notifier.subscribe(a1, b)
+    Notifier.subscribe(a2, b)
+    Notifier.on_response_done(b)
+
+    local targets = { [sends[1].bufnr] = true, [sends[2].bufnr] = true }
+    assert.equals(2, #sends)
+    assert.is_true(targets[a1])
+    assert.is_true(targets[a2])
+  end)
+
+  it("drops the subscription instead of erroring when the sender buffer is gone", function()
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    vim.api.nvim_buf_delete(a, { force = true })
+
+    assert.has_no.errors(function()
+      Notifier.on_response_done(b)
+    end)
+    assert.equals(0, #sends)
+  end)
+
+  it("neither subscribes nor delivers when the feature is disabled", function()
+    configure({ enabled = false })
+    local a, b = make_chat(), make_chat()
+
+    assert.is_false(Notifier.subscribe(a, b))
+    Notifier.on_response_done(b)
+
+    assert.equals(0, #sends)
+  end)
+
+  it("refuses a chat subscribing to itself", function()
+    local a = make_chat()
+
+    assert.is_false(Notifier.subscribe(a, a))
+  end)
+
+  it("stops the chain at max_hops and says so instead of going quiet", function()
+    configure({ max_hops = 1 })
+    local a, b = make_chat(), make_chat()
+
+    -- 1ホップ目: 購読して配達されると、A の深さが 1 になる
+    assert.is_true(Notifier.subscribe(a, b))
+    Notifier.on_response_done(b)
+    assert.equals(1, #sends)
+
+    -- 2ホップ目は上限に当たる。黙って張らないと通知が来ない理由がどこにも残らない
+    assert.is_false(Notifier.subscribe(a, b))
+    assert.equals(1, #warnings)
+    assert.equals("Chat Notifications", warnings[1].title)
+  end)
+
+  it("resets the hop count on a manual send", function()
+    configure({ max_hops = 1 })
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+    assert.is_false(Notifier.subscribe(a, b))
+
+    Notifier.reset_depth(a)
+
+    assert.is_true(Notifier.subscribe(a, b))
+  end)
+
+  it("forgets a buffer's edges and queue in both directions", function()
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    Notifier.forget(b)
+    responding[a] = false
+    Notifier.on_response_done(a)
+
+    assert.equals(0, #sends)
+  end)
+
+  it("tells the sender that finishing is not the same as succeeding", function()
+    -- `idle` はエラー終了でも、質問でターンが死んだときでも、ツール承認待ちでも通る。
+    -- 成否の判定を通知側でやると chat_status と同じ罠を踏むので、判断は受け取り側に委ねる
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    assert.is_truthy(sends[1].message:find("no request is in flight", 1, true))
+    assert.is_truthy(sends[1].message:find("do not start aggregating yet", 1, true))
+  end)
+
+  it("keeps the notification queued when delivery fails", function()
+    -- エッジは配達時点で消費済みなので、失敗した通知を捨てると二度と再現しない
+    local a, b = make_chat(), make_chat()
+    send_result = { success = false }
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+    assert.equals(1, #sends)
+    assert.equals(1, #warnings)
+
+    send_result = { success = true }
+    Notifier.on_response_done(a)
+
+    assert.equals(2, #sends)
+  end)
+
+  it("keeps the notification queued when delivery throws", function()
+    local a, b = make_chat(), make_chat()
+    send_result = { throws = true }
+
+    Notifier.subscribe(a, b)
+    assert.has_no.errors(function()
+      Notifier.on_response_done(b)
+    end)
+
+    send_result = { success = true }
+    Notifier.on_response_done(a)
+
+    assert.equals(a, sends[#sends].bufnr)
+  end)
+
+  it("does not overwrite a draft the user is still typing", function()
+    -- 配達は新しい `## User` を足すので、下書きは送られないまま宙に浮く
+    local a, b = make_chat(), make_chat()
+    drafts[a] = "half-written question"
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    assert.equals(0, #sends)
+
+    -- ユーザーがその下書きを送れば、そのターンの完了で取りこぼさず流れる
+    drafts[a] = nil
+    Notifier.on_response_done(a)
+
+    assert.equals(1, #sends)
+  end)
+
+  it("never lowers the hop count when a shallow edge is delivered late", function()
+    configure({ max_hops = 2 })
+    local a, b, c = make_chat(), make_chat(), make_chat()
+
+    -- 先に浅い時点のエッジを張っておき、配達だけ遅らせる
+    Notifier.subscribe(a, c)
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b) -- depth[a] = 1
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b) -- depth[a] = 2
+
+    -- 深さ0で張られた c のエッジがここで配達されても、カウンタは戻らない
+    Notifier.on_response_done(c)
+    assert.is_false(Notifier.subscribe(a, b))
+  end)
+
+  describe("setup", function()
+    it("delivers through the VibingResponseDone autocmd", function()
+      local a, b = make_chat(), make_chat()
+      Notifier.setup()
+      Notifier.subscribe(a, b)
+
+      vim.api.nvim_exec_autocmds("User", { pattern = "VibingResponseDone", data = { bufnr = b } })
+
+      assert.equals(1, #sends)
+      assert.equals(a, sends[1].bufnr)
+    end)
+
+    it("ignores an event with no bufnr instead of erroring", function()
+      Notifier.setup()
+
+      assert.has_no.errors(function()
+        vim.api.nvim_exec_autocmds("User", { pattern = "VibingResponseDone" })
+      end)
+    end)
+  end)
+end)

--- a/tests/lua/application/chat/orchestration_link_spec.lua
+++ b/tests/lua/application/chat/orchestration_link_spec.lua
@@ -1,0 +1,98 @@
+local Git = require("vibing.core.utils.git")
+
+describe("OrchestrationLink.resolve_bufnrs", function()
+  ---gitルートのキャッシュはモジュールレベルなのでspec間で持ち越す。毎回requireし直して捨てる
+  local OrchestrationLink
+  local original_get_root
+  local dir
+  local buffers = {}
+
+  ---@param name string
+  ---@return number bufnr
+  local function open_buffer(name)
+    local bufnr = vim.fn.bufadd(dir .. "/" .. name)
+    vim.fn.bufload(bufnr)
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  before_each(function()
+    original_get_root = Git.get_root
+    dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, "p")
+    buffers = {}
+
+    package.loaded["vibing.application.chat.orchestration_link"] = nil
+    OrchestrationLink = require("vibing.application.chat.orchestration_link")
+  end)
+
+  after_each(function()
+    Git.get_root = original_get_root
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    vim.fn.delete(dir, "rf")
+  end)
+
+  it("resolves a git-root-relative path to the open buffer", function()
+    Git.get_root = function()
+      return dir
+    end
+    local bufnr = open_buffer("worker.md")
+
+    assert.same({ bufnr }, OrchestrationLink.resolve_bufnrs({ "worker.md" }))
+  end)
+
+  it("accepts the hand-written scalar form", function()
+    Git.get_root = function()
+      return dir
+    end
+    local bufnr = open_buffer("worker.md")
+
+    assert.same({ bufnr }, OrchestrationLink.resolve_bufnrs("worker.md"))
+  end)
+
+  it("returns nothing for an absent or empty list", function()
+    assert.same({}, OrchestrationLink.resolve_bufnrs(nil))
+    assert.same({}, OrchestrationLink.resolve_bufnrs({}))
+  end)
+
+  it("re-resolves the git root after a directory becomes a repository", function()
+    -- 「gitではない」をキャッシュすると、あとから git init された（あるいはworktreeが生えた）
+    -- ディレクトリが永久に誤判定のままになり、`orchestrated_by` の解決が黙って空を返し続ける。
+    -- pcall で握りつぶされるので、エラーにもならず気づけない
+    local calls = 0
+    Git.get_root = function()
+      calls = calls + 1
+      return nil
+    end
+    local bufnr = open_buffer("worker.md")
+
+    assert.same({}, OrchestrationLink.resolve_bufnrs({ "worker.md" }))
+
+    Git.get_root = function()
+      calls = calls + 1
+      return dir
+    end
+
+    assert.same({ bufnr }, OrchestrationLink.resolve_bufnrs({ "worker.md" }))
+    assert.equals(2, calls, "a failed lookup must not be remembered")
+  end)
+
+  it("caches a successful lookup instead of spawning git per send", function()
+    local calls = 0
+    Git.get_root = function()
+      calls = calls + 1
+      return dir
+    end
+    open_buffer("worker.md")
+
+    OrchestrationLink.resolve_bufnrs({ "worker.md" })
+    OrchestrationLink.resolve_bufnrs({ "worker.md" })
+    OrchestrationLink.resolve_bufnrs({ "worker.md" })
+
+    assert.equals(1, calls)
+  end)
+end)

--- a/tests/lua/application/chat/orchestration_link_spec.lua
+++ b/tests/lua/application/chat/orchestration_link_spec.lua
@@ -1,4 +1,120 @@
 local Git = require("vibing.core.utils.git")
+local FrontmatterHandler = require("vibing.presentation.chat.modules.frontmatter_handler")
+local ChatFiles = require("tests.helpers.chat_files")
+local view = require("vibing.presentation.chat.view")
+
+describe("OrchestrationLink.link", function()
+  local OrchestrationLink
+  local original_get_root, original_get_chat_buffer
+  local dir
+  local buffers = {}
+  local refuse_writes_for = nil
+
+  ---ファイル実体を持つチャットバッファを開き、`view.get_chat_buffer` が返す形に包む
+  ---@param name string
+  ---@return number bufnr
+  local function open_chat(name)
+    ChatFiles.write(dir, name, {})
+    local bufnr = vim.fn.bufadd(dir .. "/" .. name)
+    vim.fn.bufload(bufnr)
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  ---@param path string
+  ---@return table
+  local function frontmatter_on_disk(path)
+    return ChatFiles.read_frontmatter(path)
+  end
+
+  before_each(function()
+    original_get_root = Git.get_root
+    original_get_chat_buffer = view.get_chat_buffer
+    dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, "p")
+    -- `nvim_buf_get_name` はシンボリックリンクを解決した形を返す（macOSでは `/var` が
+    -- `/private/var`）。gitルートを未解決のまま渡すと `to_display_path` が「ルート外」と
+    -- 判断して絶対パスを書くので、テストの前提から外れる
+    dir = vim.fn.resolve(dir)
+    buffers = {}
+    refuse_writes_for = nil
+
+    Git.get_root = function()
+      return dir
+    end
+    view.get_chat_buffer = function(bufnr)
+      if not vim.api.nvim_buf_is_valid(bufnr) then
+        return nil
+      end
+      return {
+        update_frontmatter_list = function(_, key, value, action)
+          -- frontmatter の閉じ `---` が走査範囲外にあるチャットでは false が返る。
+          -- 実際に長い permission 配列で起きるケースを、書き込み拒否として再現する
+          if refuse_writes_for == bufnr then
+            return false
+          end
+          return FrontmatterHandler.update_list(bufnr, key, value, action)
+        end,
+        get_frontmatter_list = function(_, key)
+          return FrontmatterHandler.get_list(bufnr, key)
+        end,
+      }
+    end
+
+    package.loaded["vibing.application.chat.orchestration_link"] = nil
+    OrchestrationLink = require("vibing.application.chat.orchestration_link")
+  end)
+
+  after_each(function()
+    Git.get_root = original_get_root
+    view.get_chat_buffer = original_get_chat_buffer
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    vim.fn.delete(dir, "rf")
+  end)
+
+  it("records both directions and saves both files", function()
+    local from, to = open_chat("orchestrator.md"), open_chat("worker.md")
+
+    assert.is_true(OrchestrationLink.link(from, to))
+
+    assert.same({ "worker.md" }, frontmatter_on_disk(dir .. "/orchestrator.md").orchestrated)
+    assert.same({ "orchestrator.md" }, frontmatter_on_disk(dir .. "/worker.md").orchestrated_by)
+  end)
+
+  it("saves the side that did get written when the other refuses", function()
+    -- 片肺でもリネーム同期は書けた側で動く。ここで保存を飛ばすと、書き込みに成功した
+    -- バッファが modified のまま一度も保存されない（呼び出し元は警告するだけで続行する）
+    local from, to = open_chat("orchestrator.md"), open_chat("worker.md")
+    refuse_writes_for = to
+
+    local ok, err = OrchestrationLink.link(from, to)
+
+    assert.is_false(ok)
+    assert.is_truthy(err)
+    assert.same({ "worker.md" }, frontmatter_on_disk(dir .. "/orchestrator.md").orchestrated)
+    assert.is_false(vim.bo[from].modified, "the written side must not be left dirty")
+  end)
+
+  it("refuses a chat linking to itself", function()
+    local bufnr = open_chat("solo.md")
+
+    assert.is_false(OrchestrationLink.link(bufnr, bufnr))
+  end)
+
+  it("does not rewrite when both sides already record the relationship", function()
+    local from, to = open_chat("orchestrator.md"), open_chat("worker.md")
+    assert.is_true(OrchestrationLink.link(from, to))
+
+    -- 作成と送信の両方で `from_bufnr` が渡るので、同じリンクが2回書かれる経路がある
+    assert.is_true(OrchestrationLink.link(from, to))
+
+    assert.same({ "worker.md" }, frontmatter_on_disk(dir .. "/orchestrator.md").orchestrated)
+  end)
+end)
 
 describe("OrchestrationLink.resolve_bufnrs", function()
   ---gitルートのキャッシュはモジュールレベルなのでspec間で持ち越す。毎回requireし直して捨てる

--- a/tests/lua/infrastructure/link/forked_chat_scanner_spec.lua
+++ b/tests/lua/infrastructure/link/forked_chat_scanner_spec.lua
@@ -1,26 +1,7 @@
 local ForkedChatScanner = require("vibing.infrastructure.link.forked_chat_scanner")
 local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+local ChatFiles = require("tests.helpers.chat_files")
 local Git = require("vibing.core.utils.git")
-
----@param dir string
----@param name string
----@param frontmatter table
----@return string path
-local function write_chat(dir, name, frontmatter)
-  local path = dir .. "/" .. name
-  local defaults = { ["vibing.nvim"] = true, session_id = "session-" .. name }
-  for k, v in pairs(frontmatter) do
-    defaults[k] = v
-  end
-  vim.fn.writefile(vim.split(Frontmatter.serialize(defaults, "## User\n"), "\n", { plain = true }), path)
-  return path
-end
-
----@param path string
----@return table
-local function read_frontmatter(path)
-  return (Frontmatter.parse(table.concat(vim.fn.readfile(path), "\n")))
-end
 
 describe("ForkedChatScanner", function()
   local dir
@@ -42,47 +23,47 @@ describe("ForkedChatScanner", function()
 
   it("finds a fork that points at the renamed source", function()
     local source = dir .. "/source.md"
-    local fork = write_chat(dir, "fork.md", { forked_from = "source.md" })
+    local fork = ChatFiles.write(dir, "fork.md", { forked_from = "source.md" })
 
     assert.is_true(ForkedChatScanner.new():contains_link(fork, source))
   end)
 
   it("ignores a chat with no forked_from", function()
-    local other = write_chat(dir, "other.md", {})
+    local other = ChatFiles.write(dir, "other.md", {})
 
     assert.is_false(ForkedChatScanner.new():contains_link(other, dir .. "/source.md"))
   end)
 
   it("ignores a fork that points somewhere else", function()
-    local fork = write_chat(dir, "fork.md", { forked_from = "elsewhere.md" })
+    local fork = ChatFiles.write(dir, "fork.md", { forked_from = "elsewhere.md" })
 
     assert.is_false(ForkedChatScanner.new():contains_link(fork, dir .. "/source.md"))
   end)
 
   it("rewrites forked_from to the new display path", function()
-    local fork = write_chat(dir, "fork.md", { forked_from = "source.md" })
+    local fork = ChatFiles.write(dir, "fork.md", { forked_from = "source.md" })
 
     local ok = ForkedChatScanner.new():update_link(fork, dir .. "/source.md", dir .. "/renamed.md")
 
     assert.is_true(ok)
-    assert.equals("renamed.md", read_frontmatter(fork).forked_from)
+    assert.equals("renamed.md", ChatFiles.read_frontmatter(fork).forked_from)
   end)
 
   it("replaces the whole key, which is why a list field needs its own scanner", function()
     -- `forked_from` はスカラーなので `Frontmatter.update` にキーごと渡して問題ない。
     -- 同じ実装をリスト（orchestrated / orchestrated_by）に流用すると他の要素が消えるため、
     -- `OrchestrationChatScanner` は要素単位で書き換えている
-    local fork = write_chat(dir, "fork.md", { forked_from = "source.md" })
+    local fork = ChatFiles.write(dir, "fork.md", { forked_from = "source.md" })
 
     ForkedChatScanner.new():update_link(fork, dir .. "/source.md", dir .. "/renamed.md")
 
-    local frontmatter = read_frontmatter(fork)
+    local frontmatter = ChatFiles.read_frontmatter(fork)
     assert.equals("renamed.md", frontmatter.forked_from)
     assert.is_true(frontmatter["vibing.nvim"])
   end)
 
   it("reports a failure when there is no forked_from to update", function()
-    local other = write_chat(dir, "other.md", {})
+    local other = ChatFiles.write(dir, "other.md", {})
 
     local ok, err = ForkedChatScanner.new():update_link(other, dir .. "/source.md", dir .. "/renamed.md")
 

--- a/tests/lua/infrastructure/link/orchestration_chat_scanner_spec.lua
+++ b/tests/lua/infrastructure/link/orchestration_chat_scanner_spec.lua
@@ -1,26 +1,7 @@
 local OrchestrationChatScanner = require("vibing.infrastructure.link.orchestration_chat_scanner")
 local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+local ChatFiles = require("tests.helpers.chat_files")
 local Git = require("vibing.core.utils.git")
-
----@param dir string
----@param name string
----@param frontmatter table
----@return string path
-local function write_chat(dir, name, frontmatter)
-  local path = dir .. "/" .. name
-  local defaults = { ["vibing.nvim"] = true, session_id = "session-" .. name }
-  for k, v in pairs(frontmatter) do
-    defaults[k] = v
-  end
-  vim.fn.writefile(vim.split(Frontmatter.serialize(defaults, "## User\n"), "\n", { plain = true }), path)
-  return path
-end
-
----@param path string
----@return table
-local function read_frontmatter(path)
-  return (Frontmatter.parse(table.concat(vim.fn.readfile(path), "\n")))
-end
 
 describe("OrchestrationChatScanner", function()
   local dir
@@ -46,14 +27,14 @@ describe("OrchestrationChatScanner", function()
   describe("contains_link", function()
     it("finds a chat that names the renamed file in orchestrated", function()
       local worker = dir .. "/worker.md"
-      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = { "worker.md" } })
+      local orchestrator = ChatFiles.write(dir, "orchestrator.md", { orchestrated = { "worker.md" } })
 
       assert.is_true(OrchestrationChatScanner.new():contains_link(orchestrator, worker))
     end)
 
     it("finds a chat that names the renamed file in orchestrated_by", function()
       local orchestrator = dir .. "/orchestrator.md"
-      local worker = write_chat(dir, "worker.md", { orchestrated_by = { "orchestrator.md" } })
+      local worker = ChatFiles.write(dir, "worker.md", { orchestrated_by = { "orchestrator.md" } })
 
       assert.is_true(OrchestrationChatScanner.new():contains_link(worker, orchestrator))
     end)
@@ -69,7 +50,7 @@ describe("OrchestrationChatScanner", function()
       local home_dir = vim.fn.expand("~") .. "/.vibing-orchestration-spec-" .. vim.fn.getpid()
       vim.fn.mkdir(home_dir, "p")
       local worker = home_dir .. "/worker.md"
-      local orchestrator = write_chat(home_dir, "orchestrator.md", {
+      local orchestrator = ChatFiles.write(home_dir, "orchestrator.md", {
         orchestrated = { vim.fn.fnamemodify(worker, ":~") },
       })
 
@@ -82,20 +63,20 @@ describe("OrchestrationChatScanner", function()
     it("reads a hand-written scalar link instead of erroring on it", function()
       -- `orchestrated: worker.md` と1行で書かれると table ではなく文字列でパースされる
       local worker = dir .. "/worker.md"
-      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = "worker.md" })
+      local orchestrator = ChatFiles.write(dir, "orchestrator.md", { orchestrated = "worker.md" })
 
       assert.is_true(OrchestrationChatScanner.new():contains_link(orchestrator, worker))
     end)
 
     it("ignores a chat with no orchestration links", function()
-      local other = write_chat(dir, "other.md", { forked_from = "worker.md" })
+      local other = ChatFiles.write(dir, "other.md", { forked_from = "worker.md" })
 
       assert.is_false(OrchestrationChatScanner.new():contains_link(other, dir .. "/worker.md"))
     end)
 
     it("ignores an empty link list rather than treating it as a match", function()
       -- 空リストは真値の table としてパースされるので、存在チェックだけでは弾けない
-      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = {} })
+      local orchestrator = ChatFiles.write(dir, "orchestrator.md", { orchestrated = {} })
 
       assert.is_false(OrchestrationChatScanner.new():contains_link(orchestrator, dir .. "/worker.md"))
     end)
@@ -112,39 +93,39 @@ describe("OrchestrationChatScanner", function()
     it("replaces only the matching element and keeps the rest of the list", function()
       -- `ForkedChatScanner` をそのままコピーすると落ちる箇所。`forked_from` はスカラーなので
       -- キーごと差し替えられるが、リストで同じことをすると他の要素が消える
-      local orchestrator = write_chat(dir, "orchestrator.md", {
+      local orchestrator = ChatFiles.write(dir, "orchestrator.md", {
         orchestrated = { "alpha.md", "worker.md", "bravo.md" },
       })
 
       local ok = OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
 
       assert.is_true(ok)
-      assert.same({ "alpha.md", "renamed.md", "bravo.md" }, read_frontmatter(orchestrator).orchestrated)
+      assert.same({ "alpha.md", "renamed.md", "bravo.md" }, ChatFiles.read_frontmatter(orchestrator).orchestrated)
     end)
 
     it("updates orchestrated_by as well as orchestrated", function()
-      local worker = write_chat(dir, "worker.md", { orchestrated_by = { "orchestrator.md" } })
+      local worker = ChatFiles.write(dir, "worker.md", { orchestrated_by = { "orchestrator.md" } })
 
       local ok =
         OrchestrationChatScanner.new():update_link(worker, dir .. "/orchestrator.md", dir .. "/renamed.md")
 
       assert.is_true(ok)
-      assert.same({ "renamed.md" }, read_frontmatter(worker).orchestrated_by)
+      assert.same({ "renamed.md" }, ChatFiles.read_frontmatter(worker).orchestrated_by)
     end)
 
     it("does not leave a duplicate when the new name is already in the list", function()
-      local orchestrator = write_chat(dir, "orchestrator.md", {
+      local orchestrator = ChatFiles.write(dir, "orchestrator.md", {
         orchestrated = { "worker.md", "renamed.md" },
       })
 
       local ok = OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
 
       assert.is_true(ok)
-      assert.same({ "renamed.md" }, read_frontmatter(orchestrator).orchestrated)
+      assert.same({ "renamed.md" }, ChatFiles.read_frontmatter(orchestrator).orchestrated)
     end)
 
     it("leaves other frontmatter keys untouched", function()
-      local orchestrator = write_chat(dir, "orchestrator.md", {
+      local orchestrator = ChatFiles.write(dir, "orchestrator.md", {
         orchestrated = { "worker.md" },
         permissions_allow = { "Read", "Edit" },
         model = "sonnet",
@@ -152,7 +133,7 @@ describe("OrchestrationChatScanner", function()
 
       OrchestrationChatScanner.new():update_link(orchestrator, dir .. "/worker.md", dir .. "/renamed.md")
 
-      local frontmatter = read_frontmatter(orchestrator)
+      local frontmatter = ChatFiles.read_frontmatter(orchestrator)
       assert.same({ "Read", "Edit" }, frontmatter.permissions_allow)
       assert.equals("sonnet", frontmatter.model)
       assert.is_true(frontmatter["vibing.nvim"])
@@ -162,7 +143,7 @@ describe("OrchestrationChatScanner", function()
       -- オーケストレーションのリンクはbufnr起点で張られるので、同期の相手は常に開いている。
       -- ディスクを直接書くと、そのバッファの次の保存が同期内容を巻き戻すか、
       -- 「読み込み後にファイルが変わった」プロンプトでNeovimを止める
-      local orchestrator = write_chat(dir, "orchestrator.md", { orchestrated = { "worker.md" } })
+      local orchestrator = ChatFiles.write(dir, "orchestrator.md", { orchestrated = { "worker.md" } })
       local bufnr = vim.fn.bufadd(orchestrator)
       vim.fn.bufload(bufnr)
 
@@ -176,7 +157,7 @@ describe("OrchestrationChatScanner", function()
       assert.is_truthy(table.concat(lines, "\n"):find("renamed.md", 1, true), "buffer should carry the new link")
       assert.is_false(modified, "the buffer should be saved, not left dirty")
       -- ディスク側も追随している
-      assert.same({ "renamed.md" }, read_frontmatter(orchestrator).orchestrated)
+      assert.same({ "renamed.md" }, ChatFiles.read_frontmatter(orchestrator).orchestrated)
     end)
 
     it("leaves the body of a loaded buffer alone", function()
@@ -204,7 +185,7 @@ describe("OrchestrationChatScanner", function()
     end)
 
     it("reports a failure when the file has no matching link", function()
-      local other = write_chat(dir, "other.md", { orchestrated = { "alpha.md" } })
+      local other = ChatFiles.write(dir, "other.md", { orchestrated = { "alpha.md" } })
 
       local ok, err = OrchestrationChatScanner.new():update_link(other, dir .. "/worker.md", dir .. "/renamed.md")
 
@@ -219,8 +200,8 @@ describe("OrchestrationChatScanner", function()
     end)
 
     it("finds both .md and .vibing chat files", function()
-      write_chat(dir, "a.md", {})
-      write_chat(dir, "b.vibing", {})
+      ChatFiles.write(dir, "a.md", {})
+      ChatFiles.write(dir, "b.vibing", {})
 
       local files = OrchestrationChatScanner.new():find_target_files(dir .. "/")
 

--- a/tests/lua/infrastructure/rpc/handlers/message_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/message_spec.lua
@@ -1,0 +1,119 @@
+-- `nvim_chat_send_message` のRPCハンドラ。
+--
+-- ここでしか再現しない相互作用がひとつある: 完了通知の購読と、実際に送れたかどうかの関係。
+-- 購読を送信より前に張ると、送信が弾かれたときに「送っていないメッセージについて相手が
+-- 終わった、読みに行け」という通知だけが後から届く。`completion_notifier` 単体テストにも
+-- `programmatic_sender` 単体テストにも、この経路は現れない。
+
+local Message = require("vibing.infrastructure.rpc.handlers.message")
+local Config = require("vibing.config")
+local view = require("vibing.presentation.chat.view")
+local OrchestrationLink = require("vibing.application.chat.orchestration_link")
+
+describe("rpc handlers.message.send_message", function()
+  local Notifier
+  local originals = {}
+  local buffers = {}
+  local chats = {}
+
+  ---@return number bufnr
+  local function make_chat()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "---", "vibing.nvim: true", "---", "" })
+    table.insert(buffers, bufnr)
+    chats[bufnr] = { responding = false, accepts = true, sends = 0 }
+    return bufnr
+  end
+
+  before_each(function()
+    originals.get = Config.get
+    originals.get_chat_buffer = view.get_chat_buffer
+    originals.link = OrchestrationLink.link
+
+    buffers, chats = {}, {}
+
+    Config.get = function()
+      return { agent = { chat_notifications = { enabled = true, max_hops = 8 } } }
+    end
+    view.get_chat_buffer = function(bufnr)
+      local chat = chats[bufnr]
+      if not chat then
+        return nil
+      end
+      return {
+        is_responding = function()
+          return chat.responding
+        end,
+        extract_user_message = function()
+          return nil
+        end,
+        send_message = function()
+          chat.sends = chat.sends + 1
+          return chat.accepts
+        end,
+      }
+    end
+    -- リンクの書き込みはこのspecの主題ではない（ディスクに触るのも避ける）
+    OrchestrationLink.link = function()
+      return true, nil
+    end
+
+    package.loaded["vibing.application.chat.completion_notifier"] = nil
+    Notifier = require("vibing.application.chat.completion_notifier")
+  end)
+
+  after_each(function()
+    Config.get = originals.get
+    view.get_chat_buffer = originals.get_chat_buffer
+    OrchestrationLink.link = originals.link
+
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end)
+
+  it("subscribes the sender once the message is actually taken", function()
+    local from, to = make_chat(), make_chat()
+
+    Message.send_message({ bufnr = to, message = "do the thing", from_bufnr = from })
+    Notifier.on_response_done(to)
+
+    assert.equals(1, chats[from].sends, "the sender should be woken by the completion")
+  end)
+
+  it("leaves no subscription when the target is busy and the send is refused", function()
+    local from, to = make_chat(), make_chat()
+    chats[to].responding = true
+
+    assert.has_error(function()
+      Message.send_message({ bufnr = to, message = "do the thing", from_bufnr = from })
+    end)
+
+    -- 送信が通らなかったのだから、宛先がいま走っているターンを終えても通知は届かない
+    chats[to].responding = false
+    Notifier.on_response_done(to)
+
+    assert.equals(0, chats[from].sends)
+  end)
+
+  it("leaves no subscription when the chat silently declines the message", function()
+    local from, to = make_chat(), make_chat()
+    chats[to].accepts = false
+
+    Message.send_message({ bufnr = to, message = "do the thing", from_bufnr = from })
+    Notifier.on_response_done(to)
+
+    assert.equals(0, chats[from].sends)
+  end)
+
+  it("sends without recording anything when from_bufnr is omitted", function()
+    local to = make_chat()
+
+    local result = Message.send_message({ bufnr = to, message = "do the thing" })
+
+    assert.is_true(result.success)
+    assert.equals(1, chats[to].sends)
+  end)
+end)

--- a/tests/lua/presentation/chat/modules/programmatic_sender_spec.lua
+++ b/tests/lua/presentation/chat/modules/programmatic_sender_spec.lua
@@ -1,0 +1,105 @@
+local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+local ChatBuffer = require("vibing.presentation.chat.buffer")
+local view = require("vibing.presentation.chat.view")
+
+describe("ProgrammaticSender.send", function()
+  local original_get_chat_buffer
+  local bufnr
+  local fake
+
+  before_each(function()
+    original_get_chat_buffer = view.get_chat_buffer
+    bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "---", "vibing.nvim: true", "---", "" })
+
+    fake = { responding = false, sends = 0, result = true }
+    view.get_chat_buffer = function(target)
+      if target ~= bufnr then
+        return nil
+      end
+      return {
+        is_responding = function()
+          return fake.responding
+        end,
+        send_message = function()
+          fake.sends = fake.sends + 1
+          return fake.result
+        end,
+      }
+    end
+  end)
+
+  after_each(function()
+    view.get_chat_buffer = original_get_chat_buffer
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end)
+
+  ---@return number
+  local function user_headers()
+    local count = 0
+    for _, line in ipairs(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)) do
+      if line:match("User") then
+        count = count + 1
+      end
+    end
+    return count
+  end
+
+  it("refuses a chat that is already responding, before touching the buffer", function()
+    -- 追加してから巻き戻すのではなく追加する前に断る。`ChatBuffer:send_message()` は
+    -- 応答中なら黙って return するので、先に append すると送られない `## User` が残り、
+    -- 次にユーザーが<CR>したときの本文に化ける
+    fake.responding = true
+    local before = user_headers()
+
+    assert.has_error(function()
+      ProgrammaticSender.send(bufnr, "hello")
+    end)
+    assert.equals(0, fake.sends)
+    assert.equals(before, user_headers())
+  end)
+
+  it("reports success only when the chat actually took the message", function()
+    assert.is_true(ProgrammaticSender.send(bufnr, "hello").success)
+
+    fake.result = false
+    assert.is_false(ProgrammaticSender.send(bufnr, "hello").success)
+  end)
+
+  it("rejects an empty message and a non-chat buffer", function()
+    assert.has_error(function()
+      ProgrammaticSender.send(bufnr, "   ")
+    end)
+    assert.has_error(function()
+      ProgrammaticSender.send(bufnr + 9999, "hello")
+    end)
+  end)
+end)
+
+describe("ChatBuffer:add_user_section", function()
+  it("does not fire VibingResponseDone on its own", function()
+    -- 完了イベントは send_message() のコールバックラッパー側にある。このメソッド本体に
+    -- 置くと、スラッシュコマンド経路（AIターンが1回も走っていない）からも完了が飛ぶ
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    local chat = setmetatable({ buf = bufnr, win = nil, _chunk_buffer = "" }, ChatBuffer)
+
+    local fired = 0
+    local group = vim.api.nvim_create_augroup("VibingCompletionNotifierSpec", { clear = true })
+    vim.api.nvim_create_autocmd("User", {
+      group = group,
+      pattern = "VibingResponseDone",
+      callback = function()
+        fired = fired + 1
+      end,
+    })
+
+    chat:add_user_section()
+
+    vim.api.nvim_del_augroup_by_id(group)
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+
+    assert.equals(0, fired)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

`nvim_chat_send_message` で別チャットにタスクを投げたあと、**送った側は相手がいつ終わったかを知る手段がない**。`vibing-orchestrate` スキルはこれを「ユーザーが『進捗は?』と聞いたら読む」というポーリング運用で埋めていて、§4 の「ポーリングするな」と「進捗を知りたい」が構造的に両立していなかった。

**A が B にリクエストを送ったという事実そのものを購読の登録にする**ことで解決する。B が応答を終えたら A に「B が止まった、読みに行け」とだけ伝え、判断は A に委ねる。B から A への質問も、B が `nvim_chat_send_message` を呼ぶだけで同じ経路に乗る。

エージェント（CLIプロセス）はターンが終われば死ぬので待ち受けはできない。**受け取り方は「A に新しいターンを起こす」しかなく**、それがこの設計。

> [!IMPORTANT]
> **stacked PR の上段。** base は `main` ではなく #629（`feat/orchestration-links`）で、`from_bufnr` と `orchestrated_by` の上に乗っている。**#629 を先にマージすること。**

既定は `false`。通知は送信元の新しいターンとして届くので無人でトークンを消費する（`subagent` / `auto_resume_on_limit` / `dap` と同じ基準）。

## Changes

- `lua/vibing/application/chat/completion_notifier.lua`（新規）— 購読テーブル、配達キュー、深さ管理
- `buffer.lua` — `callbacks.add_user_section` ラッパーで `User VibingResponseDone` を発火。`<CR>` キーマップ側で深さをリセット。`send_message()` が「実際に扱ったか」を返すように
- `programmatic_sender.lua` — 応答中のバッファへの送信を**追加する前に**拒否し、`success` を実際の結果にする
- `cli_command_builder.lua` — ワーカーに「誰に報告すればいいか」を伝える1行（`orchestrated_by` を生きた bufnr に解決）
- `config.lua` / `init.lua` — `agent.chat_notifications`（`enabled` / `max_hops`）と autocmd 登録
- `git.lua` — `from_display_path`（`to_display_path` の逆）。スキャナーと bufnr 解決で共有

## 設計上の判断

### 発火点は `callbacks.add_user_section` ラッパーだけ

`_handle_response` の完了経路は4つ（セッション破損 / mote finalize / ファイル変更なし / git patch finalize、うち2つは `vim.schedule` の中）あり、すべてこのコールバックに合流する。かつ handle_id 不一致の早期returnより後なので、キャンセル済みの古いターンでは発火しない。

- **`ChatBuffer:add_user_section()` 本体に置いてはいけない** — スラッシュコマンド経路からも呼ばれるので、AIターンが1回も走っていないのに完了が飛ぶ
- **`clear_sending()` の直後では早すぎる** — mote 経路ではまだ `### Modified Files` が書かれておらず、読みに行った側が未完成のトランスクリプトを見る（`chat_status` が抱えているのと同じ窓）

autocmd を挟むのは、ユーザーが自分の設定からも拾えるようにするため（この変更前は `lua/` 配下に `nvim_exec_autocmds` が1箇所も無かった）。

### 応答中のバッファには配達しない — ここが一番壊れやすい

`ChatBuffer:send_message()` は先頭で「前のリクエストが実行中ならキャンセル」を走らせるので、**進行中のターンを殺す**。しかも `_is_sending` ガードは**黙って return** するため、`ProgrammaticSender` は送っていないのに `success = true` を返し、送られない `## User` セクションがバッファに残って**次にユーザーが `<CR>` したときの本文に化ける**。

A が B に投げたあと A 自身のターンが続くのは普通なので、短いタスクほどこの窓に入る。追加してから巻き戻すのではなく、**追加する前に断る**形にした。積まれた通知は A 自身の完了イベントで流れ、複数件は1通に畳む（3ワーカーが同時に終わっても A のターンは1回）。

これは既存バグの修正でもあるので、`auto_resume` と `:VibingDebugAnalyze` も同じ経路で救われる。

### 深さリセットは `<CR>` キーマップ側（イシューの記述から変更）

イシューは `ChatBuffer:send_message()` でリセットと書いていたが、**そこには置けない**。通知の配達自身が `ProgrammaticSender` 経由で同じ関数を通るので、配達のたびに深さが 0 に戻り `max_hops` が一切効かなくなる。`_setup_keymaps` のコールバックだけが本当の手動送信。

A→B→A→B の往復は正当なユースケース（B の質問に A が答える）なので、循環検出ではなく深さで止める。上限超過は `vim.notify` で警告する — 黙って張らないと通知が来ない理由がどこにも残らない。

### `idle` ≠ 成功

`add_user_section` はエラー終了でも、`nvim_ask_user_question` でターンが殺されたときでも、ツール承認待ちでも通る。イベント側で成否を判定すると `chat_status` と同じ罠を踏むので、通知は「止まった、読め」に留めた。本文に B のテキストは載せない（A のコンテキストを汚さない）。

### システムプロンプトに出すのは `orchestrated_by` だけ

ワーカーの `orchestrated_by` は作成時に1回書かれて増えないので、`chat_bufnr` と同じくプロンプトキャッシュ（#469）に対してバイト安定。一方オーケストレーターの `orchestrated` は投げるたびに増えるため、会話の途中でプレフィックスが動く。**そちらは出さない** — 完了通知が読むべき bufnr を名指しするので必要もない。

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix（`ProgrammaticSender` が送っていないのに success を返していた件）
- [x] Test addition or update
- [x] Documentation update

## Testing

- [x] Ran `npm run test:lua`（136 spec ファイル。このPRで追加・変更した分はすべて green）
  - 既存の失敗が2ファイル残る: `summary_input_spec.lua` 8件 / `summary_prompt_spec.lua` 1件。
    いずれも `Could not find vibing.nvim plugin directory` で、**`main` で同一に再現する**ため
    このPRとは無関係
- [x] Ran `npm run check` / `npm run check:doc` / `npm run format:check`
- [x] `markdownlint`: 変更した md に新規指摘なし（残る1件は main と同一の既存 MD013）

追加したテスト:

- `tests/lua/application/chat/completion_notifier_spec.lua`（新規 16 件）— 配達、**responding 中は配達されず進行中ターンが kill されない**、キューの drain と1通への集約、one-shot、複数送信でも通知1回、複数購読者への配達、削除済みバッファ、`enabled = false`、`max_hops` 超過と警告、手動送信でのリセット、autocmd 経由の配達
- `tests/lua/presentation/chat/modules/programmatic_sender_spec.lua`（新規 4 件）— 応答中の拒否が**バッファに触れる前**に起きること、`success` が実際の結果を返すこと、そして **`ChatBuffer:add_user_section()` 単体では `VibingResponseDone` が飛ばない**こと（スラッシュコマンド経路で誤発火しないことの担保）
- `tests/e2e/chat_completion_notification_spec.lua`（新規）— A→B→通知→A の往復。実トークンを使うので `VIBING_E2E=1` ガードあり
- `tests/evals/tasks.lua` — `orchestrate/passes_from_bufnr`。渡し忘れは「黙って通知が来ない」で終わるので、system prompt の表明が効いているかを継続的に測る

### Test Environment

- **Operating System**: macOS (Darwin 25.6.0)

## Documentation

- [x] CLAUDE.md updated（`.claude/rules/architecture.md` の "Out of scope, deliberately" を事実に合わせて改訂し、機構の説明を追加）
- [x] `handbook/configuration.md` に `agent.chat_notifications` を追加
- [x] `claude-plugin/skills/vibing-orchestrate/SKILL.md` §3 / §4 / §5 を改訂
- [x] Code comments added/updated

スキルはポーリング手順を**残さず置き換えた**。併記するとモデルがどちらを取るか選ぶことになり、高くつく方が残る。§5 には「通知1本につきターン1回なので、まだ残っているなら集約せず終われ」を明記した — これが無いと1件終わるたびに中途半端な集約を3回書く。

## Related Issues

Fixes #627

Depends on #629

## Additional Context

**バックエンド差。** 完了イベントは `send_message.lua` 側にあるのでバックエンド非依存で、codex/copilot/grok のワーカーも**通知される側**にはなれる。ただし `nvim_chat_send_message` は MCP ツールなので、MCP サーバーに届かない codex/grok は**購読を張る側**にはなれない（`features.md` の AskUserQuestion と同じ制約）。

**永続化はしない。** Neovim が落ちればワーカーチャットも道連れなので、`pending-resume.json` のような永続化に意味がない。

**残した未決事項**: オーケストレーターが自分のターンの中でポーリングしない方針は維持。通知は A のトランスクリプトに `## User` として残る（`auto_resume` の継続プロンプトと同じ扱い）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional completion notifications between orchestrated chats.
  * Chats can automatically wake subscribed chats when their responses finish.
  * Notifications queue and combine when recipients are busy, with configurable wake-up limits.
  * Workers can now message orchestrators with questions or updates.
* **Improvements**
  * Improved chat-link discovery, path handling, and buffer saving reliability.
* **Documentation**
  * Added configuration and workflow guidance for chat notifications and orchestrated tasks.
* **Tests**
  * Added coverage for notification delivery, orchestration messaging, and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->