### PR TITLE
feat: orchestration tree visualization, tree-wide cancel, and a concurrency limit

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1483,6 +1483,40 @@ Neovim dying takes the worker chats with it. Backends other than claude can be _
 event is backend-agnostic) but cannot _subscribe_: `nvim_chat_send_message` is an MCP tool, and
 codex/grok reach no MCP server, the same constraint `features.md` records for AskUserQuestion.
 
+### Tree operations
+
+`:VibingOrchestrationTree [path]` draws the tree a chat belongs to with each node's status,
+`:VibingCancelTree [path]` stops a subtree, and `agent.orchestration.max_concurrent` (default
+`0` = unlimited) caps how many chats may be responding at once (#645). Three decisions carry
+the design:
+
+- **The tree is read from frontmatter, buffer-first.** `orchestration_tree.lua` resolves each
+  node through the open buffer when there is one and the file on disk otherwise. Most nodes are
+  windowless `back` workers, and an orchestrator appends to `orchestrated` on every dispatch, so
+  either source alone silently truncates the tree. Reading frontmatter is also what makes the
+  tree survive a restart; the _status_ half does not — it lives only on attached buffers, so a
+  chat running in another Neovim renders as `[not open]`. Rendering always starts from the root
+  (`root_of` follows the first `orchestrated_by` entry when a hand-edited file lists several —
+  picking one beats refusing to draw), and a cycle is cut with `(shown above)` rather than
+  followed.
+- **`:VibingCancelTree` drops every target's queue and subscriptions before the first cancel**
+  (`use_cases/cancel_tree.lua`). `cancel()` runs `wrapped_on_done` synchronously, which drains
+  the queue — cancelling in order with the queues intact restarts nodes as fast as they are
+  stopped. Dropping the edges also keeps the watchdog quiet about these stops: the human asked
+  for them, so "this chat stopped without reporting" would be false. The subtree is computed
+  from the same frontmatter as the visualization, so a hand-written cycle makes "descendants"
+  reach ancestors — a cancel inside such a loop stops chats above the named node. The loop is
+  visible in the tree beforehand; accepted rather than special-cased.
+- **The concurrency cap gates machine-started sends only** (`concurrency.lua`, enforced in the
+  RPC send handler and the queue drain, never in `ChatBuffer:send_message()` — a human `<CR>`
+  always goes through). The count includes every responding chat, the user's own manual turns
+  included, so one long hand-driven turn occupies a slot. A send held by the limit is **not** a
+  stop: the hold is treated like branch 2 above (edges kept, no notification), redelivery when a
+  slot frees is limited to `held_by_limit` entries — retrying every non-empty queue on each
+  completion re-delivers refused messages, which a spec pins — and a `queue_if_busy` message
+  held against an _idle_ recipient registers via `hold_for_capacity`, since no completion event
+  of the recipient's own is ever coming to trigger the retry.
+
 ### Delivered sections
 
 A message that arrived from another chat is written as its own section kind — `## Request`,

--- a/.claude/rules/commands-reference.md
+++ b/.claude/rules/commands-reference.md
@@ -17,6 +17,8 @@
 | `:VibingContext [path]`               | Add file to context (or from oil.nvim if no path)                                                                                                             |
 | `:VibingClearContext`                 | Clear all context                                                                                                                                             |
 | `:VibingCancel`                       | Cancel current request                                                                                                                                        |
+| `:VibingCancelTree [path]`            | Cancel this chat's running turn and every chat below it in the orchestration tree                                                                             |
+| `:VibingOrchestrationTree [path]`     | Draw the orchestration tree this chat belongs to, with each chat's status                                                                                     |
 | `:VibingSchedule [when]`              | Schedule this chat's unsent message (default: the recorded limit reset; or `30m`, `18:30`, …)                                                                 |
 | `:VibingClearAnnotations`             | Remove inline review annotations from every buffer                                                                                                            |
 | `:VibingDebugAnalyze`                 | Ask the agent to analyze the stopped debug session (needs nvim-dap)                                                                                           |

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -95,8 +95,10 @@ export const chatTools: Tool[] = [
         queue_if_busy: {
           type: 'boolean',
           description:
-            'Queue the message instead of failing when the target chat is already responding ' +
-            '(default false, which reports an error). A queued message is delivered as a new ' +
+            'Queue the message instead of failing when it cannot be delivered right now — the ' +
+            'target chat is already responding, or the editor is at its configured limit on how ' +
+            'many chats may respond at once (default false, which reports an error). A queued ' +
+            'message is delivered as a new ' +
             'turn the moment that chat stops, and several queued messages arrive coalesced ' +
             'into one turn. Use it for anything the other chat must receive whether or not it ' +
             'happens to be busy right now — a completion report to your orchestrator, an ' +

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -206,6 +206,22 @@ section is not kept in sync field by field.
 :VibingCancel
     Cancel the request in flight.
 
+                                                    *:VibingOrchestrationTree*
+:VibingOrchestrationTree [{path}]
+    Draw the orchestration tree this chat belongs to, read from the
+    `orchestrated` / `orchestrated_by` frontmatter, with each chat's status
+    (`responding`, `idle`, `waiting_approval`, `asked_question`, `error`, or
+    `not open`). Always drawn from the root of the tree, with `←` marking
+    the chat it was run from. With no argument, uses the current chat.
+
+                                                           *:VibingCancelTree*
+:VibingCancelTree [{path}]
+    Cancel the running turn of this chat and of every chat below it in the
+    tree — a worker created with no window cannot be reached with
+    |:VibingCancel| otherwise. Chats above it are left alone. Queued
+    deliveries for the subtree are dropped first, so cancelling does not
+    immediately restart a chat with a message waiting for it.
+
                                                              *:VibingSchedule*
 :VibingSchedule [{when}]
     Schedule this chat's unsent message to send later instead of now.

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -193,9 +193,11 @@ agent = {
                             -- is the default: switching it on changes the order in which an
                             -- existing orchestration's messages arrive. Only machine-started
                             -- sends are held (nvim_chat_send_message and queued deliveries) —
-                            -- your own <CR> never waits. A send that hits the limit is refused
-                            -- unless it passed queue_if_busy, in which case it is queued and
-                            -- delivered the moment one of the running chats finishes
+                            -- your own <CR> never waits. The count does include chats you are
+                            -- driving by hand, so one long manual turn occupies a slot. A send
+                            -- that hits the limit is refused unless it passed queue_if_busy,
+                            -- in which case it is queued and delivered the moment one of the
+                            -- running chats finishes
   },
 
   codex_provider_notice = {

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -188,6 +188,16 @@ agent = {
                             -- caught by max_round_trips first, at these defaults)
   },
 
+  orchestration = {         -- How the chat network is allowed to run
+    max_concurrent = 0,     -- How many chats may be responding at once. 0 is no limit, which
+                            -- is the default: switching it on changes the order in which an
+                            -- existing orchestration's messages arrive. Only machine-started
+                            -- sends are held (nvim_chat_send_message and queued deliveries) —
+                            -- your own <CR> never waits. A send that hits the limit is refused
+                            -- unless it passed queue_if_busy, in which case it is queued and
+                            -- delivered the moment one of the running chats finishes
+  },
+
   codex_provider_notice = {
     enabled = true,         -- Warn when a Codex lightweight call leaves your model_provider.
                             -- On by default, unlike the toggles above: it spends no tokens,

--- a/lua/vibing/application/chat/chat_locator.lua
+++ b/lua/vibing/application/chat/chat_locator.lua
@@ -79,8 +79,12 @@ end
 ---
 ---開かれていないチャットは番号を持たないので `bufnr` が `nil` のまま返る — **落とさない**のが
 ---以前の `resolve_bufnrs` との違いで、パスだけでも相手を名指しできるのが #641 の要点
+---
+---`abs` も返す。開いていないチャットのfrontmatterを読む側（`orchestration_tree`）が必要とし、
+---ここは既に git ルートのキャッシュを持っているので、呼び出し元に解決をやり直させると
+---同じ変換が2回走る
 ---@param display_paths string[]|string|nil
----@return {path: string, bufnr: number?}[]
+---@return {path: string, abs: string, bufnr: number?}[]
 function M.resolve_all(display_paths)
   -- 手で `orchestrated_by: path.md` と1行で書かれると文字列としてパースされる形も含めて、
   -- リストフィールドの3つの形は `Frontmatter.as_list` が吸収する
@@ -95,7 +99,8 @@ function M.resolve_all(display_paths)
   local entries = {}
   for _, path in ipairs(paths) do
     if type(path) == "string" and vim.trim(path) ~= "" then
-      table.insert(entries, { path = path, bufnr = open_buffers[to_abs(path, git_root)] })
+      local abs = to_abs(path, git_root)
+      table.insert(entries, { path = path, abs = abs, bufnr = open_buffers[abs] })
     end
   end
 

--- a/lua/vibing/application/chat/completion_notifier.lua
+++ b/lua/vibing/application/chat/completion_notifier.lua
@@ -38,6 +38,14 @@ local round_trips = {}
 ---@type number
 local wakes = 0
 
+---並列度上限のせいで配達を見送った宛先。枠が空いたときに配り直す対象そのもの。
+---
+---「キューが空でない宛先」で代用してはいけない。配達が断られる理由は上限のほかにもあり
+---（送信が失敗した、ユーザーが下書きを書いている）、それらを同じイベントで即座に試し直すのは
+---ただの二度打ちになる。上限だけは「他のターンが終われば解ける」ので、その1つだけを覚える
+---@type table<number, boolean>
+local held_by_limit = {}
+
 ---@return {enabled: boolean, max_round_trips: number?, max_wakes: number?}
 local function settings()
   local config = require("vibing.config").get()
@@ -92,9 +100,20 @@ end
 ---
 ---「配達したら上げる」を関数にしてあるのは、`on_response_done` に呼び出し箇所が2つあるため。
 ---どちらかで書き忘れると上限が黙って連鎖を止められなくなる
+---
+---並列度上限はここで見る。配達は新しいターンを起こすことそのものなので、機械が始める送信の
+---うち「本数を増やす」のはこれと `nvim_chat_send_message` の2つしかない。見送っても捨てないので、
+---キューはそのまま残り `retry_held` が枠の空いた瞬間に配り直す
 ---@param bufnr number
 ---@return boolean restarted
+---@return boolean held 並列度上限のため配達を見送った（＝まだ用件を抱えている）
 local function drain(bufnr)
+  if MessageQueue.has_pending(bufnr) and require("vibing.application.chat.concurrency").at_capacity() then
+    held_by_limit[bufnr] = true
+    return false, true
+  end
+  held_by_limit[bufnr] = nil
+
   local restarted, delivered = MessageQueue.flush(bufnr)
   if delivered then
     -- 配られた通知1件ごとに、そのペアの往復が1回進む。全体予算のほうは「起床」の数なので、
@@ -105,7 +124,27 @@ local function drain(bufnr)
     end
     wakes = wakes + 1
   end
-  return restarted
+  return restarted, false
+end
+
+---並列度上限で見送られたキューを配り直す
+---
+---上限を解くのはターンの終了だけなので、完了イベントがそのまま「枠が空いた」の合図になる。
+---別の合図（タイマー等）を持たないのはそのため。
+---
+---上限を使っていなければ `held_by_limit` は空のままなので、既定では `next()` 1回で終わる。
+---反復中に `drain` が触るのは、いま見ているキー自身の削除か再設定だけ（新しいキーは増えない）
+---@param except_bufnr number この tick で自分の分は既に試したので飛ばす
+local function retry_held(except_bufnr)
+  for to_bufnr in pairs(held_by_limit) do
+    if to_bufnr ~= except_bufnr then
+      -- 配達できた相手は再稼働したので、直前に自分から送ったものは最終報告ではなかった。
+      -- `on_response_done` の分岐1と同じ後始末
+      if drain(to_bufnr) then
+        reported[to_bufnr] = nil
+      end
+    end
+  end
 end
 
 ---bufnr が「自分の完了を待っている相手」以外の誰かの完了を待っているか
@@ -150,6 +189,16 @@ end
 local function stopped_needing_attention(bufnr)
   local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(bufnr)
   return chat_buf ~= nil and chat_buf:get_stop_reason() ~= nil
+end
+
+---並列度上限のせいで積まれた本文を、枠が空いたときの配り直し対象にする
+---
+---`drain` が自分で見送った分は自分で覚えるが、`queue_if_busy` は配達を試す前に積むので
+---ここを通らない。しかも積まれた理由が上限のときの宛先は **idle でありうる** — 自分の完了
+---イベントは二度と来ないので、誰かが配り直さなければその本文は永久に届かない
+---@param bufnr number
+function M.hold_for_capacity(bufnr)
+  held_by_limit[bufnr] = true
 end
 
 ---A が B に送ったことを購読として記録する
@@ -262,25 +311,27 @@ function M.on_sent(from_bufnr, to_bufnr)
   MessageQueue.drop_notification(to_bufnr, from_bufnr)
 end
 
----応答完了。自分宛キューの drain と、購読者への配達を行う
----
----発火判定は3分岐（#639 / #640）:
----  1. 自分宛キューを流せた → この tick で自分が再稼働する → 配達もエッジ消費もしない
----  2. 自分が張った未消費のエッジが残っている → 子待ちでの停止 → 親への配達を保留
----  3. どちらでもない → 本当に止まった → watchdog として購読者へ配達
----2 の例外は `stopped_needing_attention`
+---発火判定の本体。分岐は `M.on_response_done` に書いてある
 ---@param bufnr number
-function M.on_response_done(bufnr)
+local function process_done(bufnr)
   -- 自分宛キューの drain が先で、しかも設定に関わらず行う。`queue_if_busy` で積まれた本文は
   -- watchdog 通知を切っている環境でも届かなければならない。
   --
   -- 配達できた = bufnr はこのターンでは終わっておらず、続きのターンが控えているということなので、
   -- この完了は購読者に見せない。順序を逆にしても防げない理由と、この規則が拾えない側の順序は
   -- architecture.md → Multi-Agent Orchestration（#638）
-  if drain(bufnr) then
+  local restarted, held = drain(bufnr)
+  if restarted then
     -- edges[bufnr] は消費せずに残す。bufnr が本当に止まったときの完了で配達される。
     -- 再稼働した以上、直前に送ったものは最終報告ではなかったので、抑止の印も捨てる
     reported[bufnr] = nil
+    return
+  end
+
+  -- 並列度上限で見送っただけなら、このチャットはまだ配達待ちを抱えている。停止とは呼べないので
+  -- 分岐2と同じく親への配達を保留し、エッジも温存する。枠が空いた完了イベントで配り直され、
+  -- そのとき再稼働するので、上の分岐が改めて答えを出す
+  if held then
     return
   end
 
@@ -321,6 +372,22 @@ function M.on_response_done(bufnr)
   end
 end
 
+---応答完了。自分宛キューの drain と、購読者への配達を行う
+---
+---発火判定は3分岐（#639 / #640）:
+---  1. 自分宛キューを流せた → この tick で自分が再稼働する → 配達もエッジ消費もしない
+---  2. 自分が張った未消費のエッジが残っている → 子待ちでの停止 → 親への配達を保留
+---  3. どちらでもない → 本当に止まった → watchdog として購読者へ配達
+---2 の例外は `stopped_needing_attention`
+---
+---そのあとに `retry_held`。このターンが終わったことで並列度の枠が1つ空いたので、上限で
+---見送られていた配達をここで拾う。順序が逆だと、空いた枠を他所に先に取られる
+---@param bufnr number
+function M.on_response_done(bufnr)
+  process_done(bufnr)
+  retry_held(bufnr)
+end
+
 ---人間が手動送信した。上限カウンタにとってはこれが起点になる
 ---
 ---`on_response_done` と対になるイベント入口で、名前もそちらに合わせてある。「bufnr の状態を
@@ -347,12 +414,13 @@ function M.forget(bufnr)
   -- autocmdはパターン無しで登録しているので、エディタ内のどのバッファを閉じても走る。
   -- 既定（無効）では状態が空のまま、全テーブルの走査だけが通常の編集操作ごとに起きる。
   -- キューは自分の空振りを自分で弾くので、ここで見るのは自分の状態だけ
-  if not (next(edges) or next(round_trips) or next(reported)) then
+  if not (next(edges) or next(round_trips) or next(reported) or next(held_by_limit)) then
     return
   end
 
   edges[bufnr] = nil
   reported[bufnr] = nil
+  held_by_limit[bufnr] = nil
   drop_pairs_of(bufnr)
 
   -- 空になった内側のテーブルはキーごと消す。残すと `next(edges)` / `next(reported)` が真のまま

--- a/lua/vibing/application/chat/concurrency.lua
+++ b/lua/vibing/application/chat/concurrency.lua
@@ -1,0 +1,74 @@
+---@class Vibing.Application.Chat.Concurrency
+---同時に走らせるチャットの本数に上限を設ける。
+---
+---扇状に配ったワーカーは全員が同時に走る。数が増えれば増えるほど1本あたりのレート制限への
+---当たりが早くなり、ローカルでは CLI プロセスがそのぶん並ぶ。上限はそれを「後で配る」に
+---変えるだけで、捨てはしない — 配達待ちは `message_queue` に残り、枠が空いた完了イベントで
+---配り直される。
+---
+---**人間の `<CR>` は決して止めない。** 見るのは機械が始める送信（`nvim_chat_send_message` と
+---キューの配達）だけで、`ChatBuffer:send_message()` 本体には手を入れていない。ユーザーが
+---打った送信が「上限です」で黙って止まるのは、この機能が買う価値のあるものではない。
+local M = {}
+
+---0（および未設定）は無制限。既定で無効なのは、有効にすると既存のオーケストレーションの
+---配達順が黙って変わるため。この機能は「レート制限に当たるようになったら締める」ための
+---つまみで、締めていないことが問題になる環境ばかりではない
+local UNLIMITED = 0
+
+---@return number limit 0なら無制限
+function M.limit()
+  local config = require("vibing.config").get()
+  local orchestration = config.agent and config.agent.orchestration
+
+  -- 型を見るのは `orchestration = true` のような壊れた設定で `setup()` 後の送信ごとに
+  -- 落ちないため。`chat_notifications` を読む側と同じ配慮
+  if type(orchestration) ~= "table" then
+    return UNLIMITED
+  end
+
+  local limit = orchestration.max_concurrent
+  if type(limit) ~= "number" or limit < 0 then
+    return UNLIMITED
+  end
+  return limit
+end
+
+---いま応答中のチャットの本数
+---@return number
+function M.responding_count()
+  local count = 0
+  for _, chat_buf in pairs(require("vibing.presentation.chat.view").list_chat_buffers()) do
+    if chat_buf:is_responding() then
+      count = count + 1
+    end
+  end
+  return count
+end
+
+---新しいターンを1本増やせない状態か
+---@return boolean
+function M.at_capacity()
+  local limit = M.limit()
+  if limit <= UNLIMITED then
+    return false
+  end
+  return M.responding_count() >= limit
+end
+
+---上限に当たったことを送信元に返す文言
+---
+---「いま混んでいる」と「待てば通る」の両方を書く。前者だけだと、モデルは同じ送信をそのまま
+---再試行して同じ理由で断られ続ける
+---@return string
+function M.at_capacity_message()
+  return string.format(
+    "%d chats are already responding, which is the configured limit "
+      .. "(agent.orchestration.max_concurrent = %d). Pass queue_if_busy so the message is "
+      .. "delivered when one of them finishes.",
+    M.responding_count(),
+    M.limit()
+  )
+end
+
+return M

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -142,6 +142,18 @@ function M.drop_notification(to_bufnr, about_bufnr)
   end)
 end
 
+---配達待ちを抱えているか
+---
+---並列度上限の判定を配達より**前**に置くために要る。上限に当たっているかを先に見て、
+---キューが空なら見送りとして数えない — 空のキューは「上限で待たされている」ではないので、
+---枠が空くたびに配り直す対象に入ってしまう
+---@param to_bufnr number
+---@return boolean
+function M.has_pending(to_bufnr)
+  local queue = pending[to_bufnr]
+  return queue ~= nil and #queue > 0
+end
+
 ---溜まったものを1ターンにまとめて配達する
 ---
 ---相手が応答中なら**何もしない**。応答中のバッファに送ると `ChatBuffer:send_message()` が

--- a/lua/vibing/application/chat/orchestration_tree.lua
+++ b/lua/vibing/application/chat/orchestration_tree.lua
@@ -1,0 +1,158 @@
+---@class Vibing.Application.OrchestrationTree
+---`orchestrated` / `orchestrated_by` の frontmatter から、チャット網を木として読み出す。
+---
+---関係の記録は既に永続層（パスのリスト）にあり、`OrchestrationChatScanner` が改名にも
+---追従させている。足りなかったのは**それを一望する手段**だけで、オーケストレータの
+---トランスクリプトを読んでも分かるのは自分が配ったところまで — 孫は出てこない。
+---
+---読む先を「開いていればバッファ、そうでなければファイル」の順にするのがこのモジュールの
+---肝になる。木のノードの大半は `back` で作られた窓なしのワーカーで、`:VibingChat` の性質上
+---1ターン目までディスクに書かれないものもある。どちらか一方しか読まないと、木は黙って
+---途中で切れる。
+local M = {}
+
+local ChatLocator = require("vibing.application.chat.chat_locator")
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+
+---親を遡るときの上限。`orchestrated_by` は手で書ける frontmatter なので、循環していなくても
+---異常に深い鎖はありうる。`seen` で循環は止まるが、深さの歯止めはこれとは別に要る
+local MAX_ASCENT = 64
+
+---@class Vibing.Application.OrchestrationTree.Node
+---@field path string gitルート相対の表示パス
+---@field abs string 実体パス
+---@field bufnr number? 開いていなければ nil
+---@field children Vibing.Application.OrchestrationTree.Node[]
+---@field repeated boolean 木の上位に既に現れたノード。子は辿らない
+
+---ノード1つぶんの frontmatter を読む
+---
+---バッファを優先するのは、保存前の編集も含めて「いまの関係」を答えるため。オーケストレータは
+---配布のたびに `orchestrated` を書き足すので、保存が追いつく前に木を見ると新しい子が消える
+---@param entry {path: string, abs: string, bufnr: number?}
+---@return table
+local function frontmatter_of(entry)
+  local region
+  if entry.bufnr and vim.api.nvim_buf_is_valid(entry.bufnr) and vim.api.nvim_buf_is_loaded(entry.bufnr) then
+    region = Frontmatter.buffer_region(entry.bufnr)
+  end
+  region = region or Frontmatter.file_region(entry.abs)
+  if not region then
+    return {}
+  end
+
+  return (Frontmatter.parse(table.concat(region, "\n"))) or {}
+end
+
+---@param entry {path: string, abs: string, bufnr: number?}
+---@param key "orchestrated"|"orchestrated_by"
+---@return {path: string, abs: string, bufnr: number?}[]
+local function linked(entry, key)
+  return ChatLocator.resolve_all(frontmatter_of(entry)[key])
+end
+
+---@param display_path string
+---@return {path: string, abs: string, bufnr: number?}?
+local function entry_for(display_path)
+  return ChatLocator.resolve_all({ display_path })[1]
+end
+
+---表示パスを根として、`orchestrated` を辿った木を組む
+---
+---同じチャットが2度現れたら `repeated` を立ててそこで止める。frontmatter は手で書けるので
+---循環しうるし、1つのワーカーが2人のオーケストレータから使われている形も表現できてしまう。
+---どちらも落とさずに描いて、辿り直しだけをやめる
+---@param display_path string
+---@return Vibing.Application.OrchestrationTree.Node?
+function M.build(display_path)
+  local root = entry_for(display_path)
+  -- 根だけは実在を確かめる。打ち間違えたパスも表示パスとしては解決できてしまうので、
+  -- 確かめないと「そのチャットは誰も動かしていない」という体裁の1ノードの木が返る。
+  -- 子には同じ検査をしない — frontmatter がまだ名前を挙げている以上、消えた子は
+  -- 「開いていない」として描かれるほうが情報になる
+  if not root or not (root.bufnr or vim.fn.filereadable(root.abs) == 1) then
+    return nil
+  end
+
+  local seen = {}
+
+  local function node_for(entry)
+    if seen[entry.abs] then
+      return { path = entry.path, abs = entry.abs, bufnr = entry.bufnr, children = {}, repeated = true }
+    end
+    seen[entry.abs] = true
+
+    local node = { path = entry.path, abs = entry.abs, bufnr = entry.bufnr, children = {}, repeated = false }
+    for _, child in ipairs(linked(entry, "orchestrated")) do
+      table.insert(node.children, node_for(child))
+    end
+    return node
+  end
+
+  return node_for(root)
+end
+
+---`orchestrated_by` を遡って、この表示パスが属する木の根を返す
+---
+---親が複数記録されていたら先頭を採る。木として運用する前提なので分岐はしないはずだが、
+---手書きの frontmatter は何でも書けるので、選ばずに諦めるよりは1本に決めて描くほうがよい
+---@param display_path string
+---@return string root_path 遡れなければ渡されたパスがそのまま返る
+function M.root_of(display_path)
+  local seen = {}
+  local current = display_path
+
+  for _ = 1, MAX_ASCENT do
+    local entry = entry_for(current)
+    if not entry or seen[entry.abs] then
+      return current
+    end
+    seen[entry.abs] = true
+
+    local parent = linked(entry, "orchestrated_by")[1]
+    if not parent then
+      return current
+    end
+    current = parent.path
+  end
+
+  return current
+end
+
+---木を行きがけ順に平らにする
+---@param node Vibing.Application.OrchestrationTree.Node?
+---@return Vibing.Application.OrchestrationTree.Node[]
+function M.flatten(node)
+  local nodes = {}
+  local function walk(current)
+    table.insert(nodes, current)
+    for _, child in ipairs(current.children) do
+      walk(child)
+    end
+  end
+  if node then
+    walk(node)
+  end
+  return nodes
+end
+
+---表示パスを実体パスに揃える。木のどのノードが「いまいる場所」かを照合するために使う
+---@param display_path string
+---@return string?
+function M.abs_of(display_path)
+  local entry = entry_for(display_path)
+  return entry and entry.abs
+end
+
+---バッファをこのモジュールが扱う表示パスに変換する
+---@param bufnr number
+---@return string? display_path 名前のないバッファなら nil
+function M.display_path_of(bufnr)
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  if name == "" then
+    return nil
+  end
+  return require("vibing.core.utils.git").to_display_path(name)
+end
+
+return M

--- a/lua/vibing/application/chat/use_cases/cancel_tree.lua
+++ b/lua/vibing/application/chat/use_cases/cancel_tree.lua
@@ -1,0 +1,47 @@
+---@class Vibing.Application.Chat.UseCases.CancelTree
+---1つのチャットを根として、そのサブツリー全体の走行中ターンをまとめて止める。
+---
+---扇状に配ったあとで方針が変わったとき、`:VibingCancel` をワーカーの数だけ繰り返すには、
+---まずワーカーがどこにいるかを知らなければならない — 窓なしで作られているので画面には出ない。
+---木は frontmatter が既に知っているので、そこから辿って止める。
+local M = {}
+
+local OrchestrationTree = require("vibing.application.chat.orchestration_tree")
+
+---@param display_path string 根にするチャットの表示パス
+---@return {path: string, bufnr: number}[] cancelled 実際に止めたチャット
+---@return number visited 木に含まれていたチャットの数
+function M.execute(display_path)
+  local nodes = OrchestrationTree.flatten(OrchestrationTree.build(display_path))
+
+  local targets = {}
+  for _, node in ipairs(nodes) do
+    -- `repeated` は同じチャットの2度目の登場なので、1度目で既に対象に入っている
+    if node.bufnr and not node.repeated then
+      table.insert(targets, node)
+    end
+  end
+
+  -- **止める前に、木の全員ぶんの購読と配達待ちを捨てる。** `cancel_request` は
+  -- `wrapped_on_done` を同期で呼び、それが `VibingResponseDone` → キューの drain に繋がるので、
+  -- 残したまま順に止めると、止めたそばから木の別のノードが配達で再稼働する。
+  -- 木の外側の親への watchdog 通知も、根のエッジごとここで落ちる — 止めたのは人間なので、
+  -- 「ワーカーが黙って止まった、読みに行け」は事実に反する
+  local CompletionNotifier = require("vibing.application.chat.completion_notifier")
+  for _, node in ipairs(targets) do
+    CompletionNotifier.forget(node.bufnr)
+  end
+
+  local view = require("vibing.presentation.chat.view")
+  local cancelled = {}
+  for _, node in ipairs(targets) do
+    local chat_buf = view.get_chat_buffer(node.bufnr)
+    if chat_buf and chat_buf:cancel_request() then
+      table.insert(cancelled, node)
+    end
+  end
+
+  return cancelled, #nodes
+end
+
+return M

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -91,6 +91,11 @@
 ---@field max_round_trips number 2チャット間（無向ペア）で連続して配達してよい通知の数。手動送信（<CR>）でリセットされる
 ---@field max_wakes number 手動送信を挟まずに配達してよい通知の総数。ツリー全体の暴走に対する最終防壁
 
+---@class Vibing.OrchestrationConfig
+---チャット網の走らせ方に関する設定
+---@field max_concurrent number 同時に応答中にできるチャットの本数。0で無制限（デフォルト: 0）。
+---  見るのは機械が始める送信（`nvim_chat_send_message`とキューの配達）だけで、人間の<CR>は止めない
+
 ---@class Vibing.AgentConfig
 ---エージェント設定
 ---Claudeのモード（code/plan/explore）とモデル（sonnet/opus/haiku/fable）を指定
@@ -104,6 +109,7 @@
 ---@field auto_resume_on_limit Vibing.AutoResumeOnLimitConfig 使用量リミット自動継続設定
 ---@field scheduled_requests Vibing.ScheduledRequestsConfig 予約リクエスト設定
 ---@field chat_notifications Vibing.ChatNotificationsConfig チャット間の完了通知設定
+---@field orchestration Vibing.OrchestrationConfig チャット網の並列度設定
 ---@field codex_provider_notice Vibing.CodexProviderNoticeConfig codex軽量呼び出しのプロバイダ警告設定
 ---@field plugins Vibing.PluginsConfig? `--plugin-dir`で読み込むClaude Codeプラグインの設定
 
@@ -305,6 +311,15 @@ M.defaults = {
       -- 配達が多くのペアに散ってペア上限に当たらない形（扇、長い循環）への最終防壁なので、
       -- 通常の運用では届かない大きさにしてある。
       max_wakes = 50,
+    },
+    orchestration = {
+      -- 同時に応答中にできるチャットの本数。0は無制限で、既定で無効なのは、有効にすると
+      -- 既存のオーケストレーションの配達順が黙って変わるため。扇の幅がレート制限に
+      -- 当たるようになったら締めるつまみ（application/chat/concurrency.lua）。
+      --
+      -- 上限に当たった送信は捨てられずキューに残り、枠が空いた完了イベントで配り直される。
+      -- 人間の<CR>はこの上限を見ない。
+      max_concurrent = 0,
     },
     -- codexの軽量呼び出しは --ignore-user-config で走るので、ユーザーの model_provider が落ちて
     -- 既定のOpenAIエンドポイントに向く。それを1セッション1回だけ警告する。

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -11,8 +11,9 @@ local ProgrammaticSender = require("vibing.presentation.chat.modules.programmati
 ---競合する。実際に配達される直前、宛先が idle になった時点で `message_queue` が書く
 ---@param bufnr number 解決済みの宛先
 ---@param params {message: string, from_bufnr?: number}
+---@param at_capacity boolean 積んだ理由に並列度上限が含まれるか
 ---@return {success: boolean, queued: boolean, bufnr: number}
-local function queue_for_later(bufnr, params)
+local function queue_for_later(bufnr, params, at_capacity)
   -- 自分自身への送信を弾く。`validate` は応答中を理由に断っていたので、この経路が
   -- できるまでは起こりえなかった。積むと自分の配達で自分が再稼働し、しかも相手が自分なので
   -- ペアが作れず `max_round_trips` の抑止も効かない（止められるのは全体予算だけになる）。
@@ -27,8 +28,16 @@ local function queue_for_later(bufnr, params)
     error(err)
   end
 
+  local Notifier = require("vibing.application.chat.completion_notifier")
   if params.from_bufnr then
-    require("vibing.application.chat.completion_notifier").on_sent(params.from_bufnr, bufnr)
+    Notifier.on_sent(params.from_bufnr, bufnr)
+  end
+
+  -- 宛先が応答中で積んだのなら、その宛先自身の完了イベントが配達の合図になる。上限で積んだ
+  -- 場合の宛先は idle でありうるので、待っていても自分のイベントは来ない。枠が空いたときに
+  -- 配り直してもらう側に登録しておく
+  if at_capacity then
+    Notifier.hold_for_capacity(bufnr)
   end
 
   return { success = true, queued = true, bufnr = bufnr }
@@ -56,9 +65,19 @@ function M.send_message(params)
 
   -- `queue_if_busy` は明示指定したときだけ効く。既定でキューに積むと、弾かれたことを検知して
   -- 待ち直すつもりだった既存の呼び出し元が、成功したものとして先に進む。
-  -- 引き受けるのは「応答中」だけ: 無効なバッファや空メッセージは待っても解けない
-  if params.queue_if_busy and ProgrammaticSender.is_responding(bufnr) then
-    return queue_for_later(bufnr, params)
+  -- 引き受けるのは「待てば解ける」2つだけ: 宛先が応答中と、編集全体が並列度上限に達している。
+  -- 無効なバッファや空メッセージは待っても解けないので、これまで通りエラーのまま
+  local Concurrency = require("vibing.application.chat.concurrency")
+  local at_capacity = Concurrency.at_capacity()
+
+  if params.queue_if_busy and (ProgrammaticSender.is_responding(bufnr) or at_capacity) then
+    return queue_for_later(bufnr, params, at_capacity)
+  end
+
+  -- 上限に当たったのに待つ気がない呼び出しは、黙って通さない。人間の<CR>はこの経路を通らない
+  -- ので、止まるのは機械が始める送信だけ
+  if at_capacity then
+    error(Concurrency.at_capacity_message())
   end
 
   -- `from_bufnr` は任意。必須にすると渡し忘れで送信そのものが失敗し、既存の

--- a/lua/vibing/infrastructure/storage/frontmatter.lua
+++ b/lua/vibing/infrastructure/storage/frontmatter.lua
@@ -348,29 +348,41 @@ function M.buffer_region(bufnr)
   return read_region(buffer_line_iterator(bufnr))
 end
 
----ファイルパスからvibing.nvimチャットファイルかどうかを判定
+---ファイル先頭のfrontmatter領域を返す
+---
+---`M.buffer_region` のファイル版。開いていないチャットのfrontmatterを読む必要がある側
+---（`application/chat/orchestration_tree`）のために公開している。開いているものと同じ
+---「領域を読んで `M.parse` に渡す」形に揃うので、読み手が2種類の経路を覚えずに済む
 ---@param file_path string ファイルパス
----@return boolean
-function M.is_vibing_chat_file(file_path)
+---@return string[]? lines 開始`---`から閉じ`---`まで(両端を含む)。閉じていなければnil
+function M.file_region(file_path)
   if not file_path or file_path == "" then
-    return false
+    return nil
   end
 
   if vim.fn.filereadable(file_path) ~= 1 then
-    return false
+    return nil
   end
 
   -- `readfile()` cannot stop at a predicate — it takes a line count — so the file
   -- is read line by line and abandoned at the closing `---`.
   local file = io.open(file_path, "r")
   if not file then
-    return false
+    return nil
   end
 
   local ok, region = pcall(read_region, file:lines())
   file:close()
 
-  if not ok or not region then
+  return ok and region or nil
+end
+
+---ファイルパスからvibing.nvimチャットファイルかどうかを判定
+---@param file_path string ファイルパス
+---@return boolean
+function M.is_vibing_chat_file(file_path)
+  local region = M.file_region(file_path)
+  if not region then
     return false
   end
 

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -338,6 +338,22 @@ function M._register_commands()
     end
   end, { desc = "Cancel current Vibing request" })
 
+  vim.api.nvim_create_user_command("VibingOrchestrationTree", function(opts)
+    require("vibing.presentation.chat.orchestration_controller").handle_tree(opts.args)
+  end, {
+    nargs = "?",
+    complete = "file",
+    desc = "Show the orchestration tree this chat belongs to, with each chat's status",
+  })
+
+  vim.api.nvim_create_user_command("VibingCancelTree", function(opts)
+    require("vibing.presentation.chat.orchestration_controller").handle_cancel_tree(opts.args)
+  end, {
+    nargs = "?",
+    complete = "file",
+    desc = "Cancel the running turn of this chat and every chat it orchestrates",
+  })
+
   vim.api.nvim_create_user_command("VibingClearAnnotations", function()
     -- Reaches into the RPC handler rather than a presentation controller, unlike the commands
     -- around it. There is no presentation state to own here: annotations live entirely in an

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -93,17 +93,33 @@ function ChatBuffer:open()
   end
 end
 
+---実行中のリクエストを止める
+---
+---`adapter:cancel` は `wrapped_on_done` を同期で呼ぶので、ハンドルの後始末（`_current_handle_id`
+---を落とす）はここではしない。`_handle_response` の handle_id 一致判定より先に消すと、
+---キャンセルした当のターンの後始末が「別のターンの応答」として捨てられる。
+---捨てたい呼び出し元（`close` / `send_message`）が、戻ってきてから自分で消す
+---@return boolean cancelled 止めるものがあったか
+function ChatBuffer:cancel_request()
+  if not self._current_handle_id then
+    return false
+  end
+
+  local adapter = self:_get_active_adapter()
+  if not adapter then
+    return false
+  end
+
+  adapter:cancel(self._current_handle_id)
+  return true
+end
+
 ---チャットウィンドウを閉じる
 function ChatBuffer:close()
   -- 実行中のリクエストをキャンセル
-  if self._current_handle_id then
-    local adapter = self:_get_active_adapter()
-    if adapter then
-      adapter:cancel(self._current_handle_id)
-    end
-    self._current_handle_id = nil
-    self._current_adapter = nil
-  end
+  self:cancel_request()
+  self._current_handle_id = nil
+  self._current_adapter = nil
 
   if self._chunk_timer then
     vim.fn.timer_stop(self._chunk_timer)
@@ -238,10 +254,7 @@ function ChatBuffer:_setup_keymaps()
       self:send_message()
     end,
     cancel = function()
-      local adapter = self:_get_active_adapter()
-      if adapter and self._current_handle_id then
-        adapter:cancel(self._current_handle_id)
-      end
+      self:cancel_request()
     end,
     update_context_line = function()
       Renderer.updateContextLine(self.buf)
@@ -431,14 +444,9 @@ function ChatBuffer:send_message()
   end
 
   -- 前のリクエストが実行中ならキャンセル（ゾンビプロセス対策）
-  if self._current_handle_id then
-    local adapter = self:_get_active_adapter()
-    if adapter then
-      adapter:cancel(self._current_handle_id)
-    end
-    self._current_handle_id = nil
-    self._current_adapter = nil
-  end
+  self:cancel_request()
+  self._current_handle_id = nil
+  self._current_adapter = nil
 
   self._is_sending = true
 

--- a/lua/vibing/presentation/chat/modules/orchestration_tree_renderer.lua
+++ b/lua/vibing/presentation/chat/modules/orchestration_tree_renderer.lua
@@ -1,0 +1,61 @@
+---@class Vibing.Presentation.OrchestrationTreeRenderer
+---`orchestration_tree` が組んだ木を、罫線付きの行の並びにする。
+---
+---状態（`responding` / `idle` / ...）を貼るのはここで、木を組む側ではない。あちらが読むのは
+---frontmatter だけ＝ディスクに残る事実で、状態は走行中のバッファにしか無い。混ぜると
+---「開いていないチャットの状態」という答えのない欄ができる
+local M = {}
+
+local ChatStatus = require("vibing.presentation.chat.modules.chat_status")
+
+---@param node Vibing.Application.OrchestrationTree.Node
+---@param current_abs string? いま開いているチャットの実体パス
+---@return string
+local function label(node, current_abs)
+  local parts = { node.path }
+
+  if node.bufnr then
+    table.insert(parts, string.format("(buffer %d)", node.bufnr))
+    -- バッファはあるのに状態が無いのは、チャットとしてアタッチされていないとき。`idle` と
+    -- 書くとポーリングできる相手に見えるので、区別できる語を出す
+    table.insert(parts, "[" .. (ChatStatus.get(node.bufnr) or "not attached") .. "]")
+  else
+    table.insert(parts, "[not open]")
+  end
+
+  if node.repeated then
+    table.insert(parts, "(shown above)")
+  end
+
+  -- 木が数ノードを超えると、自分がどこにいるのかがパスの並びからは読み取れなくなる
+  if current_abs and node.abs == current_abs then
+    table.insert(parts, "←")
+  end
+
+  return table.concat(parts, " ")
+end
+
+---@param node Vibing.Application.OrchestrationTree.Node?
+---@param current_abs string? 印を付けるノードの実体パス
+---@return string[] lines
+function M.render(node, current_abs)
+  if not node then
+    return {}
+  end
+
+  local lines = { label(node, current_abs) }
+
+  local function walk(current, prefix)
+    local last_index = #current.children
+    for i, child in ipairs(current.children) do
+      local is_last = i == last_index
+      table.insert(lines, prefix .. (is_last and "└─ " or "├─ ") .. label(child, current_abs))
+      walk(child, prefix .. (is_last and "   " or "│  "))
+    end
+  end
+
+  walk(node, "")
+  return lines
+end
+
+return M

--- a/lua/vibing/presentation/chat/orchestration_controller.lua
+++ b/lua/vibing/presentation/chat/orchestration_controller.lua
@@ -1,0 +1,80 @@
+---@class Vibing.Presentation.OrchestrationController
+---オーケストレーション網そのものを見る・止めるコマンドのPresentation層Controller。
+---
+---`controller.lua` から分けてあるのは、あちらが「1つのチャットを開く・畳む・要約する」ための
+---入り口で、こちらの対象が**チャットの集合**だから。共有するのは下の `target_path` だけで、
+---それはこの2コマンドにしか要らない
+local M = {}
+
+local notify = require("vibing.core.utils.notify")
+
+---コマンドが対象にするチャットの表示パスを決める
+---
+---引数があればそれ、無ければ「いまのチャット」。後者の解決順は `:VibingCancel` と同じで、
+---カーソルがチャット外にあるときは直近のチャットに落ちる
+---@param args string?
+---@return string? display_path 解決できなければ nil（呼び出し元が警告する）
+local function target_path(args)
+  if args and vim.trim(args) ~= "" then
+    return vim.trim(args)
+  end
+
+  local view = require("vibing.presentation.chat.view")
+  local chat_buf = view.get_current() or view._current_buffer
+  if not chat_buf then
+    return nil
+  end
+
+  return require("vibing.application.chat.orchestration_tree").display_path_of(chat_buf:get_buffer())
+end
+
+---@param args string?
+function M.handle_tree(args)
+  local path = target_path(args)
+  if not path then
+    return notify.warn("Not in a chat buffer. Pass a chat file path to draw its tree.")
+  end
+
+  local OrchestrationTree = require("vibing.application.chat.orchestration_tree")
+
+  -- 描くのは常に木の全体。オーケストレーターの1階層下しか見えないのでは、中間ノードを
+  -- 持つ木で「どこで止まっているか」が分からず、可視化の意味がない
+  local root = OrchestrationTree.build(OrchestrationTree.root_of(path))
+  if not root then
+    return notify.warn("Could not resolve a chat at " .. path)
+  end
+
+  local Renderer = require("vibing.presentation.chat.modules.orchestration_tree_renderer")
+  local lines = Renderer.render(root, OrchestrationTree.abs_of(path))
+
+  if #lines == 1 and #root.children == 0 then
+    return notify.info("This chat orchestrates no other chats:\n" .. lines[1])
+  end
+  notify.info("Orchestration tree:\n" .. table.concat(lines, "\n"))
+end
+
+---@param args string?
+function M.handle_cancel_tree(args)
+  local path = target_path(args)
+  if not path then
+    return notify.warn("Not in a chat buffer. Pass a chat file path to cancel its subtree.")
+  end
+
+  -- 根まで遡らないのが `handle_tree` との違い。指したノードから下だけを止める、が
+  -- このコマンドの意味で、上まで巻き込むと「自分の親も道連れ」になる
+  local cancelled, visited = require("vibing.application.chat.use_cases.cancel_tree").execute(path)
+
+  if #cancelled == 0 then
+    return notify.info(string.format("Nothing was running in this subtree (%d chat(s))", visited))
+  end
+
+  local names = {}
+  for _, node in ipairs(cancelled) do
+    table.insert(names, string.format("  %s (buffer %d)", node.path, node.bufnr))
+  end
+  notify.info(
+    string.format("Cancelled %d of %d chat(s) in this subtree:\n%s", #cancelled, visited, table.concat(names, "\n"))
+  )
+end
+
+return M

--- a/lua/vibing/presentation/chat/view.lua
+++ b/lua/vibing/presentation/chat/view.lua
@@ -287,6 +287,22 @@ function M._apply_chat_buffer_settings(bufnr)
   end
 end
 
+---生きているチャットバッファを列挙する
+---
+---`_attached_buffers` は `render` と `attach_to_buffer` の両方が埋めるので、`back` で作られた
+---窓なしのワーカーも入る。`_current_buffer` はそのうちの1つを指すシングルトンにすぎないので、
+---「いま何本走っているか」を数えるにはこちらしかない（`application/chat/concurrency`）
+---@return table<number, Vibing.ChatBuffer>
+function M.list_chat_buffers()
+  local buffers = {}
+  for bufnr, chat_buf in pairs(M._attached_buffers) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      buffers[bufnr] = chat_buf
+    end
+  end
+  return buffers
+end
+
 ---アタッチ済みバッファをクリーンアップ
 function M.cleanup_attached_buffers()
   for bufnr, _ in pairs(M._attached_buffers) do

--- a/tests/lua/application/chat/chat_locator_spec.lua
+++ b/tests/lua/application/chat/chat_locator_spec.lua
@@ -47,7 +47,12 @@ describe("ChatLocator.resolve_all", function()
     end
     local bufnr = open_buffer("worker.md")
 
-    assert.same({ { path = "worker.md", bufnr = bufnr } }, ChatLocator.resolve_all({ "worker.md" }))
+    -- `abs` も返る。開いていないチャットの frontmatter を読む側（`orchestration_tree`）が
+    -- 必要とし、ここは既にgitルートのキャッシュを持っている
+    assert.same(
+      { { path = "worker.md", abs = dir .. "/worker.md", bufnr = bufnr } },
+      ChatLocator.resolve_all({ "worker.md" })
+    )
   end)
 
   it("accepts the hand-written scalar form", function()
@@ -56,7 +61,10 @@ describe("ChatLocator.resolve_all", function()
     end
     local bufnr = open_buffer("worker.md")
 
-    assert.same({ { path = "worker.md", bufnr = bufnr } }, ChatLocator.resolve_all("worker.md"))
+    assert.same(
+      { { path = "worker.md", abs = dir .. "/worker.md", bufnr = bufnr } },
+      ChatLocator.resolve_all("worker.md")
+    )
   end)
 
   it("keeps a path that is not open, with no bufnr", function()
@@ -66,7 +74,7 @@ describe("ChatLocator.resolve_all", function()
       return dir
     end
 
-    assert.same({ { path = "worker.md" } }, ChatLocator.resolve_all({ "worker.md" }))
+    assert.same({ { path = "worker.md", abs = dir .. "/worker.md" } }, ChatLocator.resolve_all({ "worker.md" }))
   end)
 
   it("returns nothing for an absent or empty list", function()

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -26,7 +26,8 @@ describe("CompletionNotifier", function()
   end
 
   ---@param opts table?
-  local function configure(opts)
+  ---@param orchestration table? 並列度上限（既定は無制限で、既存の挙動と同じ）
+  local function configure(opts, orchestration)
     Config.get = function()
       return {
         agent = {
@@ -35,6 +36,7 @@ describe("CompletionNotifier", function()
             { enabled = true, max_round_trips = 8, max_wakes = 50 },
             opts or {}
           ),
+          orchestration = orchestration or { max_concurrent = 0 },
         },
       }
     end
@@ -45,6 +47,7 @@ describe("CompletionNotifier", function()
     originals.get_chat_buffer = view.get_chat_buffer
     originals.send = ProgrammaticSender.send
     originals.warn = notify.warn
+    originals.list_chat_buffers = view.list_chat_buffers
 
     buffers, responding, drafts, sends, warnings = {}, {}, {}, {}, {}
     stop_reasons = {}
@@ -85,6 +88,16 @@ describe("CompletionNotifier", function()
     notify.warn = function(message, title)
       table.insert(warnings, { message = message, title = title })
     end
+    -- 並列度上限が「いま何本走っているか」を数える先。上限を設定しないspecでは参照されない
+    view.list_chat_buffers = function()
+      local chats = {}
+      for _, bufnr in ipairs(buffers) do
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          chats[bufnr] = view.get_chat_buffer(bufnr)
+        end
+      end
+      return chats
+    end
 
     configure()
 
@@ -101,6 +114,7 @@ describe("CompletionNotifier", function()
     view.get_chat_buffer = originals.get_chat_buffer
     ProgrammaticSender.send = originals.send
     notify.warn = originals.warn
+    view.list_chat_buffers = originals.list_chat_buffers
 
     for _, bufnr in ipairs(buffers) do
       if vim.api.nvim_buf_is_valid(bufnr) then
@@ -776,6 +790,64 @@ describe("CompletionNotifier", function()
     -- 超過しても連鎖は止まる: 以降の購読は拒否される
     responding[a] = false
     assert.is_false(Notifier.subscribe(a, make_chat()))
+  end)
+
+  describe("the concurrency limit", function()
+    it("holds a delivery while the editor is at capacity and retries when a slot frees", function()
+      configure(nil, { max_concurrent = 1 })
+      local a, b, busy = make_chat(), make_chat(), make_chat()
+      responding[busy] = true
+
+      MessageQueue.enqueue_message(a, b, "carry on")
+      Notifier.on_response_done(a)
+
+      assert.equals(0, #sends, "the one slot is taken")
+
+      responding[busy] = false
+      Notifier.on_response_done(busy)
+
+      assert.equals(1, #sends, "the freed slot is what retries the held delivery")
+      assert.equals(a, sends[1].bufnr)
+    end)
+
+    it("does not report a chat as stopped while its own delivery is held", function()
+      -- 上限で見送っただけのチャットはまだ用件を抱えている。停止として扱うと、親は
+      -- 「ワーカーが止まった」と起こされ、そのあとワーカーは配達で勝手に走り出す
+      configure(nil, { max_concurrent = 1 })
+      local parent, a, b, busy = make_chat(), make_chat(), make_chat(), make_chat()
+      responding[busy] = true
+
+      Notifier.subscribe(parent, a)
+      MessageQueue.enqueue_message(a, b, "carry on")
+
+      Notifier.on_response_done(a)
+      assert.equals(0, #sends)
+
+      responding[busy] = false
+      Notifier.on_response_done(busy)
+      assert.equals(1, #sends)
+      assert.equals(a, sends[1].bufnr)
+
+      -- 購読は温存されているので、a が本当に止まったときに親へ届く
+      responding[a] = false
+      Notifier.on_response_done(a)
+
+      assert.equals(2, #sends)
+      assert.equals(parent, sends[2].bufnr)
+    end)
+
+    it("retries nothing when no limit is configured, so one refusal is not tried twice", function()
+      -- 配達が断られる理由は上限のほかにもある（送信の失敗、ユーザーの下書き）。それらを
+      -- 同じイベントで即座に試し直すのはただの二度打ちで、警告も2回出る
+      local a, b = make_chat(), make_chat()
+      send_result = { success = false }
+
+      Notifier.subscribe(a, b)
+      Notifier.on_response_done(b)
+
+      assert.equals(1, #sends)
+      assert.equals(1, #warnings)
+    end)
   end)
 
   describe("setup", function()

--- a/tests/lua/application/chat/concurrency_spec.lua
+++ b/tests/lua/application/chat/concurrency_spec.lua
@@ -1,0 +1,90 @@
+-- 同時に応答中にできるチャットの本数の上限（#645）。既定は無制限で、有効にしたときだけ
+-- 機械が始める送信を待たせる。
+
+local Config = require("vibing.config")
+local view = require("vibing.presentation.chat.view")
+local Concurrency = require("vibing.application.chat.concurrency")
+
+describe("Concurrency", function()
+  local originals = {}
+  local responding = {}
+
+  ---@param agent table?
+  local function configure(agent)
+    Config.get = function()
+      return { agent = agent }
+    end
+  end
+
+  before_each(function()
+    originals.get = Config.get
+    originals.list = view.list_chat_buffers
+    responding = {}
+
+    view.list_chat_buffers = function()
+      local buffers = {}
+      for bufnr, is_responding in pairs(responding) do
+        buffers[bufnr] = {
+          is_responding = function()
+            return is_responding
+          end,
+        }
+      end
+      return buffers
+    end
+  end)
+
+  after_each(function()
+    Config.get = originals.get
+    view.list_chat_buffers = originals.list
+  end)
+
+  it("is unlimited by default, so nothing that works today starts waiting", function()
+    configure({})
+    responding = { [1] = true, [2] = true, [3] = true }
+
+    assert.equals(0, Concurrency.limit())
+    assert.is_false(Concurrency.at_capacity())
+  end)
+
+  it("counts only the chats that are actually responding", function()
+    configure({ orchestration = { max_concurrent = 2 } })
+    responding = { [1] = true, [2] = false, [3] = false }
+
+    assert.equals(1, Concurrency.responding_count())
+    assert.is_false(Concurrency.at_capacity())
+  end)
+
+  it("is at capacity once the configured number are responding", function()
+    configure({ orchestration = { max_concurrent = 2 } })
+    responding = { [1] = true, [2] = true }
+
+    assert.is_true(Concurrency.at_capacity())
+  end)
+
+  it("survives a broken orchestration setting instead of failing every send", function()
+    -- `vim.tbl_deep_extend("force", ...)` は非テーブルで既定値ごと置き換えるので、素朴に
+    -- 索引すると boolean を index して落ちる。`chat_notifications` を読む側と同じ配慮
+    configure({ orchestration = true })
+    responding = { [1] = true }
+
+    assert.equals(0, Concurrency.limit())
+    assert.is_false(Concurrency.at_capacity())
+  end)
+
+  it("treats a negative limit as no limit rather than as capacity zero", function()
+    configure({ orchestration = { max_concurrent = -1 } })
+
+    assert.is_false(Concurrency.at_capacity())
+  end)
+
+  it("names both the current count and the escape hatch when it refuses", function()
+    -- 「いま混んでいる」だけを返すと、モデルは同じ送信をそのまま再試行して同じ理由で断られ続ける
+    configure({ orchestration = { max_concurrent = 1 } })
+    responding = { [1] = true }
+
+    local message = Concurrency.at_capacity_message()
+    assert.is_truthy(message:find("queue_if_busy", 1, true))
+    assert.is_truthy(message:find("max_concurrent = 1", 1, true))
+  end)
+end)

--- a/tests/lua/application/chat/orchestration_tree_spec.lua
+++ b/tests/lua/application/chat/orchestration_tree_spec.lua
@@ -1,0 +1,150 @@
+-- frontmatter が既に持っている木を読み出せるか。ここが読めないと、可視化もツリー cancel も
+-- 「オーケストレーターが直接配った1階層」しか見えない（#645）。
+
+local Git = require("vibing.core.utils.git")
+local ChatFiles = require("tests.helpers.chat_files")
+
+describe("OrchestrationTree", function()
+  ---gitルートのキャッシュはモジュールレベルなのでspec間で持ち越す。毎回requireし直して捨てる
+  local Tree
+  local original_get_root
+  local dir
+  local buffers = {}
+
+  before_each(function()
+    original_get_root = Git.get_root
+    dir = vim.fn.resolve(vim.fn.tempname())
+    vim.fn.mkdir(dir, "p")
+    buffers = {}
+
+    Git.get_root = function()
+      return dir
+    end
+
+    package.loaded["vibing.application.chat.chat_locator"] = nil
+    package.loaded["vibing.application.chat.orchestration_tree"] = nil
+    Tree = require("vibing.application.chat.orchestration_tree")
+  end)
+
+  after_each(function()
+    Git.get_root = original_get_root
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    vim.fn.delete(dir, "rf")
+  end)
+
+  ---@param name string
+  ---@return number bufnr
+  local function open_buffer(name)
+    local bufnr = vim.fn.bufadd(dir .. "/" .. name)
+    vim.fn.bufload(bufnr)
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  ---@param node table
+  ---@return string[]
+  local function paths_of(node)
+    local paths = {}
+    for _, entry in ipairs(Tree.flatten(node)) do
+      table.insert(paths, entry.path)
+    end
+    return paths
+  end
+
+  it("reads a whole tree out of chat files that are not open", function()
+    -- 木のノードの大半は `back` で作られた窓なしのワーカーで、開いていないことのほうが普通
+    ChatFiles.write(dir, "root.md", { orchestrated = { "b.md", "c.md" } })
+    ChatFiles.write(dir, "b.md", { orchestrated_by = { "root.md" } })
+    ChatFiles.write(dir, "c.md", { orchestrated_by = { "root.md" }, orchestrated = { "d.md" } })
+    ChatFiles.write(dir, "d.md", { orchestrated_by = { "c.md" } })
+
+    assert.same({ "root.md", "b.md", "c.md", "d.md" }, paths_of(Tree.build("root.md")))
+  end)
+
+  it("prefers the buffer over the file, so a dispatch not yet saved still shows", function()
+    -- オーケストレーターは配布のたびに `orchestrated` を書き足す。保存が追いつく前に木を見て
+    -- 新しい子が消えるなら、いちばん見たい瞬間に見えないことになる
+    ChatFiles.write(dir, "root.md", {})
+    ChatFiles.write(dir, "b.md", {})
+
+    local bufnr = open_buffer("root.md")
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    table.insert(lines, 2, "orchestrated:")
+    table.insert(lines, 3, "  - b.md")
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+
+    assert.same({ "root.md", "b.md" }, paths_of(Tree.build("root.md")))
+  end)
+
+  it("attaches the buffer number of a chat that is open", function()
+    ChatFiles.write(dir, "root.md", { orchestrated = { "b.md" } })
+    ChatFiles.write(dir, "b.md", {})
+    local bufnr = open_buffer("b.md")
+
+    local root = Tree.build("root.md")
+    assert.is_nil(root.bufnr)
+    assert.equals(bufnr, root.children[1].bufnr)
+  end)
+
+  it("stops at a chat it has already drawn instead of looping forever", function()
+    -- frontmatter は手で書けるので循環しうる。落とさずに描いて、辿り直しだけをやめる
+    ChatFiles.write(dir, "a.md", { orchestrated = { "b.md" } })
+    ChatFiles.write(dir, "b.md", { orchestrated = { "a.md" } })
+
+    local nodes = Tree.flatten(Tree.build("a.md"))
+
+    assert.same({ "a.md", "b.md", "a.md" }, { nodes[1].path, nodes[2].path, nodes[3].path })
+    assert.equals(3, #nodes)
+    assert.is_true(nodes[3].repeated)
+  end)
+
+  it("returns nothing for a path it cannot resolve", function()
+    assert.is_nil(Tree.build(""))
+  end)
+
+  it("returns nothing for a path with no chat behind it", function()
+    -- 打ち間違えたパスも表示パスとしては解決できるので、確かめないと「誰も動かしていない
+    -- チャット」の体裁で1ノードの木が返る
+    assert.is_nil(Tree.build("typo.md"))
+  end)
+
+  it("still draws a child whose file has gone, since the frontmatter still names it", function()
+    ChatFiles.write(dir, "root.md", { orchestrated = { "gone.md" } })
+
+    assert.same({ "root.md", "gone.md" }, paths_of(Tree.build("root.md")))
+  end)
+
+  it("reads a tree from a chat file with no orchestration at all", function()
+    ChatFiles.write(dir, "solo.md", {})
+
+    local root = Tree.build("solo.md")
+    assert.same({}, root.children)
+  end)
+
+  describe("root_of", function()
+    it("walks orchestrated_by up to the top", function()
+      ChatFiles.write(dir, "root.md", { orchestrated = { "mid.md" } })
+      ChatFiles.write(dir, "mid.md", { orchestrated_by = { "root.md" }, orchestrated = { "leaf.md" } })
+      ChatFiles.write(dir, "leaf.md", { orchestrated_by = { "mid.md" } })
+
+      assert.equals("root.md", Tree.root_of("leaf.md"))
+    end)
+
+    it("returns the path itself when nothing orchestrates it", function()
+      ChatFiles.write(dir, "root.md", {})
+
+      assert.equals("root.md", Tree.root_of("root.md"))
+    end)
+
+    it("gives up on a cycle rather than climbing forever", function()
+      ChatFiles.write(dir, "a.md", { orchestrated_by = { "b.md" } })
+      ChatFiles.write(dir, "b.md", { orchestrated_by = { "a.md" } })
+
+      assert.equals("a.md", Tree.root_of("a.md"))
+    end)
+  end)
+end)

--- a/tests/lua/application/chat/use_cases/cancel_tree_spec.lua
+++ b/tests/lua/application/chat/use_cases/cancel_tree_spec.lua
@@ -1,0 +1,147 @@
+-- サブツリー全体の走行中ターンをまとめて止める（#645）。窓なしで作られたワーカーは画面に
+-- 出ないので、`:VibingCancel` を人数分繰り返すには、まずどこにいるかを知る必要がある。
+
+local Git = require("vibing.core.utils.git")
+local ChatFiles = require("tests.helpers.chat_files")
+local view = require("vibing.presentation.chat.view")
+
+describe("CancelTree", function()
+  local CancelTree, MessageQueue
+  local originals = {}
+  local dir
+  local buffers = {}
+  local running = {}
+  local cancelled = {}
+  local pending_at_cancel = {}
+
+  ---@param name string
+  ---@return number bufnr
+  local function open_buffer(name)
+    local bufnr = vim.fn.bufadd(dir .. "/" .. name)
+    vim.fn.bufload(bufnr)
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  before_each(function()
+    originals.get_root = Git.get_root
+    originals.get_chat_buffer = view.get_chat_buffer
+
+    dir = vim.fn.resolve(vim.fn.tempname())
+    vim.fn.mkdir(dir, "p")
+    buffers, running, cancelled, pending_at_cancel = {}, {}, {}, {}
+
+    Git.get_root = function()
+      return dir
+    end
+
+    view.get_chat_buffer = function(bufnr)
+      if not vim.api.nvim_buf_is_valid(bufnr) then
+        return nil
+      end
+      return {
+        cancel_request = function()
+          -- 順序の観測点。配達待ちを残したまま止めると、`wrapped_on_done` が同期で走って
+          -- キューが配られ、止めたそばから同じチャットが再稼働する
+          pending_at_cancel[bufnr] = MessageQueue.has_pending(bufnr)
+          if not running[bufnr] then
+            return false
+          end
+          table.insert(cancelled, bufnr)
+          return true
+        end,
+      }
+    end
+
+    for _, name in ipairs({
+      "vibing.application.chat.chat_locator",
+      "vibing.application.chat.orchestration_tree",
+      "vibing.application.chat.message_queue",
+      "vibing.application.chat.completion_notifier",
+      "vibing.application.chat.use_cases.cancel_tree",
+    }) do
+      package.loaded[name] = nil
+    end
+    MessageQueue = require("vibing.application.chat.message_queue")
+    CancelTree = require("vibing.application.chat.use_cases.cancel_tree")
+  end)
+
+  after_each(function()
+    Git.get_root = originals.get_root
+    view.get_chat_buffer = originals.get_chat_buffer
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    vim.fn.delete(dir, "rf")
+  end)
+
+  it("stops every running chat below the one it was given", function()
+    ChatFiles.write(dir, "root.md", { orchestrated = { "mid.md" } })
+    ChatFiles.write(dir, "mid.md", { orchestrated_by = { "root.md" }, orchestrated = { "leaf.md" } })
+    ChatFiles.write(dir, "leaf.md", { orchestrated_by = { "mid.md" } })
+
+    local mid, leaf = open_buffer("mid.md"), open_buffer("leaf.md")
+    running = { [mid] = true, [leaf] = true }
+
+    local stopped, visited = CancelTree.execute("mid.md")
+
+    assert.same({ mid, leaf }, cancelled)
+    assert.equals(2, #stopped)
+    assert.equals(2, visited)
+  end)
+
+  it("leaves the chats above the given one alone", function()
+    -- 指したノードから下だけを止める、がこのコマンドの意味。上まで巻き込むと自分の親が道連れになる
+    ChatFiles.write(dir, "root.md", { orchestrated = { "mid.md" } })
+    ChatFiles.write(dir, "mid.md", { orchestrated_by = { "root.md" } })
+
+    local root, mid = open_buffer("root.md"), open_buffer("mid.md")
+    running = { [root] = true, [mid] = true }
+
+    CancelTree.execute("mid.md")
+
+    assert.same({ mid }, cancelled)
+  end)
+
+  it("counts a chat with nothing running as visited but not cancelled", function()
+    ChatFiles.write(dir, "root.md", { orchestrated = { "b.md" } })
+    ChatFiles.write(dir, "b.md", {})
+
+    local root, b = open_buffer("root.md"), open_buffer("b.md")
+    running = { [root] = true }
+
+    local stopped, visited = CancelTree.execute("root.md")
+
+    assert.equals(1, #stopped)
+    assert.equals(2, visited)
+    assert.same({ root }, cancelled)
+    assert.is_not_nil(pending_at_cancel[b])
+  end)
+
+  it("drops the delivery queue before it stops anything", function()
+    ChatFiles.write(dir, "root.md", { orchestrated = { "b.md" } })
+    ChatFiles.write(dir, "b.md", { orchestrated_by = { "root.md" } })
+
+    local root, b = open_buffer("root.md"), open_buffer("b.md")
+    running = { [root] = true, [b] = true }
+    MessageQueue.enqueue_message(b, root, "carry on")
+    assert.is_true(MessageQueue.has_pending(b), "precondition")
+
+    CancelTree.execute("root.md")
+
+    assert.is_false(pending_at_cancel[b], "the queue must be gone by the time the turn is killed")
+    assert.is_false(MessageQueue.has_pending(b))
+  end)
+
+  it("reports nothing to stop for a tree where no chat is open", function()
+    ChatFiles.write(dir, "root.md", { orchestrated = { "b.md" } })
+    ChatFiles.write(dir, "b.md", {})
+
+    local stopped, visited = CancelTree.execute("root.md")
+
+    assert.equals(0, #stopped)
+    assert.equals(2, visited)
+  end)
+end)

--- a/tests/lua/infrastructure/rpc/handlers/message_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/message_spec.lua
@@ -26,17 +26,28 @@ describe("rpc handlers.message.send_message", function()
     return bufnr
   end
 
+  ---@param max_concurrent number 0で無制限（既定）
+  local function configure(max_concurrent)
+    Config.get = function()
+      return {
+        agent = {
+          chat_notifications = { enabled = true, max_round_trips = 8, max_wakes = 50 },
+          orchestration = { max_concurrent = max_concurrent },
+        },
+      }
+    end
+  end
+
   before_each(function()
     originals.get = Config.get
     originals.get_chat_buffer = view.get_chat_buffer
+    originals.list_chat_buffers = view.list_chat_buffers
     originals.link = OrchestrationLink.link
     originals.open = ChatLocator.open
 
     buffers, chats = {}, {}
 
-    Config.get = function()
-      return { agent = { chat_notifications = { enabled = true, max_round_trips = 8, max_wakes = 50 } } }
-    end
+    configure(0)
     view.get_chat_buffer = function(bufnr)
       local chat = chats[bufnr]
       if not chat then
@@ -55,6 +66,13 @@ describe("rpc handlers.message.send_message", function()
         end,
       }
     end
+    view.list_chat_buffers = function()
+      local open = {}
+      for _, bufnr in ipairs(buffers) do
+        open[bufnr] = view.get_chat_buffer(bufnr)
+      end
+      return open
+    end
     -- リンクの書き込みはこのspecの主題ではない（ディスクに触るのも避ける）
     OrchestrationLink.link = function()
       return true, nil
@@ -68,6 +86,7 @@ describe("rpc handlers.message.send_message", function()
   after_each(function()
     Config.get = originals.get
     view.get_chat_buffer = originals.get_chat_buffer
+    view.list_chat_buffers = originals.list_chat_buffers
     OrchestrationLink.link = originals.link
     ChatLocator.open = originals.open
 
@@ -264,6 +283,40 @@ describe("rpc handlers.message.send_message", function()
     Notifier.on_response_done(a)
 
     assert.equals(0, chats[a].sends)
+  end)
+
+  it("refuses a send that would exceed the concurrency limit, naming the escape hatch", function()
+    configure(1)
+    local from, to, busy = make_chat(), make_chat(), make_chat()
+    chats[busy].responding = true
+
+    local ok, err = pcall(Message.send_message, { bufnr = to, message = "do the thing", from_bufnr = from })
+
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("queue_if_busy", 1, true))
+    assert.equals(0, chats[to].sends)
+  end)
+
+  it("queues instead of refusing when the limit is reached and queue_if_busy was passed", function()
+    -- 宛先自身は idle。待てば解けるのは「宛先が応答中」だけではない
+    configure(1)
+    local from, to, busy = make_chat(), make_chat(), make_chat()
+    chats[busy].responding = true
+
+    local result = Message.send_message({
+      bufnr = to,
+      message = "do the thing",
+      from_bufnr = from,
+      queue_if_busy = true,
+    })
+
+    assert.is_true(result.queued)
+    assert.equals(0, chats[to].sends)
+
+    chats[busy].responding = false
+    Notifier.on_response_done(busy)
+
+    assert.equals(1, chats[to].sends, "the freed slot is what delivers it")
   end)
 
   it("does not wake a chat twice when the answer it was waiting for already arrived", function()

--- a/tests/lua/presentation/chat/modules/orchestration_tree_renderer_spec.lua
+++ b/tests/lua/presentation/chat/modules/orchestration_tree_renderer_spec.lua
@@ -1,0 +1,90 @@
+-- 木を罫線付きの行にする。状態を貼るのはここで、木を組む側ではない（#645）。
+
+local ChatStatus = require("vibing.presentation.chat.modules.chat_status")
+local Renderer = require("vibing.presentation.chat.modules.orchestration_tree_renderer")
+
+describe("OrchestrationTreeRenderer", function()
+  local original_get
+  local statuses = {}
+
+  ---@param path string
+  ---@param bufnr number?
+  ---@param children table[]?
+  ---@return table
+  local function node(path, bufnr, children)
+    return { path = path, abs = "/repo/" .. path, bufnr = bufnr, children = children or {}, repeated = false }
+  end
+
+  before_each(function()
+    original_get = ChatStatus.get
+    statuses = {}
+    ChatStatus.get = function(bufnr)
+      return statuses[bufnr]
+    end
+  end)
+
+  after_each(function()
+    ChatStatus.get = original_get
+  end)
+
+  it("draws the branches and each chat's status", function()
+    statuses = { [12] = "idle", [14] = "responding", [18] = "error" }
+
+    local tree = node("root.md", 12, {
+      node("b.md", 14),
+      node("c.md", nil, { node("d.md", 18) }),
+    })
+
+    assert.same({
+      "root.md (buffer 12) [idle]",
+      "├─ b.md (buffer 14) [responding]",
+      "└─ c.md [not open]",
+      "   └─ d.md (buffer 18) [error]",
+    }, Renderer.render(tree))
+  end)
+
+  it("keeps the rail under a branch that still has siblings below it", function()
+    statuses = {}
+    local tree = node("root.md", nil, {
+      node("b.md", nil, { node("b1.md", nil) }),
+      node("c.md", nil),
+    })
+
+    assert.same({
+      "root.md [not open]",
+      "├─ b.md [not open]",
+      "│  └─ b1.md [not open]",
+      "└─ c.md [not open]",
+    }, Renderer.render(tree))
+  end)
+
+  it("says a buffer exists but is not attached rather than calling it idle", function()
+    -- `idle` と書くとポーリングできる相手に見える
+    local tree = node("root.md", 12)
+
+    assert.same({ "root.md (buffer 12) [not attached]" }, Renderer.render(tree))
+  end)
+
+  it("marks the chat the command was run from", function()
+    local tree = node("root.md", nil, { node("b.md", nil) })
+
+    assert.same({
+      "root.md [not open]",
+      "└─ b.md [not open] ←",
+    }, Renderer.render(tree, "/repo/b.md"))
+  end)
+
+  it("says a repeated node was already shown", function()
+    local repeated = node("root.md", nil)
+    repeated.repeated = true
+
+    assert.same({
+      "b.md [not open]",
+      "└─ root.md [not open] (shown above)",
+    }, Renderer.render(node("b.md", nil, { repeated })))
+  end)
+
+  it("renders nothing for a tree that could not be built", function()
+    assert.same({}, Renderer.render(nil))
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

#639 の Phase 7。オーケストレーション網の運用性を上げる3点 —— **ツリー可視化コマンド**、
**ツリー単位の cancel**、**同時 responding 数の上限** —— を実装した。

記録そのものは既に `orchestrated` / `orchestrated_by` frontmatter にあり（#641、#629）、
`OrchestrationChatScanner` が改名にも追従させている。足りなかったのは**それを一望する手段**
と、**まとめて止める手段**だった。オーケストレーターのトランスクリプトを読んでも分かるのは
自分が配ったところまでで、孫は出てこない。ワーカーは `back` で作られて窓を持たないので、
画面にも現れない。

## Changes

### 1. ツリー可視化 — `:VibingOrchestrationTree [path]`

```
.vibing/chat/orchestrator.md (buffer 12) [idle]
├─ .vibing/chat/worker-a.md (buffer 14) [responding]
└─ .vibing/chat/worker-b.md [not open] ←
   └─ .vibing/chat/worker-b1.md (buffer 18) [error]
```

- `application/chat/orchestration_tree.lua` — frontmatter から木を組む。**開いていれば
  バッファ、閉じていればファイル**の順に読む。木のノードの大半は窓なしのワーカーで、しかも
  オーケストレーターは配布のたびに `orchestrated` を書き足すため、どちらか一方しか読まないと
  木は黙って途中で切れる
- `presentation/chat/modules/orchestration_tree_renderer.lua` — 罫線と status を貼る。
  status を貼るのはこちらで、木を組む側ではない（あちらが読むのはディスクに残る事実だけで、
  status は走行中のバッファにしかない）
- 常に**木の根から**描く。1階層だけでは中間ノードを持つ木で「どこで止まっているか」が
  分からず、可視化の意味がない。`←` が実行元
- 同じチャットが2度現れたら `(shown above)` を付けてそこで止める。frontmatter は手で書けるので
  循環しうる。落とさずに描いて、辿り直しだけをやめる

### 2. ツリー単位の cancel — `:VibingCancelTree [path]`

- `application/chat/use_cases/cancel_tree.lua` — 指したノードとその子孫の走行中ターンを止める。
  **根まで遡らない**のが可視化との違いで、上まで巻き込むと自分の親が道連れになる
- **止める前に、木の全員ぶんの購読とキューを捨てる**。`cancel_request` は `wrapped_on_done` を
  同期で呼び、それが `VibingResponseDone` → キューの drain に繋がるので、残したまま順に止めると
  止めたそばから別のノードが配達で再稼働する。木の外側の親への watchdog 通知も根のエッジごと
  落ちる —— 止めたのは人間なので「ワーカーが黙って止まった、読みに行け」は事実に反する
- `ChatBuffer:cancel_request()` を公開メソッドとして切り出した。同じ4行が `close()` /
  `send_message()` / cancel キーマップに散っていたもの。ハンドルの後始末はここではしない
  （`_handle_response` の handle_id 一致判定より先に消すと、キャンセルした当のターンの
  後始末が「別のターンの応答」として捨てられる）

### 3. 並列度上限 — `agent.orchestration.max_concurrent`（既定 `0` = 無制限）

- `application/chat/concurrency.lua` — 応答中のチャット数を数え、上限に達しているかを答える
- 見るのは**機械が始める送信だけ**。`nvim_chat_send_message` とキューの配達の2つで、
  人間の `<CR>`（`ChatBuffer:send_message()`）には手を入れていない。ユーザーが打った送信が
  「上限です」で黙って止まるのは、この機能が買う価値のあるものではない
- 上限に当たった送信は**捨てない**。`queue_if_busy` なら積まれ、枠が空いた完了イベントで
  配り直される。フラグ無しの送信は現在の本数と `queue_if_busy` を名指しして断る
  （「いま混んでいる」だけ返すと、モデルは同じ送信を再試行して同じ理由で断られ続ける）
- 上限で見送ったチャットは**停止として扱わない**。まだ用件を抱えているので、親への watchdog
  配達を保留しエッジも温存する（`on_response_done` の分岐2と同じ扱い）
- 配り直しの対象は `held_by_limit` に限る。「キューが空でない宛先」で代用すると、送信失敗や
  ユーザーの下書きで断られた配達まで同じイベントで試し直すことになり、ただの二度打ちになる
- **既定で無効**なのは、有効にすると既存のオーケストレーションの配達順が黙って変わるため。
  扇の幅がレート制限に当たるようになったら締めるつまみ

### 付随する変更

- `Frontmatter.file_region(path)` — `buffer_region` のファイル版を公開し、
  `is_vibing_chat_file` をその上に載せ替えた（読み手が2種類の経路を覚えずに済む）
- `ChatLocator.resolve_all` が `abs` も返すようになった。木の走査がノードごとに同じ正規化を
  やり直さずに済む
- `view.list_chat_buffers()` — 生きているチャットバッファの列挙。`_current_buffer` は
  シングルトンなので、「いま何本走っているか」はこちらでしか数えられない

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test addition or update
- [x] Documentation update

## Testing

- [x] `pnpm run check` — pass
- [x] `pnpm run test:lua` — pass（2139 assertions, 0 failed）
- [x] `pnpm run test:node` — pass（37, 0 failed）
- [x] `pnpm run lint` — pass
- [x] `pnpm run format:check` — pass
- [x] `pnpm run check:doc` — pass

追加した spec:

| ファイル | 対象 |
| --- | --- |
| `tests/lua/application/chat/orchestration_tree_spec.lua` | ディスクからの木の読み出し、バッファ優先、循環、根の遡り、存在しないパス |
| `tests/lua/presentation/chat/modules/orchestration_tree_renderer_spec.lua` | 罫線、status、`not attached`、`←`、`(shown above)` |
| `tests/lua/application/chat/use_cases/cancel_tree_spec.lua` | サブツリーだけを止める、上は残す、**キューを捨てるのが先**（cancel 時点での観測） |
| `tests/lua/application/chat/concurrency_spec.lua` | 既定は無制限、数え方、壊れた設定、負値、文言 |
| `completion_notifier_spec.lua`（追記） | 上限での保留と枠が空いたときの配り直し、保留中は停止として報告しない、上限未設定なら二度打ちしない |
| `message_spec.lua`（追記） | 上限超過の拒否と文言、`queue_if_busy` での積み置きと枠が空いたときの配達 |

E2E（`pnpm run test:e2e`）は実トークンを消費するため未実行。

## Documentation

- [x] doc/vibing.txt updated（`:VibingOrchestrationTree` / `:VibingCancelTree`）
- [x] handbook/configuration.md updated（`agent.orchestration.max_concurrent`）
- [x] Code comments added/updated

**未反映（要手動追記）**: `.claude/rules/commands-reference.md` と
`.claude/rules/architecture.md` は編集がツール権限で拒否されたため更新できていない。
追記すべき内容は下記「Additional Context」に置いた。

## Related Issues

Fixes #645

## Additional Context

### `.claude/rules/commands-reference.md` の User Commands 表に追加

```
| `:VibingOrchestrationTree [path]`     | Draw the orchestration tree this chat belongs to, with each chat's status |
| `:VibingCancelTree [path]`            | Cancel this chat's running turn and every chat below it in the tree       |
```

### `.claude/rules/architecture.md` → Multi-Agent Orchestration に追加すべき節

- **木は frontmatter から読み、開いていればバッファを優先する**（理由は上記）
- **ツリー cancel はキューと購読を先に捨てる**（`wrapped_on_done` が同期で走るため）
- **並列度上限は機械が始める送信だけを見る**、上限で見送った停止は分岐2と同じく保留、
  配り直しの対象を `held_by_limit` に限る理由（二度打ちの回避）、`queue_if_busy` で積まれた
  分は宛先が idle でありうるので `hold_for_capacity` で明示的に登録が要ること

### 既知の制約

- 木は**プロセスローカルではない**（frontmatter を読むので再起動を跨いで正しい）が、
  status は開いているバッファにしか付かない。別の Neovim で走っているチャットは
  `[not open]` になる
- `orchestrated_by` に複数の親が書かれていた場合、`root_of` は先頭だけを辿る。木として運用する
  前提なので分岐はしないはずだが、手書きの frontmatter は何でも書けるので、選ばずに諦めるより
  1本に決めて描くほうがよいと判断した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added orchestration tree visualization with `:VibingOrchestrationTree`.
  - Added `:VibingCancelTree` to stop active chats in a subtree.
  - Added configurable limits for simultaneous chat responses.
  - Messages can be queued automatically when the concurrency limit is reached.
  - Queued messages retry when capacity becomes available.

- **Documentation**
  - Documented orchestration commands, concurrency settings, and queueing behavior.
  - Clarified when `queue_if_busy` queues messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->