### PR TITLE
feat: give messages delivered from another chat their own section

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1505,7 +1505,8 @@ anything saying so. Its `grep -E` prefilter still names the kinds, which is the 
 is repeated, and deliberately: it only decides which lines are handed to the shared parser.
 
 **Both delivery paths build the same text.** `handlers/message.lua` (immediate) and
-`message_queue.flush` (queued) call `delivery_message.section_for` then `build`. They used to
+`message_queue.flush` (queued) both go through `delivery_message.deliver`, which owns the
+`section_for` → `build` → send ordering. Leaving those three at each call site is what let them
 diverge — the queue wrapped each body in a `### From` heading and the direct send passed the raw
 text through — so the same worker's report looked different depending on whether its orchestrator
 happened to be mid-turn when it arrived. `section_for` names the sender in the section header only

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1483,6 +1483,49 @@ Neovim dying takes the worker chats with it. Backends other than claude can be _
 event is backend-agnostic) but cannot _subscribe_: `nvim_chat_send_message` is an MCP tool, and
 codex/grok reach no MCP server, the same constraint `features.md` records for AskUserQuestion.
 
+### Delivered sections
+
+A message that arrived from another chat is written as its own section kind — `## Request`,
+`## Report` or `## Notice` — instead of the `## User` a human types into. The grammar and the
+three kinds are in `features.md` → "Message Timestamps"; what belongs here is why the seams are
+where they are.
+
+**`extract_role` answers `user` for all three, and that is the whole safety argument.** A
+section's body _is_ the prompt handed to the CLI (`conversation_extractor.extract_user_message`
+takes everything under the last `user` header), so a genuinely separate role would have to be
+taught to the send path, the conversation extractor, `commit_user_message`, both daily-summary
+parsers and the jump commands — and forgetting any one of them fails toward a delivered turn that
+is never sent, which is the silent-loss shape this whole area exists to remove. Only the display
+needed splitting, so only the display splits: callers that care read `parse_header().kind`.
+
+**The header grammar has one home.** `timestamp.lua` writes and reads it; `grep_parser` used to
+carry its own `^## User` patterns and now calls `extract_role`, because a second reader is a
+reader that goes stale — delivered turns would have dropped out of the daily summary without
+anything saying so. Its `grep -E` prefilter still names the kinds, which is the one place the list
+is repeated, and deliberately: it only decides which lines are handed to the shared parser.
+
+**Both delivery paths build the same text.** `handlers/message.lua` (immediate) and
+`message_queue.flush` (queued) call `delivery_message.section_for` then `build`. They used to
+diverge — the queue wrapped each body in a `### From` heading and the direct send passed the raw
+text through — so the same worker's report looked different depending on whether its orchestrator
+happened to be mid-turn when it arrived. `section_for` names the sender in the section header only
+when the delivery is exactly one body from one chat; `build` then drops the `### From` that would
+otherwise repeat it two lines later. A coalesced delivery keeps the per-item headings and leaves
+the section header unnamed.
+
+**A delivery fills the empty unsent section rather than appending below it.** Every turn ends with
+`add_user_section()` writing `## User <!-- unsent -->`; a human types into it, but
+`ProgrammaticSender` appended a second section, so each delivered turn left a stranded empty
+`## User` above it — one per turn, visible in any orchestrated transcript. It now drops a trailing
+unsent section that is empty. Only empty: the approval prompt and the question list are rendered
+into that same section, and dropping those would delete what the user was about to answer.
+
+**The unsent-then-commit dance is kept for delivered sections too.** Writing the timestamp
+directly at delivery would be simpler, but a send that lands under a usage limit is parked as an
+unsent section and fired later (`auto_resume`), so the unsent form has to exist for these as well.
+`commit_user_message` therefore stamps whatever kind it finds and preserves the `from`, instead of
+replacing the header with a `## User`.
+
 ### Addressing a chat
 
 **The chat file path is the identifier; the bufnr is a per-session resolution of it** (#641).

--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -181,6 +181,24 @@ timestamps are recorded when the message is sent (`<CR>`); Assistant timestamps 
 the response begins (`on_done` callback). Timestamps use the local system timezone (Lua's
 `os.date()`).
 
+A message another chat delivered gets its own section kind rather than a `## User`, so a
+transcript says who wrote what:
+
+```markdown
+## Request <!-- 2026-09-02 08:13:11 from .vibing/chat/orchestrator.md -->
+
+## Report <!-- 2026-09-02 08:14:07 from .vibing/chat/worker-a.md -->
+
+## Notice <!-- 2026-09-02 08:14:16 -->
+```
+
+`Request` is a dispatch, `Report` a reply or a completion report, `Notice` a watchdog wake-up
+vibing.nvim generated itself. Which of the first two applies is decided by
+`orchestration_link.direction`, not guessed from the text. The grammar is
+`## <Kind> <!-- <unsent|timestamp>[ from <path>] -->` and lives only in `timestamp.lua`;
+`parse_header` is what every reader goes through. Why `extract_role` still answers `user` for all
+three: `architecture.md` → "Multi-Agent Orchestration" → "Delivered sections".
+
 Implemented in `lua/vibing/utils/timestamp.lua`: `create_header(role, timestamp)`,
 `extract_role(line)`, `has_timestamp(line)`, `extract_timestamp(line)`, `is_header(line)`.
 

--- a/lua/vibing/application/chat/delivery_message.lua
+++ b/lua/vibing/application/chat/delivery_message.lua
@@ -1,28 +1,46 @@
 ---@class Vibing.Application.DeliveryMessage
 ---`message_queue` が溜めたものを、受け取るチャットに読ませる1通のテキストにする。
 ---
----キューの状態機械とは別モジュールにしてある。ここにあるのはモデルに読ませる散文であって、
----待ち合わせの規則ではない — 文面の推敲で配達の順序が変わることはないし、その逆もない。
+---キューの状態機械とは別モジュールにしてある。ここが持つのは「配られたものをどう見せるか」
+---— セクションの種別・送信元の名指し・モデルに読ませる散文 — であって、待ち合わせの規則
+---ではない。文面の推敲で配達の順序が変わることはないし、その逆もない。
+---
+---見出しと本文の判断が食い違わないよう、`deliver` が `section_for` → `build` → 送信の順序を
+---所有する。この3つを呼び出し側で並べていたころ、片方の経路だけが送信元を名乗るという
+---食い違いが実際に起きた。
 local M = {}
 
 ---@param bufnr number
 ---@param cache table<number, string>
 ---@return string
-local function display_path(bufnr, cache)
-  if cache[bufnr] then
-    return cache[bufnr]
+---バッファの表示パス。名前を持たないバッファでは nil
+---
+---`to_display_path` は解決を `git rev-parse` に投げ、それはキャッシュを持たない同期の
+---プロセス起動。1通に同じチャットが複数回現れるのは普通（同じ相手からの複数の報告）なので、
+---1通を組み立てる間だけ覚える。バッファ名は改名されうるので、それ以上は持ち越さない
+---@param bufnr number
+---@param cache table<number, string>
+---@return string?
+local function resolve_path(bufnr, cache)
+  local cached = cache[bufnr]
+  if cached ~= nil then
+    return cached ~= false and cached or nil
   end
 
   local name = vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_get_name(bufnr) or ""
   -- frontmatter の `orchestrated` と同じ表示形式にする。モデルが読みに行く先を、
   -- 記録と別の形で名指ししない
-  local path = name ~= "" and require("vibing.core.utils.git").to_display_path(name) or "unnamed"
+  local path = name ~= "" and require("vibing.core.utils.git").to_display_path(name) or nil
 
-  -- `to_display_path` は解決を `git rev-parse` に投げ、それはキャッシュを持たない同期の
-  -- プロセス起動。1通に同じチャットが複数回現れるのは普通（同じ相手からの複数の報告）なので、
-  -- 1通を組み立てる間だけ覚える。バッファ名は改名されうるので、それ以上は持ち越さない
-  cache[bufnr] = path
+  cache[bufnr] = path or false
   return path
+end
+
+---@param bufnr number
+---@param cache table<number, string>
+---@return string
+local function display_path(bufnr, cache)
+  return resolve_path(bufnr, cache) or "unnamed"
 end
 
 ---@param items Vibing.Application.MessageQueue.Item[]
@@ -75,9 +93,11 @@ local function message_section(items, cache, sender_named)
 
   -- 件数はメッセージの数であってチャットの数ではない。1つのワーカーからの2件を
   -- 「2つのチャットから」と言うと、読み手は出どころを取り違える
+  -- 「応答中に届いた」とは言わない。この経路は即配達でも通る（送信元のバッファに名前が
+  -- なければ見出しが名乗れず、ここに落ちる）ので、キューに積まれた前提の文面は嘘になる
   return table.concat({
-    #blocks == 1 and "Another chat sent you this while you were responding:"
-      or string.format("%d messages arrived while you were responding:", #blocks),
+    #blocks == 1 and "Another chat sent you this:"
+      or string.format("%d messages arrived from other chats:", #blocks),
     "",
     table.concat(blocks, "\n\n"),
   }, "\n")
@@ -97,21 +117,15 @@ end
 ---@param queue Vibing.Application.MessageQueue.Item[]
 ---@param to_bufnr number 配達先
 ---@return Vibing.Application.DeliveryMessage.Section
-function M.section_for(queue, to_bufnr)
+function M.section_for(queue, to_bufnr, cache)
   local OrchestrationLink = require("vibing.application.chat.orchestration_link")
 
-  local senders, kind, bodies = {}, nil, 0
+  local kind = nil
   for _, item in ipairs(queue) do
     if item.body then
-      bodies = bodies + 1
-      if item.bufnr then
-        senders[item.bufnr] = true
-        local direction = OrchestrationLink.direction(item.bufnr, to_bufnr)
-        kind = (kind == nil or kind == direction) and direction or "Report"
-      else
-        -- 送信元が消えた本文（`message_queue.forget`）。匿名で配達されるので向きは決められない
-        kind = kind or "Report"
-      end
+      -- 送信元が消えた本文（`message_queue.forget`）は匿名で配達されるので向きを決められない
+      local direction = item.bufnr and OrchestrationLink.direction(item.bufnr, to_bufnr) or "Report"
+      kind = (kind == nil or kind == direction) and direction or "Report"
     end
   end
 
@@ -119,23 +133,15 @@ function M.section_for(queue, to_bufnr)
     return { kind = "Notice" }
   end
 
-  local sender_count, only_sender = 0, nil
-  for bufnr in pairs(senders) do
-    sender_count, only_sender = sender_count + 1, bufnr
-  end
-
   -- 見出しが送信元を名乗れるのは、この配達が「1つのチャットからの本文1通」のときだけ。
   -- 通知が混ざっていれば通知は別のチャットについての話だし、本文が複数あれば出どころも
-  -- 複数ありうる。どちらも見出しで片方だけを名指しすると、残りの出どころが消える
-  if sender_count ~= 1 or bodies ~= 1 or #queue ~= 1 then
+  -- 複数ありうる。どちらも見出しで片方だけを名指しすると、残りの出どころが消える。
+  -- キューが1件で `kind` が決まっているなら、その1件は必ず本文なので添字で取れる
+  if #queue ~= 1 or not queue[1].bufnr then
     return { kind = kind }
   end
 
-  local name = vim.api.nvim_buf_is_valid(only_sender) and vim.api.nvim_buf_get_name(only_sender) or ""
-  return {
-    kind = kind,
-    from = name ~= "" and require("vibing.core.utils.git").to_display_path(name) or nil,
-  }
+  return { kind = kind, from = resolve_path(queue[1].bufnr, cache or {}) }
 end
 
 ---溜まったものを1通にまとめる
@@ -144,14 +150,15 @@ end
 ---**依頼**で、通知は「読みに行け」という副次情報だから
 ---@param queue Vibing.Application.MessageQueue.Item[]
 ---@param section Vibing.Application.DeliveryMessage.Section? `section_for` の結果
+---@param cache table<number, string>? 表示パスの使い回し（`section_for` と共有する）
 ---@return string
-function M.build(queue, section)
+function M.build(queue, section, cache)
   local notifications, messages = {}, {}
   for _, item in ipairs(queue) do
     table.insert(item.body and messages or notifications, item)
   end
 
-  local cache = {}
+  cache = cache or {}
   local sections = {}
   if #messages > 0 then
     table.insert(sections, message_section(messages, cache, section ~= nil and section.from ~= nil))
@@ -161,6 +168,22 @@ function M.build(queue, section)
   end
 
   return table.concat(sections, "\n\n")
+end
+
+---1通にまとめて、宛先のチャットに新しいターンとして配達する
+---
+---`section_for` → `build` → 送信の順序をここが所有する。呼び出し側に並べさせていたころ、
+---即配達経路が `section` を渡さずに送っていたせいで、同じ報告が相手の状態によって別の形に
+---見えていた。3手のうち1つを渡し忘れても文法上は成立してしまうので、手順ごと1箇所に置く
+---@param queue Vibing.Application.MessageQueue.Item[]
+---@param to_bufnr number
+---@param sender string?
+---@return {success: boolean, bufnr: number}
+function M.deliver(queue, to_bufnr, sender)
+  local cache = {}
+  local section = M.section_for(queue, to_bufnr, cache)
+  local text = M.build(queue, section, cache)
+  return require("vibing.presentation.chat.modules.programmatic_sender").send(to_bufnr, text, sender, section)
 end
 
 return M

--- a/lua/vibing/application/chat/delivery_message.lua
+++ b/lua/vibing/application/chat/delivery_message.lua
@@ -57,8 +57,15 @@ end
 
 ---@param items Vibing.Application.MessageQueue.Item[]
 ---@param cache table<number, string>
+---@param sender_named boolean セクション見出しが送信元を既に名指ししているか
 ---@return string
-local function message_section(items, cache)
+local function message_section(items, cache, sender_named)
+  -- 送信元が1つに定まる配達では、セクション見出し（`## Report <!-- ts from path -->`）が
+  -- 既に名前を持っている。ここでも `### From` を出すと同じことを2行離れて2回言うことになる
+  if sender_named and #items == 1 then
+    return items[1].body
+  end
+
   local blocks = {}
   for _, item in ipairs(items) do
     local from = item.bufnr and string.format("%s (chat buffer %d)", display_path(item.bufnr, cache), item.bufnr)
@@ -76,13 +83,69 @@ local function message_section(items, cache)
   }, "\n")
 end
 
+---@class Vibing.Application.DeliveryMessage.Section
+---@field kind "Request"|"Report"|"Notice" 配達セクションの種別
+---@field from string? 送信元の表示パス（1つに定まらない配達では nil）
+
+---この配達をどのセクションとして書くかを決める
+---
+---見出しと本文で判断が食い違わないよう、種別と送信元はここ1箇所で決めて `build` に渡す。
+---
+---向きは `orchestration_link.direction` に聞く（記録済みの関係から決まる）。合流した配達で
+---向きが混ざる場合は `Report` に倒す: 複数のワーカーからの報告が1ターンに合流するのが
+---この機構の通常の形で、依頼が同時に混ざるのは例外的だから
+---@param queue Vibing.Application.MessageQueue.Item[]
+---@param to_bufnr number 配達先
+---@return Vibing.Application.DeliveryMessage.Section
+function M.section_for(queue, to_bufnr)
+  local OrchestrationLink = require("vibing.application.chat.orchestration_link")
+
+  local senders, kind, bodies = {}, nil, 0
+  for _, item in ipairs(queue) do
+    if item.body then
+      bodies = bodies + 1
+      if item.bufnr then
+        senders[item.bufnr] = true
+        local direction = OrchestrationLink.direction(item.bufnr, to_bufnr)
+        kind = (kind == nil or kind == direction) and direction or "Report"
+      else
+        -- 送信元が消えた本文（`message_queue.forget`）。匿名で配達されるので向きは決められない
+        kind = kind or "Report"
+      end
+    end
+  end
+
+  if not kind then
+    return { kind = "Notice" }
+  end
+
+  local sender_count, only_sender = 0, nil
+  for bufnr in pairs(senders) do
+    sender_count, only_sender = sender_count + 1, bufnr
+  end
+
+  -- 見出しが送信元を名乗れるのは、この配達が「1つのチャットからの本文1通」のときだけ。
+  -- 通知が混ざっていれば通知は別のチャットについての話だし、本文が複数あれば出どころも
+  -- 複数ありうる。どちらも見出しで片方だけを名指しすると、残りの出どころが消える
+  if sender_count ~= 1 or bodies ~= 1 or #queue ~= 1 then
+    return { kind = kind }
+  end
+
+  local name = vim.api.nvim_buf_is_valid(only_sender) and vim.api.nvim_buf_get_name(only_sender) or ""
+  return {
+    kind = kind,
+    from = name ~= "" and require("vibing.core.utils.git").to_display_path(name) or nil,
+  }
+end
+
 ---溜まったものを1通にまとめる
 ---
 ---通知だけのときは通知セクションだけを出す。混在時に本文を先に置くのは、そちらが相手の
 ---**依頼**で、通知は「読みに行け」という副次情報だから
 ---@param queue Vibing.Application.MessageQueue.Item[]
+---@param section Vibing.Application.DeliveryMessage.Section? `section_for` の結果
 ---@return string
-function M.build(queue)
+function M.build(queue, section)
   local notifications, messages = {}, {}
   for _, item in ipairs(queue) do
     table.insert(item.body and messages or notifications, item)
@@ -91,7 +154,7 @@ function M.build(queue)
   local cache = {}
   local sections = {}
   if #messages > 0 then
-    table.insert(sections, message_section(messages, cache))
+    table.insert(sections, message_section(messages, cache, section ~= nil and section.from ~= nil))
   end
   if #notifications > 0 then
     table.insert(sections, notification_section(notifications, cache))

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -199,8 +199,10 @@ function M.flush(to_bufnr)
   write_links(queue, to_bufnr)
 
   local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
-  local text = require("vibing.application.chat.delivery_message").build(queue)
-  local ok, result = pcall(ProgrammaticSender.send, to_bufnr, text)
+  local DeliveryMessage = require("vibing.application.chat.delivery_message")
+  local section = DeliveryMessage.section_for(queue, to_bufnr)
+  local text = DeliveryMessage.build(queue, section)
+  local ok, result = pcall(ProgrammaticSender.send, to_bufnr, text, nil, section)
 
   -- 配達できて初めてキューを空ける。通知側はエッジを既に消費しているので、先に捨てると
   -- 失敗した配達は二度と再現しない。残しておけば次の完了イベントで作り直しなしに再試行できる

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -198,11 +198,8 @@ function M.flush(to_bufnr)
   -- 増えはしないし、リンクは記録であって配達の証明ではない
   write_links(queue, to_bufnr)
 
-  local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
   local DeliveryMessage = require("vibing.application.chat.delivery_message")
-  local section = DeliveryMessage.section_for(queue, to_bufnr)
-  local text = DeliveryMessage.build(queue, section)
-  local ok, result = pcall(ProgrammaticSender.send, to_bufnr, text, nil, section)
+  local ok, result = pcall(DeliveryMessage.deliver, queue, to_bufnr)
 
   -- 配達できて初めてキューを空ける。通知側はエッジを既に消費しているので、先に捨てると
   -- 失敗した配達は二度と再現しない。残しておけば次の完了イベントで作り直しなしに再試行できる

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -41,7 +41,29 @@ local function relation(from_bufnr, to_bufnr)
     return nil
   end
 
-  return from_chat, to_chat, Git.to_display_path(to_path), Git.to_display_path(from_path)
+  -- gitルートは1回だけ引く。`to_display_path` は既定で `get_root()` を呼び、それは
+  -- キャッシュを持たない同期の `git rev-parse` 起動なので、2つのパスで2プロセスになる
+  local git_root = Git.get_root()
+  return from_chat, to_chat, Git.to_display_path(to_path, git_root), Git.to_display_path(from_path, git_root)
+end
+
+---逆向きの関係が既に記録されているか（＝この送信は報告・返答か）
+---
+---解決済みの4つを受け取る形にしてあるのは、`link` が同じものを手元に持っているため。
+---公開の `M.direction` から呼ぶと `relation` がもう一度走り、`git rev-parse` が余分に起きる
+---@param from_chat table
+---@param to_chat table
+---@param forward string 送信先の表示パス
+---@param backward string 送信元の表示パス
+---@return "Request"|"Report"
+local function direction_from(from_chat, to_chat, forward, backward)
+  if
+    vim.tbl_contains(from_chat:get_frontmatter_list("orchestrated_by"), forward)
+    or vim.tbl_contains(to_chat:get_frontmatter_list("orchestrated"), backward)
+  then
+    return "Report"
+  end
+  return "Request"
 end
 
 ---この送信が配布か、報告・返答かを、記録済みの関係から決める
@@ -59,14 +81,7 @@ function M.direction(from_bufnr, to_bufnr)
   if not from_chat then
     return "Request"
   end
-
-  if
-    vim.tbl_contains(from_chat:get_frontmatter_list("orchestrated_by"), forward)
-    or vim.tbl_contains(to_chat:get_frontmatter_list("orchestrated"), backward)
-  then
-    return "Report"
-  end
-  return "Request"
+  return direction_from(from_chat, to_chat, forward, backward)
 end
 
 ---A が B に指示を出した関係を両者の frontmatter に書く
@@ -83,20 +98,12 @@ function M.link(from_bufnr, to_bufnr)
     return false, "A chat cannot orchestrate itself"
   end
 
-  local from_chat = resolve_chat(from_bufnr)
-  local to_chat = resolve_chat(to_bufnr)
-  if not from_chat or not to_chat then
-    return false, "Both buffers must be vibing chat buffers"
+  local from_chat, to_chat, forward, backward = relation(from_bufnr, to_bufnr)
+  if not from_chat then
+    -- 2つの理由（チャットバッファでない／ファイル名がない）を1つのメッセージに畳んである。
+    -- 呼び出し元はどちらでも「リンクを記録できなかった」と警告するだけで、分岐はしない
+    return false, "Both buffers must be vibing chat buffers with a file name"
   end
-
-  local from_path = vim.api.nvim_buf_get_name(from_bufnr)
-  local to_path = vim.api.nvim_buf_get_name(to_bufnr)
-  if from_path == "" or to_path == "" then
-    return false, "Both chats must have a file name"
-  end
-
-  local forward = Git.to_display_path(to_path)
-  local backward = Git.to_display_path(from_path)
 
   -- スキルは `nvim_chat_create` と続く `nvim_chat_send_message` の両方に `from_bufnr` を渡すので、
   -- 同じリンクが2回書かれる。`update_frontmatter_list` は要素としては重複を弾くが、行の書き換えと
@@ -120,7 +127,7 @@ function M.link(from_bufnr, to_bufnr)
   -- 片側だけでも逆向きが記録されていれば報告と見なす（`link` は片肺の書き込みを許すので、
   -- 両側揃うことを前提にはできない）。代償として A⇄B の相互オーケストレーションは
   -- 記録できないが、それは循環であって支持する形ではない
-  if M.direction(from_bufnr, to_bufnr) == "Report" then
+  if direction_from(from_chat, to_chat, forward, backward) == "Report" then
     return true, nil
   end
 

--- a/lua/vibing/application/chat/orchestration_link.lua
+++ b/lua/vibing/application/chat/orchestration_link.lua
@@ -23,6 +23,52 @@ local function resolve_chat(bufnr)
   return require("vibing.presentation.chat.view").get_chat_buffer(bufnr)
 end
 
+---2つのチャットの関係を読むのに必要なものを揃える（どちらかがチャットでなければ nil）
+---@param from_bufnr number
+---@param to_bufnr number
+---@return table? from_chat
+---@return table? to_chat
+---@return string? forward 送信先の表示パス
+---@return string? backward 送信元の表示パス
+local function relation(from_bufnr, to_bufnr)
+  local from_chat, to_chat = resolve_chat(from_bufnr), resolve_chat(to_bufnr)
+  if not from_chat or not to_chat then
+    return nil
+  end
+
+  local from_path, to_path = vim.api.nvim_buf_get_name(from_bufnr), vim.api.nvim_buf_get_name(to_bufnr)
+  if from_path == "" or to_path == "" then
+    return nil
+  end
+
+  return from_chat, to_chat, Git.to_display_path(to_path), Git.to_display_path(from_path)
+end
+
+---この送信が配布か、報告・返答かを、記録済みの関係から決める
+---
+---「送信が報告か依頼か」を機構は判別できない（`completion_notifier` の同じ制約）が、
+---「相手が既に自分のオーケストレータとして記録されている」なら向きだけは分かる。それが
+---`link` の逆向きガードであり、配達セクションの見出し（`## Request` / `## Report`）が
+---どちらになるかでもある。片側だけの記録でも報告と見なすのは `link` と同じ理由で、
+---`link` は片肺の書き込みを許すため
+---@param from_bufnr number
+---@param to_bufnr number
+---@return "Request"|"Report"
+function M.direction(from_bufnr, to_bufnr)
+  local from_chat, to_chat, forward, backward = relation(from_bufnr, to_bufnr)
+  if not from_chat then
+    return "Request"
+  end
+
+  if
+    vim.tbl_contains(from_chat:get_frontmatter_list("orchestrated_by"), forward)
+    or vim.tbl_contains(to_chat:get_frontmatter_list("orchestrated"), backward)
+  then
+    return "Report"
+  end
+  return "Request"
+end
+
 ---A が B に指示を出した関係を両者の frontmatter に書く
 ---
 ---呼び出しは `ProgrammaticSender.send` より**前**に済ませること。
@@ -74,10 +120,7 @@ function M.link(from_bufnr, to_bufnr)
   -- 片側だけでも逆向きが記録されていれば報告と見なす（`link` は片肺の書き込みを許すので、
   -- 両側揃うことを前提にはできない）。代償として A⇄B の相互オーケストレーションは
   -- 記録できないが、それは循環であって支持する形ではない
-  if
-    vim.tbl_contains(from_chat:get_frontmatter_list("orchestrated_by"), forward)
-    or vim.tbl_contains(to_chat:get_frontmatter_list("orchestrated"), backward)
-  then
+  if M.direction(from_bufnr, to_bufnr) == "Report" then
     return true, nil
   end
 

--- a/lua/vibing/core/utils/git.lua
+++ b/lua/vibing/core/utils/git.lua
@@ -37,8 +37,9 @@ end
 ---絶対パスからgitルートからの相対パスを取得
 ---@param abs_path string 絶対パス
 ---@return string|nil 相対パス（gitルートそのものの場合は"."、Git管理外の場合はnil）
-function M.get_relative_path(abs_path)
-  local git_root = M.get_root()
+---@param git_root string? 解決済みのgitルート。省略すると `get_root()` を呼ぶ（`git rev-parse` の起動1回）
+function M.get_relative_path(abs_path, git_root)
+  git_root = git_root or M.get_root()
   if not git_root then
     return nil
   end
@@ -243,8 +244,9 @@ end
 ---絶対パスをGit相対パスまたはチルダ短縮パスに変換
 ---@param abs_path string
 ---@return string
-function M.to_display_path(abs_path)
-  local relative = M.get_relative_path(abs_path)
+---@param git_root string? 解決済みのgitルート。1回の処理で複数のパスを表示形式にするときに渡す
+function M.to_display_path(abs_path, git_root)
+  local relative = M.get_relative_path(abs_path, git_root)
   if relative then
     return relative
   end

--- a/lua/vibing/core/utils/timestamp.lua
+++ b/lua/vibing/core/utils/timestamp.lua
@@ -19,6 +19,8 @@ local M = {}
 local TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
 -- タイムスタンプパターン（正規表現）
 local TIMESTAMP_PATTERN = "%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d"
+-- ヘッダーのコメント内を丸ごと照合する形。パース1回ごとに連結し直さないよう先に組んでおく
+local TIMESTAMP_ANCHORED = "^" .. TIMESTAMP_PATTERN .. "$"
 -- レガシーヘッダーパターン（タイムスタンプなし）
 local LEGACY_HEADER_PATTERN = "^## (%w+)"
 
@@ -69,7 +71,7 @@ function M.parse_header(line)
     return {
       kind = kind,
       unsent = unsent,
-      timestamp = (not unsent and stamp:match("^" .. TIMESTAMP_PATTERN .. "$")) and stamp or nil,
+      timestamp = (not unsent and stamp:match(TIMESTAMP_ANCHORED)) and stamp or nil,
       from = from,
     }
   end
@@ -101,34 +103,19 @@ function M.is_header(line)
   return M.parse_header(line) ~= nil
 end
 
----未送信ユーザーヘッダーを作成
----送信前の一時的なマーカーとして使用され、送信時にタイムスタンプ付きヘッダーに置き換えられる
----@return string header 未送信ユーザーヘッダー（例: "## User <!-- unsent -->"）
-function M.create_unsent_user_header()
-  return "## User <!-- unsent -->"
-end
-
----タイムスタンプ付きユーザーヘッダーを作成（HTMLコメント形式）
----@param timestamp? string オプションのタイムスタンプ（省略時は現在時刻）
----@return string header タイムスタンプ付きヘッダー（例: "## User <!-- 2025-12-29 14:30:55 -->"）
-function M.create_user_header_with_timestamp(timestamp)
-  timestamp = timestamp or M.now()
-  return string.format("## User <!-- %s -->", timestamp)
-end
-
----配達セクションのヘッダーを作成
+---セクションヘッダーを組み立てる（`parse_header` と対になる唯一の書き手）
 ---
 ---`stamp` を渡し分ける形にしてあるのは、配達も `## User` と同じ「未送信で書いて、送信時に
 ---コミットする」流れに乗るため。リミット中の予約（`auto_resume`）は未送信セクションが
 ---そのまま残っていることを前提にしているので、そこだけ直接タイムスタンプを書くわけには
 ---いかない
----@param kind string "Request" | "Report" | "Notice"
----@param from string? 送信元チャットの表示パス（合流した配達など、特定できないときは nil）
+---@param kind string "User" | "Request" | "Report" | "Notice"
 ---@param stamp string? タイムスタンプ（省略時は `unsent`）
+---@param from string? 送信元チャットの表示パス（合流した配達など、特定できないときは nil）
 ---@return string header
-function M.create_delivery_header(kind, from, stamp)
-  if not DELIVERY_KINDS[kind] then
-    error(string.format("Unknown delivery kind: %s", tostring(kind)))
+function M.create_header(kind, stamp, from)
+  if kind ~= "User" and not DELIVERY_KINDS[kind] then
+    error(string.format("Unknown section kind: %s", tostring(kind)))
   end
 
   local meta = stamp or "unsent"
@@ -138,34 +125,26 @@ function M.create_delivery_header(kind, from, stamp)
   return string.format("## %s <!-- %s -->", kind, meta)
 end
 
+---未送信ユーザーヘッダーを作成
+---送信前の一時的なマーカーとして使用され、送信時にタイムスタンプ付きヘッダーに置き換えられる
+---@return string header 未送信ユーザーヘッダー（例: "## User <!-- unsent -->"）
+function M.create_unsent_user_header()
+  return M.create_header("User")
+end
+
+---タイムスタンプ付きユーザーヘッダーを作成（HTMLコメント形式）
+---@param timestamp? string オプションのタイムスタンプ（省略時は現在時刻）
+---@return string header タイムスタンプ付きヘッダー（例: "## User <!-- 2025-12-29 14:30:55 -->"）
+function M.create_user_header_with_timestamp(timestamp)
+  return M.create_header("User", timestamp or M.now())
+end
+
 ---行が未送信ヘッダー（`## User` / 配達セクションのどちらでも）かどうか
 ---@param line string
 ---@return boolean
 function M.is_unsent_header(line)
   local header = M.parse_header(line)
   return header ~= nil and header.unsent
-end
-
----行が他のチャットからの配達セクションのヘッダーかどうか
----@param line string
----@return boolean
-function M.is_delivery_header(line)
-  local header = M.parse_header(line)
-  return header ~= nil and DELIVERY_KINDS[header.kind] == true
-end
-
----行が未送信ユーザーヘッダーかどうかチェック
----@param line string チェック対象の行
----@return boolean is_unsent 未送信ヘッダーの場合true
-function M.is_unsent_user_header(line)
-  return line:match("^## User <!%-%- unsent %-%->$") ~= nil
-end
-
----行がタイムスタンプ付きユーザーヘッダー（HTMLコメント形式）かどうかチェック
----@param line string チェック対象の行
----@return boolean is_timestamped タイムスタンプ付きヘッダーの場合true
-function M.is_timestamped_user_header(line)
-  return line:match("^## User <!%-%- " .. TIMESTAMP_PATTERN .. " %-%->$") ~= nil
 end
 
 ---ヘッダーからタイムスタンプを抽出（HTMLコメント形式）

--- a/lua/vibing/core/utils/timestamp.lua
+++ b/lua/vibing/core/utils/timestamp.lua
@@ -1,5 +1,16 @@
 ---タイムスタンプユーティリティ
----チャットメッセージのヘッダーにタイムスタンプを追加・パースする機能を提供
+---チャットセクションのヘッダーを組み立て・分解する。
+---
+---ヘッダーの文法はこの1ファイルにしかない: `## <Kind> <!-- <stamp>[ from <path>] -->`。
+---`Kind` は `User` / `Assistant` に加えて、他のチャットから配達されたものを表す
+---`Request` / `Report` / `Notice`（#657 の押し出し型報告）。`stamp` は `unsent` か
+---タイムスタンプで、`from` は送信元のチャットファイルのパス。
+---
+---**配達セクションも `extract_role` は "user" を返す。** セクションの中身はそのまま CLI へ送る
+---プロンプトなので（`conversation_extractor.extract_user_message`）、別ロールにすると
+---送信・会話抽出・デイリーサマリ・ジャンプの各所を個別に教育することになり、どれか1つ
+---忘れた時点で「配達されたターンが送信されない」＝報告が黙って消える側に倒れる。見た目を
+---分けたいだけなので、区別は `parse_header().kind` を見る側の仕事にしてある。
 
 ---@class Vibing.Utils.Timestamp
 local M = {}
@@ -10,6 +21,14 @@ local TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
 local TIMESTAMP_PATTERN = "%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d"
 -- レガシーヘッダーパターン（タイムスタンプなし）
 local LEGACY_HEADER_PATTERN = "^## (%w+)"
+
+---他のチャットから配達されたセクションの種別
+---
+---`Request` は配布（オーケストレーター→ワーカー）、`Report` は報告・返答（その逆向き）、
+---`Notice` は vibing.nvim 自身が出す watchdog 通知。どちらの向きかは
+---`orchestration_link.direction` が frontmatter の記録から決める
+---@type table<string, boolean>
+local DELIVERY_KINDS = { Request = true, Report = true, Notice = true }
 
 ---現在時刻のタイムスタンプを生成
 ---フォーマット: "YYYY-MM-DD HH:MM:SS"
@@ -25,42 +44,62 @@ function M.now()
   return timestamp
 end
 
+---@class Vibing.Utils.Timestamp.Header
+---@field kind string "User" | "Assistant" | "Request" | "Report" | "Notice"
+---@field unsent boolean 送信前のマーカー（`<!-- unsent -->`）か
+---@field timestamp string? 送信済みなら記録された時刻
+---@field from string? 配達セクションの送信元チャットのパス
 
----ヘッダー行からロールを抽出（HTMLコメント形式/レガシー対応）
----@param line string ヘッダー行
----@return string? role "user" | "assistant" | nil（ヘッダーでない場合はnil）
-function M.extract_role(line)
-  -- 未送信ユーザーヘッダー: "## User <!-- unsent -->"
-  if M.is_unsent_user_header(line) then
-    return "user"
-  end
+---ヘッダー行を分解する（ヘッダーでなければ nil）
+---
+---読めない `<!-- ... -->` の中身は**種別を捨てずに**受け入れる。ここは表示のための分解で、
+---壊れたコメント1つでセクションそのものが行方不明になるほうが害が大きい
+---@param line string
+---@return Vibing.Utils.Timestamp.Header?
+function M.parse_header(line)
+  local kind, meta = line:match("^## (%a+) <!%-%- (.-) %-%->%s*$")
+  if kind then
+    if kind ~= "User" and kind ~= "Assistant" and not DELIVERY_KINDS[kind] then
+      return nil
+    end
 
-  -- HTMLコメント形式タイムスタンプ: "## User <!-- YYYY-MM-DD HH:MM:SS -->"
-  if M.is_timestamped_user_header(line) then
-    return "user"
+    local stamp, from = meta:match("^(.-) from (.+)$")
+    stamp = stamp or meta
+    local unsent = stamp == "unsent"
+    return {
+      kind = kind,
+      unsent = unsent,
+      timestamp = (not unsent and stamp:match("^" .. TIMESTAMP_PATTERN .. "$")) and stamp or nil,
+      from = from,
+    }
   end
 
   -- レガシーパターン（シンプルヘッダー）: "## User" or "## Assistant"
-  local role = line:match(LEGACY_HEADER_PATTERN)
-  if role then
-    local lower_role = role:lower()
-    -- "user" または "assistant" のみ有効なロールとして認識
-    if lower_role == "user" or lower_role == "assistant" then
-      return lower_role
-    end
+  local legacy = line:match(LEGACY_HEADER_PATTERN)
+  if legacy == "User" or legacy == "Assistant" then
+    return { kind = legacy, unsent = false }
   end
 
   return nil
 end
 
+---ヘッダー行からロールを抽出（HTMLコメント形式/レガシー対応）
+---@param line string ヘッダー行
+---@return string? role "user" | "assistant" | nil（ヘッダーでない場合はnil）
+function M.extract_role(line)
+  local header = M.parse_header(line)
+  if not header then
+    return nil
+  end
+  return header.kind == "Assistant" and "assistant" or "user"
+end
 
 ---行がメッセージヘッダーかどうかチェック
 ---@param line string チェック対象の行
 ---@return boolean is_header ヘッダーの場合true
 function M.is_header(line)
-  return M.extract_role(line) ~= nil
+  return M.parse_header(line) ~= nil
 end
-
 
 ---未送信ユーザーヘッダーを作成
 ---送信前の一時的なマーカーとして使用され、送信時にタイムスタンプ付きヘッダーに置き換えられる
@@ -75,6 +114,44 @@ end
 function M.create_user_header_with_timestamp(timestamp)
   timestamp = timestamp or M.now()
   return string.format("## User <!-- %s -->", timestamp)
+end
+
+---配達セクションのヘッダーを作成
+---
+---`stamp` を渡し分ける形にしてあるのは、配達も `## User` と同じ「未送信で書いて、送信時に
+---コミットする」流れに乗るため。リミット中の予約（`auto_resume`）は未送信セクションが
+---そのまま残っていることを前提にしているので、そこだけ直接タイムスタンプを書くわけには
+---いかない
+---@param kind string "Request" | "Report" | "Notice"
+---@param from string? 送信元チャットの表示パス（合流した配達など、特定できないときは nil）
+---@param stamp string? タイムスタンプ（省略時は `unsent`）
+---@return string header
+function M.create_delivery_header(kind, from, stamp)
+  if not DELIVERY_KINDS[kind] then
+    error(string.format("Unknown delivery kind: %s", tostring(kind)))
+  end
+
+  local meta = stamp or "unsent"
+  if from and from ~= "" then
+    meta = meta .. " from " .. from
+  end
+  return string.format("## %s <!-- %s -->", kind, meta)
+end
+
+---行が未送信ヘッダー（`## User` / 配達セクションのどちらでも）かどうか
+---@param line string
+---@return boolean
+function M.is_unsent_header(line)
+  local header = M.parse_header(line)
+  return header ~= nil and header.unsent
+end
+
+---行が他のチャットからの配達セクションのヘッダーかどうか
+---@param line string
+---@return boolean
+function M.is_delivery_header(line)
+  local header = M.parse_header(line)
+  return header ~= nil and DELIVERY_KINDS[header.kind] == true
 end
 
 ---行が未送信ユーザーヘッダーかどうかチェック
@@ -95,8 +172,11 @@ end
 ---@param line string タイムスタンプ付きヘッダー行
 ---@return string? timestamp タイムスタンプ文字列（存在しない場合はnil）
 function M.extract_timestamp_from_comment(line)
-  local timestamp = line:match("^## User <!%-%- (" .. TIMESTAMP_PATTERN .. ") %-%->$")
-  return timestamp
+  local header = M.parse_header(line)
+  if not header or header.kind == "Assistant" then
+    return nil
+  end
+  return header.timestamp
 end
 
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -63,31 +63,27 @@ function M.send_message(params)
 
   -- `from_bufnr` は任意。必須にすると渡し忘れで送信そのものが失敗し、既存の
   -- オーケストレーション経路が壊れる。渡されなければリンクを張らないだけ（＝従来の動作）
+  -- 即配達もキュー配達とまったく同じ組み立てを通す。経路が2本あったころは、相手がたまたま
+  -- 応答中だったかどうかで同じ報告の見え方が変わっていた（キュー経由だけが送信元を名乗る）
+  local result
   if params.from_bufnr then
     -- リンクは送信より前に書く必要がある（`update_frontmatter_list` はバッファを直接触るので、
     -- 宛先の応答が始まってから書くとストリーミングと競合する）。ただし送信が弾かれると
     -- 行われなかったやり取りの関係だけが永久に残るので、先に送信可能かを確かめる
     ProgrammaticSender.validate(bufnr, params.message)
-
     require("vibing.application.chat.orchestration_link").link_or_warn(params.from_bufnr, bufnr)
-  end
 
-  -- 即配達もキュー配達とまったく同じ組み立てを通す。経路が2本あったころは、相手がたまたま
-  -- 応答中だったかどうかで同じ報告の見え方が変わっていた（キュー経由だけが送信元を名乗る）。
-  -- 文面と見出しを決める場所は1つにする
-  --
-  -- 向きの判定は上の `link_or_warn` の**後**でよい: 配布ならリンクは今書かれたばかりで
-  -- `direction` は Request を返し、報告なら `link` は逆向きガードで何も書かずに戻る
-  local text, section = params.message, nil
-  if params.from_bufnr then
-    local DeliveryMessage = require("vibing.application.chat.delivery_message")
-    local queue = { { bufnr = params.from_bufnr, body = params.message } }
-    section = DeliveryMessage.section_for(queue, bufnr)
-    text = DeliveryMessage.build(queue, section)
+    -- 向きの判定は `link_or_warn` の**後**でよい: 配布ならリンクは今書かれたばかりで
+    -- `direction` は Request を返し、報告なら `link` は逆向きガードで何も書かずに戻る
+    result = require("vibing.application.chat.delivery_message").deliver(
+      { { bufnr = params.from_bufnr, body = params.message } },
+      bufnr,
+      params.sender
+    )
+  else
+    -- ProgrammaticSender.send already validates parameters
+    result = ProgrammaticSender.send(bufnr, params.message, params.sender)
   end
-
-  -- ProgrammaticSender.send already validates parameters
-  local result = ProgrammaticSender.send(bufnr, text, params.sender, section)
 
   -- 送ったという事実そのものを購読の登録として扱う。宛先が応答を終えたら送信元に
   -- 「読みに行け」とだけ伝わる（application/chat/completion_notifier.lua）。同時に、逆向きの

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -72,8 +72,22 @@ function M.send_message(params)
     require("vibing.application.chat.orchestration_link").link_or_warn(params.from_bufnr, bufnr)
   end
 
+  -- 即配達もキュー配達とまったく同じ組み立てを通す。経路が2本あったころは、相手がたまたま
+  -- 応答中だったかどうかで同じ報告の見え方が変わっていた（キュー経由だけが送信元を名乗る）。
+  -- 文面と見出しを決める場所は1つにする
+  --
+  -- 向きの判定は上の `link_or_warn` の**後**でよい: 配布ならリンクは今書かれたばかりで
+  -- `direction` は Request を返し、報告なら `link` は逆向きガードで何も書かずに戻る
+  local text, section = params.message, nil
+  if params.from_bufnr then
+    local DeliveryMessage = require("vibing.application.chat.delivery_message")
+    local queue = { { bufnr = params.from_bufnr, body = params.message } }
+    section = DeliveryMessage.section_for(queue, bufnr)
+    text = DeliveryMessage.build(queue, section)
+  end
+
   -- ProgrammaticSender.send already validates parameters
-  local result = ProgrammaticSender.send(bufnr, params.message, params.sender)
+  local result = ProgrammaticSender.send(bufnr, text, params.sender, section)
 
   -- 送ったという事実そのものを購読の登録として扱う。宛先が応答を終えたら送信元に
   -- 「読みに行け」とだけ伝わる（application/chat/completion_notifier.lua）。同時に、逆向きの

--- a/lua/vibing/infrastructure/section_parser/grep_parser.lua
+++ b/lua/vibing/infrastructure/section_parser/grep_parser.lua
@@ -40,16 +40,12 @@ local function parse_grep_line(grep_line)
   local role = nil
   local timestamp = nil
 
-  -- Check for User header with timestamp (allow trailing whitespace)
-  local ts = content:match("^## User <!%-%- (%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d) %-%->%s*$")
-  if ts then
-    role = "user"
-    timestamp = ts
-  elseif content:match("^## User") then
-    role = "user"
-  elseif content:match("^## Assistant") then
-    role = "assistant"
-  end
+  -- ヘッダの文法は `core/utils/timestamp.lua` が唯一の定義元。ここで書き直すと、
+  -- 配達セクション（`## Request` / `## Report` / `## Notice`）がデイリーサマリから
+  -- 黙って抜け落ちる
+  local Timestamp = require("vibing.core.utils.timestamp")
+  role = Timestamp.extract_role(content)
+  timestamp = Timestamp.extract_timestamp_from_comment(content)
 
   if not role then
     return nil
@@ -141,10 +137,9 @@ local function parse_message_content(lines)
   local current_role = nil
 
   for _, line in ipairs(lines) do
-    if line:match("^## User") then
-      current_role = "user"
-    elseif line:match("^## Assistant") then
-      current_role = "assistant"
+    local line_role = require("vibing.core.utils.timestamp").extract_role(line)
+    if line_role then
+      current_role = line_role
     elseif current_role and not line:match("^---") and not line:match("^Context:") then
       if current_role == "user" then
         table.insert(user_lines, line)
@@ -176,7 +171,9 @@ function GrepParser:extract_messages(file_path, target_date)
   -- Step 1: Get all headers with line numbers using grep
   local grep_cmd = {
     "grep", "-n",
-    "-E", "^## (User|Assistant)",
+    -- `timestamp.lua` が受け付ける種別と揃えること。ここは grep に渡す前段の絞り込みで、
+    -- 行の解釈そのものは `parse_header_line` が同じモジュールに任せている
+    "-E", "^## (User|Assistant|Request|Report|Notice)",
     file_path,
   }
 

--- a/lua/vibing/infrastructure/section_parser/grep_parser.lua
+++ b/lua/vibing/infrastructure/section_parser/grep_parser.lua
@@ -3,6 +3,7 @@
 ---Available on macOS/Linux environments
 
 local Base = require("vibing.infrastructure.section_parser.base")
+local Timestamp = require("vibing.core.utils.timestamp")
 
 local GrepParser = setmetatable({}, { __index = Base })
 GrepParser.__index = GrepParser
@@ -37,15 +38,12 @@ local function parse_grep_line(grep_line)
   end
 
   local line_number = tonumber(line_num_str)
-  local role = nil
-  local timestamp = nil
-
   -- ヘッダの文法は `core/utils/timestamp.lua` が唯一の定義元。ここで書き直すと、
   -- 配達セクション（`## Request` / `## Report` / `## Notice`）がデイリーサマリから
   -- 黙って抜け落ちる
-  local Timestamp = require("vibing.core.utils.timestamp")
-  role = Timestamp.extract_role(content)
-  timestamp = Timestamp.extract_timestamp_from_comment(content)
+  local header = Timestamp.parse_header(content)
+  local role = header and (header.kind == "Assistant" and "assistant" or "user") or nil
+  local timestamp = header and header.kind ~= "Assistant" and header.timestamp or nil
 
   if not role then
     return nil
@@ -137,7 +135,7 @@ local function parse_message_content(lines)
   local current_role = nil
 
   for _, line in ipairs(lines) do
-    local line_role = require("vibing.core.utils.timestamp").extract_role(line)
+    local line_role = Timestamp.extract_role(line)
     if line_role then
       current_role = line_role
     elseif current_role and not line:match("^---") and not line:match("^Context:") then
@@ -171,9 +169,10 @@ function GrepParser:extract_messages(file_path, target_date)
   -- Step 1: Get all headers with line numbers using grep
   local grep_cmd = {
     "grep", "-n",
-    -- `timestamp.lua` が受け付ける種別と揃えること。ここは grep に渡す前段の絞り込みで、
-    -- 行の解釈そのものは `parse_header_line` が同じモジュールに任せている
-    "-E", "^## (User|Assistant|Request|Report|Notice)",
+    -- 種別を列挙しない。ここは grep に渡す前段の絞り込みでしかなく、行が本当にヘッダーかは
+    -- `parse_grep_line` が `timestamp.parse_header` に任せて弾く。列挙すると文法の写しが
+    -- もう1つでき、種別が増えた日にデイリーサマリから黙って抜け落ちる
+    "-E", "^## ",
     file_path,
   }
 

--- a/lua/vibing/presentation/chat/modules/conversation_extractor.lua
+++ b/lua/vibing/presentation/chat/modules/conversation_extractor.lua
@@ -117,9 +117,7 @@ function M.commit_user_message(buf)
     return
   end
 
-  local committed = last_unsent_header.kind == "User"
-      and Timestamp.create_user_header_with_timestamp()
-    or Timestamp.create_delivery_header(last_unsent_header.kind, last_unsent_header.from, Timestamp.now())
+  local committed = Timestamp.create_header(last_unsent_header.kind, Timestamp.now(), last_unsent_header.from)
   vim.api.nvim_buf_set_lines(buf, last_unsent_line - 1, last_unsent_line, false, { committed })
 end
 

--- a/lua/vibing/presentation/chat/modules/conversation_extractor.lua
+++ b/lua/vibing/presentation/chat/modules/conversation_extractor.lua
@@ -92,6 +92,10 @@ function M.extract_user_message(buf)
 end
 
 ---未送信ヘッダーをタイムスタンプ付きヘッダーに置き換える
+---
+---種別と送信元を保ったまま時刻だけ入れる。`## User` に決め打つと、配達セクション
+---（`## Request` / `## Report` / `## Notice`）が送信の瞬間にただの User に化けて、
+---誰から届いたものかがバッファから消える
 ---@param buf number バッファ番号
 function M.commit_user_message(buf)
   if not vim.api.nvim_buf_is_valid(buf) then
@@ -99,27 +103,24 @@ function M.commit_user_message(buf)
   end
 
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-  local last_unsent_user_line = nil
+  local last_unsent_line, last_unsent_header = nil, nil
 
   for i = #lines, 1, -1 do
-    if Timestamp.is_unsent_user_header(lines[i]) then
-      last_unsent_user_line = i
+    local header = Timestamp.parse_header(lines[i])
+    if header and header.unsent then
+      last_unsent_line, last_unsent_header = i, header
       break
     end
   end
 
-  if not last_unsent_user_line then
+  if not last_unsent_line then
     return
   end
 
-  local timestamped_header = Timestamp.create_user_header_with_timestamp()
-  vim.api.nvim_buf_set_lines(
-    buf,
-    last_unsent_user_line - 1,
-    last_unsent_user_line,
-    false,
-    { timestamped_header }
-  )
+  local committed = last_unsent_header.kind == "User"
+      and Timestamp.create_user_header_with_timestamp()
+    or Timestamp.create_delivery_header(last_unsent_header.kind, last_unsent_header.from, Timestamp.now())
+  vim.api.nvim_buf_set_lines(buf, last_unsent_line - 1, last_unsent_line, false, { committed })
 end
 
 return M

--- a/lua/vibing/presentation/chat/modules/programmatic_sender.lua
+++ b/lua/vibing/presentation/chat/modules/programmatic_sender.lua
@@ -83,25 +83,21 @@ end
 local function drop_empty_trailing_section(buf)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 
-  local last_header = nil
-  for i = #lines, 1, -1 do
-    if Timestamp.is_header(lines[i]) then
-      last_header = i
-      break
-    end
+  -- 末尾から空行を飛ばして最初に当たった行がヘッダーなら、それが最後のセクションで、かつ
+  -- 中身は空。ヘッダー行が空行であることはないので、この1走査が「最後のヘッダー」と
+  -- 「その下は空」の両方を同時に確かめている
+  local last = #lines
+  while last > 0 and vim.trim(lines[last]) == "" do
+    last = last - 1
   end
 
-  if not last_header or not Timestamp.is_unsent_header(lines[last_header]) then
+  if last == 0 or not Timestamp.is_unsent_header(lines[last]) then
     return
   end
 
-  for i = last_header + 1, #lines do
-    if vim.trim(lines[i]) ~= "" then
-      return
-    end
-  end
-
-  local first = last_header
+  -- ヘッダーの手前の空行も一緒に落とす。残しても `addUserSection` が末尾の空行を畳むが、
+  -- 畳む対象を残したまま返すと「何を消したか」が2箇所に分かれる
+  local first = last
   while first > 1 and vim.trim(lines[first - 1]) == "" do
     first = first - 1
   end
@@ -130,7 +126,7 @@ function M.send(bufnr, message, sender, delivery)
       or nil
 
     -- Add user section and send
-    local header = delivery and Timestamp.create_delivery_header(delivery.kind, delivery.from) or nil
+    local header = delivery and Timestamp.create_header(delivery.kind, nil, delivery.from) or nil
     drop_empty_trailing_section(bufnr)
     Renderer.addUserSection(bufnr, nil, nil, nil, message, header)
     sent = chat_buf:send_message()

--- a/lua/vibing/presentation/chat/modules/programmatic_sender.lua
+++ b/lua/vibing/presentation/chat/modules/programmatic_sender.lua
@@ -4,6 +4,7 @@ local M = {}
 
 local view = require("vibing.presentation.chat.view")
 local Renderer = require("vibing.presentation.chat.modules.renderer")
+local Timestamp = require("vibing.core.utils.timestamp")
 
 -- Per-buffer send locks to prevent concurrent sends
 local _send_locks = {}
@@ -69,7 +70,50 @@ function M.validate(bufnr, message)
   return chat_buf
 end
 
-function M.send(bufnr, message, sender)
+---末尾の空の未送信セクションを落とす
+---
+---ターンが終わるたび `add_user_section()` が空の `## User <!-- unsent -->` を置く。人間はそこに
+---打ち込むのでセクションは1つのままだが、配達はその下に**もう1つ**足していたので、配達された
+---ターンの上には毎回空の User セクションが取り残されていた（実際のオーケストレーションで
+---1ターンにつき1つ増えるのを確認）。
+---
+---落とすのは中身が空のときだけ。承認プロンプトや質問の選択肢は同じ未送信セクションに
+---描かれるので、それらは「空でない」として残る
+---@param buf number
+local function drop_empty_trailing_section(buf)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+
+  local last_header = nil
+  for i = #lines, 1, -1 do
+    if Timestamp.is_header(lines[i]) then
+      last_header = i
+      break
+    end
+  end
+
+  if not last_header or not Timestamp.is_unsent_header(lines[last_header]) then
+    return
+  end
+
+  for i = last_header + 1, #lines do
+    if vim.trim(lines[i]) ~= "" then
+      return
+    end
+  end
+
+  local first = last_header
+  while first > 1 and vim.trim(lines[first - 1]) == "" do
+    first = first - 1
+  end
+  vim.api.nvim_buf_set_lines(buf, first - 1, #lines, false, {})
+end
+
+---@param bufnr number
+---@param message string
+---@param sender string?
+---@param delivery Vibing.Application.DeliveryMessage.Section? 他のチャットからの配達なら、
+---  そのセクション見出しに使う種別と送信元。省略すると通常の `## User` セクションになる
+function M.send(bufnr, message, sender, delivery)
   sender = sender or "User"
 
   local chat_buf = M.validate(bufnr, message)
@@ -86,7 +130,9 @@ function M.send(bufnr, message, sender)
       or nil
 
     -- Add user section and send
-    Renderer.addUserSection(bufnr, nil, nil, nil, message)
+    local header = delivery and Timestamp.create_delivery_header(delivery.kind, delivery.from) or nil
+    drop_empty_trailing_section(bufnr)
+    Renderer.addUserSection(bufnr, nil, nil, nil, message, header)
     sent = chat_buf:send_message()
 
     -- Restore cursor

--- a/lua/vibing/presentation/chat/modules/renderer.lua
+++ b/lua/vibing/presentation/chat/modules/renderer.lua
@@ -158,7 +158,10 @@ M.move_cursor_to_end = M.moveCursorToEnd
 ---@param pendingChoices table? Pending choices
 ---@param pendingApproval table? Pending tool approval request
 ---@param initial_message string? Initial message content (for programmatic send)
-function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_message)
+---@param header string? Section header to use instead of the plain unsent `## User` one.
+---  Delivered chat-to-chat messages pass their own (`## Request` / `## Report` / `## Notice`);
+---  it must still be an unsent header, since `commit_user_message` is what stamps it at send
+function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_message, header)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 
   while #lines > 0 and lines[#lines] == "" do
@@ -168,7 +171,7 @@ function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_mes
 
   local newLines = {
     "",
-    Timestamp.create_unsent_user_header(),
+    header or Timestamp.create_unsent_user_header(),
     "",
   }
 

--- a/tests/lua/application/chat/delivery_message_spec.lua
+++ b/tests/lua/application/chat/delivery_message_spec.lua
@@ -1,0 +1,101 @@
+describe("DeliveryMessage.section_for", function()
+  local DeliveryMessage
+  local original_link
+  local direction_answers
+  local buffers
+
+  ---@param name string?
+  ---@return number
+  local function make_buf(name)
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    if name then
+      vim.api.nvim_buf_set_name(bufnr, vim.fn.tempname() .. "-" .. name)
+    end
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  before_each(function()
+    buffers = {}
+    direction_answers = {}
+    original_link = package.loaded["vibing.application.chat.orchestration_link"]
+    package.loaded["vibing.application.chat.orchestration_link"] = {
+      direction = function(from_bufnr, _)
+        return direction_answers[from_bufnr] or "Request"
+      end,
+    }
+    package.loaded["vibing.application.chat.delivery_message"] = nil
+    DeliveryMessage = require("vibing.application.chat.delivery_message")
+  end)
+
+  after_each(function()
+    package.loaded["vibing.application.chat.orchestration_link"] = original_link
+    package.loaded["vibing.application.chat.delivery_message"] = nil
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end)
+
+  it("names the sender when one chat sent one message", function()
+    local sender, recipient = make_buf("worker.md"), make_buf()
+    direction_answers[sender] = "Report"
+
+    local section = DeliveryMessage.section_for({ { bufnr = sender, body = "done" } }, recipient)
+
+    assert.equals("Report", section.kind)
+    assert.is_true(section.from:find("worker.md", 1, true) ~= nil, tostring(section.from))
+  end)
+
+  it("drops the redundant From heading once the section header carries it", function()
+    local sender, recipient = make_buf("worker.md"), make_buf()
+    local queue = { { bufnr = sender, body = "done" } }
+    local section = DeliveryMessage.section_for(queue, recipient)
+
+    assert.equals("done", DeliveryMessage.build(queue, section))
+  end)
+
+  it("keeps the From headings when several senders coalesce", function()
+    local a, b, recipient = make_buf("a.md"), make_buf("b.md"), make_buf()
+    direction_answers[a], direction_answers[b] = "Report", "Report"
+    local queue = { { bufnr = a, body = "one" }, { bufnr = b, body = "two" } }
+
+    local section = DeliveryMessage.section_for(queue, recipient)
+    assert.equals("Report", section.kind)
+    assert.is_nil(section.from, "no single sender to name")
+
+    local text = DeliveryMessage.build(queue, section)
+    assert.is_true(text:find("### From", 1, true) ~= nil, text)
+  end)
+
+  it("calls a watchdog-only delivery a Notice", function()
+    local about, recipient = make_buf("worker.md"), make_buf()
+
+    local section = DeliveryMessage.section_for({ { bufnr = about } }, recipient)
+
+    assert.equals("Notice", section.kind)
+    assert.is_nil(section.from)
+  end)
+
+  it("does not name a sender when a notice rides along with the message", function()
+    -- 通知は別のチャットについての話なので、見出しが本文の送信元だけを名指しすると
+    -- 通知が指しているチャットの出どころが消える
+    local sender, about, recipient = make_buf("worker.md"), make_buf("other.md"), make_buf()
+    direction_answers[sender] = "Report"
+
+    local section = DeliveryMessage.section_for({ { bufnr = sender, body = "done" }, { bufnr = about } }, recipient)
+
+    assert.equals("Report", section.kind)
+    assert.is_nil(section.from)
+  end)
+
+  it("falls back to Report when a coalesced delivery mixes directions", function()
+    local a, b, recipient = make_buf("a.md"), make_buf("b.md"), make_buf()
+    direction_answers[a], direction_answers[b] = "Request", "Report"
+
+    local section = DeliveryMessage.section_for({ { bufnr = a, body = "x" }, { bufnr = b, body = "y" } }, recipient)
+
+    assert.equals("Report", section.kind)
+  end)
+end)

--- a/tests/lua/core/utils/timestamp_spec.lua
+++ b/tests/lua/core/utils/timestamp_spec.lua
@@ -1,0 +1,61 @@
+local Timestamp = require("vibing.core.utils.timestamp")
+
+describe("Timestamp header grammar", function()
+  it("reads the plain and legacy User headers", function()
+    assert.same({ kind = "User", unsent = true }, Timestamp.parse_header("## User <!-- unsent -->"))
+    assert.equals("2026-09-02 08:13:11", Timestamp.parse_header("## User <!-- 2026-09-02 08:13:11 -->").timestamp)
+    assert.equals("user", Timestamp.extract_role("## User"))
+    assert.equals("assistant", Timestamp.extract_role("## Assistant"))
+  end)
+
+  it("reads a delivery header's kind and sender", function()
+    local header = Timestamp.parse_header("## Report <!-- 2026-09-02 08:14:07 from .vibing/chat/worker.md -->")
+
+    assert.equals("Report", header.kind)
+    assert.equals("2026-09-02 08:14:07", header.timestamp)
+    assert.equals(".vibing/chat/worker.md", header.from)
+    assert.is_false(header.unsent)
+  end)
+
+  it("reports every delivery kind as the user role", function()
+    -- セクションの中身はそのまま CLI へ送るプロンプトなので、別ロールにすると
+    -- `extract_user_message` が拾わず、配達されたターンが送信されないまま消える
+    for _, kind in ipairs({ "Request", "Report", "Notice" }) do
+      local line = Timestamp.create_delivery_header(kind, ".vibing/chat/x.md")
+      assert.equals("user", Timestamp.extract_role(line), line)
+      assert.is_true(Timestamp.is_delivery_header(line))
+      assert.is_true(Timestamp.is_unsent_header(line))
+    end
+  end)
+
+  it("round-trips what it writes", function()
+    local unsent = Timestamp.create_delivery_header("Request", ".vibing/chat/boss.md")
+    assert.equals("## Request <!-- unsent from .vibing/chat/boss.md -->", unsent)
+
+    local sent = Timestamp.create_delivery_header("Report", nil, "2026-09-02 08:14:07")
+    assert.equals("## Report <!-- 2026-09-02 08:14:07 -->", sent)
+    assert.is_nil(Timestamp.parse_header(sent).from)
+    assert.equals("2026-09-02 08:14:07", Timestamp.extract_timestamp_from_comment(sent))
+  end)
+
+  it("refuses to write a kind nothing can read back", function()
+    assert.has_error(function()
+      Timestamp.create_delivery_header("Whatever", nil)
+    end)
+  end)
+
+  it("is not a header for an unrelated heading", function()
+    assert.is_nil(Timestamp.parse_header("## Modified Files"))
+    assert.is_nil(Timestamp.parse_header("### From .vibing/chat/x.md (chat buffer 3)"))
+    assert.is_false(Timestamp.is_header("Some prose about ## User"))
+  end)
+
+  it("keeps the section when the comment is unreadable", function()
+    -- ここは表示のための分解。壊れたコメント1つでセクションそのものが行方不明になるほうが害が大きい
+    local header = Timestamp.parse_header("## Report <!-- who knows -->")
+
+    assert.equals("Report", header.kind)
+    assert.is_nil(header.timestamp)
+    assert.is_false(header.unsent)
+  end)
+end)

--- a/tests/lua/core/utils/timestamp_spec.lua
+++ b/tests/lua/core/utils/timestamp_spec.lua
@@ -21,26 +21,31 @@ describe("Timestamp header grammar", function()
     -- セクションの中身はそのまま CLI へ送るプロンプトなので、別ロールにすると
     -- `extract_user_message` が拾わず、配達されたターンが送信されないまま消える
     for _, kind in ipairs({ "Request", "Report", "Notice" }) do
-      local line = Timestamp.create_delivery_header(kind, ".vibing/chat/x.md")
+      local line = Timestamp.create_header(kind, nil, ".vibing/chat/x.md")
       assert.equals("user", Timestamp.extract_role(line), line)
-      assert.is_true(Timestamp.is_delivery_header(line))
+      assert.equals(kind, Timestamp.parse_header(line).kind)
       assert.is_true(Timestamp.is_unsent_header(line))
     end
   end)
 
   it("round-trips what it writes", function()
-    local unsent = Timestamp.create_delivery_header("Request", ".vibing/chat/boss.md")
+    local unsent = Timestamp.create_header("Request", nil, ".vibing/chat/boss.md")
     assert.equals("## Request <!-- unsent from .vibing/chat/boss.md -->", unsent)
 
-    local sent = Timestamp.create_delivery_header("Report", nil, "2026-09-02 08:14:07")
+    local sent = Timestamp.create_header("Report", "2026-09-02 08:14:07")
     assert.equals("## Report <!-- 2026-09-02 08:14:07 -->", sent)
     assert.is_nil(Timestamp.parse_header(sent).from)
     assert.equals("2026-09-02 08:14:07", Timestamp.extract_timestamp_from_comment(sent))
   end)
 
+  it("writes the plain User header through the same constructor", function()
+    assert.equals("## User <!-- unsent -->", Timestamp.create_unsent_user_header())
+    assert.equals("## User <!-- 2026-09-02 08:13:11 -->", Timestamp.create_user_header_with_timestamp("2026-09-02 08:13:11"))
+  end)
+
   it("refuses to write a kind nothing can read back", function()
     assert.has_error(function()
-      Timestamp.create_delivery_header("Whatever", nil)
+      Timestamp.create_header("Whatever")
     end)
   end)
 

--- a/tests/lua/presentation/chat/modules/conversation_extractor_spec.lua
+++ b/tests/lua/presentation/chat/modules/conversation_extractor_spec.lua
@@ -1,0 +1,57 @@
+local ConversationExtractor = require("vibing.presentation.chat.modules.conversation_extractor")
+
+describe("ConversationExtractor.commit_user_message", function()
+  local bufnr
+
+  before_each(function()
+    bufnr = vim.api.nvim_create_buf(false, true)
+  end)
+
+  after_each(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end)
+
+  ---@return string
+  local function header_line()
+    for _, line in ipairs(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)) do
+      if line:match("^## ") then
+        return line
+      end
+    end
+    return ""
+  end
+
+  it("stamps a plain user section", function()
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "## User <!-- unsent -->", "", "hi" })
+
+    ConversationExtractor.commit_user_message(bufnr)
+
+    assert.is_true(header_line():match("^## User <!%-%- %d%d%d%d%-") ~= nil, header_line())
+  end)
+
+  it("keeps a delivery section's kind and sender when it stamps it", function()
+    -- `## User` に決め打つと、送信の瞬間に配達セクションがただの User に化けて、
+    -- 誰から届いたものかがバッファから消える
+    vim.api.nvim_buf_set_lines(
+      bufnr,
+      0,
+      -1,
+      false,
+      { "## Report <!-- unsent from .vibing/chat/worker.md -->", "", "done" }
+    )
+
+    ConversationExtractor.commit_user_message(bufnr)
+
+    local line = header_line()
+    assert.is_true(line:match("^## Report <!%-%- %d%d%d%d%-") ~= nil, line)
+    assert.is_true(line:find("from .vibing/chat/worker.md", 1, true) ~= nil, line)
+  end)
+
+  it("extracts a delivery section's body as the message to send", function()
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "## Report <!-- unsent from x.md -->", "", "the report" })
+
+    assert.equals("the report", ConversationExtractor.extract_user_message(bufnr))
+  end)
+end)

--- a/tests/lua/presentation/chat/modules/programmatic_sender_spec.lua
+++ b/tests/lua/presentation/chat/modules/programmatic_sender_spec.lua
@@ -47,6 +47,46 @@ describe("ProgrammaticSender.send", function()
     return count
   end
 
+  ---@return string[]
+  local function buffer_lines()
+    return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  end
+
+  it("writes the delivery header it was handed instead of a plain User section", function()
+    ProgrammaticSender.send(bufnr, "done", nil, { kind = "Report", from = ".vibing/chat/worker.md" })
+
+    local lines = buffer_lines()
+    assert.is_true(
+      vim.tbl_contains(lines, "## Report <!-- unsent from .vibing/chat/worker.md -->"),
+      table.concat(lines, "\n")
+    )
+  end)
+
+  it("fills the empty unsent section a finished turn left behind", function()
+    -- ターンが終わるたび `add_user_section()` が空の未送信セクションを置く。人間はそこに
+    -- 打ち込むが、配達はその下にもう1つ足していたので、配達されたターンの上に空の
+    -- `## User` が毎回取り残されていた
+    vim.api.nvim_buf_set_lines(bufnr, -1, -1, false, { "## User <!-- unsent -->", "", "" })
+
+    ProgrammaticSender.send(bufnr, "hello", nil, { kind = "Request" })
+
+    local headers = vim.tbl_filter(function(line)
+      return line:match("^## ")
+    end, buffer_lines())
+    assert.same({ "## Request <!-- unsent -->" }, headers)
+  end)
+
+  it("keeps a trailing section that still has something in it", function()
+    -- 承認プロンプトや質問の選択肢は同じ未送信セクションに描かれる。空でないものを
+    -- 落とすと、ユーザーが答えようとしていた選択肢が配達のたびに消える
+    vim.api.nvim_buf_set_lines(bufnr, -1, -1, false, { "## User <!-- unsent -->", "", "1. PostgreSQL", "" })
+
+    ProgrammaticSender.send(bufnr, "hello", nil, { kind = "Request" })
+
+    local lines = buffer_lines()
+    assert.is_true(vim.tbl_contains(lines, "1. PostgreSQL"), table.concat(lines, "\n"))
+  end)
+
   it("refuses a chat that is already responding, before touching the buffer", function()
     -- 追加してから巻き戻すのではなく追加する前に断る。`ChatBuffer:send_message()` は
     -- 応答中なら黙って return するので、先に append すると送られない `## User` が残り、


### PR DESCRIPTION
# Pull Request

## Summary

#657 の動作テスト中に見つかった3つを直す。ベースは `feat/orchestrate-push-reporting`（#657）で、その向き判定を使う。

1. 他のチャットから配達されたメッセージが `## User` セクションとして入るので、人間が書いたものと区別がつかない
2. 同じ報告なのに、相手がたまたま応答中だったかどうかで見え方が変わる（キュー経由だけが送信元を名乗る）
3. 配達されたターンの上に、空の `## User <!-- unsent -->` が毎回取り残される

## Changes

### 配達セクション

```markdown
## Request <!-- 2026-09-02 08:13:11 from .vibing/chat/orchestrator.md -->
## Report <!-- 2026-09-02 08:14:07 from .vibing/chat/worker-a.md -->
## Notice <!-- 2026-09-02 08:14:16 -->
```

`Request` は配布、`Report` は報告・返答、`Notice` は vibing.nvim 自身が出す watchdog 通知。前2つの区別は `orchestration_link.direction`（#657 で入れた逆向き判定）が frontmatter の記録から決めるので、文面からの推測ではない。

**`extract_role` はどれも `user` を返す。** セクションの中身はそのまま CLI に渡すプロンプトなので、本当に別ロールにすると送信経路・会話抽出・`commit_user_message`・デイリーサマリのパーサ2つ・ジャンプコマンドを個別に教育することになり、どれか1つ忘れた時点で「配達されたターンが送信されない」＝報告が黙って消える側に倒れる。分けたかったのは見た目だけなので、区別は `parse_header().kind` を見る側の仕事にした。

ヘッダの文法（`## <Kind> <!-- <unsent|timestamp>[ from <path>] -->`）は `timestamp.lua` にのみ置き、`grep_parser` は自前の `^## User` パターンをやめて `extract_role` を通す。読み手が2つあると片方が腐り、配達されたターンがデイリーサマリから黙って抜ける。

### 経路の一本化

`handlers/message.lua`（即配達）と `message_queue.flush`（キュー配達）が、どちらも `delivery_message.section_for` → `build` を通る。`section_for` が「1チャットからの本文1通」のときだけ見出しに送信元を書き、そのとき `build` は本文側の `### From` を省く（2行離れて同じことを2回言わないため）。合流した配達では見出しは送信元を名乗らず、`### From` が残る。

### 空セクションの取り残し

ターンが終わるたび `add_user_section()` が空の `## User <!-- unsent -->` を置く。人間はそこに打ち込むが、配達はその下にもう1つ足していた。末尾の未送信セクションが**空のときだけ**落とす — 承認プロンプトと質問の選択肢は同じセクションに描かれるので、それらは残す。

未送信→コミットの流れは配達セクションでも維持している。リミット中の送信は未送信セクションとして予約され後で送られる（`auto_resume`）ので、配達にも未送信の形が要る。`commit_user_message` は見つけた種別と `from` を保ったまま時刻だけ入れる。

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] `pnpm run test:lua`（全 spec pass、exit 0）
- [x] `pnpm run test:node`（37 pass / 0 fail）
- [x] `pnpm run check` / `format:check` / `lint:md`（触ったファイルの指摘0）

新規 spec 3ファイル・16ケース:

- `tests/lua/core/utils/timestamp_spec.lua` — ヘッダ文法の読み書き、全配達種別が `user` ロールを返すこと、読めないコメントでも種別を失わないこと
- `tests/lua/application/chat/delivery_message_spec.lua` — `section_for` の種別・送信元判定（単独／合流／通知のみ／向きが混ざる場合）
- `tests/lua/presentation/chat/modules/conversation_extractor_spec.lua` — コミット時に種別と送信元が保たれること、配達セクションの本文が送信対象として取り出されること
- `programmatic_sender_spec.lua` に3ケース追加 — 配達ヘッダが書かれること、空の未送信セクションが埋められること、空でないセクションは残ること

E2E は未実行（実トークンを消費するため）。

## Documentation

- [x] CLAUDE.md updated（`.claude/rules/features.md` にヘッダ形式、`architecture.md` に「Delivered sections」節）

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes

## Related Issues

#639 の運用で見つかったもの。#643 / #657 の後始末にあたる。

## Additional Context

`## Notice` は issue にも当初の相談にも無かったが、入れてある。watchdog 通知は依頼でも報告でもなく、これを `## User` のままにすると「ユーザーが書いていない User セクション」が残り、今回の変更の目的が半分残ってしまうため。不要なら落とせる。

合流した配達で向きが混ざった場合は `Report` に倒している。複数ワーカーの報告が1ターンに合流するのがこの機構の通常の形で、依頼が同時に混ざるのは例外的という判断。
