### PR TITLE
fix: reject a from_bufnr that names no chat buffer

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1145,7 +1145,12 @@ Four details are load-bearing:
 - **`from_bufnr` is optional, in both directions of version skew.** The wire format carries no
   protocol version, so an older Neovim ignores the extra key and an older MCP server never sends
   it. Requiring it would turn a forgotten argument into a refused send — a worse failure than a
-  missing link, and one that would break every existing caller at once.
+  missing link, and one that would break every existing caller at once. Present-but-wrong is the
+  opposite case and errors the call (`bufnr.resolve_from_bufnr`, #661): a number that names no
+  chat buffer — typically one remembered from before a Neovim restart — used to drop the link
+  _and_ the completion subscription in silence while the caller was told the call succeeded, and
+  the MCP caller is the one party that can correct it. The check runs before any side effect, so
+  a refused `nvim_chat_create` leaves no orphaned worker chat behind.
 - **The link is written before the message is sent.** `update_frontmatter_list` edits the buffer
   directly, so writing after the worker's reply starts would race its streaming.
 - **`update_frontmatter_list` writes to the buffer, not to disk**, and the rename scanner reads

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -44,8 +44,10 @@ export const chatTools: Tool[] = [
           type: 'number',
           description:
             'Your own chat: the exact "Current vibing.nvim chat buffer number" from your ' +
-            'system prompt. Pass it whenever you create a worker — it records the ' +
-            'relationship in both chat files, which survives renames and restarts.',
+            'system prompt THIS turn — never a number remembered from earlier in the ' +
+            'conversation, which a Neovim restart silently invalidates. Pass it whenever you ' +
+            'create a worker — it records the relationship in both chat files, which survives ' +
+            'renames and restarts. A number that names no chat buffer fails the call.',
         },
       }),
       required: requireRpcPort([]),
@@ -89,8 +91,10 @@ export const chatTools: Tool[] = [
           type: 'number',
           description:
             'Your own chat: the exact "Current vibing.nvim chat buffer number" from your ' +
-            'system prompt. Pass it whenever you drive another chat — it records the ' +
-            'relationship in both chat files, which survives renames and restarts.',
+            'system prompt THIS turn — never a number remembered from earlier in the ' +
+            'conversation, which a Neovim restart silently invalidates. Pass it whenever you ' +
+            'drive another chat — it records the relationship in both chat files, which ' +
+            'survives renames and restarts. A number that names no chat buffer fails the call.',
         },
         queue_if_busy: {
           type: 'boolean',

--- a/lua/vibing/infrastructure/rpc/handlers/bufnr.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/bufnr.lua
@@ -80,4 +80,40 @@ function M.resolve_chat_target(params)
   return bufnr
 end
 
+--- Validate an optional `from_bufnr` argument — the calling chat's own buffer number.
+---
+--- Absent (nil / JSON `null`) stays fine: the orchestration link is optional by design, and a
+--- forgotten argument must not refuse the call (version skew, older MCP servers). But a value
+--- that is present and names no chat buffer is an error rather than a warning. The typical way
+--- to get here is a number carried over from before a Neovim restart; proceeding would drop the
+--- `orchestrated`/`orchestrated_by` link and the completion subscription in silence, while the
+--- MCP caller — the one party able to correct the number — is told the call succeeded (#661).
+--- @param value any
+--- @return number|nil
+function M.resolve_from_bufnr(value)
+  value = present(value)
+  if value == nil then
+    return nil
+  end
+  if type(value) ~= "number" then
+    error("from_bufnr must be a number")
+  end
+  if
+    not (
+      vim.api.nvim_buf_is_valid(value)
+      and require("vibing.presentation.chat.view").get_chat_buffer(value) ~= nil
+    )
+  then
+    error(
+      string.format(
+        "from_bufnr %d does not name a chat buffer in this Neovim session "
+          .. "(buffer numbers do not survive a restart). Pass the exact chat buffer number "
+          .. "from your current system prompt, or omit from_bufnr",
+        value
+      )
+    )
+  end
+  return value
+end
+
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -22,6 +22,10 @@ function M.create_chat(params)
     )
   end
 
+  -- チャットを作る**前**に検証する。作ったあとに弾くと、拒否されたのに空のワーカーチャットと
+  -- そのファイルだけが残る
+  local from_bufnr = require("vibing.infrastructure.rpc.handlers.bufnr").resolve_from_bufnr(params.from_bufnr)
+
   local session = require("vibing.application.chat.use_cases.create_chat").execute({
     working_dir = params.working_dir,
   })
@@ -36,8 +40,8 @@ function M.create_chat(params)
 
   -- 作成した時点でリンクを張る。送信を待つ形でも記録はできるが、`from_bufnr` の渡し忘れが
   -- 「黙って関係が残らない」失敗になるので、関係が確定する最も早い時点で書く
-  if params.from_bufnr then
-    local ok, err = require("vibing.application.chat.orchestration_link").link(params.from_bufnr, chat_buf.buf)
+  if from_bufnr then
+    local ok, err = require("vibing.application.chat.orchestration_link").link(from_bufnr, chat_buf.buf)
     if not ok then
       require("vibing.core.utils.notify").warn(
         string.format("Created chat %d but could not link it: %s", chat_buf.buf, err or "unknown"),
@@ -53,7 +57,7 @@ function M.create_chat(params)
     -- ワーカーは「誰に報告すればいいか」の行を得られない（`send_message` が
     -- `orchestrated_by` を読むため）が、オーケストレーター側が完了を知る手段まで一緒に
     -- 失う理由はない。通知はインメモリで、frontmatter を必要としない
-    require("vibing.application.chat.completion_notifier").subscribe(params.from_bufnr, chat_buf.buf)
+    require("vibing.application.chat.completion_notifier").subscribe(from_bufnr, chat_buf.buf)
   end
 
   return {

--- a/lua/vibing/infrastructure/rpc/handlers/message.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/message.lua
@@ -49,10 +49,16 @@ function M.send_message(params)
 
   -- 宛先の解決は他の副作用より先に済ませる。パスは未オープンのチャットを開く経路を通るので、
   -- ここで失敗するならリンクも購読も張られていない状態で止まってほしい
-  local bufnr = require("vibing.infrastructure.rpc.handlers.bufnr").resolve_chat_target(params)
+  local Bufnr = require("vibing.infrastructure.rpc.handlers.bufnr")
+  local bufnr = Bufnr.resolve_chat_target(params)
   if not bufnr then
     error("Missing bufnr or file_path parameter")
   end
+
+  -- `from_bufnr` も送信・キュー・リンクのどれより先に検証する。古い番号（典型は Neovim 再起動を
+  -- 跨いで使い回された値）を黙って流すと、リンクも購読も無いまま送信だけが成功し、
+  -- 訂正できる唯一の相手である呼び出し元に何も伝わらない
+  params.from_bufnr = Bufnr.resolve_from_bufnr(params.from_bufnr)
 
   -- `queue_if_busy` は明示指定したときだけ効く。既定でキューに積むと、弾かれたことを検知して
   -- 待ち直すつもりだった既存の呼び出し元が、成功したものとして先に進む。

--- a/tests/lua/infrastructure/rpc/handlers/chat_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/chat_spec.lua
@@ -78,6 +78,31 @@ describe("rpc handlers: create_chat", function()
     end
   end)
 
+  it("rejects a from_bufnr that names no chat buffer, before creating anything", function()
+    -- 典型は Neovim 再起動を跨いで会話履歴から使い回された番号（#661）。作成後に弾くと、
+    -- 拒否されたのに空のワーカーチャットとそのファイルだけが残る
+    local bufs_before = #vim.api.nvim_list_bufs()
+
+    assert.has_error(function()
+      handler.create_chat({ from_bufnr = 99999 })
+    end)
+    assert.equals(bufs_before, #vim.api.nvim_list_bufs())
+  end)
+
+  it("accepts a from_bufnr that names a real chat", function()
+    local orchestrator = handler.create_chat({})
+
+    local worker = handler.create_chat({ from_bufnr = orchestrator.bufnr })
+
+    assert.is_true(vim.api.nvim_buf_is_valid(worker.bufnr))
+  end)
+
+  it("treats an explicit null from_bufnr as absent", function()
+    local result = handler.create_chat({ from_bufnr = vim.NIL })
+
+    assert.is_true(vim.api.nvim_buf_is_valid(result.bufnr))
+  end)
+
   it("rejects a working_dir that does not exist", function()
     local ok, err = pcall(handler.create_chat, { working_dir = "nope/not/here" })
 

--- a/tests/lua/infrastructure/rpc/handlers/message_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/message_spec.lua
@@ -186,6 +186,51 @@ describe("rpc handlers.message.send_message", function()
     assert.equals(1, chats[to].sends)
   end)
 
+  it("refuses a from_bufnr that names no buffer instead of silently dropping the link", function()
+    -- 典型は Neovim 再起動を跨いで会話履歴から使い回された番号（#661）。黙って流すと
+    -- リンクも購読も無いまま送信だけが成功し、訂正できる唯一の相手（呼び出し元）に何も伝わらない
+    local to = make_chat()
+
+    assert.has_error(function()
+      Message.send_message({ bufnr = to, message = "do the thing", from_bufnr = 99999 })
+    end)
+    assert.equals(0, chats[to].sends)
+  end)
+
+  it("refuses a from_bufnr that names a buffer that is not a chat", function()
+    local to = make_chat()
+    local plain = vim.api.nvim_create_buf(false, true)
+    table.insert(buffers, plain)
+
+    assert.has_error(function()
+      Message.send_message({ bufnr = to, message = "do the thing", from_bufnr = plain })
+    end)
+    assert.equals(0, chats[to].sends)
+  end)
+
+  it("refuses a stale from_bufnr before queueing, not after", function()
+    local to = make_chat()
+    chats[to].responding = true
+
+    assert.has_error(function()
+      Message.send_message({ bufnr = to, message = "report", from_bufnr = 99999, queue_if_busy = true })
+    end)
+
+    -- 積まれていないことまで確かめる: 宛先が完了してもこのメッセージは配達されない
+    chats[to].responding = false
+    Notifier.on_response_done(to)
+    assert.equals(0, chats[to].sends)
+  end)
+
+  it("treats an explicit null from_bufnr as absent, not as a stale number", function()
+    local to = make_chat()
+
+    local result = Message.send_message({ bufnr = to, message = "do the thing", from_bufnr = vim.NIL })
+
+    assert.is_true(result.success)
+    assert.equals(1, chats[to].sends)
+  end)
+
   it("queues instead of refusing when the target is busy and the caller asked for it", function()
     local from, to = make_chat(), make_chat()
     chats[to].responding = true


### PR DESCRIPTION
# Pull Request

## Summary

`nvim_chat_create` / `nvim_chat_send_message` の `from_bufnr` に、存在しない・またはチャットでないバッファ番号が渡されたとき、警告で流す代わりに呼び出し元へエラーを返す。

典型は Neovim 再起動を跨いで会話履歴から使い回された番号（fixes #661 に実例）。従来はリンク（`orchestrated` / `orchestrated_by`）も completion 購読も**黙って**張られないまま呼び出しが成功し、訂正できる唯一の相手である MCP 呼び出し元（モデル）に何も伝わらなかった。ワーカーが完遂しても報告先を解決できず、watchdog 通知も鳴らない、という #639 のツリーオーケストレーションの土台を崩す事故につながる。

## Changes

- `handlers/bufnr.lua` に `resolve_from_bufnr` を追加。absent（`nil` / JSON `null` = `vim.NIL`）は従来どおり許容（省略可の設計は維持）。present で有効なチャットバッファを指さない場合はエラー
- `handlers/chat.lua` (create_chat): チャット作成**前**に検証。拒否時に空のワーカーチャットとファイルを残さない
- `handlers/message.lua` (send_message): 送信・キュー・リンク書き込みのどの副作用よりも先に検証（`queue_if_busy` 経路も同じ入口を通る）
- `claude-plugin/mcp-server/src/tools/chat.ts`: 両ツールの `from_bufnr` 説明に「今ターンのシステムプロンプトの値を使う。過去の会話から覚えている番号は再起動で無効」「チャットバッファを指さない番号は失敗する」を明記
- テスト追加: message_spec 4件（無効番号・非チャットバッファ・キュー経路・明示 null）、chat_spec 3件（作成前拒否・正常リンク・明示 null）

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Ran `pnpm run check`（pass）
- [x] Ran `pnpm run test:lua`（exit 0 / 2111 successes / Failed 0）
- [x] Ran `pnpm run test:node`（37 ok / 0 fail）
- [x] Ran `pnpm run lint`
- [x] Ran `pnpm run format:check`

### Test Environment

- **Neovim version**: NVIM v0.11
- **Operating System**: macOS 15 (Darwin 25.6.0)
- **Node.js version**: v22

## Documentation

- [x] Code comments added/updated (if applicable)
- [x] CLAUDE.md updated (if applicable) — `.claude/rules/architecture.md`

`.claude/rules/architecture.md` の「Multi-Agent Orchestration」→ `from_bufnr` is optional の箇条書きにも present-but-wrong の設計メモを追記済み（2コミット目）。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat creation and message sending now reject missing or invalid chat buffer references before performing any actions.
  * Stale buffer numbers from previous Neovim sessions no longer silently proceed without proper chat linking or notifications.
  * Buffer references from the current system prompt are now clearly documented.
  * Optional `from_bufnr` values are handled correctly when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
