### PR TITLE
feat: revise vibing-orchestrate for push-style reporting and the fan-in convention

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1163,6 +1163,17 @@ rename can collide with an entry the list already had. Two parser behaviours bit
 empty list parses to a **truthy** `{}`, and a hand-written `orchestrated: path.md` parses to a
 **string** rather than a list.
 
+**A send whose reverse is already recorded writes no link**, and that is what keeps the record a
+tree rather than a set of pairs. A push report (#643) is a `nvim_chat_send_message` in the opposite
+direction from the dispatch, so writing it as a new relationship put each worker into its
+orchestrator's `orchestrated_by` — and `cli_command_builder` builds the worker prompt out of that
+key, so the orchestrator was then told to report to its own worker. Reproduced across three chats
+before fixing. The mechanism still cannot tell a report from a request at send time, which is the
+constraint `completion_notifier` documents; what it can read is whether the recipient is already
+this chat's orchestrator, and that answers the direction question on its own. One side recording it
+is enough, since `link` tolerates a half-written pair. The cost is that a genuine A⇄B mutual
+orchestration cannot be recorded — a cycle, and not a shape worth supporting.
+
 A one-sided write warns rather than failing the send: the link is a record, and rename sync still
 works from whichever side did get written. Fork and subagent chats do **not** inherit these fields
 — `inherited_frontmatter.from_source` is an explicit whitelist, and a fork claiming its parent's

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1439,6 +1439,28 @@ event would repeat `chat_status`'s mistake. The message names each finished chat
 current bufnr in parentheses) and instructs A to read the transcript's tail — not the worker's
 text, which would pull B's context into A for no reason.
 
+**Reporting is the worker's job; the notification is a watchdog** (#643). A worker is told — by the
+system-prompt line below, and again by the brief `vibing-orchestrate` has the orchestrator write —
+to finish by calling `nvim_chat_send_message` on its orchestrator's path with `queue_if_busy: true`
+and a summary that stands on its own. That is the path a healthy fan-out takes, and it needs
+nothing from `chat_notifications`: `queue_if_busy` and the drain are ungated, so a report is
+delivered whether or not the watchdog is switched on.
+
+Which is what lets the notice be worded as a warning rather than a status line. `on_sent`'s
+suppression mark drops the watchdog for the stop that follows a worker's own report, so a chat that
+reaches `enqueue_notification` is one that stopped **without** reporting — likelier a failure, a
+question or an approval prompt than a finished task. `delivery_message.lua` says so in as many
+words, and the skill's step 5 splits the two wake-ups on that line: a report is read as text, a
+watchdog notice sends the orchestrator to the transcript.
+
+**Fan-in is a convention, not a barrier.** A chat that is both a worker and an orchestrator holds
+its own report until every worker of its own has reported — stated in `vibing-orchestrate` step 7,
+enforced by nothing. A barrier in the mechanism would have to answer "what if a child never
+reports", and both honest answers are bad: a timeout, or a tree that stalls for good. The
+convention instead tells the middle node to report early, naming the stuck child, when a child
+stops on `asked_question` / `waiting_approval` / `error` — the same three exceptions branch 2
+already makes. Worth revisiting if a middle node forgetting turns out to cost anything in practice.
+
 A worker learns its orchestrator from a system-prompt line built out of its `orchestrated_by`
 frontmatter. Only that direction is exposed: a worker's list is written once at creation and stays
 byte-stable across turns (#469), while an orchestrator's `orchestrated` grows with each dispatch

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -71,12 +71,42 @@ request, not the files already discussed, not the decisions already made. Write 
 someone who just walked in — goal, the files or directories involved, the constraints, and what
 "done" looks like. A brief that says "do the refactor we discussed" produces nothing useful.
 
-Say in the brief that the worker should report its result in its own chat and stop. Add that if it
-gets stuck or the brief turns out to be ambiguous, it should ask you rather than guess — a worker
-you passed `from_bufnr` to is told your buffer number and can call `nvim_chat_send_message` back.
-A question costs one turn; a worker guessing wrong costs the whole task.
+### The brief must tell the worker to report back
 
-## 4. End your turn — you will be woken
+This is not optional decoration — it is how the fan-out finishes without you polling. Every brief
+carries three things beyond the task:
+
+1. **Where to report** — this chat's `file_path`. The worker is told it in its own system prompt
+   too, but a brief is read on its own and should not depend on that.
+2. **How to report** — `nvim_chat_send_message` with the worker's own chat buffer number as
+   `from_bufnr` and **`queue_if_busy: true`**. Without that flag the send is refused outright
+   whenever you happen to be mid-turn, and the report is simply lost.
+3. **What to report** — a summary that stands on its own: what changed, what failed, what is left.
+   "Done, read my chat" costs you a `nvim_get_buffer` and pulls that worker's entire transcript
+   into this conversation, once per worker. Avoiding that is the whole reason reporting is pushed
+   rather than polled.
+
+Add that if it gets stuck or the brief turns out to be ambiguous, it should ask you the same way
+rather than guess. A question costs one turn; a worker guessing wrong costs the whole task.
+
+A closing paragraph you can paste into a brief:
+
+```text
+終わったら、次の呼び出しで報告してから止まってください。
+
+  nvim_chat_send_message({
+    rpc_port,
+    file_path: "<このチャットの file_path>",
+    from_bufnr: <あなた自身の chat buffer 番号>,
+    queue_if_busy: true,
+    message: "<結果の要約>",
+  })
+
+要約だけで判断できる内容にしてください（何を変えたか・何が失敗したか・何が残っているか）。
+詰まったとき、ブリーフが曖昧なときも、推測せず同じ方法で聞いてください。
+```
+
+## 4. End your turn — the workers come back to you
 
 Do **not** loop on `nvim_get_buffer` waiting for workers to finish. A turn spent polling burns
 tokens, blocks this chat, and will hit the turn limit long before a real task completes.
@@ -86,15 +116,29 @@ Once every brief is sent, end the turn with the worker list:
 > 3件のワーカーチャットにタスクを配りました（`.vibing/chat/a.md` / `b.md` / `c.md`）。
 > 終わり次第ここに戻ります。
 
-If completion notifications are enabled (`agent.chat_notifications.enabled`), each worker you
-messaged wakes this chat with a new turn when it stops, naming the buffer to read. If they are
-not, nothing wakes you — say "進捗は?と聞いてください" instead and wait for the user.
+Each worker's own report is what wakes you. `queue_if_busy: true` makes that delivery reliable: a
+report that arrives while you are mid-turn waits and starts a new turn the moment you stop, and
+several arriving together are coalesced into one turn. This works regardless of
+`agent.chat_notifications.enabled` — the report is a message the worker chose to send you, not a
+notification vibing.nvim volunteers.
 
-## 5. Read the chat the notification named
+That setting governs the **watchdog** instead: with it enabled, a worker that stops _without_
+reporting wakes you anyway (step 5). With it disabled, a worker that never reports is silent — say
+"進捗は?と聞いてください" and wait for the user.
 
-A notification tells you which chat(s) stopped, by path. Read those with
-`nvim_get_buffer({ rpc_port, file_path })` — not every worker. Alongside the transcript the result
-carries a chat-status line:
+## 5. Read what arrived
+
+You get woken in two ways, and they do not mean the same thing.
+
+**A worker's report** — the turn carries its summary as text. This is the normal path, and the
+summary is meant to be enough on its own. Do not call `nvim_get_buffer` on that worker unless the
+summary actually leaves something open.
+
+**A watchdog notice** — "the following chat(s) you sent a message to have stopped without reporting
+back". Under the convention above a finished worker reports, so a stop with no report is more
+likely a worker that failed, stopped to ask something, or is sitting on a tool approval. Read those
+with `nvim_get_buffer({ rpc_port, file_path })` — not every worker. Alongside the transcript the
+result carries a chat-status line:
 
 - `status: responding` — a reply is still being streamed in. Whatever you just read is partial;
   report it as in progress and do not summarize its conclusion.
@@ -113,9 +157,9 @@ brief and stopped is `idle` too. Read the tail of the transcript before calling 
 three statuses above are the cases that used to hide inside `idle`; a status this server has no
 wording for is reported by name, and means the same thing — go read the transcript.
 
-**One notification is one turn, so three workers wake you three times.** If workers you dispatched
-are still running, do not start aggregating: say in one or two lines what this one produced, and
-end the turn. Aggregate only on the last one. An orchestrator that writes a full summary each time
+**One report is one turn, so three workers wake you three times.** If workers you dispatched are
+still running, do not start aggregating: say in one or two lines what this one produced, and end
+the turn. Aggregate only on the last one. An orchestrator that writes a full summary each time
 produces three contradictory summaries and pays for all of them.
 
 Track which workers are still outstanding by writing the list into your reply each time — that
@@ -137,3 +181,25 @@ Report it as blocked and say what it needs.
 If you used worktrees, offer the `vibing-worktree-finish` skill for each branch once its work has
 been merged or abandoned. Don't remove a worktree on your own initiative; unmerged work lives
 there.
+
+## 7. If you are also someone else's worker
+
+A chat can be a worker and an orchestrator at once: briefed by a parent, and splitting its own task
+across workers of its own. Everything above still applies — plus one rule.
+
+**Report to your parent only once every worker of yours has reported.** Nothing enforces this;
+there is no barrier in vibing.nvim, and a message sent early is delivered normally. The whole
+fan-in is this convention, so keeping it is on you.
+
+- While workers are outstanding, end each turn with a line naming which ones you are still waiting
+  on. That text is the only place the count survives — you are a fresh process every turn, and
+  the wake-up that brings a report carries no tally.
+- Report to your parent when the last one is in. One report, summarizing all of them, not one per
+  worker: your parent's job is the same as yours, and forwarding raw worker output makes it pay for
+  a transcript twice.
+- **Do not wait forever.** A worker that stops `asked_question`, `waiting_approval` or `error` is
+  not going to report on its own. Deal with it if you can (answer the question, re-brief it); if
+  you cannot, report to your parent now with that worker's state named, rather than holding the
+  whole tree open for something only the user can clear.
+- If your own brief turns out to be ambiguous, ask your parent before dispatching. Splitting a
+  misunderstood task fans the misunderstanding out across several chats.

--- a/lua/vibing/application/chat/delivery_message.lua
+++ b/lua/vibing/application/chat/delivery_message.lua
@@ -36,19 +36,22 @@ local function notification_section(items, cache)
     table.insert(lines, string.format("- %s (chat buffer %d)", display_path(item.bufnr, cache), item.bufnr))
   end
 
+  -- 文面が「止まった、読みに行け」から「報告なしで止まった」に変わったのは #643。規約では
+  -- ワーカーは終わったら自分から報告し、`on_sent` の抑止マークがその直後の停止1回ぶんの
+  -- watchdog を落とす。つまりここに載るのは「報告せずに止まった」チャットで、それは規約から
+  -- 外れた止まり方 — 失敗・質問・承認待ちのどれか — である可能性のほうが高い
   return table.concat({
-    "The following chat(s) you sent a message to have finished responding:",
+    "The following chat(s) you sent a message to have stopped without reporting back:",
     "",
     table.concat(lines, "\n"),
     "",
-    "Read each one with nvim_get_buffer({ rpc_port, file_path }) and decide what to do next.",
+    "A chat that finishes its task is expected to report the result to you itself, so a stop with",
+    "no report is more likely to be something else: it failed, it stopped to ask a question, or it",
+    "is waiting on a tool approval. Read each one with nvim_get_buffer({ rpc_port, file_path }),",
+    "look at the tail of the transcript, and decide what to do — do not treat its task as done.",
     "",
-    '"Finished" only means no request is in flight. A chat may have failed, stopped to ask the',
-    "user something, or be waiting on a tool approval. Read the tail of the transcript before",
-    "treating its task as done.",
-    "",
-    "If other chats you dispatched are still running, do not start aggregating yet — say what",
-    "this one produced and end the turn. You will be woken again when the next one finishes.",
+    "If other chats you dispatched are still running, do not start aggregating yet — say what you",
+    "found and end the turn. You will be woken again when the next one stops.",
   }, "\n")
 end
 

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -62,6 +62,25 @@ function M.link(from_bufnr, to_bufnr)
     return true, nil
   end
 
+  -- 逆向きの関係が既にあるなら、この送信は**報告か返答**であって新しい配下関係ではない。
+  --
+  -- 「送信が報告か依頼か」を機構は判別できない（`completion_notifier` の同じ制約）が、
+  -- 「相手が既に自分のオーケストレータとして記録されている」なら向きだけは分かる。それが
+  -- 無いと、押し出し型の報告（#643）が届くたびにここが逆向きのリンクを書き、親の
+  -- `orchestrated_by` に自分のワーカーが並ぶ。frontmatter は木ではなくペアの二重記録になり、
+  -- `cli_command_builder` はその `orchestrated_by` からシステムプロンプトを組むので、親が
+  -- 「終わったら自分のワーカーに報告しろ」と指示される。実際に3チャットで再現したもの。
+  --
+  -- 片側だけでも逆向きが記録されていれば報告と見なす（`link` は片肺の書き込みを許すので、
+  -- 両側揃うことを前提にはできない）。代償として A⇄B の相互オーケストレーションは
+  -- 記録できないが、それは循環であって支持する形ではない
+  if
+    vim.tbl_contains(from_chat:get_frontmatter_list("orchestrated_by"), forward)
+    or vim.tbl_contains(to_chat:get_frontmatter_list("orchestrated"), backward)
+  then
+    return true, nil
+  end
+
   -- 戻り値を捨ててはいけない。`update_frontmatter_list` は frontmatter の閉じ `---` が
   -- 先頭100行に収まらないと false を返す（長い permission 配列を持つチャットで現実に起きる）。
   -- 捨てると、このモジュールが防ぐために存在している「黙って関係が残らない」がそのまま起きる

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -341,6 +341,12 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     -- `orchestrated` is deliberately not exposed: an orchestrator's list grows with every
     -- dispatch, so it would move the prefix on a normal turn rather than an unusual one — and the
     -- completion notification already names the chat it wants read.
+    --
+    -- Reporting back is stated as an obligation rather than an option (#643). The brief the
+    -- orchestrator writes says the same thing, but a brief is prose the worker may skim; this
+    -- line is the one place the rule is always present. It is also what the watchdog notice now
+    -- assumes — a stop with no report reads as a failure, a question, or an approval prompt, so a
+    -- worker that finishes silently is reported to its orchestrator as suspect.
     if opts.orchestrators and #opts.orchestrators > 0 then
       local named = vim.tbl_map(function(orchestrator)
         return orchestrator.bufnr
@@ -351,11 +357,13 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         system_prompt_lines,
         "This chat was started by vibing.nvim chat "
           .. table.concat(named, ", ")
-          .. ". If you need to ask it something, or want to report back before you finish, call "
-          .. "nvim_chat_send_message with that file_path and your own chat buffer number as "
-          .. "from_bufnr. Address it by file_path rather than by buffer number: the path keeps "
-          .. "working after a restart, and the chat is opened for you if it is closed. "
-          .. "Otherwise just do the work and report in this chat — it is told when you stop."
+          .. ". When your task is done, report the result to it by calling nvim_chat_send_message "
+          .. "with that file_path, your own chat buffer number as from_bufnr, queue_if_busy: true, "
+          .. "and a summary that stands on its own — it should not have to read this transcript to "
+          .. "learn what happened. Ask it the same way if the brief turns out to be ambiguous or "
+          .. "you get stuck, rather than guessing. Address it by file_path rather than by buffer "
+          .. "number: the path keeps working after a restart, and the chat is opened for you if it "
+          .. "is closed."
       )
     end
 

--- a/tests/e2e/chat_completion_notification_spec.lua
+++ b/tests/e2e/chat_completion_notification_spec.lua
@@ -72,7 +72,7 @@ describe("E2E: chat completion notification", function()
       local text = exec(
         string.format("return table.concat(vim.api.nvim_buf_get_lines(%d, 0, -1, false), '\\n')", orchestrator)
       )
-      notified = text:find("finished responding", 1, true) ~= nil
+      notified = text:find("stopped without reporting back", 1, true) ~= nil
     end
 
     assert.is_true(notified, "orchestrator should be told the worker stopped")

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -352,15 +352,16 @@ describe("CompletionNotifier", function()
     assert.equals(0, #sends)
   end)
 
-  it("tells the sender that finishing is not the same as succeeding", function()
+  it("tells the sender that stopping is not the same as succeeding", function()
     -- `idle` はエラー終了でも、質問でターンが死んだときでも、ツール承認待ちでも通る。
-    -- 成否の判定を通知側でやると chat_status と同じ罠を踏むので、判断は受け取り側に委ねる
+    -- 成否の判定を通知側でやると chat_status と同じ罠を踏むので、判断は受け取り側に委ねる。
+    -- 規約（#643）ではワーカーは終わったら自分から報告するので、ここに載るのは報告なしの停止
     local a, b = make_chat(), make_chat()
 
     Notifier.subscribe(a, b)
     Notifier.on_response_done(b)
 
-    assert.is_truthy(sends[1].message:find("no request is in flight", 1, true))
+    assert.is_truthy(sends[1].message:find("do not treat its task as done", 1, true))
     assert.is_truthy(sends[1].message:find("do not start aggregating yet", 1, true))
   end)
 
@@ -633,7 +634,7 @@ describe("CompletionNotifier", function()
 
     assert.equals(1, #sends)
     assert.is_truthy(sends[1].message:find("here is what I found", 1, true))
-    assert.is_falsy(sends[1].message:find("finished responding", 1, true))
+    assert.is_falsy(sends[1].message:find("stopped without reporting back", 1, true))
   end)
 
   it("keeps the subscription alive when the report turns out to be an intermediate one", function()

--- a/tests/lua/application/chat/orchestration_link_spec.lua
+++ b/tests/lua/application/chat/orchestration_link_spec.lua
@@ -114,4 +114,38 @@ describe("OrchestrationLink.link", function()
 
     assert.same({ "worker.md" }, frontmatter_on_disk(dir .. "/orchestrator.md").orchestrated)
   end)
+
+  it("does not record the reverse direction when the worker reports back", function()
+    -- 押し出し型の報告（#643）は、配布とは逆向きの `nvim_chat_send_message` として届く。
+    -- そのまま書くと親の `orchestrated_by` に自分のワーカーが入り、システムプロンプトが
+    -- 親に「終わったら自分のワーカーに報告しろ」と指示するようになる
+    local orchestrator, worker = open_chat("orchestrator.md"), open_chat("worker.md")
+    assert.is_true(OrchestrationLink.link(orchestrator, worker))
+
+    assert.is_true(OrchestrationLink.link(worker, orchestrator))
+
+    local on_orchestrator = frontmatter_on_disk(dir .. "/orchestrator.md")
+    local on_worker = frontmatter_on_disk(dir .. "/worker.md")
+    assert.same({ "worker.md" }, on_orchestrator.orchestrated)
+    assert.is_nil(on_orchestrator.orchestrated_by)
+    assert.same({ "orchestrator.md" }, on_worker.orchestrated_by)
+    assert.is_nil(on_worker.orchestrated)
+  end)
+
+  it("treats a one-sided reverse record as enough to call it a report", function()
+    -- `link` は片側だけ書けた状態を許して続行する（保存できた側でリネーム同期は動く）ので、
+    -- 両側が揃っていることを前提にすると、その状態のチャットで逆向きが書かれてしまう
+    local orchestrator, worker = open_chat("orchestrator.md"), open_chat("worker.md")
+    refuse_writes_for = worker
+    OrchestrationLink.link(orchestrator, worker)
+    refuse_writes_for = nil
+
+    assert.same({ "worker.md" }, frontmatter_on_disk(dir .. "/orchestrator.md").orchestrated)
+    assert.is_nil(frontmatter_on_disk(dir .. "/worker.md").orchestrated_by)
+
+    assert.is_true(OrchestrationLink.link(worker, orchestrator))
+
+    assert.is_nil(frontmatter_on_disk(dir .. "/worker.md").orchestrated)
+    assert.is_nil(frontmatter_on_disk(dir .. "/orchestrator.md").orchestrated_by)
+  end)
 end)


### PR DESCRIPTION
# Pull Request

## Summary

#639 の Phase 5。ワーカーの完了を「オーケストレータが読みに行く」pull 型から、「ワーカーが自分から報告する」push 型に切り替え、completion notification を watchdog に格下げする。

機構（#641 パス指定 / #642 `queue_if_busy` / #640 発火判定 / #644 ペアカウンタ）は既にマージ済みなので、本 PR はその上に**規約**を載せるもの。新しい機構は追加していない。

## Changes

- **`cli_command_builder.lua`** — ワーカー向けシステムプロンプトの orchestrator 行を改訂。末尾の「Otherwise just do the work and report in this chat — it is told when you stop」（pull 型前提）を、`nvim_chat_send_message` + `file_path` + `from_bufnr` + `queue_if_busy: true` + 自己完結した要約で報告する義務に差し替え
- **`delivery_message.lua`** — watchdog 通知の文言を変更。`finished responding` → `stopped without reporting back`。規約下では正常完了は push 報告で届き、`on_sent` の抑止マークがその直後の停止1回ぶんの watchdog を落とすので、ここに載るのは「報告せずに止まった」チャット＝失敗・質問・承認待ちの可能性が高い側になる
- **`vibing-orchestrate/SKILL.md`** —
  - §3 にブリーフ必須3点（報告先パス／`queue_if_busy: true`／自己完結した要約）とペースト可能なテンプレを追加
  - §4 を「ワーカーの報告で起こされる」に書き換え。`queue_if_busy` の配達は `chat_notifications.enabled` に依存しないので、通知が無効でも push 報告は届くことを明記
  - §5 を「報告」と「watchdog 通知」の2種類の起こされ方に分割。transcript を読みに行くのは後者のとき
  - **§7「If you are also someone else's worker」を新設** — 中間ノードの fan-in 規約。子全員の報告が揃うまで親に報告しない。ただし子が `asked_question` / `waiting_approval` / `error` で止まったら、その状態を名指しして早めに報告する（バリア機構は作らないので永久待ちを避ける）
- **テスト** — 文言変更に追随（`completion_notifier_spec.lua` 2箇所、`tests/e2e/chat_completion_notification_spec.lua` 1箇所）。assert は意味ベース（`do not treat its task as done` など）に寄せた

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

- [x] Ran `pnpm run check`（luac 構文チェック）
- [x] Ran `pnpm run test:lua`（全 spec pass、exit 0）
- [x] Ran `pnpm run test:node`（37 pass / 0 fail）
- [x] Ran `pnpm run format:check`
- [x] Ran `pnpm run lint:md`（本 PR で触ったファイルの指摘は 0。残る指摘は `handbook/superpowers/` など既存のもの）

`pnpm run test:e2e` は未実行（実トークンを消費するため）。`chat_completion_notification_spec.lua` の文字列だけを更新している。

### Test Environment

- **Operating System**: macOS 15 (Darwin 25.6.0)

## Documentation

- [x] CLAUDE.md updated（`.claude/rules/architecture.md`）
- [x] Code comments added/updated

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally with my changes

## Related Issues

Fixes #643

## Additional Context

`.claude/rules/architecture.md` の Multi-Agent Orchestration 節にも、push 報告の規約・watchdog への格下げ・fan-in を規約で解く判断を追記しています。

設計判断で残したもの:

- **fan-in はバリア機構ではなく規約**。機構にすると「子が報告せずに死んだらどうするか」に答える必要があり、答えはタイムアウトか永久停止のどちらかになる。代わりに「子が質問・承認待ち・エラーで止まったら、その状態を名指しして早めに親に報告する」を規約に書いた（#639 本文の判断に従っている）
- **`queue_if_busy` の配達は `chat_notifications` に依存しない**という既存の性質を SKILL.md に明記した。通知を無効にしていても push 報告は届く＝規約が既定設定でも成立する、が今回の前提になっている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved multi-chat orchestration with explicit worker report-back instructions.
  * Added support for workers to queue reports, request clarification, and report blocked or incomplete work.
  * Updated orchestration handling to prevent reports from creating incorrect relationships.

* **Bug Fixes**
  * Completion notifications now identify workers that stop without reporting, improving watchdog accuracy.

* **Documentation**
  * Clarified orchestration workflows, reporting responsibilities, and handling of multi-level orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->