### PR TITLE
fix: locate the prompts directory without relying on the checkout being named vibing.nvim

### DIFF
--- a/lua/vibing/core/utils/prompt_loader.lua
+++ b/lua/vibing/core/utils/prompt_loader.lua
@@ -21,14 +21,31 @@ local function substitute_variables(template, replacements)
   return result
 end
 
+---`prompts/` を持つプラグインルートを返す
+---
+---このモジュール自身の位置から辿る。runtimepath を「`vibing.nvim` という名前のディレクトリ」で
+---探す方法も取れるが、それはチェックアウトのディレクトリ名に依存する: git worktree
+---（`.vibing/worktrees/<branch>/`）、任意の名前でのclone、プラグインマネージャによっては
+---付くサフィックスのいずれでも外れ、`prompts/` が読めずに要約とタイトル生成が丸ごと失敗する。
+---モジュールのパスはインストール方法に依らない。
 ---@return string|nil
 local function get_plugin_root()
-  local runtime_paths = vim.api.nvim_list_runtime_paths()
-  for _, path in ipairs(runtime_paths) do
-    if path:match("vibing%.nvim/?$") then
+  local source = debug.getinfo(1, "S").source
+  if source:sub(1, 1) == "@" then
+    -- <root>/lua/vibing/core/utils/prompt_loader.lua から <root> まで5階層
+    local root = vim.fn.fnamemodify(source:sub(2), ":p:h:h:h:h:h")
+    if vim.fn.isdirectory(root .. "/prompts") == 1 then
+      return root
+    end
+  end
+
+  -- 素の `require` ではなく文字列から読み込まれた場合（source が "@path" でない）に備えた保険
+  for _, path in ipairs(vim.api.nvim_list_runtime_paths()) do
+    if vim.fn.isdirectory(path .. "/prompts") == 1 and vim.fn.isdirectory(path .. "/lua/vibing") == 1 then
       return path
     end
   end
+
   return nil
 end
 

--- a/tests/lua/core/utils/prompt_loader_spec.lua
+++ b/tests/lua/core/utils/prompt_loader_spec.lua
@@ -1,0 +1,52 @@
+-- プロンプトの読み込みは、プラグインがどのディレクトリ名で置かれていても通らなければならない。
+--
+-- 元の実装は runtimepath から「`vibing.nvim` という名前で終わるエントリ」を探していた。これは
+-- インストールの仕方に依存する: git worktree（`.vibing/worktrees/<branch>/`）や任意の名前での
+-- clone では一致せず、`prompts/` が読めないので `:VibingSummarize` とタイトル生成が丸ごと
+-- 失敗する。実際、このリポジトリの worktree では summary 系のspecが9件落ちていた。
+
+local PromptLoader = require("vibing.core.utils.prompt_loader")
+
+describe("PromptLoader.load", function()
+  it("loads a bundled prompt", function()
+    local content, err = PromptLoader.load("chat_summary")
+
+    assert.is_nil(err)
+    assert.is_truthy(content)
+  end)
+
+  it("finds the prompts directory with no runtimepath entry named vibing.nvim", function()
+    local original = vim.o.runtimepath
+
+    local kept = {}
+    for _, path in ipairs(vim.api.nvim_list_runtime_paths()) do
+      if not path:match("vibing%.nvim/?$") then
+        table.insert(kept, path)
+      end
+    end
+    vim.o.runtimepath = table.concat(kept, ",")
+
+    local content, err = PromptLoader.load("chat_summary")
+    vim.o.runtimepath = original
+
+    assert.is_nil(err)
+    assert.is_truthy(content)
+  end)
+
+  it("substitutes template variables", function()
+    local content = assert(PromptLoader.load("chat_summary", {
+      conversation = "MARKER-CONVERSATION",
+      repository_instruction = "MARKER-REPO",
+    }))
+
+    assert.is_truthy(content:find("MARKER-CONVERSATION", 1, true))
+    assert.is_nil(content:find("{{conversation}}", 1, true))
+  end)
+
+  it("reports a missing prompt instead of returning empty content", function()
+    local content, err = PromptLoader.load("no_such_prompt_here")
+
+    assert.is_nil(content)
+    assert.is_truthy(err)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

`prompts/` の場所を探す `get_plugin_root()` が、runtimepath から**末尾が `vibing.nvim` のエントリ**を探していた。これはプラグインの性質ではなく「どう置かれているか」の性質なので、置き方が変われば外れる。

git worktree では チェックアウトが `.vibing/worktrees/<branch>/` になるため一致せず、**同梱プロンプトが1つも読めなくなる**。`:VibingSummarize`、`:VibingSetFileTitle` のタイトル生成、daily summary が揃って `Could not find vibing.nvim plugin directory` で落ちる。任意の名前で clone した場合も同じ。

モジュール自身のソースパスから辿る形に変えた。これは置き場所に依存しない。

## Changes

- `get_plugin_root()` を `debug.getinfo` 起点の解決に変更
- フォールバックの runtimepath 走査は残したが、**名前ではなく構造**（`prompts/` と `lua/vibing/` の両方を持つか）で判定する
- `tests/lua/core/utils/prompt_loader_spec.lua` を新規追加（このモジュールには従来テストが無かった）

## なぜ今まで気づかれなかったか

**CI は `vibing.nvim` という名前のディレクトリにチェックアウトするので一致する。** 踏むのは worktree で開発している人だけで、実際このリポジトリの worktree では summary 系の spec が9件落ちていた（`summary_input_spec.lua` 8件 / `summary_prompt_spec.lua` 1件）。CI が緑のまま、ローカルでだけ落ちる形になっていた。

`.claude/rules/self-development.md` が worktree での開発を標準手順として案内しているので、この状態は放置すると案内どおりに動いた人が必ず踏む。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition or update

## Testing

- [x] Ran `npm run test:lua`: worktree で **137 spec / 失敗0**。この修正前は同じ worktree で9件失敗していた
- [x] 追加した spec の1本は、**runtimepath から `vibing.nvim` 名のエントリを取り除いた状態**でプロンプトが読めることを直接固定している（通常のチェックアウトでも回帰を検出できる）
- [x] Ran `npm run check` / `npm run format:check`

### Test Environment

- **Operating System**: macOS (Darwin 25.6.0)

## Documentation

- [x] Code comments added/updated（名前ベースの探索に戻さないよう、理由をコメントに残した）

## Related Issues

なし（#629 / #631 の作業中に発見した独立した不具合）

## Additional Context

`grep` した限り、名前でプラグインルートを探しているのはこの1箇所だけ。
