### PR TITLE
fix: complete CLI cancellation without exit callback

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -213,20 +213,19 @@ genuinely disagree on the child environment. `cli_runtime` covers the pieces ins
 repeat.
 
 Two behaviours were unified rather than parameterised while extracting them, because the split
-was drift rather than intent. `cancel()` now kills the CLI's children before the parent on every
-backend; claude killed only the parent, so the shells its tools spawned kept the stdout pipe open
-and `vim.system()`'s exit handler — which waits for that pipe to close — never fired, leaving the
-chat UI frozen. And `execute()` now cancels a run that outlives its timeout instead of returning
-and leaving the process alive; only grok did that. `cli_runtime_spec.lua` runs both over every
-backend.
+was drift rather than intent. `cancel()` now kills the CLI's descendants before the parent on every
+backend; killing only the parent lets shells or MCP servers spawned by tools keep the stdout pipe
+open, and `vim.system()`'s exit handler waits for that pipe to close. And `execute()` now cancels
+a run that outlives its timeout instead of returning and leaving the process alive; only grok did
+that. `cli_runtime_spec.lua` runs both over every backend.
 
-The pkill is asynchronous (`vim.system`, grok's form) rather than blocking (`vim.fn.system`, what
-codex and copilot used), because `cancel()` can be reached from a `vim.schedule` callback and
-should not stall the main loop there. The cost is that the parent's `kill(9)` is not sequenced
-after the children's: signal delivery is effectively immediate, so an orphan is theoretical rather
-than observed, but it is a real ordering change and not something a test can pin while the call is
-fire-and-forget. Revisit by chaining the parent kill onto the pkill's `on_exit` if orphans ever
-show up.
+The descendant walk is asynchronous (`vim.system`) rather than blocking (`vim.fn.system`), because
+`cancel()` can be reached from a `vim.schedule` callback and should not stall the main loop there.
+The shell script walks descendants with `pgrep -P`, kills them deepest-first, then kills the
+parent; `handle:kill(9)` is only a fallback chained to the shell's `on_exit`, preserving that
+ordering. Separately, `cancel()` calls the adapter's wrapped `on_done` path immediately after
+starting termination, so registry cleanup, permission-opt cleanup, timers, and chat UI state do
+not depend on the process exit callback ever arriving.
 
 **Chat (presentation + application):**
 

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -366,7 +366,7 @@ function M._handle_response(response, callbacks, adapter, config, modified_file_
     pcall(AutoResume.discard_scheduled, chat_file_path)
   end
 
-  if response.error then
+  if response.error and not response._cancelled then
     callbacks.append_chunk("\n\n**Error:** " .. response.error)
 
     if is_session_error(tostring(response.error)) and callbacks.get_session_id() then

--- a/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
@@ -60,11 +60,27 @@ kill_descendants() {
   done
 }
 kill_descendants %d
-]], pid)
-  vim.system({ "sh", "-c", script }, {}, function() end)
-  pcall(function()
-    handle:kill(9)
+kill -9 %d 2>/dev/null
+]], pid, pid)
+  vim.system({ "sh", "-c", script }, {}, function()
+    pcall(function()
+      handle:kill(9)
+    end)
   end)
+end
+
+--- Run the stream completion callback without letting one failed callback stop later cancels.
+--- @param handle table
+local function complete_cancel(handle)
+  if not handle.on_cancel then
+    return
+  end
+  local ok, err = pcall(handle.on_cancel)
+  if not ok then
+    vim.schedule(function()
+      vim.notify("[vibing] Cancel cleanup failed: " .. tostring(err), vim.log.levels.WARN)
+    end)
+  end
 end
 
 --- Wrap vim.system's handle with the extra metadata cancel() needs while preserving the small
@@ -220,9 +236,7 @@ function M.install(Class, features)
       if handle then
         self._handles[handle_id] = nil
         M.kill_tree(handle)
-        if handle.on_cancel then
-          handle.on_cancel()
-        end
+        complete_cancel(handle)
       end
       return
     end
@@ -230,9 +244,7 @@ function M.install(Class, features)
     for id, handle in pairs(self._handles) do
       self._handles[id] = nil
       M.kill_tree(handle)
-      if handle.on_cancel then
-        handle.on_cancel()
-      end
+      complete_cancel(handle)
     end
   end
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_runtime.lua
@@ -30,14 +30,15 @@ function M.new_handle_id()
   return string.format("%016x_%x", vim.loop.hrtime(), math.random(100000))
 end
 
---- Kill a spawned CLI along with the children holding its stdout pipe open.
+--- Kill a spawned CLI along with the descendants holding its stdout pipe open.
 ---
 --- Killing only the parent is not enough: the CLI's tool execution spawns shells (and MCP
 --- servers) that inherit the pipe, so `vim.system()`'s exit handler -- which waits for stdout to
---- close -- never fires. The animation never stops and the chat UI stays frozen.
+--- close -- never fires. A single `pkill -P` is not enough either when a backend leaves the pipe
+--- in a grandchild. Kill descendants deepest-first, then the process handle itself.
 ---
---- The pkill is fire-and-forget rather than `vim.fn.system`, because cancel can be reached from a
---- `vim.schedule` callback and blocking Neovim's main loop on it is avoidable.
+--- The descendant walk is fire-and-forget rather than `vim.fn.system`, because cancel can be
+--- reached from a `vim.schedule` callback and blocking Neovim's main loop on it is avoidable.
 ---
 --- @param handle table? a vim.system handle
 function M.kill_tree(handle)
@@ -50,10 +51,36 @@ function M.kill_tree(handle)
     return
   end
 
-  vim.system({ "sh", "-c", string.format("pkill -9 -P %d 2>/dev/null", pid) }, {}, function() end)
+  local script = string.format([[
+kill_descendants() {
+  parent="$1"
+  for child in $(pgrep -P "$parent" 2>/dev/null); do
+    kill_descendants "$child"
+    kill -9 "$child" 2>/dev/null
+  done
+}
+kill_descendants %d
+]], pid)
+  vim.system({ "sh", "-c", script }, {}, function() end)
   pcall(function()
     handle:kill(9)
   end)
+end
+
+--- Wrap vim.system's handle with the extra metadata cancel() needs while preserving the small
+--- handle surface the rest of the adapters use (`pid` and `:kill()`).
+--- @param process table vim.system handle
+--- @param on_cancel fun()
+--- @return table
+local function stream_handle(process, on_cancel)
+  return {
+    process = process,
+    pid = process.pid,
+    kill = function(_, signal)
+      process:kill(signal)
+    end,
+    on_cancel = on_cancel,
+  }
 end
 
 --- An error message with its `file.lua:123:` prefix removed.
@@ -140,7 +167,9 @@ function M.spawn(handles, handle_id, cmd, sys_opts, on_exit, on_done)
     return false
   end
 
-  handles[handle_id] = handle_or_err
+  handles[handle_id] = stream_handle(handle_or_err, function()
+    on_done({ content = "", error = "Cancelled", _handle_id = handle_id, _cancelled = true })
+  end)
   return true
 end
 
@@ -178,7 +207,7 @@ function M.install(Class, features)
     -- Three of the four adapters used to return here and leave the process running.
     if not done then
       self:cancel(handle_id)
-      result.error = result.error or "Execution timeout"
+      result.error = "Execution timeout"
     end
     return result
   end
@@ -189,15 +218,21 @@ function M.install(Class, features)
     if handle_id then
       local handle = self._handles[handle_id]
       if handle then
-        M.kill_tree(handle)
         self._handles[handle_id] = nil
+        M.kill_tree(handle)
+        if handle.on_cancel then
+          handle.on_cancel()
+        end
       end
       return
     end
 
     for id, handle in pairs(self._handles) do
-      M.kill_tree(handle)
       self._handles[id] = nil
+      M.kill_tree(handle)
+      if handle.on_cancel then
+        handle.on_cancel()
+      end
     end
   end
 

--- a/tests/lua/application/chat/send_message_spec.lua
+++ b/tests/lua/application/chat/send_message_spec.lua
@@ -76,6 +76,7 @@ describe("send_message", function()
     ---  how the handler tells which backend ran. `before` seeds a store once the chat's path is
     ---  known but before the turn runs.
     ---@return string chat_path The buffer's name, which is the key both stores use.
+    ---@return string[] appended chunks written to the chat buffer
     local function handle_turn(response, opts)
       opts = opts or {}
       local buf = vim.api.nvim_create_buf(false, true)
@@ -87,6 +88,7 @@ describe("send_message", function()
         opts.before(chat_path)
       end
 
+      local appended = {}
       local callbacks = {
         clear_sending = function() end,
         get_bufnr = function()
@@ -96,7 +98,9 @@ describe("send_message", function()
           return nil
         end,
         update_session_id = function(_) end,
-        append_chunk = function(_) end,
+        append_chunk = function(chunk)
+          table.insert(appended, chunk)
+        end,
         add_user_section = function() end,
       }
       local adapter = {
@@ -109,7 +113,7 @@ describe("send_message", function()
       SendMessage._handle_response(response, callbacks, adapter, {}, {}, "do the thing")
 
       vim.api.nvim_buf_delete(buf, { force = true })
-      return chat_path
+      return chat_path, appended
     end
 
     describe("pending-entry cleanup", function()
@@ -195,6 +199,12 @@ describe("send_message", function()
 
         assert.is_nil(LimitState.load(chat_dir))
       end)
+    end)
+
+    it("does not render an explicit cancellation as a chat error", function()
+      local _, appended = handle_turn({ error = "Cancelled", _cancelled = true, _handle_id = "h-cancel" })
+
+      assert.is_nil(table.concat(appended, ""):find("**Error:** Cancelled", 1, true))
     end)
   end)
 

--- a/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
@@ -25,13 +25,15 @@ describe("cli_runtime", function()
   end)
 
   describe("kill_tree", function()
-    local original_system, spawned
+    local original_system, spawned, exit_callbacks
 
     before_each(function()
       spawned = {}
+      exit_callbacks = {}
       original_system = vim.system
-      vim.system = function(cmd)
+      vim.system = function(cmd, _, on_exit)
         table.insert(spawned, table.concat(cmd, " "))
+        table.insert(exit_callbacks, on_exit)
         return { pid = 1, kill = function() end }
       end
     end)
@@ -52,6 +54,11 @@ describe("cli_runtime", function()
       assert.equals(1, #spawned)
       assert.is_truthy(spawned[1]:find("kill_descendants 4242", 1, true))
       assert.is_truthy(spawned[1]:find("pgrep -P", 1, true))
+      assert.is_truthy(spawned[1]:find("kill -9 4242", 1, true))
+      assert.is_true(spawned[1]:find("kill_descendants 4242", 1, true) < spawned[1]:find("kill -9 4242", 1, true))
+      assert.is_nil(killed)
+
+      exit_callbacks[1]({ code = 0 })
       assert.equals(9, killed)
     end)
 
@@ -87,6 +94,7 @@ describe("cli_runtime", function()
             error("already gone")
           end,
         })
+        exit_callbacks[1]({ code = 0 })
       end)
     end)
   end)
@@ -230,15 +238,19 @@ for _, backend in ipairs(helper.adapters()) do
       adapter:cancel()
 
       local descendant_kill = nil
+      local descendant_kill_on_exit = nil
       for i = before + 1, #system.calls do
         local cmd = table.concat(system.calls[i].cmd, " ")
         if cmd:find("kill_descendants", 1, true) then
           descendant_kill = cmd
+          descendant_kill_on_exit = system.calls[i].on_exit
         end
       end
 
       assert.is_truthy(descendant_kill, "no descendant kill issued: the exit handler would never fire")
       assert.is_truthy(descendant_kill:find("kill_descendants " .. tostring(handle.pid), 1, true))
+      assert.is_false(killed)
+      descendant_kill_on_exit({ code = 0 })
       assert.is_true(killed)
     end)
 
@@ -262,6 +274,41 @@ for _, backend in ipairs(helper.adapters()) do
       assert.has_no.errors(function()
         adapter:cancel()
       end)
+    end)
+
+    it("cancel all keeps cancelling when one completion callback throws", function()
+      local completed = {}
+      adapter._handles = {
+        h1 = {
+          pid = 9001,
+          kill = function() end,
+          on_cancel = function()
+            completed.h1 = true
+            error("cleanup failed")
+          end,
+        },
+        h2 = {
+          pid = 9002,
+          kill = function() end,
+          on_cancel = function()
+            completed.h2 = true
+          end,
+        },
+      }
+
+      local original_notify = vim.notify
+      vim.notify = function() end
+      local ok, err = pcall(function()
+        adapter:cancel()
+      end)
+      vim.wait(20)
+      vim.notify = original_notify
+      assert.is_true(ok, tostring(err))
+
+      assert.is_true(completed.h1)
+      assert.is_true(completed.h2)
+      assert.is_nil(adapter._handles.h1)
+      assert.is_nil(adapter._handles.h2)
     end)
 
     it("execute cancels a run that never finishes rather than leaving it alive", function()

--- a/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua
@@ -1,5 +1,6 @@
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local helper = require("tests.helpers.adapter_stream")
+local ActiveStreamRegistry = require("vibing.infrastructure.adapter.modules.active_stream_registry")
 
 describe("cli_runtime", function()
   describe("new_handle_id", function()
@@ -49,13 +50,14 @@ describe("cli_runtime", function()
       })
 
       assert.equals(1, #spawned)
-      assert.is_truthy(spawned[1]:find("pkill -9 -P 4242", 1, true))
+      assert.is_truthy(spawned[1]:find("kill_descendants 4242", 1, true))
+      assert.is_truthy(spawned[1]:find("pgrep -P", 1, true))
       assert.equals(9, killed)
     end)
 
     it("uses vim.system, not vim.fn.system, so the main loop is not blocked", function()
-      -- cancel() can be reached from a vim.schedule callback; a blocking pkill there stalls
-      -- Neovim for as long as it takes.
+      -- cancel() can be reached from a vim.schedule callback; a blocking descendant walk there
+      -- stalls Neovim for as long as it takes.
       local blocking = false
       local original_fn_system = vim.fn.system
       vim.fn.system = function(...)
@@ -157,7 +159,8 @@ describe("cli_runtime", function()
       end)
 
       assert.is_true(started)
-      assert.equals(handle, handles.h1)
+      assert.equals(handle, handles.h1.process)
+      assert.equals(handle.pid, handles.h1.pid)
       assert.is_false(reported)
     end)
 
@@ -226,17 +229,31 @@ for _, backend in ipairs(helper.adapters()) do
       local before = #system.calls
       adapter:cancel()
 
-      local pkill = nil
+      local descendant_kill = nil
       for i = before + 1, #system.calls do
         local cmd = table.concat(system.calls[i].cmd, " ")
-        if cmd:find("pkill", 1, true) then
-          pkill = cmd
+        if cmd:find("kill_descendants", 1, true) then
+          descendant_kill = cmd
         end
       end
 
-      assert.is_truthy(pkill, "no pkill issued: the exit handler would never fire")
-      assert.is_truthy(pkill:find("-P " .. tostring(handle.pid), 1, true))
+      assert.is_truthy(descendant_kill, "no descendant kill issued: the exit handler would never fire")
+      assert.is_truthy(descendant_kill:find("kill_descendants " .. tostring(handle.pid), 1, true))
       assert.is_true(killed)
+    end)
+
+    it("cancel completes the stream even if the process never reports exit", function()
+      local result = helper.run_stream(adapter)
+
+      adapter:cancel(result.handle_id)
+      vim.wait(200, function()
+        return #result.done_responses > 0
+      end)
+
+      assert.equals(1, #result.done_responses)
+      assert.is_true(result.done_responses[1]._cancelled)
+      assert.equals("Cancelled", result.done_responses[1].error)
+      assert.is_nil(ActiveStreamRegistry.get(result.handle_id))
     end)
 
     it("cancel forgets the handle so a later cancel is a no-op", function()


### PR DESCRIPTION
## Summary
- kill CLI descendants recursively so child/grandchild processes cannot keep stdout open after cancellation
- make cancel complete stream cleanup immediately instead of waiting for the process exit callback
- suppress `**Error:** Cancelled` in the chat buffer while preserving cancellation as a non-successful turn internally

## Tests
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/infrastructure/adapter/modules/cli_runtime_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/infrastructure/adapter/stream_options_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/infrastructure/adapter/codex_cli_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/application/chat/send_message_spec.lua"`
- `HOME=/tmp/vibing-test-home npm run test:lua` (with local Plenary symlink)
- `git diff --check`
- Neovim `loadfile()` Lua syntax check

Note: `npm run check` could not run in the workspace environment because `luac` is not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled chat responses no longer appear as error messages.
  * Cancelling or timing out command execution now reliably closes active streams.
  * Process termination now closes descendant processes cleanly, preventing stalled output.

* **Tests**
  * Added coverage for cancelled responses, descendant process termination, and stream cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->