### PR TITLE
fix: stage AskUserQuestion choices synchronously so the question renders

### DIFF
--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -215,6 +215,18 @@ in-flight turn and renders the choice list via `on_insert_choices`. Because the 
 the tool's return value never reaches the model — the user's answer arrives as the next `--resume`d
 turn's user message, so no Promise/state handling is required.
 
+**The choice list is only staged, so the staging has to be synchronous.** `on_insert_choices`
+writes `_pending_choices` and nothing else; the one thing that renders it is `add_user_section()`
+at the end of `_handle_response`. But `cancel()` runs the adapter's wrapped `on_done`, and that is
+what queues the completion — so a staging deferred by its own `vim.schedule` lands one tick too
+late, the completion consumes a nil, and the turn ends cut short with nothing in the buffer to
+answer (#649). Neither this callback nor `on_approval_required` may add an inner `vim.schedule`:
+both are already on the main thread when `permission.lua` calls them. `on_approval_required` had
+always obeyed that rule; `on_insert_choices` was the one that did not.
+
+Rendering from `insert_choices` itself is not the alternative — `### Modified Files` and the patch
+comment are appended _before_ the User section, so the diff would land underneath the choices.
+
 Native `AskUserQuestion` is unavailable in headless `claude -p` mode and is opaque to vibing.nvim,
 so the PreToolUse hook intercepts and denies it, rendering the same UI as a fallback.
 

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -204,9 +204,10 @@ function M.execute(adapter, callbacks, message, config)
       end
     end,
     on_insert_choices = function(questions)
-      vim.schedule(function()
-        callbacks.insert_choices(questions)
-      end)
+      -- permission.lua から呼ばれるためすでにメインスレッド上（on_approval_required と同じ）
+      -- 二重 vim.schedule を避けることで _pending_choices が add_user_section より確実に先に設定される。
+      -- 挟むと cancel() が積んだ _handle_response が先に走り、選択肢が nil のまま消費される（#649）
+      callbacks.insert_choices(questions)
     end,
     on_session_corrupted = function(old_session_id)
       vim.schedule(function()

--- a/tests/lua/application/chat/send_message_spec.lua
+++ b/tests/lua/application/chat/send_message_spec.lua
@@ -50,6 +50,63 @@ describe("send_message", function()
 
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
+
+    -- The choice list is only staged here; add_user_section() at the end of _handle_response is
+    -- what renders it, and cancel() queues that completion. Deferring the staging by one tick put
+    -- it after that completion, so the questions were consumed as nil and the turn ended with the
+    -- reply cut short and nothing to answer (#649).
+    it("stages AskUserQuestion choices synchronously rather than a tick later", function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_name(buf, vim.fn.tempname() .. ".md")
+
+      local staged
+      local callbacks = {
+        get_bufnr = function()
+          return buf
+        end,
+        get_session_id = function()
+          return "test-session"
+        end,
+        parse_frontmatter = function()
+          return {}
+        end,
+        extract_conversation = function()
+          return {}
+        end,
+        update_filename_from_message = function(_) end,
+        start_response = function() end,
+        get_session_allow = function()
+          return {}
+        end,
+        get_session_deny = function()
+          return {}
+        end,
+        add_user_section = function() end,
+        insert_choices = function(questions)
+          staged = questions
+        end,
+      }
+
+      local captured = {}
+      local adapter = {
+        supports = function(_, _feature)
+          return false
+        end,
+        execute = function(_, _prompt, opts)
+          captured.opts = opts
+          return { content = "ok" }
+        end,
+      }
+
+      SendMessage.execute(adapter, callbacks, "hello", {})
+
+      local questions = { { question = "Which one?", options = { { label = "a" } } } }
+      captured.opts.on_insert_choices(questions)
+      -- Asserted without running the event loop: a vim.schedule here would leave this nil.
+      assert.same(questions, staged)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
   end)
 
   describe("_handle_response", function()


### PR DESCRIPTION
fixes #649

## 問題

`nvim_ask_user_question` を呼ぶとターンは kill されるのに、チャットバッファに選択肢が一切
描かれないことがある。ユーザーからは「レスポンスが途切れて、何の質問も来ない」ように見える。

## 原因

`on_insert_choices`（`send_message.lua`）は `_pending_choices` に置くだけで、実際に描くのは
`_handle_response` 終端の `add_user_section()` ただ1箇所（`buffer.lua:705`, `681`）。
ところが staging が **内側で `vim.schedule` していた**。

`adapter:cancel()` はアダプタの `wrapped_on_done` を呼び、それが `send_message.lua:255` の
`vim.schedule(_handle_response)` を積む。つまり kill そのものが「ターンの締めくくり」を
キューに入れる。staging がさらに1tick遅れると、`_handle_response` のほうが先に走り、
`_pending_choices` が nil のまま消費されて選択肢は永久に描かれない。

`_handle_response` が **同期的に** `add_user_section()` を呼ぶ経路（`send_message.lua:456`、
スナップショットが取れずファイル変更も無かったターン）でだけ表面化する。差分が出る経路は
`_emit_diff_output` が `vim.schedule` 越しに呼ぶので、たまたま競り勝っていた。
「出るときは出る」のはこれが理由。

456行に落ちる条件:

- gitスナップショットのベースラインが取れない / 読めない
- 同じ worktree で別チャットのターンと時間が重なった（`had_overlap`）
- かつ、そのターンでファイル変更が1つも無い（質問は普通まだ何も書いていない段階で出る）

## 修正

`on_insert_choices` から内側の `vim.schedule` を外すだけ。呼び出し元は permission.lua の
2箇所のみで、どちらもすでにメインスレッド上（`cancel_and_deny` は `vim.schedule` 内、
`M.ask_user_question` は RPC ディスパッチが `vim.schedule` 内）。

承認UI側の `on_approval_required` には元から

> 二重 vim.schedule を避けることで `_pending_approval` が `add_user_section` より先に設定される

というコメントがあり、`on_insert_choices` だけがこの規約から漏れていた。今回それを揃えた。

### 検討して採らなかった案

- **permission.lua で `cancel()` の前に staging する**: 最初はこれも入れていたが、staging が
  同期になった時点で冗長。`_handle_response` は必ず `vim.schedule` 越しなので、同じtick内の
  呼び出し順は結果に影響しない。承認UIが同じ並び（cancel → callback）で長く動いてきたのが
  その証拠。permission.lua は無変更に戻した
- **`insert_choices` 側で直接描く**: `### Modified Files` や patch コメントが
  `_handle_response` の中で **Userセクションより前に** 追記されるので、選択肢リストの下に
  差分が生える形になる

## テスト

`tests/lua/application/chat/send_message_spec.lua` にケースを追加。フェイクアダプタで
`opts.on_insert_choices` を捕まえて呼び、**イベントループを回さずに** staging 済みかを見る。
`vim.schedule` を戻すと落ちることを確認済み。

`pnpm run test:lua` 1834 passed / 0 failed（exit 0）、`pnpm run check` / `format:check` /
`lint:md`（該当ファイル）も通過。

## 残っている穴（別件）

`_handle_response` の handle_id 不一致による早期 return（`send_message.lua:291-297`）では
`add_user_section()` が呼ばれないので、そのターンの選択肢は次のセクションまで持ち越される。
`_pending_choices` が handle_id で紐付いていないことに由来する既存の性質で、今回の変更が
生んだものではない。#653 として起票済み。
