### PR TITLE
fix: stop naming gitignored .vibing in the snapshot's git add pathspec

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -781,7 +781,24 @@ Three details are not interchangeable:
   patches themselves and changes during the turn, so for anyone who has not git-ignored it every
   turn would list the conversation log as its own output and put the whole transcript in the patch.
   The removed mote integration excluded the same directory through `.moteignore`. The exclusion is
-  on the diff calls (where it matters) and on `git add -A` (where it saves hashing).
+  unconditional on the diff calls (where it matters) and **conditional on `git add -A`**, where it
+  only ever saved hashing — because naming it there is what killed the whole mechanism until #664.
+  `git add` exits 1 when a pathspec explicitly names an ignored path, and it applies that to a
+  **negative** pathspec too, so in any project that git-ignores `.vibing/` — the setup this
+  plugin's own docs recommend, and this repository's own `.gitignore` —
+  `git add -A -- . ':(exclude).vibing'` always failed. Only the exit code failed: staging completed
+  and `write-tree` succeeded, but `snapshot()` reads the code, so no baseline was ever taken and
+  every turn fell silently back to `request_diff` — losing exactly the Bash-driven changes #625 was
+  filed about. `add_pathspec` therefore asks `git check-ignore -q .vibing` once per worktree root
+  and drops the exclude when git is already skipping the directory. An undecidable answer keeps the
+  exclude, since keeping it wrongly costs only the one case above while dropping it wrongly puts a
+  whole `.vibing/worktrees/` checkout in the patch. Measured against git 2.50.1: `--ignore-errors`
+  and every `:(exclude...)` spelling exit 1 alike, and plain `-- .` exits 0.
+
+  The spec that missed this is worth naming, because the gap was in the fixture rather than in the
+  assertions: its `.gitignore` held `ignored/` and `*.log` only, so `.vibing/` was never ignored in
+  any test, and the one case pinned for this directory was literally the working one — "even when
+  it is not gitignored". Both are pinned now.
 
 **The two baselines are taken under separate `pcall`s** (`permission._capture_baselines`). Sharing
 one would let the fallback take the main path down with it: `request_diff.capture` builds its

--- a/lua/vibing/core/utils/git_snapshot.lua
+++ b/lua/vibing/core/utils/git_snapshot.lua
@@ -31,6 +31,34 @@ local SESSION_TTL_SEC = 3600
 ---@type string
 local EXCLUDE_VIBING_DIR = ":(exclude).vibing"
 
+---`git add` の pathspec。`.vibing` が既に無視されているworktreeでは exclude を **付けない**
+---
+---`git add` は「無視対象のパスを明示的に指定した」と判断すると exit 1 を返す。これは
+---`:(exclude)` のネガティブ pathspec でも起きる — git はネガティブ側の要素も
+---「明示的に指定されたパス」として無視判定にかけるため、`.vibing/` を `.gitignore` に
+---入れているプロジェクト（このプラグインがドキュメントで勧めている構成そのもの）では
+---`git add -A -- . ':(exclude).vibing'` が必ず失敗する。
+---
+---厄介なのは **失敗しているのは終了コードだけ** という点。ステージングは正常に完了し
+---`write-tree` も通るが、`snapshot()` は `added.code ~= 0` で nil を返すので、
+---ベースラインが1度も作られず、スナップショット経路が丸ごと死ぬ。実測（git 2.50.1）:
+---
+---    git add -A -- . ':(exclude).vibing'          -> 1  ("paths are ignored by .gitignore")
+---    git add -A -- . ':(exclude).vibing/'         -> 1
+---    git add -A --ignore-errors -- . ':(exclude)…'-> 1
+---    git add -A -- .                              -> 0
+---
+---`add` 側の exclude はそもそも「`.vibing/` 配下をハッシュ計算しない」ための節約でしかない
+---（本命は `git diff` 側で、そちらは常に付ける）。無視されているなら git がどうせ飛ばすので、
+---外しても何も失われない。逆に無視されていないプロジェクトでは exclude が必要で、そちらでは
+---git は文句を言わない。だから「無視されているか」を1度聞いて分岐するのが両方成立する形。
+---
+---判定できなかったときは exclude を **付ける** 側に倒す。付けて壊れるのは無視されている
+---場合だけで、外して壊れるのは `.vibing/worktrees/` を丸ごとpatchに入れてしまう場合なので、
+---不明なときの被害が小さいのは前者。
+---@type table<string, string[]>
+local add_pathspec_cache = {}
+
 ---commit-treeはcommitterのidentityを要求する。ユーザーが `user.email` を設定していない環境
 ---（CI・素のコンテナ）でスナップショットだけ失敗するのを避けるため、この呼び出しにだけ効く
 ---identityを渡す。ユーザーのgit設定は読みも書きもしない。
@@ -103,6 +131,22 @@ local function git(cmd, root, env)
     return nil
   end
   return result
+end
+
+---`git add` に渡す pathspec を決める（rootにつき1回だけgitに聞く）
+---理由は `add_pathspec_cache` のコメント参照
+---@param root string worktreeルート
+---@return string[] pathspec
+local function add_pathspec(root)
+  local cached = add_pathspec_cache[root]
+  if cached then
+    return cached
+  end
+  -- check-ignore は 0=無視されている / 1=されていない / 128=エラー
+  local ignored = git({ "git", "check-ignore", "-q", ".vibing" }, root)
+  local spec = (ignored and ignored.code == 0) and { "." } or { ".", EXCLUDE_VIBING_DIR }
+  add_pathspec_cache[root] = spec
+  return spec
 end
 
 ---worktreeルートを解決する
@@ -182,7 +226,9 @@ local function snapshot(root)
 
   local env = vim.tbl_extend("force", { GIT_INDEX_FILE = tmp_index }, GIT_ENV)
 
-  local added = git({ "git", "add", "-A", "--", ".", EXCLUDE_VIBING_DIR }, root, env)
+  local add_cmd = { "git", "add", "-A", "--" }
+  vim.list_extend(add_cmd, add_pathspec(root))
+  local added = git(add_cmd, root, env)
   if not added or added.code ~= 0 then
     vim.fn.delete(tmp_index)
     return nil
@@ -600,6 +646,7 @@ function M._reset()
   sessions = {}
   root_cache = {}
   swept_roots = {}
+  add_pathspec_cache = {}
 end
 
 M._REF_PREFIX = REF_PREFIX

--- a/tests/lua/core/utils/git_snapshot_spec.lua
+++ b/tests/lua/core/utils/git_snapshot_spec.lua
@@ -242,6 +242,35 @@ describe("git_snapshot", function()
       assert.is_nil(turn.patch:find(".vibing", 1, true))
     end)
 
+    it("still snapshots when .vibing itself is gitignored", function()
+      -- `git add` は「無視対象のパスを明示的に指定した」と判断すると exit 1 を返し、それは
+      -- `:(exclude)` のネガティブ pathspec でも起きる。つまり `.vibing/` を `.gitignore` に
+      -- 入れている構成 — このプラグインが勧めている構成そのもの — では
+      -- `git add -A -- . ':(exclude).vibing'` が必ず失敗し、ベースラインが1度も作られず
+      -- スナップショット経路が丸ごと死ぬ。ステージング自体は成功していて終了コードだけが
+      -- 1 なので、何の警告も出ないまま毎ターン request_diff にフォールバックしていた。
+      --
+      -- 上の「gitignoreしていない場合」のケースだけがテストされていたのが見逃した理由なので、
+      -- 両方を並べて固定する。
+      write(repo .. "/.gitignore", "ignored/\n*.log\n.vibing/\n")
+      git_ok({ "add", ".gitignore" })
+      git_ok({ "commit", "-q", "-m", "ignore .vibing" })
+      write(repo .. "/.vibing/chat/2026-01-01.md", "## User\nhello\n")
+      GitSnapshot._reset()
+
+      local handle = next_handle()
+      GitSnapshot.ensure_baseline(handle, repo, "Bash")
+      assert.is_true(GitSnapshot.has_baseline(handle))
+
+      write(repo .. "/tracked.txt", "after\n")
+      local files, _, patch, ok = GitSnapshot.generate(handle, nil)
+
+      assert.is_true(ok)
+      assert.same({ "tracked.txt" }, files)
+      assert.is_truthy(patch:find("+after", 1, true))
+      assert.is_nil(patch:find(".vibing", 1, true))
+    end)
+
     it("lists a tool-event path that git does not see, without a patch section", function()
       -- .gitignore対象でもツール引数で分かっている分は一覧には載せる（patchは作らない）
       local turn = run_turn(function()


### PR DESCRIPTION
## Summary

`#626` で入れたリクエスト単位のツリースナップショット差分が、**このリポジトリを含む「`.vibing/` を `.gitignore` に入れている構成」では一度も成立していませんでした。** 主経路が黙って死んでいたため、毎ターン `request_diff` にフォールバックしており、`#625` で解決したはずの「Bash 由来の変更が差分に出ない」がそのまま残っていました。

原因は `git add` の終了コードです。

```console
$ git add -A -- . ':(exclude).vibing'
The following paths are ignored by one of your .gitignore files:
.vibing
hint: Use -f if you really want to add them.
$ echo $?
1
```

git は **ネガティブ pathspec の要素も「明示的に指定されたパス」として無視判定にかける** ため、`.vibing/` が `.gitignore` に入っていると必ず exit 1 になります。厄介なのは **壊れているのが終了コードだけ** という点で、ステージングは正常に完了し `write-tree` も通ります。しかし `snapshot()` は `added.code ~= 0` で `nil` を返すので:

1. `ensure_baseline` がセッションを作らない
2. `get_root()` が常に nil → `use_snapshot = false`
3. 毎ターン `request_diff`（Write/Edit の引数に出たファイルしか退避しない）にフォールバック

結果として、Bash（`sed -i` / フォーマッタ / `mv`）・MCP の `nvim_set_buffer`・サブエージェント経由の変更は:

- `### Modified Files` にはツールイベント由来のパスだけが載り、`<!-- patch: … -->` コメントが出ない → `gd` が `PatchViewer` に入らず `DiffSelector` にフォールバックしてフロートが出ない
- Bash だけで完結したターンでは Modified Files すら出ず、しかも「変更を読めませんでした」警告は `use_snapshot` で gate されていてこの場合まさに false → **完全に無言**

実際に残っている patch ファイルは `#626` マージ後のものも含めて全て `request_diff` 形式（`index <sha>..<sha>` 行が無い）で、`refs/worktree/vibing/*` は 1 本も作られた形跡がありませんでした。稼働中の Neovim で直接確認した結果:

```
:lua =require("vibing.core.utils.git_snapshot")._session("<このターンの handle>")
→ "nil"    -- Bash を何度も実行したターンなのにセッションが無い
```

## Changes

- `git_snapshot.lua` に `add_pathspec()` を追加。worktree ルートごとに `git check-ignore -q .vibing` を **1 回だけ** 聞き、既に無視されているなら `git add` の pathspec から exclude を外す（無視されているなら git がどうせ飛ばすので、外しても何も失われない）
- `git diff` 側の exclude は **無変更**。会話ログを patch から外す本命はそちらなので、常に付ける
- 判定不能（`check-ignore` が 128 等）なら exclude を **付ける** 側に倒す。付けて壊れるのは今回直したケースだけだが、外して壊れると `.vibing/worktrees/` の checkout が丸ごと patch に入るため
- `.claude/rules/architecture.md` の「The exclusion is on the diff calls (where it matters) and on `git add -A` (where it saves hashing)」を実装に合わせて修正し、exit code の挙動・実測値・spec の穴を記録
- 回帰テストを追加

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Tested locally in Neovim
- [x] Ran `pnpm run test:lua`（全 spec 通過、exit 0）
- [x] Ran `pnpm run format:check`
- [x] Ran `pnpm run check:doc`
- [x] Manual testing completed

追加した回帰テスト `"still snapshots when .vibing itself is gitignored"` が **vacuous でないこと** を確認しています。`add_pathspec()` の呼び出しを元の `{ ".", EXCLUDE_VIBING_DIR }` に戻すと落ちます。

```text
修正を戻した状態: Fail || git_snapshot generate still snapshots when .vibing itself is gitignored
                  Success: 53   Failed : 1

修正あり:         Success: 54   Failed : 0   Errors : 0
```

git 2.50.1 に対する実測（pathspec の綴りを変えても回避できないことの確認）:

| コマンド | exit |
| --- | --- |
| `git add -A -- . ':(exclude).vibing'` | 1 |
| `git add -A -- . ':(exclude).vibing/'` | 1 |
| `git add -A -- . ':(exclude,glob).vibing/**'` | 1 |
| `git add -A --ignore-errors -- . ':(exclude).vibing'` | 1 |
| `git add -A -- .` | 0 |

### Test Environment

- **Neovim version**: NVIM v0.11 系（ローカル `~/.local/nvim`）
- **Operating System**: macOS (Darwin 25.6.0)
- **git version**: 2.50.1 (Apple Git-155)

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [x] CLAUDE.md updated (if applicable) — `.claude/rules/architecture.md`
- [x] Code comments added/updated (if applicable)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

#625 で報告された「Bash 由来の変更が差分に出ない」は `#626` でマージされたものの、上記の理由で実際には効いていませんでした。close キーワードは付けていません（#625 は既に closed で、こちらはその follow-up です）。

## Additional Context

`.vibing/` を `.gitignore` に入れていないユーザーでは `git add` が文句を言わないため、この不具合は発生しません。テストのフィクスチャがまさにその構成（`.gitignore` が `ignored/` と `*.log` のみ）だったことが、`#626` の spec 群を通り抜けた理由です。今回そこに両方のケースを並べました。

また、**このバグの影響下では `send_message.lua` の「変更を読めませんでした」警告が届かない** ことも確認しています。あの警告は `use_snapshot` が真のときだけ出るので、スナップショットが成立しない今回のケースでは点灯しません。本 PR でスナップショットが成立するようになるため実害は解消しますが、フォールバックの無言化そのものは別途検討の余地があります。
