### PR TITLE
fix: hold the completion edge through a chat's intermediate turn

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1169,6 +1169,48 @@ rolling back), and the notifier queues instead, flushing on the recipient's own 
 Queued notifications coalesce into one message: three workers finishing while the orchestrator is
 busy is one turn, not three.
 
+**A chat drains its own queue before it notifies anyone, and a turn that drained is not reported as
+a completion at all.** `on_response_done` tries `flush(bufnr)` first and returns leaving
+`edges[bufnr]` intact when it delivered, because a delivery _is_ a restart — so the turn that just
+ended was an intermediate one, and the real answer is still being written.
+
+The order used to be the reverse, on the reasoning that draining first would let a subscriber be
+told "B stopped" about a B that had already started again. It does not prevent that. The order
+fixes only who is _sent to_ first within one tick, and a subscriber is a separate CLI process that
+reads seconds later — by which time the synchronous drain has long since restarted B. The edge is
+one-shot, so B's actual report, the turn after the restart, then had nothing left to notify
+through. In a tree of chats where a middle node waits on a leaf this happens every time rather than
+sometimes: "B's queue is non-empty" _means_ "B is about to restart" (#638).
+
+A drain the recipient **refuses** — it is responding, or the user has a draft in it — restarts
+nothing, so subscribers are notified exactly as before.
+
+Three limits are worth writing down, because the rule reads more general than it is.
+
+- **The mirror ordering is untouched.** When the leaf finishes _after_ the middle chat's dispatch
+  turn rather than before — the commoner case, since dispatching takes seconds and the leaf takes
+  minutes — that turn's queue is empty, so A is woken and the edge consumed exactly as before, and
+  B's later report has nothing left to notify through. The signal that would catch it is already
+  live: `edges[c][b]` exists from B's send until C completes and means "B is waiting on a chat that
+  has not finished". Acting on it would also stop A hearing anything at all mid-chain, which is a
+  behaviour change rather than a fix, so it is left open.
+- **The hold is gated on a turn actually starting, not on the send being accepted.**
+  `send_message()` returns "treated as a request", which is also true for a message _parked_ behind
+  a usage limit (`_try_schedule_instead_of_send`) and for one `SendMessage.execute` drops at its
+  no-adapter or shared-session guards — both `clear_sending()` and return without a stream, so no
+  `VibingResponseDone` is ever coming. `flush` therefore reports the recipient's `is_responding()`
+  rather than the send's own result: a turn that never began cannot be the one a subscriber waits
+  for, and notifying now is exactly what the old order did.
+- **A held edge still has no exit but `BufDelete`.** Every edge used to be consumed on the
+  subscribed chat's next completion; one that waits on a follow-up turn is stranded silently if
+  that turn dies before reaching the `add_user_section` wrapper. The gate above removes the routes
+  that never started a turn at all, but not a turn that starts and then vanishes. This is the one
+  case where the new behaviour is worse than the old, and it is accepted for the same reason the
+  module holds no timers.
+
+None of that promises B's next turn is a report for A rather than a reply to the leaf either. Under
+a one-shot edge, "when B next stops" is simply the best moment available.
+
 Two smaller rules. Edges are **one-shot** — delivering consumes them, so a worker completing again
 without a fresh send is silent, and A messaging B three times still notifies once. And the chain is
 bounded by **hops, not cycle detection**: A→B→A→B is a legitimate question-and-answer, so

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -83,25 +83,26 @@ end
 ---A が B に投げたあと A 自身のターンが続くのは普通なので、短いタスクほどこの窓に入る。
 ---積んだままにしておけば、A 自身の VibingResponseDone でここが呼び直される。
 ---@param from_bufnr number
+---@return boolean restarted 配達の結果 from_bufnr が新しいターンを走らせた
 local function flush(from_bufnr)
   local queue = pending[from_bufnr]
   if not queue or #queue == 0 then
-    return
+    return false
   end
 
   if not vim.api.nvim_buf_is_valid(from_bufnr) then
     pending[from_bufnr] = nil
-    return
+    return false
   end
 
   local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(from_bufnr)
   if not chat_buf then
     pending[from_bufnr] = nil
-    return
+    return false
   end
 
   if chat_buf:is_responding() then
-    return
+    return false
   end
 
   -- ユーザーが書きかけの `## User` を残しているなら触らない。配達は新しいセクションを足すので、
@@ -111,7 +112,7 @@ local function flush(from_bufnr)
   if chat_buf.extract_user_message then
     local draft = chat_buf:extract_user_message()
     if draft and vim.trim(draft) ~= "" then
-      return
+      return false
     end
   end
 
@@ -130,12 +131,21 @@ local function flush(from_bufnr)
     -- 下げてはいけない。深く連鎖したチャットが、浅い時点で張られたエッジの配達を受けたときに
     -- カウンタが戻ると、max_hops が連鎖を止められなくなる
     depth[from_bufnr] = math.max(depth[from_bufnr] or 0, deepest + 1)
-  else
-    notify.warn(
-      string.format("Could not notify chat %d: %s", from_bufnr, ok and "the chat refused the message" or tostring(result)),
-      "Chat Notifications"
-    )
+
+    -- 送信が受理されたことと、ターンが始まったことは別。`ChatBuffer:send_message()` が返すのは
+    -- 「リクエストとして扱ったか」で、リミット中の予約（`_try_schedule_instead_of_send`）でも、
+    -- `SendMessage.execute` がアダプタ未設定・セッション競合で降りた場合でも true になる。
+    -- 後者はストリームを張らないので `VibingResponseDone` が来ず、呼び出し元がこれを再稼働と
+    -- 読むとエッジが宙に浮く。始まっていないターンを購読者の待ち先にはできないので、
+    -- 送信結果ではなく相手の状態を返す
+    return chat_buf:is_responding()
   end
+
+  notify.warn(
+    string.format("Could not notify chat %d: %s", from_bufnr, ok and "the chat refused the message" or tostring(result)),
+    "Chat Notifications"
+  )
+  return false
 end
 
 ---A が B に送ったことを購読として記録する
@@ -188,15 +198,22 @@ function M.subscribe(from_bufnr, to_bufnr)
   return true
 end
 
----応答完了。購読者への配達と、自分宛キューの drain を行う
+---応答完了。自分宛キューの drain と、購読者への配達を行う
 ---@param bufnr number
 function M.on_response_done(bufnr)
   if not settings().enabled then
     return
   end
 
-  -- 購読者への配達が先。自分のキューを先に流すと bufnr が新しいターンを始めてしまい、
-  -- 「bufnr は終わった、読め」という通知を、走り出した直後の bufnr について配ることになる
+  -- 自分宛キューの drain が先。配達できた = bufnr はこのターンでは終わっておらず、続きの
+  -- ターンが控えている（リミット中なら予約として）ということなので、この完了は購読者に見せない。
+  -- 順序を逆にしても防げない理由と、この規則が拾えない側の順序は
+  -- architecture.md → Multi-Agent Orchestration（#638）
+  if flush(bufnr) then
+    -- edges[bufnr] は消費せずに残す。bufnr が本当に止まったときの完了で配達される
+    return
+  end
+
   local subscribers = edges[bufnr]
   if subscribers then
     -- 配達した時点で購読は消える（one-shot）。B が次に完了しても、A が改めて送っていなければ
@@ -211,8 +228,6 @@ function M.on_response_done(bufnr)
       flush(from_bufnr)
     end
   end
-
-  flush(bufnr)
 end
 
 ---ユーザーが手動送信したので通知チェーンの深さをリセットする

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -57,6 +57,12 @@ describe("CompletionNotifier", function()
       if send_result.throws then
         error("boom")
       end
+      -- 実物と同じく、送信が通ればその場でターンが走り出す。`send_result.starts_turn = false` が
+      -- リミット中の予約や `SendMessage.execute` の早期returnで、受理はされたがターンは
+      -- 始まらなかった場合
+      if send_result.success and send_result.starts_turn ~= false then
+        responding[bufnr] = true
+      end
       return { success = send_result.success, bufnr = bufnr }
     end
     notify.warn = function(message, title)
@@ -319,6 +325,71 @@ describe("CompletionNotifier", function()
     assert.equals(1, #sends)
   end)
 
+  it("holds the edge through a turn that only exists to restart the chat", function()
+    -- A → B → C の2段。C の完了通知が B に滞留している間に、B の中間ターン（「C に送った、
+    -- 待つ」だけのターン）が終わるケース
+    local a, b, c = make_chat(), make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.subscribe(b, c)
+
+    responding[b] = true
+    Notifier.on_response_done(c)
+    assert.equals(0, #sends, "B is responding, so C's completion stays queued")
+
+    responding[b] = false
+    Notifier.on_response_done(b)
+
+    assert.equals(1, #sends, "only B's own queue drains; A is not woken mid-flight")
+    assert.equals(b, sends[1].bufnr)
+
+    -- B の2ターン目（本命の報告）が終わって初めて A に配達される
+    Notifier.on_response_done(b)
+
+    assert.equals(2, #sends)
+    assert.equals(a, sends[2].bufnr)
+  end)
+
+  it("does not hold the edge for a delivery that started no turn", function()
+    -- `ChatBuffer:send_message()` は「リクエストとして扱ったか」を返すので、リミット中の予約でも
+    -- `SendMessage.execute` がアダプタ未設定・セッション競合で降りた場合でも true になる。
+    -- 後者はストリームを張らず `VibingResponseDone` も来ないので、これを再稼働と読むと
+    -- エッジは二度と配達されずに残る
+    local a, b, c = make_chat(), make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.subscribe(b, c)
+
+    responding[b] = true
+    Notifier.on_response_done(c)
+
+    responding[b] = false
+    send_result = { success = true, starts_turn = false }
+    Notifier.on_response_done(b)
+
+    assert.equals(2, #sends, "B's queue drains, and A is told because B did not restart")
+    assert.equals(b, sends[1].bufnr)
+    assert.equals(a, sends[2].bufnr)
+  end)
+
+  it("still notifies subscribers when the queued delivery was refused", function()
+    -- 配達が拒否された = そのバッファは再稼働しないので、購読者への配達を見送る理由がない
+    local a, b, c = make_chat(), make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.subscribe(b, c)
+
+    responding[b] = true
+    Notifier.on_response_done(c)
+
+    responding[b] = false
+    drafts[b] = "the user is typing in the middle chat"
+    Notifier.on_response_done(b)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+  end)
+
   it("never lowers the hop count when a shallow edge is delivered late", function()
     configure({ max_hops = 2 })
     local a, b, c = make_chat(), make_chat(), make_chat()
@@ -328,8 +399,10 @@ describe("CompletionNotifier", function()
 
     Notifier.subscribe(a, b)
     Notifier.on_response_done(b) -- depth[a] = 1
+    responding[a] = false -- 起こされた A のターンが終わる
     Notifier.subscribe(a, b)
     Notifier.on_response_done(b) -- depth[a] = 2
+    responding[a] = false
 
     -- 深さ0で張られた c のエッジがここで配達されても、カウンタは戻らない
     Notifier.on_response_done(c)


### PR DESCRIPTION
# Pull Request

## Summary

A → B → C とチャット網を2段に張ったとき（A がオーケストレータ、B が中間、C が末端）、B の
**中間ターン**（「C に送りました、待っています」だけのターン）の完了で A←B のエッジが消費され、
A は `status: responding` の書きかけトランスクリプトを読まされたうえ、B の本命の報告ターンが
終わっても二度と通知が来なくなっていた。

`completion_notifier.on_response_done` が、自分宛キューの drain より先に購読者へ配達していた
のが原因。旧コードのコメントは「自分のキューを先に流すと bufnr が新しいターンを始めてしまう」
のを避けるためだと説明していたが、**この順序ではそれを防げていない**。順序が保証するのは同一
tick 内の送信順だけで、購読者（別の CLI プロセス）が実際に読みに来るのは数秒後。その頃には
直後の `flush(bufnr)` が同期的に bufnr を再稼働させ終えている。しかも「bufnr のキューが空でない」
＝「この直後に必ず再稼働する」なので、中間ノードが待ち合わせをするトポロジでは毎回発生する。
競合ではなく構造的なもの。

## Changes

- `flush()` を `boolean` を返す関数に変更。返す値は「送信が受理されたか」ではなく
  **「配達の結果、相手が新しいターンを走らせたか」**
- `on_response_done()` で自分宛キューの drain を先に試み、それが成功したら購読者への配達と
  エッジの消費を見送って return。`edges[bufnr]` を残すので、bufnr が本当に止まったときの完了で
  改めて配達される
- 配達が拒否された場合（相手が応答中／下書きあり／送信失敗）は再稼働しないので、従来どおり
  購読者へ配達する
- 保持の判定を `chat_buf:is_responding()` で行う。`ChatBuffer:send_message()` が返すのは
  「リクエストとして扱ったか」で、リミット中の予約（`_try_schedule_instead_of_send`）でも、
  `SendMessage.execute` がアダプタ未設定・セッション競合で降りた場合でも `true` になる。
  後者はストリームを張らず `VibingResponseDone` も来ないため、送信結果を再稼働と読むと
  エッジが宙に浮く
- 回帰テスト3件を追加、`.claude/rules/architecture.md` の Multi-Agent Orchestration 節を更新

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Ran `pnpm run test:lua` — exit 0、全 spec ファイルの Failed + Errors 合計 0
- [x] Ran `pnpm run check`（`luac -p`）
- [x] Ran `pnpm run format:check`
- [x] `pnpm run lint:md` — `.claude/rules/architecture.md` は 0 件（総エラー数は変更前後とも
      502 で、既存分のみ）
- [ ] Tested locally in Neovim

`completion_notifier_spec.lua` は 24 件すべて成功（既存 21 + 新規 3）。追加したのは以下。

| テスト | 検証内容 |
| --- | --- |
| `holds the edge through a turn that only exists to restart the chat` | A→B→C で、B の中間ターン完了時は B 宛のみ配達され A には配達されない。B の2ターン目完了で初めて A に配達される |
| `does not hold the edge for a delivery that started no turn` | 受理はされたがターンが始まらなかった場合は、従来どおり購読者へ配達する |
| `still notifies subscribers when the queued delivery was refused` | 下書きありで drain が拒否された場合は従来どおり購読者へ配達する |

`chat_notifications` はインメモリのチャット間通知機構で、実 CLI を起動しないため E2E の対象外。
`pnpm run test:e2e` は実行していない（実トークンを消費するため）。

### Test Environment

- **Neovim version**: NVIM v0.11.x
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: pnpm / Node 20 系

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [x] CLAUDE.md updated (`.claude/rules/architecture.md`)
- [x] Code comments added/updated

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

Fixes #638

関連: #646（下記「Additional Context」参照）、#627、#631

## Additional Context

### この修正が拾えない側の順序

末端 C が中間 B のディスパッチターンより**後**に終わる場合（ディスパッチは数秒、末端の作業は
数分かかるのでこちらが通常）、B のキューは空なので判定が通らず、従来どおり A に配達して
エッジを消費する。同じ取りこぼしが残るが、これを直すには A が連鎖の途中で一切通知を受けなく
なるという挙動変更が必要なため、#638 のスコープから外して **#646** に分離した。

### 受け入れた限界

- **保持されたエッジの出口は `BufDelete` しかない。** 従来はどのエッジも購読先チャットの次の
  完了で必ず消費されていた。ターンが始まってから `add_user_section` ラッパーに到達せず死んだ
  場合、エッジは黙って残る。ターンが始まらなかった経路は `is_responding()` のゲートで除いたが、
  始まってから消えた場合は残る。このモジュールがタイマーを持たない方針と同じ理由で受け入れた
- **B の次のターンが A 宛の報告とは限らない。** C への返答かもしれない。ただし one-shot 設計の
  下では「B が次に止まったとき」が通知できる最善のタイミングであり、確実に途中経過と分かって
  いる時点で起こす現状よりは常に良い

いずれも `.claude/rules/architecture.md` に明記した。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery ordering during chat turn transitions.
  * Prevented premature completion notifications when queued messages restart a turn.
  * Preserved notification routing during restart-only turns.
  * Ensured subscribers are still notified when queued delivery cannot begin a new turn.
  * Improved handling of edge cases where a delivery does not start a turn.

* **Documentation**
  * Updated architecture documentation to describe notification ordering, safeguards, and lifecycle limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->