### PR TITLE
fix: stop the test suite reading and writing ShaDa

### DIFF
--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -27,4 +27,16 @@ end
 vim.opt.swapfile = false
 vim.opt.backup = false
 
+-- ShaDaを一切読み書きしない。
+--
+-- `PlenaryBustedDirectory` はspecファイルごとに子Neovimを起動するので、スイート1回で100以上の
+-- プロセスが同じ ShaDa ファイルを同時に読み書きする。`vim.fn.bufload()` はマーク復元のために
+-- ShaDa を読むため、書き込み途中のファイルに当たると
+-- `E576: Reading ShaDa file: last entry specified that it occupies N bytes, but file ended earlier`
+-- で **specが落ちる**。落ちるファイルは実行ごとに変わり、単体では必ず通るので、コードの不具合と
+-- 見分けがつかない偽陽性になる。
+--
+-- テストがユーザーのShaDa（コマンド履歴・マーク・レジスタ）を読む理由も、汚す理由も無い。
+vim.opt.shadafile = "NONE"
+
 print("Test environment initialized")


### PR DESCRIPTION
# Pull Request

## Summary

`PlenaryBustedDirectory` は spec ファイルごとに子 Neovim を起動するので、スイート1回で **140個のプロセスが同じ ShaDa ファイルを同時に読み書き**する。`vim.fn.bufload()` はマーク復元のために ShaDa を読むため、書き込み途中のファイルに当たった子は

```
E576: Reading ShaDa file: last entry specified that it occupies N bytes, but file ended earlier
```

で spec ごと落ちる。

**落ちるファイルは実行ごとに変わり、単体では必ず通る**ので、コードの不具合と見分けがつかない偽陽性になる。実際この作業中に `window_open_file_spec` → `dap_spec` → `orchestration_link_spec` と3回、別々のファイルで踏んで、そのたびに原因を切り分ける必要があった。

テストがユーザーの ShaDa（コマンド履歴・マーク・レジスタ）を読む理由も、汚す理由も無い。

## Changes

- `tests/minimal_init.lua` に `vim.opt.shadafile = "NONE"` を追加

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] `npm run test:lua` を**3回連続**実行し、いずれも 140 spec / 失敗0
- この修正前は、同じ環境で `bufload` を使う spec が実行ごとに1〜2件ランダムに落ちていた

### Test Environment

- **Operating System**: macOS (Darwin 25.6.0)

## Documentation

- [x] Code comments added/updated（同じ症状を次に見た人が原因に辿り着けるよう、エラーメッセージそのものをコメントに残した）

## Related Issues

なし（#629 / #631 のマージ後に顕在化した既存のテスト基盤の問題）

## Additional Context

以前から到達可能だったが、`bufload` を多用する spec が増えて発生頻度が上がった。CI は1ジョブあたりのプロセス数や実行タイミングが異なるため今のところ緑だが、根本的には同じ競合を抱えている。
