### PR TITLE
feat: generalize the notification queue into a message queue with queue_if_busy delivery

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1165,9 +1165,69 @@ returns _silently_, so `ProgrammaticSender` used to report success for a message
 leaving an orphan `## User` section that became the body of the user's next `<CR>`. A dispatched
 chat normally keeps working after dispatching, so the shorter the worker's task the more likely
 this window is. So `ProgrammaticSender` now refuses before appending (rather than appending and
-rolling back), and the notifier queues instead, flushing on the recipient's own completion event.
-Queued notifications coalesce into one message: three workers finishing while the orchestrator is
-busy is one turn, not three.
+rolling back), and `application/chat/message_queue.lua` queues instead, flushing on the
+recipient's own completion event. Queued items coalesce into one message: three workers finishing
+while the orchestrator is busy is one turn, not three.
+
+**That queue carries bodies as well as notices**, which is what `nvim_chat_send_message`'s
+`queue_if_busy` is (#642). Both kinds need the same wait — the only way to deliver anything is to
+start a turn, and a turn can only be started on a chat that is not responding — so they share one
+queue and one flush, and a turn woken by it can carry both. An item with a `body` is a relayed
+message and one without is a completion notice — there is no separate kind flag, because a
+derivable one goes stale. `application/chat/delivery_message.lua` renders the coalesced turn and
+keeps the notice-only case byte-identical to what it was, since that is still the common shape;
+splitting it out keeps prompt wording out of the queue's state machine.
+
+Four things about it are not incidental:
+
+- **`queue_if_busy` is not gated on `chat_notifications.enabled`, and the drain is not either.**
+  That flag decides whether vibing.nvim volunteers a watchdog wake-up; a queued message is a
+  delivery the caller explicitly asked for. Gating it would mean a worker's report vanishing in
+  silence on the default config. So `on_response_done` drains first and unconditionally, and only
+  the `edges` half below it reads the flag.
+- **It is off by default on the tool, in both directions of version skew.** An older Neovim
+  ignores the key and refuses a busy chat exactly as before, which is what a caller that did not
+  ask to queue already expects; an older MCP server never sends it. It also only covers
+  `"responding"` — an invalid buffer or an empty message is not something waiting fixes, so those
+  still error. That is why `ProgrammaticSender` grew a `is_responding` predicate rather than the
+  caller matching on the error _text_ `validate` raises, which would stop working the day the
+  wording changed, silently.
+- **The orchestration link is written just before delivery, not when the message is queued.**
+  `update_frontmatter_list` edits the recipient's buffer, and the precondition for queueing is
+  that the recipient is streaming — so the usual "link before the send" ordering has to be kept by
+  moving both, not by writing early. Flush only ever delivers into an idle chat, which makes that
+  the one safe moment. A message whose recipient is deleted before delivery therefore leaves no
+  record of an exchange that never happened.
+- **The queue is capped per buffer (20) and a message past the cap is refused, not dropped.** A
+  notice can be deduplicated by the bufnr it is about; a body cannot, so a worker in a retry loop
+  would otherwise pile up without bound. The refusal is returned to the sender as an error, which
+  is the whole point — a report that disappears quietly is the failure this mechanism exists to
+  remove. The one case that cannot be reported back is a _notification_ arriving at a full queue,
+  since its edge is already consumed by then; that one warns.
+
+**A message the sender delivered itself silences the watchdog for one stop.** A send is one event
+with two opposite consequences, so `completion_notifier.on_sent(from, to)` performs both rather
+than leaving the pairing to each caller: it records `edges[to][from]` (the send _is_ the
+subscription), and marks `edges[from][to]` as already-reported, dropping any notice about `from`
+already sitting in `to`'s queue. "B stopped, go and read it" is the same errand as B's own report,
+and A does not need waking twice for it. The reversed indices are the reason it is one function:
+written out at a call site, `subscribe(a, b)` next to a suppression of `edges[a][b]` reads like a
+typo.
+
+**It is a mark and not a deletion, and that distinction is the whole of #638 again.** Nothing at
+send time can tell a final report from a progress note — and in a tree the middle node's first
+message is _always_ a progress note, because it stops once to wait for its own worker and only
+writes the real answer after that worker reports. Deleting the edge there would lose the
+orchestrator's subscription permanently, defeating the hold this PR's base branch added. So the
+mark suppresses exactly one stop: `on_response_done` clears it when the drain restarts the chat
+(the report was not final after all), and otherwise consumes the subscription silently, since the
+one-shot edge was spent on a delivery the subscriber already received.
+
+**Queued messages do not spend hop budget.** A direct send to an idle chat has never counted
+against `max_hops` — it just starts a turn — and `queue_if_busy` is that same send arriving late.
+Only notices carry a `depth`, and the queue treats it as an opaque number it hands back on delivery
+so the notifier can raise its counter; the queue itself never interprets it. Bounding A⇄B
+ping-pong through direct sends is #644's pair-wise counter, not this.
 
 **A chat drains its own queue before it notifies anyone, and a turn that drained is not reported as
 a completion at all.** `on_response_done` tries `flush(bufnr)` first and returns leaving

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1203,7 +1203,10 @@ Four things about it are not incidental:
   would otherwise pile up without bound. The refusal is returned to the sender as an error, which
   is the whole point — a report that disappears quietly is the failure this mechanism exists to
   remove. The one case that cannot be reported back is a _notification_ arriving at a full queue,
-  since its edge is already consumed by then; that one warns.
+  since its edge is already consumed by then; that one warns. `forget` follows the same rule when
+  a chat is deleted: a notice _about_ that chat has lost its subject and goes, but a queued body
+  whose **sender** was the deleted chat is still deliverable, so it loses only the sender's name
+  and arrives anonymously.
 
 **A message the sender delivered itself silences the watchdog for one stop.** A send is one event
 with two opposite consequences, so `completion_notifier.on_sent(from, to)` performs both rather

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1224,7 +1224,10 @@ writes the real answer after that worker reports. Deleting the edge there would 
 orchestrator's subscription permanently, defeating the hold this PR's base branch added. So the
 mark suppresses exactly one stop: `on_response_done` clears it when the drain restarts the chat
 (the report was not final after all), and otherwise consumes the subscription silently, since the
-one-shot edge was spent on a delivery the subscriber already received.
+one-shot edge was spent on a delivery the subscriber already received. That consumption happens
+**before** the `enabled` gate, not after — a mark is a one-stop temporary, so a completion the
+gate declines to act on still has to spend it, or a spell of the feature being off leaves a stale
+mark that silences the first genuine edge after it is turned back on.
 
 **Queued messages do not spend hop budget.** A direct send to an idle chat has never counted
 against `max_hops` — it just starts a turn — and `queue_if_busy` is that same send arriving late.

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -117,6 +117,14 @@ refuse a call that passes the pair rather than preferring one of them. Why the p
 the number, why it opens chat files and refuses everything else, and why `from_bufnr` stays a
 bufnr while these do not: `architecture.md` → "Multi-Agent Orchestration" → "Addressing a chat".
 
+`nvim_chat_send_message` also takes `queue_if_busy` (default `false`). A chat that is responding
+normally refuses the send; with the flag the message is queued instead and delivered as a new turn
+the moment that chat stops, with several queued items coalesced into one turn. The reply says which
+happened, and "queued" means no request has started yet — an orchestrator that read it as "sent"
+would poll a transcript that has not moved. Why it is not gated on `chat_notifications`, why the
+frontmatter link is written at delivery rather than when the message is queued, and why the queue
+is capped: `architecture.md` → "Multi-Agent Orchestration".
+
 The workflow is the bundled `vibing-orchestrate` skill. Why `position` defaults to `back`, why the
 chat file is written at creation, why the status is a field rather than a text heuristic, and what
 is deliberately out of scope: `architecture.md` → "Multi-Agent Orchestration".

--- a/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
@@ -182,6 +182,50 @@ describe('chat tools (worktree redesign)', () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it('nvim_chat_send_message forwards queue_if_busy and reports that the message was queued', async () => {
+    // The tool's own description promises the caller can tell "queued" from "sent", and only this
+    // layer decides the wording the model reads. A queued reply read as "sent" makes an
+    // orchestrator poll a transcript that has not moved.
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true, queued: true, bufnr: 14 });
+
+    const result = await handlers.nvim_chat_send_message({
+      rpc_port: 9878,
+      bufnr: 14,
+      message: 'my report',
+      queue_if_busy: true,
+    });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'send_message',
+      {
+        bufnr: 14,
+        file_path: undefined,
+        message: 'my report',
+        sender: undefined,
+        from_bufnr: undefined,
+        queue_if_busy: true,
+      },
+      9878
+    );
+    expect(result._meta.queued).toBe(true);
+    expect(result.content[0].text).toContain('queued');
+    expect(result.content[0].text).not.toContain('AI request initiated');
+  });
+
+  it('nvim_chat_send_message reports an ordinary send when nothing was queued', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true, bufnr: 14 });
+
+    const result = await handlers.nvim_chat_send_message({
+      rpc_port: 9878,
+      bufnr: 14,
+      message: 'do the thing',
+      queue_if_busy: true,
+    });
+
+    expect(result._meta.queued).toBe(false);
+    expect(result.content[0].text).toContain('AI request initiated');
+  });
+
   it('nvim_chat_send_message accepts a file_path instead of a bufnr', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ success: true, bufnr: 21 });
 

--- a/claude-plugin/mcp-server/src/handlers/chat.ts
+++ b/claude-plugin/mcp-server/src/handlers/chat.ts
@@ -48,6 +48,7 @@ const chatSendMessageArgsSchema = z.object({
   message: z.string(),
   sender: z.string().optional(),
   from_bufnr: z.number().optional(),
+  queue_if_busy: z.boolean().optional(),
   rpc_port: z.number(),
 });
 
@@ -65,11 +66,17 @@ const chatSendMessageArgsSchema = z.object({
  * files' frontmatter, so it outlives the buffer numbers and the file names it was built from.
  * It is optional for compatibility in both directions of Lua/Node version skew: an older Neovim
  * ignores the extra key, an older server never sends it, and neither breaks the send.
+ *
+ * `queue_if_busy` is optional for the same reason, and defaults to off on both sides: an older
+ * Neovim ignores it and refuses a busy chat exactly as before, which is the behaviour a caller
+ * that did not ask to queue already expects. The reply distinguishes the two outcomes, because
+ * "queued" means no turn has started yet — an orchestrator that read it as "sent" would go on to
+ * poll a transcript that has not moved.
  */
 export async function handleChatSendMessage(args: any): Promise<any> {
   // Zod schema already validates required fields and types
   const parsed = chatSendMessageArgsSchema.parse(args);
-  const { message, sender, from_bufnr, rpc_port } = parsed;
+  const { message, sender, from_bufnr, queue_if_busy, rpc_port } = parsed;
   // Collapse an explicit null to "not given" once, here, so nothing downstream has to know the
   // difference — including the Lua side, where a JSON null decodes to the truthy vim.NIL.
   const bufnr = parsed.bufnr ?? undefined;
@@ -80,15 +87,25 @@ export async function handleChatSendMessage(args: any): Promise<any> {
 
   const result = await callNeovim(
     'send_message',
-    { bufnr, file_path, message, sender, from_bufnr },
+    { bufnr, file_path, message, sender, from_bufnr, queue_if_busy },
     rpc_port
   );
 
+  const queued = result?.queued === true;
+
   return {
-    content: [{ type: 'text', text: 'Message sent and AI request initiated in chat buffer' }],
+    content: [
+      {
+        type: 'text',
+        text: queued
+          ? 'That chat is responding right now, so the message was queued. It will be delivered ' +
+            'as a new turn as soon as that chat stops — no request has started yet.'
+          : 'Message sent and AI request initiated in chat buffer',
+      },
+    ],
     // The Lua side resolved file_path to a buffer, so report what it actually reached rather than
     // echoing an argument that may have been a path.
-    _meta: { bufnr: result?.bufnr ?? bufnr, sender: sender || 'User' },
+    _meta: { bufnr: result?.bufnr ?? bufnr, sender: sender || 'User', queued },
   };
 }
 

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -92,6 +92,16 @@ export const chatTools: Tool[] = [
             'system prompt. Pass it whenever you drive another chat — it records the ' +
             'relationship in both chat files, which survives renames and restarts.',
         },
+        queue_if_busy: {
+          type: 'boolean',
+          description:
+            'Queue the message instead of failing when the target chat is already responding ' +
+            '(default false, which reports an error). A queued message is delivered as a new ' +
+            'turn the moment that chat stops, and several queued messages arrive coalesced ' +
+            'into one turn. Use it for anything the other chat must receive whether or not it ' +
+            'happens to be busy right now — a completion report to your orchestrator, an ' +
+            'answer to a question it asked you.',
+        },
       }),
       // Neither bufnr nor file_path is required on its own; the handler enforces that exactly one
       // arrives. JSON Schema could say that with oneOf, but the advertised schema is flattened

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -6,11 +6,13 @@
 ---「A に新しいターンを起こす」しかなく、それがこの設計。B から A への質問も、B が A に
 ---`nvim_chat_send_message` を呼ぶだけで同じ経路に乗る。
 ---
----購読テーブルもキューも**インメモリのみ**。Neovim が落ちればワーカーチャットも道連れなので、
+---**配達そのものは `message_queue.lua` が持つ。** ここが持つのは購読（`edges`）と暴走抑止
+---（`depth`）だけで、どちらもインメモリのみ。Neovim が落ちればワーカーチャットも道連れなので、
 ---`pending-resume.json` のような永続化に意味がない。
 local M = {}
 
 local notify = require("vibing.core.utils.notify")
+local MessageQueue = require("vibing.application.chat.message_queue")
 
 local AUGROUP = "VibingCompletionNotifier"
 local DEFAULT_MAX_HOPS = 8
@@ -20,13 +22,14 @@ local DEFAULT_MAX_HOPS = 8
 ---@type table<number, table<number, number>>
 local edges = {}
 
----配達先が応答中だったために積んだ通知。from_bufnr 自身の完了で流す
----@type table<number, {bufnr: number, depth: number}[]>
-local pending = {}
-
 ---通知チェーンで何回起こされたか。手動送信で 0 に戻る
 ---@type table<number, number>
 local depth = {}
+
+---reported[from_bufnr][to_bufnr] = from が to に自分から送った。
+---「次に from が止まったときの watchdog は冗長」を表す、エッジとは別の一時マーク
+---@type table<number, table<number, boolean>>
+local reported = {}
 
 ---@return {enabled: boolean, max_hops: number?}
 local function settings()
@@ -34,119 +37,20 @@ local function settings()
   return (config.agent and config.agent.chat_notifications) or { enabled = false }
 end
 
----@param queue {bufnr: number, depth: number}[]
----@return string
-local function build_message(queue)
-  local lines = {}
-  for _, item in ipairs(queue) do
-    local name = vim.api.nvim_buf_is_valid(item.bufnr) and vim.api.nvim_buf_get_name(item.bufnr) or ""
-    -- frontmatter の `orchestrated` と同じ表示形式にする。モデルが読みに行く先を、
-    -- 記録と別の形で名指ししない。パスを先に置くのはシステムプロンプトの orchestrator 行と
-    -- 同じ理由で、再起動を跨いで意味を保つのはパスのほうだから（#641）
-    local display = name ~= "" and require("vibing.core.utils.git").to_display_path(name) or "unnamed"
-    table.insert(lines, string.format("- %s (chat buffer %d)", display, item.bufnr))
-  end
-
-  return table.concat({
-    "The following chat(s) you sent a message to have finished responding:",
-    "",
-    table.concat(lines, "\n"),
-    "",
-    "Read each one with nvim_get_buffer({ rpc_port, file_path }) and decide what to do next.",
-    "",
-    '"Finished" only means no request is in flight. A chat may have failed, stopped to ask the',
-    "user something, or be waiting on a tool approval. Read the tail of the transcript before",
-    "treating its task as done.",
-    "",
-    "If other chats you dispatched are still running, do not start aggregating yet — say what",
-    "this one produced and end the turn. You will be woken again when the next one finishes.",
-  }, "\n")
-end
-
----@param from_bufnr number
----@param done_bufnr number
----@param edge_depth number
-local function enqueue(from_bufnr, done_bufnr, edge_depth)
-  local queue = pending[from_bufnr] or {}
-  for _, item in ipairs(queue) do
-    if item.bufnr == done_bufnr then
-      return
-    end
-  end
-  table.insert(queue, { bufnr = done_bufnr, depth = edge_depth })
-  pending[from_bufnr] = queue
-end
-
----積まれた通知を1通にまとめて配達する
+---自分宛キューを流し、配達できた通知の深さぶんだけ hop カウンタを上げる
 ---
----相手が応答中なら**何もしない**。応答中のバッファに送ると `ChatBuffer:send_message()` が
----進行中のターンを kill する（buffer.lua の「前のリクエストが実行中ならキャンセル」）。
----A が B に投げたあと A 自身のターンが続くのは普通なので、短いタスクほどこの窓に入る。
----積んだままにしておけば、A 自身の VibingResponseDone でここが呼び直される。
----@param from_bufnr number
----@return boolean restarted 配達の結果 from_bufnr が新しいターンを走らせた
-local function flush(from_bufnr)
-  local queue = pending[from_bufnr]
-  if not queue or #queue == 0 then
-    return false
-  end
-
-  if not vim.api.nvim_buf_is_valid(from_bufnr) then
-    pending[from_bufnr] = nil
-    return false
-  end
-
-  local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(from_bufnr)
-  if not chat_buf then
-    pending[from_bufnr] = nil
-    return false
-  end
-
-  if chat_buf:is_responding() then
-    return false
-  end
-
-  -- ユーザーが書きかけの `## User` を残しているなら触らない。配達は新しいセクションを足すので、
-  -- 下書きは送られないまま宙に浮き、次の<CR>は空のヘッダを読んで「No message to send」になる。
-  -- auto_resume が未送信セクションを上書きしないのと同じ扱い。
-  -- ユーザーがその下書きを送れば、そのターンの完了でここが呼び直されるので取りこぼさない
-  if chat_buf.extract_user_message then
-    local draft = chat_buf:extract_user_message()
-    if draft and vim.trim(draft) ~= "" then
-      return false
-    end
-  end
-
-  local deepest = 0
-  for _, item in ipairs(queue) do
-    deepest = math.max(deepest, item.depth)
-  end
-
-  local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
-  local ok, result = pcall(ProgrammaticSender.send, from_bufnr, build_message(queue))
-
-  -- 配達できて初めてキューを空ける。エッジは既に消費済みなので、先に捨てると失敗した通知は
-  -- 二度と再現しない。残しておけば次の完了イベントで作り直しなしに再試行できる
-  if ok and result and result.success then
-    pending[from_bufnr] = nil
+---「配達したら上げる」を関数にしてあるのは、`on_response_done` に呼び出し箇所が2つあるため。
+---どちらかで書き忘れると `max_hops` が黙って連鎖を止められなくなる
+---@param bufnr number
+---@return boolean restarted
+local function drain(bufnr)
+  local restarted, deepest = MessageQueue.flush(bufnr)
+  if deepest then
     -- 下げてはいけない。深く連鎖したチャットが、浅い時点で張られたエッジの配達を受けたときに
     -- カウンタが戻ると、max_hops が連鎖を止められなくなる
-    depth[from_bufnr] = math.max(depth[from_bufnr] or 0, deepest + 1)
-
-    -- 送信が受理されたことと、ターンが始まったことは別。`ChatBuffer:send_message()` が返すのは
-    -- 「リクエストとして扱ったか」で、リミット中の予約（`_try_schedule_instead_of_send`）でも、
-    -- `SendMessage.execute` がアダプタ未設定・セッション競合で降りた場合でも true になる。
-    -- 後者はストリームを張らないので `VibingResponseDone` が来ず、呼び出し元がこれを再稼働と
-    -- 読むとエッジが宙に浮く。始まっていないターンを購読者の待ち先にはできないので、
-    -- 送信結果ではなく相手の状態を返す
-    return chat_buf:is_responding()
+    depth[bufnr] = math.max(depth[bufnr] or 0, deepest + 1)
   end
-
-  notify.warn(
-    string.format("Could not notify chat %d: %s", from_bufnr, ok and "the chat refused the message" or tostring(result)),
-    "Chat Notifications"
-  )
-  return false
+  return restarted
 end
 
 ---A が B に送ったことを購読として記録する
@@ -199,34 +103,71 @@ function M.subscribe(from_bufnr, to_bufnr)
   return true
 end
 
+---`from_bufnr` が `to_bufnr` に送った（即配達でもキュー投入でも）ことを記録する
+---
+---1つの出来事に対して2つの向きの後始末が要るので、呼び出し元に両方を覚えさせない。
+---
+---- **購読**: 「to が止まったら from に知らせる」を張る（送ったこと自体が購読の登録）
+---- **watchdog の退役**: 「from が止まったら to に知らせる」を落とす。from 自身が口を開いた
+---  以上それは同じ用件の二度目で、残すと to は同じことで二度起こされる。`to → from` の送信が
+---  あればそこで張り直される
+---
+---向きが逆なことに注意: 張るのは `edges[to][from]`、抑止するのは `edges[from][to]`
+---@param from_bufnr number
+---@param to_bufnr number
+function M.on_sent(from_bufnr, to_bufnr)
+  if type(from_bufnr) ~= "number" or type(to_bufnr) ~= "number" then
+    return
+  end
+
+  M.subscribe(from_bufnr, to_bufnr)
+
+  -- **エッジそのものは消さない。** 消すと、from が「作業中の途中経過」を送っただけの場合にも
+  -- 購読が永久に失われる。ツリー状のチャット網ではそれが常態で、中間ノードは子を待つ間に
+  -- 一度停止し、子の報告で再稼働してから本命の報告を書く（#638）。送信の時点では、その
+  -- メッセージが最終報告なのか途中経過なのかは機構には分からない。
+  -- 代わりに「次の停止1回ぶんだけ黙らせる」印を置き、再稼働したらその印を捨てる
+  reported[from_bufnr] = reported[from_bufnr] or {}
+  reported[from_bufnr][to_bufnr] = true
+
+  MessageQueue.drop_notification(to_bufnr, from_bufnr)
+end
+
 ---応答完了。自分宛キューの drain と、購読者への配達を行う
 ---@param bufnr number
 function M.on_response_done(bufnr)
+  -- 自分宛キューの drain が先で、しかも設定に関わらず行う。`queue_if_busy` で積まれた本文は
+  -- watchdog 通知を切っている環境でも届かなければならない。
+  --
+  -- 配達できた = bufnr はこのターンでは終わっておらず、続きのターンが控えているということなので、
+  -- この完了は購読者に見せない。順序を逆にしても防げない理由と、この規則が拾えない側の順序は
+  -- architecture.md → Multi-Agent Orchestration（#638）
+  if drain(bufnr) then
+    -- edges[bufnr] は消費せずに残す。bufnr が本当に止まったときの完了で配達される。
+    -- 再稼働した以上、直前に送ったものは最終報告ではなかったので、抑止の印も捨てる
+    reported[bufnr] = nil
+    return
+  end
+
   if not settings().enabled then
     return
   end
 
-  -- 自分宛キューの drain が先。配達できた = bufnr はこのターンでは終わっておらず、続きの
-  -- ターンが控えている（リミット中なら予約として）ということなので、この完了は購読者に見せない。
-  -- 順序を逆にしても防げない理由と、この規則が拾えない側の順序は
-  -- architecture.md → Multi-Agent Orchestration（#638）
-  if flush(bufnr) then
-    -- edges[bufnr] は消費せずに残す。bufnr が本当に止まったときの完了で配達される
-    return
-  end
-
   local subscribers = edges[bufnr]
+  local suppressed = reported[bufnr] or {}
+  reported[bufnr] = nil
+
   if subscribers then
     -- 配達した時点で購読は消える（one-shot）。B が次に完了しても、A が改めて送っていなければ
-    -- 通知は飛ばない
+    -- 通知は飛ばない。自分から報告済みの相手も、購読は同じように使い切る — 用件は届いている
     edges[bufnr] = nil
     for from_bufnr, edge_depth in pairs(subscribers) do
-      if vim.api.nvim_buf_is_valid(from_bufnr) then
-        enqueue(from_bufnr, bufnr, edge_depth)
+      if not suppressed[from_bufnr] and vim.api.nvim_buf_is_valid(from_bufnr) then
+        MessageQueue.enqueue_notification(from_bufnr, bufnr, edge_depth)
       end
     end
     for from_bufnr in pairs(subscribers) do
-      flush(from_bufnr)
+      drain(from_bufnr)
     end
   end
 end
@@ -240,25 +181,24 @@ end
 ---バッファが消えたので関連する購読・キューを捨てる
 ---@param bufnr number
 function M.forget(bufnr)
+  MessageQueue.forget(bufnr)
+
   -- autocmdはパターン無しで登録しているので、エディタ内のどのバッファを閉じても走る。
-  -- 既定（無効）では状態が空のまま、全テーブルの走査だけが通常の編集操作ごとに起きる
-  if not (next(edges) or next(pending) or next(depth)) then
+  -- 既定（無効）では状態が空のまま、全テーブルの走査だけが通常の編集操作ごとに起きる。
+  -- キューは自分の空振りを自分で弾くので、ここで見るのは自分の状態だけ
+  if not (next(edges) or next(depth) or next(reported)) then
     return
   end
 
   edges[bufnr] = nil
-  pending[bufnr] = nil
   depth[bufnr] = nil
+  reported[bufnr] = nil
 
   for _, subscribers in pairs(edges) do
     subscribers[bufnr] = nil
   end
-  for _, queue in pairs(pending) do
-    for i = #queue, 1, -1 do
-      if queue[i].bufnr == bufnr then
-        table.remove(queue, i)
-      end
-    end
+  for _, targets in pairs(reported) do
+    targets[bufnr] = nil
   end
 end
 

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -155,13 +155,18 @@ function M.on_response_done(bufnr)
     return
   end
 
+  -- 抑止マークの消費は `enabled` の判定より**前**。マークは「次の停止1回ぶん」の一時状態なので、
+  -- 完了を見送るときも一緒に使い切らないと、無効化を挟んだ間のマークが残り、有効化後に張り直された
+  -- 正当なエッジを黙って落とす。`on_sent` が無効時にマークを立てないのと対になる配慮で、
+  -- `setup()` の「実行中に設定を変えた場合も追従する」はこの経路のこと
+  local suppressed = reported[bufnr] or {}
+  reported[bufnr] = nil
+
   if not settings().enabled then
     return
   end
 
   local subscribers = edges[bufnr]
-  local suppressed = reported[bufnr] or {}
-  reported[bufnr] = nil
 
   if subscribers then
     -- 配達した時点で購読は消える（one-shot）。B が次に完了しても、A が改めて送っていなければ

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -120,6 +120,12 @@ function M.on_sent(from_bufnr, to_bufnr)
     return
   end
 
+  -- 抑止マークは `edges` のためだけにある。無効ならエッジは張られないので、溜めても無駄なうえ、
+  -- セッション中に有効化されたときに、無効だった間の送信が新しいエッジを誤って黙らせる
+  if not settings().enabled then
+    return
+  end
+
   M.subscribe(from_bufnr, to_bufnr)
 
   -- **エッジそのものは消さない。** 消すと、from が「作業中の途中経過」を送っただけの場合にも

--- a/lua/vibing/application/chat/delivery_message.lua
+++ b/lua/vibing/application/chat/delivery_message.lua
@@ -1,0 +1,100 @@
+---@class Vibing.Application.DeliveryMessage
+---`message_queue` が溜めたものを、受け取るチャットに読ませる1通のテキストにする。
+---
+---キューの状態機械とは別モジュールにしてある。ここにあるのはモデルに読ませる散文であって、
+---待ち合わせの規則ではない — 文面の推敲で配達の順序が変わることはないし、その逆もない。
+local M = {}
+
+---@param bufnr number
+---@param cache table<number, string>
+---@return string
+local function display_path(bufnr, cache)
+  if cache[bufnr] then
+    return cache[bufnr]
+  end
+
+  local name = vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_get_name(bufnr) or ""
+  -- frontmatter の `orchestrated` と同じ表示形式にする。モデルが読みに行く先を、
+  -- 記録と別の形で名指ししない
+  local path = name ~= "" and require("vibing.core.utils.git").to_display_path(name) or "unnamed"
+
+  -- `to_display_path` は解決を `git rev-parse` に投げ、それはキャッシュを持たない同期の
+  -- プロセス起動。1通に同じチャットが複数回現れるのは普通（同じ相手からの複数の報告）なので、
+  -- 1通を組み立てる間だけ覚える。バッファ名は改名されうるので、それ以上は持ち越さない
+  cache[bufnr] = path
+  return path
+end
+
+---@param items Vibing.Application.MessageQueue.Item[]
+---@param cache table<number, string>
+---@return string
+local function notification_section(items, cache)
+  -- パスを先に置くのはシステムプロンプトの orchestrator 行と同じ理由で、再起動を跨いで
+  -- 意味を保つのはパスのほうだから（#641）
+  local lines = {}
+  for _, item in ipairs(items) do
+    table.insert(lines, string.format("- %s (chat buffer %d)", display_path(item.bufnr, cache), item.bufnr))
+  end
+
+  return table.concat({
+    "The following chat(s) you sent a message to have finished responding:",
+    "",
+    table.concat(lines, "\n"),
+    "",
+    "Read each one with nvim_get_buffer({ rpc_port, file_path }) and decide what to do next.",
+    "",
+    '"Finished" only means no request is in flight. A chat may have failed, stopped to ask the',
+    "user something, or be waiting on a tool approval. Read the tail of the transcript before",
+    "treating its task as done.",
+    "",
+    "If other chats you dispatched are still running, do not start aggregating yet — say what",
+    "this one produced and end the turn. You will be woken again when the next one finishes.",
+  }, "\n")
+end
+
+---@param items Vibing.Application.MessageQueue.Item[]
+---@param cache table<number, string>
+---@return string
+local function message_section(items, cache)
+  local blocks = {}
+  for _, item in ipairs(items) do
+    local from = item.bufnr and string.format("%s (chat buffer %d)", display_path(item.bufnr, cache), item.bufnr)
+      or "another chat"
+    table.insert(blocks, string.format("### From %s\n\n%s", from, item.body))
+  end
+
+  -- 件数はメッセージの数であってチャットの数ではない。1つのワーカーからの2件を
+  -- 「2つのチャットから」と言うと、読み手は出どころを取り違える
+  return table.concat({
+    #blocks == 1 and "Another chat sent you this while you were responding:"
+      or string.format("%d messages arrived while you were responding:", #blocks),
+    "",
+    table.concat(blocks, "\n\n"),
+  }, "\n")
+end
+
+---溜まったものを1通にまとめる
+---
+---通知だけのときは通知セクションだけを出す。混在時に本文を先に置くのは、そちらが相手の
+---**依頼**で、通知は「読みに行け」という副次情報だから
+---@param queue Vibing.Application.MessageQueue.Item[]
+---@return string
+function M.build(queue)
+  local notifications, messages = {}, {}
+  for _, item in ipairs(queue) do
+    table.insert(item.body and messages or notifications, item)
+  end
+
+  local cache = {}
+  local sections = {}
+  if #messages > 0 then
+    table.insert(sections, message_section(messages, cache))
+  end
+  if #notifications > 0 then
+    table.insert(sections, notification_section(notifications, cache))
+  end
+
+  return table.concat(sections, "\n\n")
+end
+
+return M

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -218,7 +218,16 @@ function M.flush(to_bufnr)
   return false
 end
 
----バッファが消えたので、その宛先のキューと、他のキューに残る言及を捨てる
+---バッファが消えたので、その宛先のキューと、他のキューに残る言及を始末する
+---
+---`item.bufnr` は2つの意味を持つので、扱いも2つに分かれる。
+---
+---- **通知**では「止まったチャット」。それが消えた以上「読みに行け」は宛先を失うので捨てる
+---- **本文**では送信元の記録にすぎない。表示とリンクのためのメタデータで、本文そのものの
+---  届け先とは無関係なので、送信元が消えても配達はできる。ここで捨てると「報告が黙って
+---  消える」— このモジュールが防ぐために存在しているものそのものになる。名前だけ落として
+---  匿名の本文として残す（`delivery_message` は送信元なしの形を元から扱える）。
+---  同時に、消えたバッファへの `link_or_warn` が配達のたびに警告するのも防げる
 ---
 ---`BufDelete` はパターン無しで張られていて、エディタ内のどのバッファを閉じても走る。
 ---既定（この機能は未使用）では空振りなので、自分の状態が空なら何もしない
@@ -230,9 +239,15 @@ function M.forget(bufnr)
 
   pending[bufnr] = nil
 
-  for to_bufnr in pairs(pending) do
+  for to_bufnr, queue in pairs(pending) do
+    for _, item in ipairs(queue) do
+      if item.body and item.bufnr == bufnr then
+        item.bufnr = nil
+      end
+    end
+
     remove_where(to_bufnr, function(item)
-      return item.bufnr == bufnr
+      return not item.body and item.bufnr == bufnr
     end)
   end
 end

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -1,0 +1,240 @@
+---@class Vibing.Application.MessageQueue
+---チャットバッファ宛の「いま配達できないもの」を溜めて、そのバッファが止まった瞬間に
+---1ターンにまとめて届ける。
+---
+---エージェント（CLIプロセス）はターンが終われば死ぬので、待ち受けはできない。何かを届ける
+---唯一の方法は**新しいターンを起こすこと**で、それは相手が応答中でない瞬間にしか行えない
+---（応答中に送ると `ChatBuffer:send_message()` が進行中のターンを kill する）。この待ち合わせが
+---このモジュールの全部。
+---
+---積まれるものは2種類あり、どちらも同じ待ち合わせを必要とする:
+---
+---- 通知 — 「あのチャットが止まった、読みに行け」（`completion_notifier` の watchdog）
+---- 本文 — 送信元のテキストそのもの（`nvim_chat_send_message` の `queue_if_busy`）
+---
+---キューは**インメモリのみ**。Neovim が落ちればワーカーチャットも道連れなので、永続化に意味がない。
+local M = {}
+
+local notify = require("vibing.core.utils.notify")
+
+---1バッファに溜められる上限。超えたら**捨てずに拒否する**: 捨てると報告が黙って消え、
+---それはこのモジュールが防ぐために存在しているものそのものになる
+local MAX_QUEUED = 20
+
+local WARN_TITLE = "Chat Delivery"
+
+---@class Vibing.Application.MessageQueue.Item
+---@field bufnr number? 相手のチャット。通知なら応答を終えた側、本文なら送信元（本文では任意）
+---@field body string? 配達する本文。**これがあるかどうかが種別**で、別途フラグは持たない
+---@field depth number? 通知が購読を張った時点の深さ。運ぶだけで解釈はしない
+
+---@type table<number, Vibing.Application.MessageQueue.Item[]>
+local pending = {}
+
+---@param to_bufnr number
+---@param predicate fun(item: Vibing.Application.MessageQueue.Item): boolean
+local function remove_where(to_bufnr, predicate)
+  local queue = pending[to_bufnr]
+  if not queue then
+    return
+  end
+
+  for i = #queue, 1, -1 do
+    if predicate(queue[i]) then
+      table.remove(queue, i)
+    end
+  end
+
+  if #queue == 0 then
+    pending[to_bufnr] = nil
+  end
+end
+
+---配達される本文について、オーケストレーション関係を frontmatter に書く
+---
+---即配達経路（`rpc/handlers/message.lua`）は送信の**前**に書くが、こちらはそれができない。
+---キューに積まれる条件が「宛先が応答中」で、`update_frontmatter_list` はその宛先バッファを
+---直接編集するため、積んだ時点で書くとストリーミングと競合する。`flush` が配達するのは宛先が
+---idle のときだけなので、ここが唯一安全な瞬間になる
+---@param queue Vibing.Application.MessageQueue.Item[]
+---@param to_bufnr number
+local function write_links(queue, to_bufnr)
+  local OrchestrationLink = require("vibing.application.chat.orchestration_link")
+  local seen = {}
+  for _, item in ipairs(queue) do
+    -- 同じ送信元からの複数の本文はリンク1本。`link` 自身も重複を弾くが、そこに至るまでに
+    -- frontmatter を2回パースするので手前で止める（orchestration_link.lua の早期returnを参照）
+    if item.body and item.bufnr and not seen[item.bufnr] then
+      seen[item.bufnr] = true
+      OrchestrationLink.link_or_warn(item.bufnr, to_bufnr)
+    end
+  end
+end
+
+---「done_bufnr が止まった」という通知を積む
+---
+---同じチャットについて二重には積まない。宛先が忙しい間に同じワーカーが2度止まっても、
+---伝えるべきことは「止まった、読みに行け」の1回きり
+---@param to_bufnr number
+---@param done_bufnr number
+---@param depth number?
+function M.enqueue_notification(to_bufnr, done_bufnr, depth)
+  local queue = pending[to_bufnr] or {}
+  for _, item in ipairs(queue) do
+    if not item.body and item.bufnr == done_bufnr then
+      return
+    end
+  end
+
+  if #queue >= MAX_QUEUED then
+    -- 呼び出し元は既にエッジを消費しているので、黙って捨てると通知は二度と再現しない
+    notify.warn(
+      string.format(
+        "Chat %d already has %d items queued; dropping the completion notice for chat %d",
+        to_bufnr,
+        #queue,
+        done_bufnr
+      ),
+      WARN_TITLE
+    )
+    return
+  end
+
+  table.insert(queue, { bufnr = done_bufnr, depth = depth })
+  pending[to_bufnr] = queue
+end
+
+---本文を積む
+---@param to_bufnr number
+---@param from_bufnr number?
+---@param body string
+---@return boolean ok
+---@return string? err 積まなかった理由。送信元に返して伝える
+function M.enqueue_message(to_bufnr, from_bufnr, body)
+  -- 空の本文は待っても送れるようにならない。積めば `ProgrammaticSender` が配達時に弾き、
+  -- そのときにはもう送信元に伝える先がない
+  if type(body) ~= "string" or vim.trim(body) == "" then
+    return false, "Empty message"
+  end
+
+  local queue = pending[to_bufnr] or {}
+  if #queue >= MAX_QUEUED then
+    return false,
+      string.format(
+        "Chat buffer %d already has %d messages waiting for it; not queueing another. "
+          .. "Wait for it to catch up before sending again.",
+        to_bufnr,
+        #queue
+      )
+  end
+
+  table.insert(queue, { bufnr = from_bufnr, body = body })
+  pending[to_bufnr] = queue
+  return true
+end
+
+---`about_bufnr` についての滞留通知を落とす
+---
+---その相手から本文が直接届くなら、「止まった、読みに行け」は冗長になる
+---@param to_bufnr number
+---@param about_bufnr number
+function M.drop_notification(to_bufnr, about_bufnr)
+  remove_where(to_bufnr, function(item)
+    return not item.body and item.bufnr == about_bufnr
+  end)
+end
+
+---溜まったものを1ターンにまとめて配達する
+---
+---相手が応答中なら**何もしない**。応答中のバッファに送ると `ChatBuffer:send_message()` が
+---進行中のターンを kill する（buffer.lua の「前のリクエストが実行中ならキャンセル」）。
+---積んだままにしておけば、相手自身の `VibingResponseDone` でここが呼び直される。
+---@param to_bufnr number
+---@return boolean restarted 配達の結果 to_bufnr が新しいターンを走らせた
+---@return number? deepest 配達した通知が運んでいた最大の深さ
+function M.flush(to_bufnr)
+  local queue = pending[to_bufnr]
+  if not queue or #queue == 0 then
+    return false
+  end
+
+  if not vim.api.nvim_buf_is_valid(to_bufnr) then
+    pending[to_bufnr] = nil
+    return false
+  end
+
+  local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(to_bufnr)
+  if not chat_buf then
+    pending[to_bufnr] = nil
+    return false
+  end
+
+  if chat_buf:is_responding() then
+    return false
+  end
+
+  -- ユーザーが書きかけの `## User` を残しているなら触らない。配達は新しいセクションを足すので、
+  -- 下書きは送られないまま宙に浮き、次の<CR>は空のヘッダを読んで「No message to send」になる。
+  -- auto_resume が未送信セクションを上書きしないのと同じ扱い。
+  -- ユーザーがその下書きを送れば、そのターンの完了でここが呼び直されるので取りこぼさない
+  if chat_buf.extract_user_message then
+    local draft = chat_buf:extract_user_message()
+    if draft and vim.trim(draft) ~= "" then
+      return false
+    end
+  end
+
+  local deepest
+  for _, item in ipairs(queue) do
+    if item.depth then
+      deepest = math.max(deepest or 0, item.depth)
+    end
+  end
+
+  write_links(queue, to_bufnr)
+
+  local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+  local text = require("vibing.application.chat.delivery_message").build(queue)
+  local ok, result = pcall(ProgrammaticSender.send, to_bufnr, text)
+
+  -- 配達できて初めてキューを空ける。通知側はエッジを既に消費しているので、先に捨てると
+  -- 失敗した配達は二度と再現しない。残しておけば次の完了イベントで作り直しなしに再試行できる
+  if ok and result and result.success then
+    pending[to_bufnr] = nil
+
+    -- 送信が受理されたことと、ターンが始まったことは別。`ChatBuffer:send_message()` が返すのは
+    -- 「リクエストとして扱ったか」で、リミット中の予約（`_try_schedule_instead_of_send`）でも、
+    -- `SendMessage.execute` がアダプタ未設定・セッション競合で降りた場合でも true になる。
+    -- 後者はストリームを張らないので `VibingResponseDone` が来ず、呼び出し元がこれを再稼働と
+    -- 読むとエッジが宙に浮く。始まっていないターンを購読者の待ち先にはできないので、
+    -- 送信結果ではなく相手の状態を返す
+    return chat_buf:is_responding(), deepest
+  end
+
+  notify.warn(
+    string.format("Could not deliver to chat %d: %s", to_bufnr, ok and "the chat refused the message" or tostring(result)),
+    WARN_TITLE
+  )
+  return false
+end
+
+---バッファが消えたので、その宛先のキューと、他のキューに残る言及を捨てる
+---
+---`BufDelete` はパターン無しで張られていて、エディタ内のどのバッファを閉じても走る。
+---既定（この機能は未使用）では空振りなので、自分の状態が空なら何もしない
+---@param bufnr number
+function M.forget(bufnr)
+  if next(pending) == nil then
+    return
+  end
+
+  pending[bufnr] = nil
+
+  for to_bufnr in pairs(pending) do
+    remove_where(to_bufnr, function(item)
+      return item.bufnr == bufnr
+    end)
+  end
+end
+
+return M

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -191,6 +191,11 @@ function M.flush(to_bufnr)
     end
   end
 
+  -- 送信の成否を待たずに書く。順序は即配達経路と同じ（リンクが先、送信が後）で、理由も同じ:
+  -- `addUserSection` が走ったあとに frontmatter を触ると、始まったストリーミングと競合する。
+  -- 送信が失敗したときはキューが残って再試行されるので、いずれ辻褄は合う。恒久的に失敗し続ける
+  -- 相手についてだけは「一度も届いていない関係」が記録に残るが、`link` は重複を弾くので
+  -- 増えはしないし、リンクは記録であって配達の証明ではない
   write_links(queue, to_bufnr)
 
   local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -94,4 +94,23 @@ function M.link(from_bufnr, to_bufnr)
   return true, nil
 end
 
+---`link` を呼び、失敗しても警告だけして続行する
+---
+---「リンクは記録であって、失敗が送信を止める理由にはならない」は送信経路2つ（即配達と
+---キュー配達）に共通の方針だったので、方針と文言をここに1つ置く。2箇所に散らしておくと、
+---片方だけ直した日に食い違う。`rpc/handlers/chat.lua` は作成時点の別文言を使うので通さない
+---@param from_bufnr number
+---@param to_bufnr number
+---@return boolean success
+function M.link_or_warn(from_bufnr, to_bufnr)
+  local ok, err = M.link(from_bufnr, to_bufnr)
+  if not ok then
+    require("vibing.core.utils.notify").warn(
+      string.format("Could not link chats %d -> %d: %s", from_bufnr, to_bufnr, err or "unknown"),
+      "Orchestration"
+    )
+  end
+  return ok
+end
+
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -4,14 +4,44 @@ local M = {}
 
 local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
 
+---宛先が応答中なのでキューに積む（`queue_if_busy`）
+---
+---リンク（`orchestrated` / `orchestrated_by`）はここでは書かない。積む条件が「宛先が応答中」で、
+---`update_frontmatter_list` はその宛先バッファを直接編集するため、いま書くとストリーミングと
+---競合する。実際に配達される直前、宛先が idle になった時点で `message_queue` が書く
+---@param bufnr number 解決済みの宛先
+---@param params {message: string, from_bufnr?: number}
+---@return {success: boolean, queued: boolean, bufnr: number}
+local function queue_for_later(bufnr, params)
+  -- 自分自身への送信を弾く。`validate` は応答中を理由に断っていたので、この経路が
+  -- できるまでは起こりえなかった。積むと自分の配達で自分が再稼働し、`depth` を持たない
+  -- ぶん `max_hops` の抑止も効かない。`subscribe` と `orchestration_link.link` の
+  -- 同じガードに揃える
+  if params.from_bufnr and params.from_bufnr == bufnr then
+    error("A chat cannot queue a message to itself")
+  end
+
+  local ok, err =
+    require("vibing.application.chat.message_queue").enqueue_message(bufnr, params.from_bufnr, params.message)
+  if not ok then
+    error(err)
+  end
+
+  if params.from_bufnr then
+    require("vibing.application.chat.completion_notifier").on_sent(params.from_bufnr, bufnr)
+  end
+
+  return { success = true, queued = true, bufnr = bufnr }
+end
+
 ---Send message to chat buffer
 ---
 ---宛先は `bufnr` か `file_path` のどちらか一方で指す。パスで指せることが要点で、bufnr は
 ---Neovim を再起動すれば別のバッファを指すのに対し、frontmatter が記録するパスは残る（#641）。
 ---閉じているチャットは `chat_locator.open` が背景で開くので、再起動後も frontmatter の
 ---パスからそのまま繋ぎ直せる
----@param params {bufnr?: number, file_path?: string, message: string, sender?: string, from_bufnr?: number}
----@return {success: boolean, bufnr: number}
+---@param params {bufnr?: number, file_path?: string, message: string, sender?: string, from_bufnr?: number, queue_if_busy?: boolean}
+---@return {success: boolean, bufnr: number, queued?: boolean}
 function M.send_message(params)
   if not params then
     error("Missing parameters")
@@ -24,6 +54,13 @@ function M.send_message(params)
     error("Missing bufnr or file_path parameter")
   end
 
+  -- `queue_if_busy` は明示指定したときだけ効く。既定でキューに積むと、弾かれたことを検知して
+  -- 待ち直すつもりだった既存の呼び出し元が、成功したものとして先に進む。
+  -- 引き受けるのは「応答中」だけ: 無効なバッファや空メッセージは待っても解けない
+  if params.queue_if_busy and ProgrammaticSender.is_responding(bufnr) then
+    return queue_for_later(bufnr, params)
+  end
+
   -- `from_bufnr` は任意。必須にすると渡し忘れで送信そのものが失敗し、既存の
   -- オーケストレーション経路が壊れる。渡されなければリンクを張らないだけ（＝従来の動作）
   if params.from_bufnr then
@@ -32,15 +69,7 @@ function M.send_message(params)
     -- 行われなかったやり取りの関係だけが永久に残るので、先に送信可能かを確かめる
     ProgrammaticSender.validate(bufnr, params.message)
 
-    local ok, err = require("vibing.application.chat.orchestration_link").link(params.from_bufnr, bufnr)
-    -- リンクは記録であって、失敗が送信を止める理由にはならない。片方だけ書けた状態でも
-    -- リネーム同期は残った側で動く
-    if not ok then
-      require("vibing.core.utils.notify").warn(
-        string.format("Could not link chats %d -> %d: %s", params.from_bufnr, bufnr, err or "unknown"),
-        "Orchestration"
-      )
-    end
+    require("vibing.application.chat.orchestration_link").link_or_warn(params.from_bufnr, bufnr)
   end
 
   -- ProgrammaticSender.send already validates parameters
@@ -57,7 +86,7 @@ function M.send_message(params)
   -- 遅すぎることはない: CLIの起動は非同期で、宛先の完了は `vim.schedule` 経由なので
   -- この関数が返るより先には走らない
   if params.from_bufnr and result and result.success then
-    require("vibing.application.chat.completion_notifier").subscribe(params.from_bufnr, bufnr)
+    require("vibing.application.chat.completion_notifier").on_sent(params.from_bufnr, bufnr)
   end
 
   return result

--- a/lua/vibing/presentation/chat/modules/programmatic_sender.lua
+++ b/lua/vibing/presentation/chat/modules/programmatic_sender.lua
@@ -8,6 +8,25 @@ local Renderer = require("vibing.presentation.chat.modules.renderer")
 -- Per-buffer send locks to prevent concurrent sends
 local _send_locks = {}
 
+---いま新しいメッセージを受け付けられない状態か
+---
+---`validate` の一部を述語として切り出したのではなく、**別の問い**を立てている。呼び出し元が
+---知りたいのは「待てば送れるようになるか」で、その答えが yes なのは応答中のときだけ。
+---無効なバッファも空メッセージも待って解けるものではないので、それらは `validate` の
+---エラーのままでよい（`nvim_chat_send_message` の `queue_if_busy`）。
+---
+---エラーメッセージの文字列一致で代用させないために公開している。文言を直した日に、
+---キューが黙って効かなくなる
+---@param bufnr number
+---@return boolean
+function M.is_responding(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return false
+  end
+  local chat_buf = view.get_chat_buffer(bufnr)
+  return chat_buf ~= nil and chat_buf:is_responding()
+end
+
 ---送信できる状態かを確かめ、対象のChatBufferを返す（送れないなら error）
 ---
 ---`send`から切り出してあるのは、送信の前に別の副作用を済ませたい呼び出し元があるため。

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -543,6 +543,29 @@ describe("CompletionNotifier", function()
     assert.equals(a, sends[1].bufnr)
   end)
 
+  it("does not carry a suppression mark across a spell of the feature being disabled", function()
+    -- マークは「次の停止1回ぶん」の一時状態。無効化を挟んだ完了で使い切らないと残り、
+    -- 有効化後に張り直された正当なエッジを黙って落とす — このリポジトリが繰り返し
+    -- 防いでいる「黙って消える」そのものになる
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_sent(b, a)
+
+    -- B が止まる前に無効化される。完了は購読者に配らないが、印はここで使い切られる
+    configure({ enabled = false })
+    Notifier.on_response_done(b)
+    assert.equals(0, #sends)
+
+    -- 有効化して改めて購読を張り直す。古い印に黙らされてはいけない
+    configure({ enabled = true })
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+  end)
+
   it("suppresses only the one stop that follows the report", function()
     local a, b = make_chat(), make_chat()
 

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -7,6 +7,7 @@ describe("CompletionNotifier", function()
   ---モジュールレベルの購読テーブルはspec間で共有されるので、毎回requireし直して捨てる。
   ---本番側にリセット用のAPIを生やすより、追加した状態が自動的にリセット対象になる
   local Notifier
+  local MessageQueue
   local originals = {}
   local buffers = {}
   local responding = {}
@@ -71,8 +72,12 @@ describe("CompletionNotifier", function()
 
     configure()
 
+    -- 配達キューは別モジュールに分かれていて、そちらもモジュールレベルの状態を持つ。
+    -- notifier だけ捨てても、キャッシュされたキューの滞留がspec間で持ち越される
+    package.loaded["vibing.application.chat.message_queue"] = nil
     package.loaded["vibing.application.chat.completion_notifier"] = nil
     Notifier = require("vibing.application.chat.completion_notifier")
+    MessageQueue = require("vibing.application.chat.message_queue")
   end)
 
   after_each(function()
@@ -407,6 +412,149 @@ describe("CompletionNotifier", function()
     -- 深さ0で張られた c のエッジがここで配達されても、カウンタは戻らない
     Notifier.on_response_done(c)
     assert.is_false(Notifier.subscribe(a, b))
+  end)
+
+  it("drains a queued message even when watchdog notifications are disabled", function()
+    -- `chat_notifications.enabled` が gate するのは「読みに行け」を自動で飛ばすかどうか。
+    -- `queue_if_busy` は呼び出し側が明示的に出した配達要求なので、設定に従わせると
+    -- 通知を切っている環境でワーカーの報告が黙って消える
+    configure({ enabled = false })
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    assert.is_true(MessageQueue.enqueue_message(a, b, "the migration is done"))
+    responding[a] = false
+    Notifier.on_response_done(a)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+    assert.is_truthy(sends[1].message:find("the migration is done", 1, true))
+  end)
+
+  it("carries the sender's body rather than telling the reader to go and fetch it", function()
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    MessageQueue.enqueue_message(a, b, "found the leak in parser.lua")
+    responding[a] = false
+    Notifier.on_response_done(a)
+
+    assert.is_truthy(sends[1].message:find("found the leak in parser.lua", 1, true))
+    assert.is_truthy(sends[1].message:find("chat buffer " .. b, 1, true))
+  end)
+
+  it("coalesces queued messages and completion notices into one turn", function()
+    local a, b, c = make_chat(), make_chat(), make_chat()
+    responding[a] = true
+
+    Notifier.subscribe(a, c)
+    Notifier.on_response_done(c)
+    MessageQueue.enqueue_message(a, b, "worker b reporting in")
+
+    responding[a] = false
+    Notifier.on_response_done(a)
+
+    assert.equals(1, #sends)
+    assert.is_truthy(sends[1].message:find("worker b reporting in", 1, true))
+    assert.is_truthy(sends[1].message:find("chat buffer " .. c, 1, true))
+  end)
+
+  it("drops the watchdog edge once the watched chat has reported for itself", function()
+    -- B が A に自分から送った以上、「B が止まった、読みに行け」は同じ用件の二度目になる
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_sent(b, a)
+    Notifier.on_response_done(b)
+
+    assert.equals(0, #sends)
+
+    -- A が改めて B に送れば張り直される
+    assert.is_true(Notifier.subscribe(a, b))
+    Notifier.on_response_done(b)
+    assert.equals(1, #sends)
+  end)
+
+  it("drops a completion notice already queued about the chat that then reported", function()
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    MessageQueue.enqueue_message(a, b, "here is what I found")
+    Notifier.on_sent(b, a)
+
+    responding[a] = false
+    Notifier.on_response_done(a)
+
+    assert.equals(1, #sends)
+    assert.is_truthy(sends[1].message:find("here is what I found", 1, true))
+    assert.is_falsy(sends[1].message:find("finished responding", 1, true))
+  end)
+
+  it("keeps the subscription alive when the report turns out to be an intermediate one", function()
+    -- A → B → C。B が「C に投げた、待つ」を A に伝えてから、C の報告で再稼働する。
+    -- 送信の時点では、それが最終報告か途中経過かは機構には分からない。エッジを消してしまうと
+    -- B の本命の報告が終わっても A には二度と通知が来ない（#638 が直したのと同じ取りこぼし）
+    local a, b, c = make_chat(), make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.subscribe(b, c)
+
+    -- B が A に途中経過を送る（A は応答中なので積まれるだけ）
+    responding[a] = true
+    Notifier.on_sent(b, a)
+    MessageQueue.enqueue_message(a, b, "dispatched to C, waiting")
+
+    -- C が先に終わり、B のキューに滞留する
+    responding[b] = true
+    Notifier.on_response_done(c)
+
+    -- B の中間ターンが終わる: 自分のキューで再稼働するので A には知らせない
+    responding[b] = false
+    Notifier.on_response_done(b)
+    assert.equals(b, sends[#sends].bufnr, "only B's own queue drains; A is not woken mid-flight")
+
+    -- B の本命の報告ターンが終わる。購読は生きていなければならない
+    responding[a] = false
+    responding[b] = false
+    Notifier.on_response_done(b)
+
+    -- A には B の途中経過と「B が止まった」が1ターンにまとまって届く
+    assert.equals(a, sends[#sends].bufnr)
+    assert.is_truthy(sends[#sends].message:find("dispatched to C, waiting", 1, true))
+    assert.is_truthy(sends[#sends].message:find("chat buffer " .. b, 1, true))
+  end)
+
+  it("suppresses only the one stop that follows the report", function()
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_sent(b, a)
+
+    Notifier.on_response_done(b)
+    assert.equals(0, #sends, "A heard from B directly, so the watchdog is redundant")
+
+    -- 購読は使い切られている。改めて送らなければ次の完了でも黙ったまま
+    Notifier.on_response_done(b)
+    assert.equals(0, #sends)
+  end)
+
+  it("does not raise the hop count for a queued message", function()
+    -- 直接送信は今も hop 予算の対象外で、`queue_if_busy` はその同じ送信が遅れて届くだけ。
+    -- ペア単位の往復カウンタは #644 の担当
+    configure({ max_hops = 1 })
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    MessageQueue.enqueue_message(a, b, "a report")
+    responding[a] = false
+    Notifier.on_response_done(a)
+    assert.equals(1, #sends)
+
+    responding[a] = false
+    assert.is_true(Notifier.subscribe(a, b), "the delivery must not have spent A's hop budget")
   end)
 
   describe("setup", function()

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -527,6 +527,22 @@ describe("CompletionNotifier", function()
     assert.is_truthy(sends[#sends].message:find("chat buffer " .. b, 1, true))
   end)
 
+  it("records no suppression while the feature is disabled", function()
+    -- 無効な間はエッジが張られないので印は無駄なうえ、途中で有効化されたときに
+    -- 無効だった間の送信が新しいエッジを誤って黙らせる
+    configure({ enabled = false })
+    local a, b = make_chat(), make_chat()
+
+    Notifier.on_sent(b, a)
+
+    configure({ enabled = true })
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+  end)
+
   it("suppresses only the one stop that follows the report", function()
     local a, b = make_chat(), make_chat()
 

--- a/tests/lua/application/chat/message_queue_spec.lua
+++ b/tests/lua/application/chat/message_queue_spec.lua
@@ -1,0 +1,226 @@
+-- 配達キューそのものの責務。購読・hop 予算との組み合わせは completion_notifier_spec が見る。
+--
+-- ここでしか現れないのはリンク書き込みのタイミングで、`orchestration_link.link` は宛先バッファの
+-- frontmatter を直接編集する。積む条件が「宛先が応答中」なので、積んだ時点で書くとその宛先の
+-- ストリーミングと競合する。配達直前まで遅らせているのはそのため。
+local view = require("vibing.presentation.chat.view")
+local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+local OrchestrationLink = require("vibing.application.chat.orchestration_link")
+local notify = require("vibing.core.utils.notify")
+
+describe("MessageQueue", function()
+  local Queue
+  local originals = {}
+  local buffers = {}
+  local responding = {}
+  local sends = {}
+  local links = {}
+  local warnings = {}
+
+  ---@return number bufnr
+  local function make_chat()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  before_each(function()
+    originals.get_chat_buffer = view.get_chat_buffer
+    originals.send = ProgrammaticSender.send
+    originals.link = OrchestrationLink.link
+    originals.warn = notify.warn
+
+    buffers, responding, sends, links, warnings = {}, {}, {}, {}, {}
+
+    view.get_chat_buffer = function(bufnr)
+      if not vim.api.nvim_buf_is_valid(bufnr) then
+        return nil
+      end
+      return {
+        is_responding = function()
+          return responding[bufnr] == true
+        end,
+        extract_user_message = function()
+          return nil
+        end,
+      }
+    end
+    ProgrammaticSender.send = function(bufnr, message)
+      table.insert(sends, { bufnr = bufnr, message = message })
+      responding[bufnr] = true
+      return { success = true, bufnr = bufnr }
+    end
+    -- 本物はディスクに触るので差し替える。順序の観測だけがここの目的
+    OrchestrationLink.link = function(from, to)
+      table.insert(links, { from = from, to = to, sends_so_far = #sends })
+      return true, nil
+    end
+    notify.warn = function(message, title)
+      table.insert(warnings, { message = message, title = title })
+    end
+
+    package.loaded["vibing.application.chat.message_queue"] = nil
+    Queue = require("vibing.application.chat.message_queue")
+  end)
+
+  after_each(function()
+    view.get_chat_buffer = originals.get_chat_buffer
+    ProgrammaticSender.send = originals.send
+    OrchestrationLink.link = originals.link
+    notify.warn = originals.warn
+
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end)
+
+  it("writes the orchestration link at delivery, not while the recipient is responding", function()
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Queue.enqueue_message(a, b, "a report")
+    assert.equals(0, #links, "nothing may touch A's frontmatter while it is streaming")
+
+    responding[a] = false
+    Queue.flush(a)
+
+    assert.equals(1, #links)
+    assert.equals(b, links[1].from)
+    assert.equals(a, links[1].to)
+    assert.equals(0, links[1].sends_so_far, "the link must precede the send, as on the direct path")
+  end)
+
+  it("writes one link per sender however many messages that sender queued", function()
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Queue.enqueue_message(a, b, "first")
+    Queue.enqueue_message(a, b, "second")
+
+    responding[a] = false
+    Queue.flush(a)
+
+    assert.equals(1, #links)
+  end)
+
+  it("writes no link for a message that named no sender", function()
+    local a = make_chat()
+
+    Queue.enqueue_message(a, nil, "from nobody in particular")
+    Queue.flush(a)
+
+    assert.equals(0, #links)
+    assert.equals(1, #sends)
+  end)
+
+  it("delivers every queued message in one turn, in the order they were queued", function()
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Queue.enqueue_message(a, b, "FIRST-BODY")
+    Queue.enqueue_message(a, b, "SECOND-BODY")
+
+    responding[a] = false
+    Queue.flush(a)
+
+    assert.equals(1, #sends)
+    local first = sends[1].message:find("FIRST-BODY", 1, true)
+    local second = sends[1].message:find("SECOND-BODY", 1, true)
+    assert.is_truthy(first)
+    assert.is_truthy(second)
+    assert.is_true(first < second)
+  end)
+
+  it("reports whether the delivery actually started a turn", function()
+    local a = make_chat()
+    Queue.enqueue_message(a, nil, "body")
+
+    assert.is_true(Queue.flush(a))
+  end)
+
+  it("keeps the queue when the recipient is responding and delivers nothing", function()
+    local a = make_chat()
+    responding[a] = true
+
+    Queue.enqueue_message(a, nil, "body")
+    assert.is_false(Queue.flush(a))
+    assert.equals(0, #sends)
+
+    responding[a] = false
+    assert.is_true(Queue.flush(a))
+    assert.equals(1, #sends)
+  end)
+
+  it("warns rather than silently dropping a completion notice past the cap", function()
+    -- 通知側は呼ぶ前にエッジを消費しているので、黙って捨てると二度と再現しない
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    for _ = 1, 20 do
+      Queue.enqueue_message(a, nil, "filler")
+    end
+    Queue.enqueue_notification(a, b, 0)
+
+    assert.equals(1, #warnings)
+    assert.equals("Chat Delivery", warnings[1].title)
+  end)
+
+  it("does not count a repeat notice about the same chat against the cap", function()
+    -- 「止まった、読みに行け」は同じ相手について何度あっても伝えることは1つ
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Queue.enqueue_notification(a, b, 0)
+    Queue.enqueue_notification(a, b, 0)
+
+    responding[a] = false
+    Queue.flush(a)
+
+    local _, count = sends[1].message:gsub("chat buffer " .. b, "")
+    assert.equals(1, count)
+  end)
+
+  it("forgets a deleted buffer as a recipient and as a sender", function()
+    local a, b, c = make_chat(), make_chat(), make_chat()
+    responding[a] = true
+    responding[c] = true
+
+    Queue.enqueue_message(a, b, "from b")
+    Queue.enqueue_message(c, b, "also from b")
+
+    Queue.forget(b)
+
+    responding[a], responding[c] = false, false
+    Queue.flush(a)
+    Queue.flush(c)
+
+    assert.equals(0, #sends)
+  end)
+
+  it("counts messages rather than claiming that many chats sent them", function()
+    -- 1つのワーカーからの2件を「2つのチャットから」と言うと、読み手は出どころを取り違える
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Queue.enqueue_message(a, b, "first")
+    Queue.enqueue_message(a, b, "second")
+
+    responding[a] = false
+    Queue.flush(a)
+
+    assert.is_falsy(sends[1].message:find("2 other chats", 1, true))
+    assert.is_truthy(sends[1].message:find("2 messages", 1, true))
+  end)
+
+  it("refuses an empty body rather than queueing something that can never be sent", function()
+    -- 積んでしまうと配達時に `ProgrammaticSender` が弾き、そのときにはもう送信元に伝える先がない
+    local a = make_chat()
+
+    local ok, err = Queue.enqueue_message(a, nil, "   ")
+
+    assert.is_false(ok)
+    assert.is_truthy(err)
+  end)
+end)

--- a/tests/lua/application/chat/message_queue_spec.lua
+++ b/tests/lua/application/chat/message_queue_spec.lua
@@ -182,21 +182,50 @@ describe("MessageQueue", function()
     assert.equals(1, count)
   end)
 
-  it("forgets a deleted buffer as a recipient and as a sender", function()
-    local a, b, c = make_chat(), make_chat(), make_chat()
+  it("drops the queue of a deleted recipient", function()
+    local a, b = make_chat(), make_chat()
     responding[a] = true
-    responding[c] = true
 
-    Queue.enqueue_message(a, b, "from b")
-    Queue.enqueue_message(c, b, "also from b")
+    Queue.enqueue_message(a, b, "for a")
+    Queue.forget(a)
 
-    Queue.forget(b)
-
-    responding[a], responding[c] = false, false
+    responding[a] = false
     Queue.flush(a)
-    Queue.flush(c)
 
     assert.equals(0, #sends)
+  end)
+
+  it("drops a completion notice about a chat that no longer exists", function()
+    -- 「あれが止まった、読みに行け」は、読みに行く先が消えた時点で意味を失う
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Queue.enqueue_notification(a, b, 0)
+    Queue.forget(b)
+
+    responding[a] = false
+    Queue.flush(a)
+
+    assert.equals(0, #sends)
+  end)
+
+  it("still delivers a body whose sender was deleted, anonymously", function()
+    -- 送信元の記録は表示とリンクのためのメタデータで、本文の届け先とは無関係。
+    -- 送信元のバッファが閉じられただけで報告を捨てると、このモジュールが防ぐために
+    -- 存在している「黙って消える」がそのまま起きる
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    Queue.enqueue_message(a, b, "the last thing B said")
+    Queue.forget(b)
+
+    responding[a] = false
+    Queue.flush(a)
+
+    assert.equals(1, #sends)
+    assert.is_truthy(sends[1].message:find("the last thing B said", 1, true))
+    assert.is_falsy(sends[1].message:find("chat buffer " .. b, 1, true))
+    assert.equals(0, #links, "a chat that is gone must not be linked, nor warned about")
   end)
 
   it("counts messages rather than claiming that many chats sent them", function()

--- a/tests/lua/infrastructure/rpc/handlers/message_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/message_spec.lua
@@ -60,6 +60,7 @@ describe("rpc handlers.message.send_message", function()
       return true, nil
     end
 
+    package.loaded["vibing.application.chat.message_queue"] = nil
     package.loaded["vibing.application.chat.completion_notifier"] = nil
     Notifier = require("vibing.application.chat.completion_notifier")
   end)
@@ -183,5 +184,98 @@ describe("rpc handlers.message.send_message", function()
 
     assert.is_true(result.success)
     assert.equals(1, chats[to].sends)
+  end)
+
+  it("queues instead of refusing when the target is busy and the caller asked for it", function()
+    local from, to = make_chat(), make_chat()
+    chats[to].responding = true
+
+    local result =
+      Message.send_message({ bufnr = to, message = "my report", from_bufnr = from, queue_if_busy = true })
+
+    assert.is_true(result.success)
+    assert.is_true(result.queued)
+    assert.equals(0, chats[to].sends, "nothing may be appended while the target is streaming")
+
+    chats[to].responding = false
+    Notifier.on_response_done(to)
+
+    assert.equals(1, chats[to].sends)
+  end)
+
+  it("subscribes on the queued path too, so the sender still hears the target stop", function()
+    local from, to = make_chat(), make_chat()
+    chats[to].responding = true
+
+    Message.send_message({ bufnr = to, message = "my report", from_bufnr = from, queue_if_busy = true })
+
+    chats[to].responding = false
+    Notifier.on_response_done(to)
+
+    assert.equals(1, chats[from].sends)
+  end)
+
+  it("queues a target that was named by file_path", function()
+    -- 宛先の解決は `queue_if_busy` の判定より前。パスのまま積むと、キューは配達先を
+    -- 引けないバッファ番号として持つことになる
+    local from, to = make_chat(), make_chat()
+    chats[to].responding = true
+    ChatLocator.open = function()
+      return to
+    end
+
+    local result = Message.send_message({
+      file_path = "worker.md",
+      message = "my report",
+      from_bufnr = from,
+      queue_if_busy = true,
+    })
+
+    assert.is_true(result.queued)
+    assert.equals(to, result.bufnr)
+
+    chats[to].responding = false
+    Notifier.on_response_done(to)
+
+    assert.equals(1, chats[to].sends)
+  end)
+
+  it("still refuses a target that waiting cannot make sendable", function()
+    -- `queue_if_busy` が引き受けるのは「応答中」だけ。空メッセージや実在しないバッファは
+    -- いくら待っても解けないので、従来どおりのエラーにする
+    local to = make_chat()
+
+    assert.has_error(function()
+      Message.send_message({ bufnr = to, message = "  ", queue_if_busy = true })
+    end)
+  end)
+
+  it("refuses a chat queueing a message to itself", function()
+    -- `validate` は応答中を理由に断っていたので、この経路ができるまでは起こりえなかった。
+    -- 積むと自分の配達で自分が再稼働し、hop 予算の抑止も効かない
+    local a = make_chat()
+    chats[a].responding = true
+
+    assert.has_error(function()
+      Message.send_message({ bufnr = a, message = "note to self", from_bufnr = a, queue_if_busy = true })
+    end)
+
+    chats[a].responding = false
+    Notifier.on_response_done(a)
+
+    assert.equals(0, chats[a].sends)
+  end)
+
+  it("does not wake a chat twice when the answer it was waiting for already arrived", function()
+    -- B が A に質問し、A が答える。答えが届いた以上「A が止まった、読みに行け」は同じ用件の二度目
+    local a, b = make_chat(), make_chat()
+
+    Message.send_message({ bufnr = a, message = "which schema?", from_bufnr = b })
+    Message.send_message({ bufnr = b, message = "use the second one", from_bufnr = a })
+    local delivered = chats[b].sends
+
+    Notifier.on_response_done(a)
+
+    assert.equals(delivered, chats[b].sends)
   end)
 end)


### PR DESCRIPTION
# Pull Request

## Summary

#639 の Phase 4。`completion_notifier` の pending キューは「あのチャットが止まった、読みに行け」
しか運べなかった。**本文も運べる汎用キューに一般化**し、`nvim_chat_send_message` に
`queue_if_busy` を追加した。相手が応答中のとき、送信はエラーで終わる代わりに積まれ、相手が
止まった瞬間に新しいターンとして配達される。

2種は同じ待ち合わせを必要とする ── 何かを届ける唯一の方法は相手にターンを起こすことで、それは
相手が応答中でない瞬間にしか行えない ── ので、1つのキューと1つの flush を共有し、起こされた
1ターンが両方を運べる。

**baseは #647**（`fix-notifier-intermediate-turn`）。同じ配達経路を作り直すため。

## Changes

- **新** `application/chat/message_queue.lua` — キューの状態機械（enqueue / drop / flush /
  forget、上限20）
- **新** `application/chat/delivery_message.lua` — 連結された1ターンの文面。プロンプトの著述で
  あって待ち合わせの規則ではないので分離
- `completion_notifier.lua` は購読（`edges`）と暴走抑止（`depth`）だけを持つ形に。
  `on_reported`/`subscribe` の対を `on_sent(from, to)` に統合
- `ProgrammaticSender.is_responding()` を追加。`validate` の既存コードは無改変
- `orchestration_link.link_or_warn()` — 「リンク失敗は警告のみ、送信は止めない」方針と文言が
  3ファイルに散っていたのを1箇所に
- `nvim_chat_send_message` に `queue_if_busy`（既定 `false`）。返答で queued / sent を区別
- `.claude/rules/{architecture,mcp-integration}.md` を更新

## 設計上の決定

### `queue_if_busy` は `chat_notifications.enabled` に従属しない

あのフラグが決めるのは「vibing.nvim が自発的に watchdog を飛ばすか」で、キューに積まれた本文は
呼び出し側が明示的に出した配達要求。従属させると既定設定でワーカーの報告が黙って消える。
`on_response_done` は drain を先に無条件で行い、`edges` を見る側だけがフラグを読む。

### 既定オフ、引き受けるのは「応答中」だけ

古い Neovim はキーを無視して従来どおり断り、古い MCP サーバーは送らない。無効なバッファや空
メッセージは待っても解けないので従来どおりエラー。この分岐のために `ProgrammaticSender` に
`is_responding` 述語を足した（エラー文字列の一致で代用すると、文言を直した日に黙って効かなくなる）。

### リンクは配達直前に書く

`update_frontmatter_list` は宛先バッファを直接編集し、積む条件は「宛先が応答中」。積んだ時点で
書くとストリーミングと競合するので、「送信の前にリンク」という既存の順序ごと配達直前に移した。
`flush` が配達するのは宛先が idle のときだけなので、そこが唯一安全な瞬間。配達されずバッファが
消えたら、行われなかったやり取りのリンクも残らない。

### watchdog は「消す」のではなく「1回だけ黙らせる」

B が A に送った時点で `edges[B][A]` を**削除**すると、B のメッセージが途中経過だった場合に
購読が永久に失われる。ツリーでは中間ノードの最初のメッセージは**必ず**途中経過になる（子を待つ
ために一度停止し、子の報告で再稼働してから本命を書く）。送信の時点で最終報告か途中経過かは機構
には分からないので、代わりに「次の停止1回ぶんだけ抑止する」印を置き、drain で再稼働したら印を
捨てる。**これを削除で実装すると #647 が入れた hold を打ち消す**（セルフレビューで検出）。

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] `pnpm run test:lua` — **exit 0**
- [x] `pnpm run test:node` — fail 0
- [x] `pnpm run check`（`luac -p`）
- [x] `pnpm run lint` / `format:check` / `lint:md`（該当2ファイル0件）
- [x] `tsc --noEmit`（mcp-server）
- [ ] Tested locally in Neovim

| spec | 件数 |
| --- | --- |
| `message_queue_spec.lua`（新規） | 12 |
| `completion_notifier_spec.lua` | 32（既存22は無改変で通過） |
| `rpc/handlers/message_spec.lua` | 9 |

`chat_notifications` はインメモリのチャット間機構で実 CLI を起動しないため E2E の対象外。
`pnpm run test:e2e` は実行していない（実トークンを消費するため）。

### Test Environment

- **Neovim version**: NVIM v0.11.x
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: pnpm / Node 20 系

## セルフレビューで見つけて直したもの

実装後の `/simplify`（4観点）と `/code-review high` を回し、後者が挙げた3件はすべて実在した。

| 指摘 | 対応 |
| --- | --- |
| `on_sent` がエッジを無条件削除するため、途中経過の送信で購読が永久に失われる（#638 と同じ取りこぼしの再導入） | 削除をやめ、1回ぶんの抑止マークに。回帰テスト2件 |
| キュー経路に `from == to` ガードが無く、自分宛にキューできる（自分の配達で自分が再稼働し、`depth` が無いので `max_hops` も効かない） | ガードを追加。回帰テスト1件 |
| 「N 個のチャットから」と本文の件数を数えており、1ワーカーからの2件を誤った出どころで伝える | 「N messages arrived」に。回帰テスト1件 |

`/simplify` 側では7件を適用（リンク警告の集約、hop 更新の一箇所化、`on_sent` への統合、
`check`+enum の撤回、文面モジュールの分離と表示パスのメモ化、`kind` フィールドの導出化、
空本文の拒否）。4件は理由付きでスキップ。

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [x] CLAUDE.md updated (`.claude/rules/architecture.md`, `.claude/rules/mcp-integration.md`)
- [x] Code comments added/updated

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

Fixes #642

前提: #647（base）、#638。関連: #639（設計）、#643 / #644（後続フェーズ）

## Additional Context

### この PR でやらないこと

- `chat_status` の拡張（#640）
- パス一次識別子（#641）
- `vibing-orchestrate` スキル改訂（#643）— `queue_if_busy` を実際に使わせるのは向こう
- ペア単位の往復カウンタ（#644）。**キューに積まれた本文は hop 予算を触らない** —
  相手が idle なら即ターンが走る直接送信は今も予算の対象外で、`queue_if_busy` はその同じ送信が
  遅れて届くだけ。A⇄B の往復の抑止は #644 の担当
- 永続化（#639 の「やらないこと」に明記）

### 受け入れた限界

- **通知が満杯のキューに来た場合だけは warn で落とす。** 本文は上限超過を送信元にエラーで返すが、
  通知は呼び出し元が既にエッジを消費した後なので返す先がない
- **`orchestration_link.link` は毎回 `git rev-parse` を同期起動する。** 同ファイルに
  `cached_git_root` があるのに `resolve_bufnrs` しか使っていない。実在する無駄だが共有モジュールの
  キャッシュ挙動を変える話なので、この差分の外として残した
