### PR TITLE
feat: replace the global wake counter with per-pair round-trip counters

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1277,13 +1277,84 @@ Three limits are worth writing down, because the rule reads more general than it
 None of that promises B's next turn is a report for A rather than a reply to the leaf either. Under
 a one-shot edge, "when B next stops" is simply the best moment available.
 
-Two smaller rules. Edges are **one-shot** — delivering consumes them, so a worker completing again
-without a fresh send is silent, and A messaging B three times still notifies once. And the chain is
-bounded by **hops, not cycle detection**: A→B→A→B is a legitimate question-and-answer, so
-`max_hops` (default 8) counts how many times a chat has been woken without a human `<CR>`, and
-exceeding it warns rather than declining in silence. The reset lives in the `<CR>` keymap callback
-rather than in `send_message()`, because delivery itself goes through `send_message()` — resetting
-there would zero the counter on every hop and disable the limit entirely.
+Edges are **one-shot** — delivering consumes them, so a worker completing again without a fresh
+send is silent, and A messaging B three times still notifies once.
+
+**The chain is bounded per chat pair, not per chat.** A→B→A→B is a legitimate question-and-answer,
+so this counts rather than detecting cycles: `max_round_trips` (default 8) is how many
+notifications may be delivered between one pair of chats without a human `<CR>`, and `subscribe`
+refuses once the pair is spent — with a warning, rather than declining in silence.
+
+The pair is **undirected**. What is bounded is the A⇄B ping-pong, and a worker asking its
+orchestrator a question arrives as `subscribe(B, A)` while the orchestrator's brief was
+`subscribe(A, B)`. Two directional counters would give one conversation two budgets and put the
+real ceiling at twice the configured one. The cost of that choice is that the unit is a
+_delivery_, not a full exchange: an orchestrator waking on its worker's completion spends one,
+but a worker's question and the orchestrator's answer spend two.
+
+It used to be one counter per chat — `depth[bufnr]`, how many times that chat had been woken —
+and in a tree that stopped the wrong thing (#644). An orchestrator is woken once per worker
+completion, so five workers reporting in spent five of its eight hops before any ping-pong
+happened at all: the limit fired on fan-in, which is the normal shape of the feature, and left
+A⇄B free until that same shared budget happened to run out. Keyed by pair, fan-in costs each pair
+one and only the ping-pong accumulates.
+
+Moving to pairs also removed machinery, and the removal reaches across the module boundary. The
+old counter had to be monotonic across a chain, so each edge carried the depth it was created at,
+every queued item carried it onward as `Item.depth`, `MessageQueue.flush` returned the deepest of
+them, and delivery raised the recipient to `max(current, deepest + 1)` — all of that to stop an
+edge subscribed early and delivered late from lowering the count. A pair counter is incremented
+from the delivery's own `(from, done)`, which _is_ the pair, so the queue stops carrying a number
+it never interpreted. `flush` now reports **which** chats the delivered notifications were about
+instead, and that list doubles as the "did anything go out" signal the wake budget needs — an
+empty table for a turn that carried only queued bodies, `nil` for no delivery at all.
+
+`max_wakes` (default 50) is the second bound: notifications delivered without a human `<CR>`,
+counted across the whole editor. It exists for the shapes a pair counter is bad at, which are the
+ones that spread deliveries over many pairs — an unbounded fan that never reaches the same chat
+twice, and a long cycle (A→B→C→A advances three counters by one per lap). Which of the two limits
+fires first depends on the shape and the configured values; at the defaults a 3-chat cycle is
+still caught by `max_round_trips` first, at 24 deliveries, well under the budget.
+
+It is deliberately **not** scoped to a connected component, and the reason is sharper than "more
+work". The budget is checked in `subscribe`, and the escape it exists to catch — a fan reaching
+chats never contacted before — has no `round_trips` entry at that moment, so component membership
+is precisely unknowable for the case it guards. `edges` cannot supply it either: edges are
+one-shot and consumed on delivery, so the live set is a transient slice rather than the chat
+graph. The accepted cost is that two unrelated orchestrations share one budget — either can
+exhaust it for the other, and a `<CR>` in either refills both.
+
+Both reset on a manual `<CR>`, through `on_manual_send(bufnr)`. It is named for the event rather
+than for the buffer, matching `on_response_done`, because it is not "clear this chat's state": it
+is "a human acted", and what that implies is the module's to decide. So it drops every pair that
+chat belongs to _and_ zeroes the tree-wide budget — a human typing anywhere breaks the "running
+unattended" premise that budget guards, and keeping it would leave a chain the user is actively
+steering unable to notify anyone until Neovim restarts.
+
+The reset lives in the `<CR>` keymap callback rather than in `send_message()`, because delivery
+itself goes through `send_message()` — resetting there would zero the counters on every hop and
+disable the limits entirely.
+
+**Both limits are checked only when the subscription is created, never again at delivery.** An
+edge that was authorized while budget remained is still delivered after other edges have spent it,
+so either limit can be exceeded by however many edges were live at that moment. Checking again in
+`flush` was rejected: it would drop an already-authorized completion notice, and an orchestrator
+silently never hearing that its worker finished is the exact failure this whole mechanism exists to
+remove — worse than a one-off bounded overshoot, after which every further `subscribe` is refused
+and the chain stops anyway.
+
+A deleted buffer's pair counters go with it (`forget`), since Neovim reuses buffer numbers and a
+stale entry would throttle an unrelated new chat on its first send. Emptied inner tables are
+dropped along with the entry, in `round_trips`, `edges` and `reported` alike: `forget` runs from a
+pattern-less `BufDelete` and short-circuits on `next()` over those three, so a table left holding
+zero entries would disarm that fast path for the rest of the session and put a full scan back on
+every ordinary buffer close.
+
+The removed `max_hops` is not silently ignored: `config.lua` drops it and warns through
+`notify.warn_once`, so the message appears once per Neovim session rather than once per `setup()`
+— a config that calls `setup()` again does not repeat it. That is the same treatment
+`diff.tool = "mote"` gets, and the three of them share the mechanism rather than each keeping a
+flag. A limit that reads as configured while doing nothing is worse than one that was never set.
 
 **The notification says "stopped", never "succeeded".** `idle` is also what a failed turn, a
 pending tool approval, and an `nvim_ask_user_question` look like, so judging outcomes from the

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -175,9 +175,17 @@ agent = {
   chat_notifications = {    -- Tell a chat when a chat it messaged finishes responding
     enabled = false,        -- Opt-in: the notification arrives as a new turn, so it spends
                             -- tokens with nobody watching
-    max_hops = 8,           -- How many times a chat may be woken without a manual <CR>.
-                            -- A→B→A→B is legitimate (B asks, A answers), so the chain is
-                            -- bounded by depth rather than refused as a cycle
+    max_round_trips = 8,    -- Notifications delivered between one pair of chats without a
+                            -- manual <CR>. A→B→A→B is legitimate (B asks, A answers), so the
+                            -- chain is bounded by count rather than refused as a cycle. The
+                            -- pair is undirected, so a worker's question and the answer to it
+                            -- spend two of these, while an orchestrator waking on a worker's
+                            -- completion spends one
+    max_wakes = 50,         -- Whole-tree budget: notifications delivered without a manual <CR>,
+                            -- counted across the editor. A last resort for shapes that spread
+                            -- over many pairs and so stay under the limit above — an unbounded
+                            -- fan reaches it, and so does a long enough cycle (a 3-chat one is
+                            -- caught by max_round_trips first, at these defaults)
   },
 
   codex_provider_notice = {

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -7,48 +7,103 @@
 ---`nvim_chat_send_message` を呼ぶだけで同じ経路に乗る。
 ---
 ---**配達そのものは `message_queue.lua` が持つ。** ここが持つのは購読（`edges`）と暴走抑止
----（`depth`）だけで、どちらもインメモリのみ。Neovim が落ちればワーカーチャットも道連れなので、
----`pending-resume.json` のような永続化に意味がない。
+---（`round_trips` / `wakes`）だけで、どれもインメモリのみ。Neovim が落ちればワーカーチャットも
+---道連れなので、`pending-resume.json` のような永続化に意味がない。
 local M = {}
 
 local notify = require("vibing.core.utils.notify")
 local MessageQueue = require("vibing.application.chat.message_queue")
 
 local AUGROUP = "VibingCompletionNotifier"
-local DEFAULT_MAX_HOPS = 8
+local DEFAULT_MAX_ROUND_TRIPS = 8
+local DEFAULT_MAX_WAKES = 50
 
----edges[to_bufnr][from_bufnr] = 購読を張った時点の深さ。
+---edges[to_bufnr][from_bufnr] = true。
 ---「to_bufnr が終わったら from_bufnr に知らせる」を表す
----@type table<number, table<number, number>>
+---@type table<number, table<number, boolean>>
 local edges = {}
-
----通知チェーンで何回起こされたか。手動送信で 0 に戻る
----@type table<number, number>
-local depth = {}
 
 ---reported[from_bufnr][to_bufnr] = from が to に自分から送った。
 ---「次に from が止まったときの watchdog は冗長」を表す、エッジとは別の一時マーク
 ---@type table<number, table<number, boolean>>
 local reported = {}
 
----@return {enabled: boolean, max_hops: number?}
+---round_trips[lo][hi] = 手動送信を挟まずに (lo, hi) の2チャット間で配達された通知の回数。
+---キーは無向ペアに正規化する（lo < hi）: 止めたいのは A⇄B の往復そのものなので、方向ごとに
+---分けると A→B と B→A が別々の予算を持ち、上限が実質2倍になる
+---@type table<number, table<number, number>>
+local round_trips = {}
+
+---手動送信を挟まずにこの Neovim で配達を行った回数
+---@type number
+local wakes = 0
+
+---@return {enabled: boolean, max_round_trips: number?, max_wakes: number?}
 local function settings()
   local config = require("vibing.config").get()
   return (config.agent and config.agent.chat_notifications) or { enabled = false }
 end
 
----自分宛キューを流し、配達できた通知の深さぶんだけ hop カウンタを上げる
+---無向ペアを lo < hi に正規化する
+---@param a number
+---@param b number
+---@return number lo
+---@return number hi
+local function pair_of(a, b)
+  if a > b then
+    return b, a
+  end
+  return a, b
+end
+
+---@param a number
+---@param b number
+---@return number
+local function trips_between(a, b)
+  local lo, hi = pair_of(a, b)
+  local partners = round_trips[lo]
+  return partners and partners[hi] or 0
+end
+
+---@param a number
+---@param b number
+local function record_trip(a, b)
+  local lo, hi = pair_of(a, b)
+  round_trips[lo] = round_trips[lo] or {}
+  round_trips[lo][hi] = (round_trips[lo][hi] or 0) + 1
+end
+
+---bufnr が関わるペアのカウンタを全て捨てる
+---
+---空になった内側のテーブルはキーごと消す。残すと `round_trips` が `next()` で真のまま0件を
+---抱えることになり、`M.forget` の早期returnが以降ずっと素通りしなくなる
+---@param bufnr number
+local function drop_pairs_of(bufnr)
+  round_trips[bufnr] = nil
+  for partner, partners in pairs(round_trips) do
+    partners[bufnr] = nil
+    if next(partners) == nil then
+      round_trips[partner] = nil
+    end
+  end
+end
+
+---自分宛キューを流し、配達できたぶんだけ暴走抑止のカウンタを上げる
 ---
 ---「配達したら上げる」を関数にしてあるのは、`on_response_done` に呼び出し箇所が2つあるため。
----どちらかで書き忘れると `max_hops` が黙って連鎖を止められなくなる
+---どちらかで書き忘れると上限が黙って連鎖を止められなくなる
 ---@param bufnr number
 ---@return boolean restarted
 local function drain(bufnr)
-  local restarted, deepest = MessageQueue.flush(bufnr)
-  if deepest then
-    -- 下げてはいけない。深く連鎖したチャットが、浅い時点で張られたエッジの配達を受けたときに
-    -- カウンタが戻ると、max_hops が連鎖を止められなくなる
-    depth[bufnr] = math.max(depth[bufnr] or 0, deepest + 1)
+  local restarted, delivered = MessageQueue.flush(bufnr)
+  if delivered then
+    -- 配られた通知1件ごとに、そのペアの往復が1回進む。全体予算のほうは「起床」の数なので、
+    -- 3件が1通に合流した配達でも消費は1（相手が走るターンは1本）。本文だけを配った場合も
+    -- 起床は起きているので、`delivered` が空でもここは通る
+    for _, done_bufnr in ipairs(delivered) do
+      record_trip(bufnr, done_bufnr)
+    end
+    wakes = wakes + 1
   end
   return restarted
 end
@@ -56,7 +111,7 @@ end
 ---A が B に送ったことを購読として記録する
 ---@param from_bufnr number 送信元（通知を受け取る側）
 ---@param to_bufnr number 送信先（完了を監視される側）
----@return boolean subscribed 深さ上限などで張らなかった場合 false
+---@return boolean subscribed ペアの往復上限・全体予算などで張らなかった場合 false
 function M.subscribe(from_bufnr, to_bufnr)
   local cfg = settings()
   if not cfg.enabled then
@@ -70,27 +125,50 @@ function M.subscribe(from_bufnr, to_bufnr)
     return false
   end
 
-  edges[to_bufnr] = edges[to_bufnr] or {}
-
   -- 同じ (A, B) への複数送信は1本に畳む。A が B に3回送っても通知は1回。
-  -- この判定を hop 上限より**前**に置く: 既に張ってあるエッジは生きていて通知も届くのに、
+  -- この判定を上限より**前**に置く: 既に張ってあるエッジは生きていて通知も届くのに、
   -- 上限に当たったという理由で「購読しなかった」と警告するのは事実に反する。
   -- 同じワーカーに複数回ブリーフを送るのは `vibing-orchestrate` の通常の手順
-  if edges[to_bufnr][from_bufnr] ~= nil then
+  if edges[to_bufnr] and edges[to_bufnr][from_bufnr] then
     return true
   end
 
-  local current = depth[from_bufnr] or 0
-  local max_hops = cfg.max_hops or DEFAULT_MAX_HOPS
-  if current >= max_hops then
-    -- 黙って張らないと、通知が来ない理由がどこにも残らない。A→B→A→B の往復自体は
-    -- 正当なユースケース（Bの質問にAが答える）なので、循環検出ではなく深さで止めている
+  -- 黙って張らないと、通知が来ない理由がどこにも残らない。A→B→A→B の往復自体は正当な
+  -- ユースケース（Bの質問にAが答える）なので、循環検出ではなく回数で止めている
+  local trips = trips_between(from_bufnr, to_bufnr)
+  local max_round_trips = cfg.max_round_trips or DEFAULT_MAX_ROUND_TRIPS
+  if trips >= max_round_trips then
     notify.warn(
       string.format(
-        "Chat %d has already been woken %d times without a manual send; not subscribing to chat %d. "
-          .. "Send a message in that chat yourself to reset the chain.",
+        "Chats %d and %d have gone back and forth %d times without a manual send; not subscribing. "
+          .. "Send a message in either chat yourself to reset the pair.",
         from_bufnr,
-        current,
+        to_bufnr,
+        trips
+      ),
+      "Chat Notifications"
+    )
+    return false
+  end
+
+  -- ペアカウンタが苦手な形に効く最終防壁。苦手なのは配達が多くのペアに散る形で、毎回違う相手に
+  -- 配り続ける扇（どのペアも1のまま）と、長い循環（A→B→C→A は1周でどのペアも1しか進まない）。
+  -- どちらが先に当たるかは形と設定値次第で、既定では3チャットの循環はペア上限が先に拾う
+  -- （8周＝24配達で、予算は50に届かない）
+  --
+  -- **両方の上限は購読の時点でしか見ない。** 既に張られたエッジは、その配達までに他のエッジが
+  -- 予算を使い切っても配られるので、上限は「その時点で生きているエッジの数」ぶんだけ超過しうる。
+  -- 配達直前に見る設計にはしていない: 認可済みの通知を配達時に落とすと、オーケストレータは
+  -- ワーカーの完了を黙って取りこぼす。それはこのモジュールが避けるために存在している失敗そのもので、
+  -- 一度きり・有界の超過より悪い。超過しても以降の `subscribe` は拒否されるので連鎖は止まる
+  local max_wakes = cfg.max_wakes or DEFAULT_MAX_WAKES
+  if wakes >= max_wakes then
+    notify.warn(
+      string.format(
+        "Chat notifications have woken chats %d times without a manual send; "
+          .. "not subscribing chat %d to chat %d. Send a message in any chat yourself to reset the budget.",
+        wakes,
+        from_bufnr,
         to_bufnr
       ),
       "Chat Notifications"
@@ -98,7 +176,8 @@ function M.subscribe(from_bufnr, to_bufnr)
     return false
   end
 
-  edges[to_bufnr][from_bufnr] = current
+  edges[to_bufnr] = edges[to_bufnr] or {}
+  edges[to_bufnr][from_bufnr] = true
 
   return true
 end
@@ -172,9 +251,9 @@ function M.on_response_done(bufnr)
     -- 配達した時点で購読は消える（one-shot）。B が次に完了しても、A が改めて送っていなければ
     -- 通知は飛ばない。自分から報告済みの相手も、購読は同じように使い切る — 用件は届いている
     edges[bufnr] = nil
-    for from_bufnr, edge_depth in pairs(subscribers) do
+    for from_bufnr in pairs(subscribers) do
       if not suppressed[from_bufnr] and vim.api.nvim_buf_is_valid(from_bufnr) then
-        MessageQueue.enqueue_notification(from_bufnr, bufnr, edge_depth)
+        MessageQueue.enqueue_notification(from_bufnr, bufnr)
       end
     end
     for from_bufnr in pairs(subscribers) do
@@ -183,10 +262,22 @@ function M.on_response_done(bufnr)
   end
 end
 
----ユーザーが手動送信したので通知チェーンの深さをリセットする
+---人間が手動送信した。上限カウンタにとってはこれが起点になる
+---
+---`on_response_done` と対になるイベント入口で、名前もそちらに合わせてある。「bufnr の状態を
+---消す」関数ではなく「人間が動いた、その帰結をモジュールが決める」関数なので、bufnr を取りつつ
+---全体予算まで触るのが正しい形になる。
+---
+---ペアは bufnr が関わるものを全て落とす。人間が A に介入した以上、A を通る連鎖はもう無人では
+---ない。全体予算は「無人で走り続けている」ことへの防壁なので、その前提が切れたら残す意味がない。
+---
+---代償として、全体予算は1本しかないので無関係な2つのオーケストレーションが同じ予算を分け合う:
+---一方が使い切れば他方も止まり、一方への `<CR>` が他方の予算も戻す。連結成分ごとに持つ設計は
+---`subscribe` の時点で成分が決まらない（新しい相手への扇はどのペアにも属さない）ため採らない
 ---@param bufnr number
-function M.reset_depth(bufnr)
-  depth[bufnr] = nil
+function M.on_manual_send(bufnr)
+  drop_pairs_of(bufnr)
+  wakes = 0
 end
 
 ---バッファが消えたので関連する購読・キューを捨てる
@@ -197,19 +288,28 @@ function M.forget(bufnr)
   -- autocmdはパターン無しで登録しているので、エディタ内のどのバッファを閉じても走る。
   -- 既定（無効）では状態が空のまま、全テーブルの走査だけが通常の編集操作ごとに起きる。
   -- キューは自分の空振りを自分で弾くので、ここで見るのは自分の状態だけ
-  if not (next(edges) or next(depth) or next(reported)) then
+  if not (next(edges) or next(round_trips) or next(reported)) then
     return
   end
 
   edges[bufnr] = nil
-  depth[bufnr] = nil
   reported[bufnr] = nil
+  drop_pairs_of(bufnr)
 
-  for _, subscribers in pairs(edges) do
+  -- 空になった内側のテーブルはキーごと消す。残すと `next(edges)` / `next(reported)` が真のまま
+  -- 0件を抱えることになり、上の早期returnが以降ずっと素通りしなくなる。この関数はパターン無しの
+  -- `BufDelete` から走るので、それは通常の編集操作のたびに全走査が復活するということ
+  for other, subscribers in pairs(edges) do
     subscribers[bufnr] = nil
+    if next(subscribers) == nil then
+      edges[other] = nil
+    end
   end
-  for _, targets in pairs(reported) do
+  for other, targets in pairs(reported) do
     targets[bufnr] = nil
+    if next(targets) == nil then
+      reported[other] = nil
+    end
   end
 end
 

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -26,7 +26,6 @@ local WARN_TITLE = "Chat Delivery"
 ---@class Vibing.Application.MessageQueue.Item
 ---@field bufnr number? 相手のチャット。通知なら応答を終えた側、本文なら送信元（本文では任意）
 ---@field body string? 配達する本文。**これがあるかどうかが種別**で、別途フラグは持たない
----@field depth number? 通知が購読を張った時点の深さ。運ぶだけで解釈はしない
 
 ---@type table<number, Vibing.Application.MessageQueue.Item[]>
 local pending = {}
@@ -77,8 +76,7 @@ end
 ---伝えるべきことは「止まった、読みに行け」の1回きり
 ---@param to_bufnr number
 ---@param done_bufnr number
----@param depth number?
-function M.enqueue_notification(to_bufnr, done_bufnr, depth)
+function M.enqueue_notification(to_bufnr, done_bufnr)
   local queue = pending[to_bufnr] or {}
   for _, item in ipairs(queue) do
     if not item.body and item.bufnr == done_bufnr then
@@ -100,7 +98,7 @@ function M.enqueue_notification(to_bufnr, done_bufnr, depth)
     return
   end
 
-  table.insert(queue, { bufnr = done_bufnr, depth = depth })
+  table.insert(queue, { bufnr = done_bufnr })
   pending[to_bufnr] = queue
 end
 
@@ -151,7 +149,9 @@ end
 ---積んだままにしておけば、相手自身の `VibingResponseDone` でここが呼び直される。
 ---@param to_bufnr number
 ---@return boolean restarted 配達の結果 to_bufnr が新しいターンを走らせた
----@return number? deepest 配達した通知が運んでいた最大の深さ
+---@return number[]? delivered 配達できたとき、その中の通知が指していたチャットの一覧。
+---  **配達したかどうかの signal も兼ねる**ので、本文だけを配ったときも空tableで返る（nilは
+---  「配達しなかった」）。呼び出し元はこれで暴走抑止のカウンタを進める
 function M.flush(to_bufnr)
   local queue = pending[to_bufnr]
   if not queue or #queue == 0 then
@@ -184,10 +184,10 @@ function M.flush(to_bufnr)
     end
   end
 
-  local deepest
+  local delivered = {}
   for _, item in ipairs(queue) do
-    if item.depth then
-      deepest = math.max(deepest or 0, item.depth)
+    if not item.body and item.bufnr then
+      table.insert(delivered, item.bufnr)
     end
   end
 
@@ -213,7 +213,7 @@ function M.flush(to_bufnr)
     -- 後者はストリームを張らないので `VibingResponseDone` が来ず、呼び出し元がこれを再稼働と
     -- 読むとエッジが宙に浮く。始まっていないターンを購読者の待ち先にはできないので、
     -- 送信結果ではなく相手の状態を返す
-    return chat_buf:is_responding(), deepest
+    return chat_buf:is_responding(), delivered
   end
 
   notify.warn(

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -88,7 +88,8 @@
 ---別チャットに送ったリクエストの完了を、送信元のチャットに通知する
 ---通知は送信元の新しいターンとして届くため、無人でトークンを消費する
 ---@field enabled boolean 完了通知を配達するか（デフォルト: false、無人でトークンを消費するため）
----@field max_hops number 通知が連鎖して自走するのを止める上限。手動送信（<CR>）でリセットされる
+---@field max_round_trips number 2チャット間（無向ペア）で連続して配達してよい通知の数。手動送信（<CR>）でリセットされる
+---@field max_wakes number 手動送信を挟まずに配達してよい通知の総数。ツリー全体の暴走に対する最終防壁
 
 ---@class Vibing.AgentConfig
 ---エージェント設定
@@ -192,9 +193,6 @@
 
 local notify = require("vibing.core.utils.notify")
 
----削除された`diff.*`設定について警告済みか。setup()は複数回呼ばれうるので、設定ごとに1回だけ出す
----@type table<string, boolean>
-local warned_removed_diff = {}
 local tools_const = require("vibing.core.constants.tools")
 local language_utils = require("vibing.core.utils.language")
 
@@ -296,9 +294,17 @@ M.defaults = {
     -- ワーカーに「誰に報告すればいいか」を伝えるシステムプロンプトの1行だけ。
     chat_notifications = {
       enabled = false,
-      -- 通知が連鎖して自走するのを止める上限。A→B→A→B の往復は正当なユースケース
-      -- （Bの質問にAが答える）なので循環検出ではなく深さで止める。<CR>による手動送信で0に戻る。
-      max_hops = 8,
+      -- 通知が連鎖して自走するのを止める上限は2段。A→B→A→B の往復は正当なユースケース
+      -- （Bの質問にAが答える）なので、循環検出ではなく回数で止める。どちらも<CR>による
+      -- 手動送信で0に戻る。
+      --
+      -- 上限を「起こされた回数」のグローバルカウンタから (A,B) ペア単位に変えたのは、
+      -- 止めたいのが A⇄B の無限往復であって扇状の受信数ではないため。子N人からの完了通知を
+      -- 受けるだけで上限に当たるのは、正当なオーケストレータを止めていた（#644）。
+      max_round_trips = 8,
+      -- 配達が多くのペアに散ってペア上限に当たらない形（扇、長い循環）への最終防壁なので、
+      -- 通常の運用では届かない大きさにしてある。
+      max_wakes = 50,
     },
     -- codexの軽量呼び出しは --ignore-user-config で走るので、ユーザーの model_provider が落ちて
     -- 既定のOpenAIエンドポイントに向く。それを1セッション1回だけ警告する。
@@ -527,24 +533,18 @@ function M.setup(opts)
     --
     -- 正規化した値は `M.options` にしか書かないので、ユーザーの `opts` テーブルには古い設定が
     -- 残ったまま。setup()を2回以上呼ぶ構成（設定の再読み込み等）だと、そのたびに同じ警告が
-    -- 出ることになる。警告は一度だけという方針（send_message.luaの`warned_modes`と同じ）に
-    -- 合わせて、設定ごとに出したかを覚えておく。
+    -- 出ることになる。削除された設定の案内はどれも `notify.warn_once` に乗せて1回に抑える。
     if M.options.diff.tool == "mote" then
-      if not warned_removed_diff.tool then
-        warned_removed_diff.tool = true
-        notify.warn(
-          "diff.tool = \"mote\" is no longer supported and is being treated as \"git\". "
-            .. "mote integration was removed: diffs now come from a git tree snapshot taken per "
-            .. "request, which also catches Bash-driven file changes. Remove the setting."
-        )
-      end
+      notify.warn_once(
+        "config.diff.tool",
+        "diff.tool = \"mote\" is no longer supported and is being treated as \"git\". "
+          .. "mote integration was removed: diffs now come from a git tree snapshot taken per "
+          .. "request, which also catches Bash-driven file changes. Remove the setting."
+      )
       M.options.diff.tool = "git"
     end
     if M.options.diff.mote ~= nil then
-      if not warned_removed_diff.mote then
-        warned_removed_diff.mote = true
-        notify.warn("diff.mote is no longer used and can be removed from your setup() call.")
-      end
+      notify.warn_once("config.diff.mote", "diff.mote is no longer used and can be removed from your setup() call.")
       M.options.diff.mote = nil
     end
     M.options.diff.tool = validate_enum(
@@ -556,6 +556,24 @@ function M.setup(opts)
   end
 
   if M.options.agent then
+    -- `max_hops`（起こされた回数のグローバルカウンタ）は (A,B) ペアの往復カウンタと
+    -- 全体予算に置き換わった。黙って無視すると「上限を下げたはずなのに効いていない」に
+    -- 気づけないので、`diff.tool = "mote"` と同じく名指しで案内する
+    -- 型を見るのは、`chat_notifications = true` のような壊れた設定でも `setup()` を落とさない
+    -- ため。`vim.tbl_deep_extend("force", ...)` は非テーブルで既定値ごと置き換えるので、素朴に
+    -- 索引すると boolean を index して落ちる。この経路は今回追加したものなので、少なくとも
+    -- 変更前より壊れやすくはしない
+    local notifications = M.options.agent.chat_notifications
+    if type(notifications) == "table" and notifications.max_hops ~= nil then
+      notify.warn_once(
+        "config.agent.chat_notifications.max_hops",
+        "agent.chat_notifications.max_hops is no longer used and is being ignored. "
+          .. "The chain is now bounded per chat pair by max_round_trips (default 8), with "
+          .. "max_wakes (default 50) as a whole-tree budget. Remove the setting."
+      )
+      notifications.max_hops = nil
+    end
+
     local modes = require("vibing.core.constants.modes")
     local valid_agent_modes = {}
     for _, mode in ipairs(modes.AGENT_MODES) do

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -14,9 +14,9 @@ local ProgrammaticSender = require("vibing.presentation.chat.modules.programmati
 ---@return {success: boolean, queued: boolean, bufnr: number}
 local function queue_for_later(bufnr, params)
   -- 自分自身への送信を弾く。`validate` は応答中を理由に断っていたので、この経路が
-  -- できるまでは起こりえなかった。積むと自分の配達で自分が再稼働し、`depth` を持たない
-  -- ぶん `max_hops` の抑止も効かない。`subscribe` と `orchestration_link.link` の
-  -- 同じガードに揃える
+  -- できるまでは起こりえなかった。積むと自分の配達で自分が再稼働し、しかも相手が自分なので
+  -- ペアが作れず `max_round_trips` の抑止も効かない（止められるのは全体予算だけになる）。
+  -- `subscribe` と `orchestration_link.link` の同じガードに揃える
   if params.from_bufnr and params.from_bufnr == bufnr then
     error("A chat cannot queue a message to itself")
   end

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -207,11 +207,11 @@ function ChatBuffer:_setup_keymaps()
 
   local callbacks = {
     send_message = function()
-      -- 手動送信は通知チェーンの起点なので、ここで深さをリセットする。
+      -- 手動送信は通知チェーンの起点なので、ここで往復カウンタをリセットする。
       -- `ChatBuffer:send_message()` 本体ではなくこのキーマップ側に置くのは、通知の配達自身が
       -- `ProgrammaticSender` 経由で同じ関数を通るため。本体でリセットすると配達のたびに 0 に
-      -- 戻り、`max_hops` が一切効かなくなる
-      require("vibing.application.chat.completion_notifier").reset_depth(self.buf)
+      -- 戻り、上限が一切効かなくなる
+      require("vibing.application.chat.completion_notifier").on_manual_send(self.buf)
       self:send_message()
     end,
     cancel = function()

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -4,7 +4,10 @@ describe("vibing.config", function()
   local config
 
   before_each(function()
-    -- Reload module before each test
+    -- Reload module before each test.
+    -- `notify` も一緒に捨てるのは、削除設定の案内が `notify.warn_once` の memo に載っている
+    -- ため。configだけ作り直しても、前のテストが立てたフラグが残って警告が出なくなる
+    package.loaded["vibing.core.utils.notify"] = nil
     package.loaded["vibing.config"] = nil
     config = require("vibing.config")
   end)
@@ -134,4 +137,52 @@ describe("vibing.config", function()
     end)
   end)
 
+  describe("removed chat_notifications.max_hops", function()
+    local messages
+    local original_notify
+
+    before_each(function()
+      messages = {}
+      original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(messages, { msg = msg, level = level })
+      end
+    end)
+
+    after_each(function()
+      vim.notify = original_notify
+    end)
+
+    it("drops it and names the settings that replaced it", function()
+      -- 黙って無視すると「上限を下げたはずなのに効いていない」に気づけない
+      config.setup({ agent = { chat_notifications = { enabled = true, max_hops = 2 } } })
+
+      assert.is_nil(config.get().agent.chat_notifications.max_hops)
+      assert.equals(1, #messages)
+      assert.is_truthy(messages[1].msg:find("max_round_trips", 1, true))
+      assert.is_truthy(messages[1].msg:find("max_wakes", 1, true))
+    end)
+
+    it("keeps the replacement defaults when the removed key was set", function()
+      config.setup({ agent = { chat_notifications = { enabled = true, max_hops = 2 } } })
+
+      local notifications = config.get().agent.chat_notifications
+      assert.equals(8, notifications.max_round_trips)
+      assert.equals(50, notifications.max_wakes)
+    end)
+
+    it("warns only once even when setup() runs again", function()
+      local opts = { agent = { chat_notifications = { enabled = true, max_hops = 2 } } }
+      config.setup(opts)
+      config.setup(opts)
+
+      assert.equals(1, #messages)
+    end)
+
+    it("says nothing for a config that never mentioned max_hops", function()
+      config.setup({ agent = { chat_notifications = { enabled = true } } })
+
+      assert.equals(0, #messages)
+    end)
+  end)
 end)

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -27,7 +27,15 @@ describe("CompletionNotifier", function()
   ---@param opts table?
   local function configure(opts)
     Config.get = function()
-      return { agent = { chat_notifications = vim.tbl_extend("force", { enabled = true, max_hops = 8 }, opts or {}) } }
+      return {
+        agent = {
+          chat_notifications = vim.tbl_extend(
+            "force",
+            { enabled = true, max_round_trips = 8, max_wakes = 50 },
+            opts or {}
+          ),
+        },
+      }
     end
   end
 
@@ -210,50 +218,116 @@ describe("CompletionNotifier", function()
     assert.is_false(Notifier.subscribe(a, a))
   end)
 
-  it("stops the chain at max_hops and says so instead of going quiet", function()
-    configure({ max_hops = 1 })
+  it("stops a pair at max_round_trips and says so instead of going quiet", function()
+    configure({ max_round_trips = 1 })
     local a, b = make_chat(), make_chat()
 
-    -- 1ホップ目: 購読して配達されると、A の深さが 1 になる
+    -- 1往復目: 購読して配達されると、(a, b) のカウンタが 1 になる
     assert.is_true(Notifier.subscribe(a, b))
     Notifier.on_response_done(b)
     assert.equals(1, #sends)
 
-    -- 2ホップ目は上限に当たる。黙って張らないと通知が来ない理由がどこにも残らない
+    -- 2往復目は上限に当たる。黙って張らないと通知が来ない理由がどこにも残らない
     assert.is_false(Notifier.subscribe(a, b))
     assert.equals(1, #warnings)
     assert.equals("Chat Notifications", warnings[1].title)
   end)
 
-  it("does not warn about an edge it already holds when at the hop limit", function()
+  it("counts a pair in both directions as one counter", function()
+    -- 止めたいのは A⇄B の往復そのもの。方向ごとに分けると A→B と B→A が別々の予算を持ち、
+    -- 上限が実質2倍になる
+    configure({ max_round_trips = 1 })
+    local a, b = make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+    assert.equals(1, #sends)
+
+    -- B が A に投げ返す向きも、同じペアの予算を見る
+    assert.is_false(Notifier.subscribe(b, a))
+  end)
+
+  it("does not stop an orchestrator receiving from many workers", function()
+    -- #644 の本題。旧実装は「起こされた回数」のグローバルカウンタだったので、子N人からの
+    -- 完了通知を受けるだけで正当なオーケストレータが上限に当たっていた
+    configure({ max_round_trips = 1 })
+    local a = make_chat()
+    local workers = {}
+
+    for i = 1, 5 do
+      workers[i] = make_chat()
+      assert.is_true(Notifier.subscribe(a, workers[i]), "worker " .. i .. " must be subscribable")
+      Notifier.on_response_done(workers[i])
+      responding[a] = false
+    end
+
+    assert.equals(5, #sends)
+    assert.equals(0, #warnings)
+  end)
+
+  it("stops a fan that never repeats a pair at max_wakes", function()
+    -- ペア上限をすり抜ける形（毎回違う相手に配り続ける）に効く最終防壁
+    configure({ max_round_trips = 8, max_wakes = 2 })
+    local a = make_chat()
+
+    for _ = 1, 2 do
+      local worker = make_chat()
+      assert.is_true(Notifier.subscribe(a, worker))
+      Notifier.on_response_done(worker)
+      responding[a] = false
+    end
+    assert.equals(2, #sends)
+
+    assert.is_false(Notifier.subscribe(a, make_chat()))
+    assert.equals(1, #warnings)
+    assert.equals("Chat Notifications", warnings[1].title)
+  end)
+
+  it("does not warn about an edge it already holds when at the limit", function()
     -- 同じワーカーに複数回ブリーフを送るのは通常の手順。既に張ってあるエッジは生きていて
     -- 通知も届くので、上限に当たったからといって「購読しなかった」と警告するのは事実に反する
-    configure({ max_hops = 0 })
+    configure({ max_round_trips = 0 })
     local a, b = make_chat(), make_chat()
 
     -- 上限0でも、既存エッジがあれば黙って成功を返す
     Notifier.subscribe(a, b)
     assert.equals(1, #warnings, "the first subscribe is genuinely refused")
 
-    configure({ max_hops = 8 })
+    configure({ max_round_trips = 8 })
     assert.is_true(Notifier.subscribe(a, b))
-    configure({ max_hops = 0 })
+    configure({ max_round_trips = 0 })
 
     assert.is_true(Notifier.subscribe(a, b))
     assert.equals(1, #warnings, "re-sending to an already-subscribed chat must not warn")
   end)
 
-  it("resets the hop count on a manual send", function()
-    configure({ max_hops = 1 })
+  it("resets the pair counter on a manual send", function()
+    configure({ max_round_trips = 1 })
     local a, b = make_chat(), make_chat()
 
     Notifier.subscribe(a, b)
     Notifier.on_response_done(b)
     assert.is_false(Notifier.subscribe(a, b))
 
-    Notifier.reset_depth(a)
+    Notifier.on_manual_send(a)
 
     assert.is_true(Notifier.subscribe(a, b))
+  end)
+
+  it("resets the whole-tree budget on a manual send too", function()
+    -- 全体予算は「無人で走り続けている」ことへの防壁なので、人間が連鎖のどこかに入れば
+    -- その前提が切れる。手動送信したのが予算を使い切ったチャットである必要はない
+    configure({ max_wakes = 1 })
+    local a, b, other = make_chat(), make_chat(), make_chat()
+
+    Notifier.subscribe(a, b)
+    Notifier.on_response_done(b)
+    responding[a] = false
+    assert.is_false(Notifier.subscribe(a, make_chat()))
+
+    Notifier.on_manual_send(other)
+
+    assert.is_true(Notifier.subscribe(a, make_chat()))
   end)
 
   it("forgets a buffer's edges and queue in both directions", function()
@@ -395,23 +469,19 @@ describe("CompletionNotifier", function()
     assert.equals(a, sends[1].bufnr)
   end)
 
-  it("never lowers the hop count when a shallow edge is delivered late", function()
-    configure({ max_hops = 2 })
-    local a, b, c = make_chat(), make_chat(), make_chat()
-
-    -- 先に浅い時点のエッジを張っておき、配達だけ遅らせる
-    Notifier.subscribe(a, c)
+  it("drops a deleted buffer's pair counters", function()
+    -- Neovim は閉じたバッファの番号を別のバッファに使い回す。残しておくと、無関係な新しい
+    -- チャットが最初の送信でいきなり上限に当たる
+    configure({ max_round_trips = 1 })
+    local a, b = make_chat(), make_chat()
 
     Notifier.subscribe(a, b)
-    Notifier.on_response_done(b) -- depth[a] = 1
-    responding[a] = false -- 起こされた A のターンが終わる
-    Notifier.subscribe(a, b)
-    Notifier.on_response_done(b) -- depth[a] = 2
-    responding[a] = false
-
-    -- 深さ0で張られた c のエッジがここで配達されても、カウンタは戻らない
-    Notifier.on_response_done(c)
+    Notifier.on_response_done(b)
     assert.is_false(Notifier.subscribe(a, b))
+
+    Notifier.forget(b)
+
+    assert.is_true(Notifier.subscribe(a, b))
   end)
 
   it("drains a queued message even when watchdog notifications are disabled", function()
@@ -580,10 +650,11 @@ describe("CompletionNotifier", function()
     assert.equals(0, #sends)
   end)
 
-  it("does not raise the hop count for a queued message", function()
-    -- 直接送信は今も hop 予算の対象外で、`queue_if_busy` はその同じ送信が遅れて届くだけ。
-    -- ペア単位の往復カウンタは #644 の担当
-    configure({ max_hops = 1 })
+  it("does not advance the pair counter for a queued message", function()
+    -- ペアカウンタが数えるのは watchdog 通知の配達。本文は送信元のモデルが明示的に送った
+    -- もので、`on_sent` 経由で `subscribe` の判定を既に通っている。しかも即配達の経路は
+    -- キューを通らないので、ここで数えると「宛先がたまたま応答中だったか」で消費が変わる
+    configure({ max_round_trips = 1 })
     local a, b = make_chat(), make_chat()
     responding[a] = true
 
@@ -593,7 +664,44 @@ describe("CompletionNotifier", function()
     assert.equals(1, #sends)
 
     responding[a] = false
-    assert.is_true(Notifier.subscribe(a, b), "the delivery must not have spent A's hop budget")
+    assert.is_true(Notifier.subscribe(a, b), "the delivery must not have spent the pair's budget")
+  end)
+
+  it("spends the tree-wide budget for a queued message even so", function()
+    -- ペアには乗らないが起床は起きている。全体予算が数えるのは「無人でターンが1本走った」
+    -- ことなので、本文だけの配達もここには乗る
+    configure({ max_wakes = 1 })
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    MessageQueue.enqueue_message(a, b, "a report")
+    responding[a] = false
+    Notifier.on_response_done(a)
+    assert.equals(1, #sends)
+
+    assert.is_false(Notifier.subscribe(a, make_chat()))
+  end)
+
+  it("still delivers an edge that was authorized before the budget ran out", function()
+    -- 上限は購読の時点でしか見ない。認可済みの通知を配達時に落とすと、オーケストレータは
+    -- ワーカーの完了を黙って取りこぼす — このモジュールが避けるために存在している失敗そのもの。
+    -- 代償として、上限は「その時点で生きているエッジの数」ぶんだけ超過しうる
+    configure({ max_wakes = 1 })
+    local a, b, c = make_chat(), make_chat(), make_chat()
+
+    -- 予算が残っているうちに2本張る
+    assert.is_true(Notifier.subscribe(a, b))
+    assert.is_true(Notifier.subscribe(a, c))
+
+    Notifier.on_response_done(b)
+    responding[a] = false
+    Notifier.on_response_done(c)
+
+    assert.equals(2, #sends, "both authorized edges deliver, even though the budget allowed one")
+
+    -- 超過しても連鎖は止まる: 以降の購読は拒否される
+    responding[a] = false
+    assert.is_false(Notifier.subscribe(a, make_chat()))
   end)
 
   describe("setup", function()

--- a/tests/lua/infrastructure/rpc/handlers/message_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/message_spec.lua
@@ -35,7 +35,7 @@ describe("rpc handlers.message.send_message", function()
     buffers, chats = {}, {}
 
     Config.get = function()
-      return { agent = { chat_notifications = { enabled = true, max_hops = 8 } } }
+      return { agent = { chat_notifications = { enabled = true, max_round_trips = 8, max_wakes = 50 } } }
     end
     view.get_chat_buffer = function(bufnr)
       local chat = chats[bufnr]


### PR DESCRIPTION
# Pull Request

## Summary

`completion_notifier` のループ抑止を、チャット単位のグローバルカウンタから **(A,B) ペア単位の
往復カウンタ** へ置き換える。#639 の Phase 6。

旧実装の `depth[bufnr]` は「そのチャットが手動送信なしで何回起こされたか」を数え、`max_hops`
（既定8）で止めていた。ツリーではこれが**止めたいものと違うものを止めていた**: オーケストレータは
ワーカーの完了ごとに1回起こされるので、ワーカー5人が報告してくるだけで、A⇄B の往復が一度も
起きないうちに8ホップ中5を消費する。上限が fan-in（この機能の通常の形）で発火し、本来の対象で
ある往復はその共有予算が尽きるまで自由だった。

ペア単位にすると fan-in は各ペア1で済み、往復だけが積み上がる。

## Changes

- `depth[bufnr]` を廃し、`round_trips[lo][hi]`（無向ペアに正規化）へ。配達1件ごとにそのペアが
  1進む。`subscribe` はペアが尽きたら警告して拒否
- **ペアは無向**。ワーカーからの質問は `subscribe(B, A)`、オーケストレータのブリーフは
  `subscribe(A, B)` として来るので、方向を分けると1つの会話に2つの予算が付き実効上限が倍になる
- `max_wakes`（既定50）を追加。配達が多くのペアに散ってペア上限に当たらない形（扇、長い循環）
  への最終防壁。連結成分ごとにはしない — `subscribe` の時点では新しい相手への扇がどの成分にも
  属さず、成分が決まらないため
- `reset_depth` → **`on_manual_send`** に改名。`on_response_done` と対になるイベント入口で、
  「bufnr の状態を消す」のではなく「人間が動いた、その帰結をモジュールが決める」関数。bufnr が
  関わる全ペアに加えて全体予算も 0 に戻す
- **消えた機構**: 旧カウンタは連鎖をまたいで単調である必要があり、エッジが生成時の深さを持ち、
  キューも持ち回り、配達時に `max(current, deepest + 1)` していた。ペアカウンタは配達自身の
  `(from, done)` から進むので全部不要。`pending` も `{bufnr = n}` のラッパーから素の `number[]` へ
- `forget` でペアカウンタも落とす（Neovim はバッファ番号を使い回すので、残すと無関係な新チャットが
  最初の送信でいきなり上限に当たる）。空になった内側テーブルはキーごと消す — 残すと
  `round_trips` が `next()` で真のまま0件を抱え、`forget` の早期return（パターン無し `BufDelete`
  autocmd 上）が以降ずっと素通りしなくなる
- `max_hops` は削除。設定されていたら `notify.warn_once` で1回だけ案内して落とす。ついでに
  既存の `diff.tool = "mote"` / `diff.mote` の手書き warn-once ガードも `warn_once` に集約し、
  `warned_removed` テーブルを削除

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Test addition or update
- [ ] CI/CD update

`max_hops` の削除は BREAKING CHANGE 扱いにしていない。値を設定していても警告が出るだけで、
上限そのものは（意味を変えつつ）既定値で効き続けるため、手動対応なしにチャットは動く。

## Testing

- [x] Ran `pnpm run test:lua` — exit 0、全 spec ファイルの Failed + Errors 合計 0
- [x] Ran `pnpm run check`（`luac -p`）
- [x] Ran `pnpm run format:check`
- [x] `pnpm run lint:md` — 502件で変更前と同数（既存分のみ。変更した
      `handbook/configuration.md` と `.claude/rules/architecture.md` はいずれも0件）
- [ ] Tested locally in Neovim

`chat_notifications` はインメモリのチャット間通知機構で実 CLI を起動しないため E2E の対象外。
`pnpm run test:e2e` は実行していない（実トークンを消費するため）。

追加・変更したテスト:

| テスト | 検証内容 |
| --- | --- |
| `stops a pair at max_round_trips ...` | ペア上限で警告して拒否 |
| `counts a pair in both directions as one counter` | `subscribe(a,b)` の消費が `subscribe(b,a)` にも効く |
| `does not stop an orchestrator receiving from many workers` | **本題**。上限1でもワーカー5人からの受信は全て通り、警告0 |
| `stops a fan that never repeats a pair at max_wakes` | ペアを繰り返さない扇が全体予算に当たる |
| `resets the pair counter on a manual send` | 手動送信でペアが戻る |
| `resets the whole-tree budget on a manual send too` | 予算を使い切ったのとは別のチャットへの手動送信でも戻る |
| `drops a deleted buffer's pair counters` | `forget` でペアが消える |
| `config_spec` 4件 | `max_hops` の削除・警告1回・置換後の既定値・無関係な設定では黙る |

削除したのは `never lowers the hop count when a shallow edge is delivered late` 1件。守っていた
単調増加の機構ごと無くなったため。

### Test Environment

- **Neovim version**: NVIM v0.11.x
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: pnpm / Node 20 系

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [x] CLAUDE.md updated（`.claude/rules/architecture.md` → Multi-Agent Orchestration）
- [x] `handbook/configuration.md` updated
- [x] Code comments added/updated

`architecture.md` の該当段落は `max_hops` を生きた機構として記述していたので、以下に差し替えた:
ペア単位・無向であることとその理由、fan-in で誤発火していた問題、消えた単調増加の機構、
`max_wakes` をグローバル1本にした理由と受け入れた代償、`on_manual_send` の命名と全体予算まで
戻す理由、`forget` がペアを落とす理由、`max_hops` を黙って無視しない理由。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

Fixes #644

親issue: #639。前提だった #638（#647 でマージ済み）の上に積んでいたが、#647 が main に入った
ため main へリベースした。#648 の `build_message` 変更（パスを先に置く表示形式）と1箇所競合し、
#648 側の形式を採用して解決している。

## Additional Context

### 受け入れた限界

- **`max_wakes` は単一のグローバル予算**。無関係な2つのオーケストレーションが同じ予算を共有し、
  一方が使い切れば他方も止まり、一方への `<CR>` が他方の予算も戻す。連結成分ごとに持たないのは
  手間の問題ではなく、この予算が守る当のケース（一度も接触していない相手への扇）が `subscribe`
  の時点でどの成分にも属さず、成分が原理的に決まらないため。`edges` も one-shot で配達時に
  消えるので、チャットグラフではなく一瞬の断面しか持っていない
- **`max_round_trips` が数えるのは「配達数」**。オーケストレータ→ワーカーのループでは
  1配達 = 1往復だが、無向ペアなのでワーカーの質問とその回答は2消費する。設定名は往復の語を
  残しつつ、handbook・型注釈・architecture.md には配達数を数えると明記した
- **どちらの上限が先に当たるかは形と設定値次第**。既定では3チャットの循環はペア上限が先に拾い
  （8周＝24配達で予算50に届かない）、`max_wakes` が実際に効くのは扇と7チャット程度以上の循環


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate limits for notification round trips between each chat pair and total editor-wide notification wakes.
  - Manual messages now reset relevant notification limits.
- **Bug Fixes**
  - Improved cleanup of notification tracking when chat buffers are closed.
- **Configuration**
  - Replaced `max_hops` with `max_round_trips` and `max_wakes`.
  - Deprecated settings are removed safely and generate a single warning.
- **Documentation**
  - Updated configuration guidance and notification-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->