### PR TITLE
test: stop the permission decision spec snapshotting the developer's repository

### DIFF
--- a/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
@@ -20,6 +20,17 @@ local comm_dir
 ---gitの外を指しておけば `worktree_root` が nil を返し、スナップショットは試みられない。
 local sandbox_cwd
 
+---`active_opts` を差し替える唯一の入口
+---
+---`set_active_opts` は渡したテーブルで **丸ごと置き換える** ので、権限だけを差し替えたい
+---テストが `cwd` を書き忘れると、そのテストだけが実リポジトリをスナップショットしてしまう。
+---before_each で1度渡すだけでは足りず、実際に1件見落としていた（#665 のレビュー指摘）。
+---入口を1つにしておけば、テストを足すときに `cwd` を意識する必要がなくなる。
+---@param opts table
+local function activate(opts)
+  permission.set_active_opts(HANDLE_ID, vim.tbl_extend("force", { cwd = sandbox_cwd }, opts))
+end
+
 local function write_request(request_id, tool_name, tool_input)
   local f = assert(io.open(comm_dir .. "/" .. request_id .. ".req", "w"))
   f:write(vim.json.encode({ tool_name = tool_name, tool_input = tool_input or {} }))
@@ -47,23 +58,29 @@ describe("permission handler hook decision", function()
     vim.env.VIBING_HOOK_COMM_DIR = comm_dir
     sandbox_cwd = vim.fn.tempname()
     vim.fn.mkdir(sandbox_cwd, "p")
-    permission.set_active_opts(HANDLE_ID, {
+    activate({
       permissions_allow = { "Read" },
       permissions_deny = { "Bash" },
       permission_mode = "acceptEdits",
-      cwd = sandbox_cwd,
     })
   end)
 
   after_each(function()
     permission.clear_active_opts(HANDLE_ID)
-    -- sandbox_cwd がgitの外である限りセッションは作られないが、ここは「作られていたら
-    -- 実リポジトリのrefを残さずに片付ける」ための保険。clearは冪等。
+    -- 「このspecはスナップショットを取らない」を全テストに効く不変条件として毎回見る。
+    -- `activate` を入口に1つ用意しても、それを通さない `set_active_opts` を直に呼ぶテストが
+    -- 足されれば `cwd` は落ちる（#665 のレビューで実在した見落とし）。ここで見ておけば、
+    -- あとから足したテストも書き手が意識せずに守られる — `after_each` の失敗は
+    -- PlenaryBustedDirectory の終了コードに乗るので、CIのゲートに届く（実測）。
+    --
+    -- clearを先に済ませてからassertするのは、落ちた場合でも実リポジトリにrefを残さないため。
     -- 下の `_capture_baselines` describe は git_snapshot を丸ごと差し替えるので、その復元より
-    -- こちらが先に走ると `clear` が存在しない。保険をspecの失敗にはしない
+    -- こちらが先に走ることがある。差し替え中は見ない
     local GitSnapshot = require("vibing.core.utils.git_snapshot")
-    if GitSnapshot.clear then
+    if GitSnapshot.has_baseline and GitSnapshot.clear then
+      local snapshotted = GitSnapshot.has_baseline(HANDLE_ID)
       GitSnapshot.clear(HANDLE_ID)
+      assert.is_false(snapshotted)
     end
     vim.env.VIBING_HOOK_COMM_DIR = original_comm_dir
     vim.fn.delete(comm_dir, "rf")
@@ -73,9 +90,16 @@ describe("permission handler hook decision", function()
   it("takes no working-tree snapshot of the repository the suite runs in", function()
     -- 決定パスを通しても、このspecがスナップショットを取らないことを固定する。`cwd` を
     -- 実リポジトリに向け直すと、ここが落ちる
-    decide("req-no-snapshot", "Edit", { file_path = sandbox_cwd .. "/x.txt" })
+    local GitSnapshot = require("vibing.core.utils.git_snapshot")
 
-    assert.is_false(require("vibing.core.utils.git_snapshot").has_baseline(HANDLE_ID))
+    decide("req-no-snapshot", "Edit", { file_path = sandbox_cwd .. "/x.txt" })
+    assert.is_false(GitSnapshot.has_baseline(HANDLE_ID))
+
+    -- 権限を差し替えたあとも同じであること。`set_active_opts` を直に呼ぶと `cwd` が落ちるので、
+    -- `activate` を経由しない再設定が入ったらここが落ちる
+    activate({ permissions_allow = { "Edit" }, permission_mode = "acceptEdits" })
+    decide("req-no-snapshot-2", "Edit", { file_path = sandbox_cwd .. "/y.txt" })
+    assert.is_false(GitSnapshot.has_baseline(HANDLE_ID))
   end)
 
   it("grants vibing-nvim's own MCP tools outright", function()
@@ -99,7 +123,7 @@ describe("permission handler hook decision", function()
     -- gets. "allow" would hand an unrelated MCP server the same bypass of the user's own
     -- settings.json that vibing-nvim's own tools get.
     local LOOKALIKE = "mcp__my-vibing-nvim__nvim_get_buffer"
-    permission.set_active_opts(HANDLE_ID, {
+    activate({
       permissions_allow = { LOOKALIKE },
       permission_mode = "acceptEdits",
     })

--- a/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_decision_spec.lua
@@ -9,6 +9,17 @@ local HANDLE_ID = "decision-spec-handle"
 
 local comm_dir
 
+---`active_opts.cwd` に渡す、gitの外のディレクトリ
+---
+---許可された決定はどれも `_capture_baselines` を通り、そこで本当にベースラインを取る。
+---`cwd` を渡さないと `git_snapshot` は Neovim のカレントディレクトリ — つまり開発中の
+---リポジトリそのもの — を対象にしてしまい、テストを走らせるだけで実リポジトリに
+---`refs/worktree/vibing/decision-spec-handle` とスナップショットのオブジェクトが残る。
+---#664 で `git add` が通るようになって初めて表面化した（それまでは `git add` が exit 1 で
+---落ちていたので、何も起きていなかった）。
+---gitの外を指しておけば `worktree_root` が nil を返し、スナップショットは試みられない。
+local sandbox_cwd
+
 local function write_request(request_id, tool_name, tool_input)
   local f = assert(io.open(comm_dir .. "/" .. request_id .. ".req", "w"))
   f:write(vim.json.encode({ tool_name = tool_name, tool_input = tool_input or {} }))
@@ -34,17 +45,37 @@ describe("permission handler hook decision", function()
     comm_dir = vim.fn.tempname()
     vim.fn.mkdir(comm_dir, "p")
     vim.env.VIBING_HOOK_COMM_DIR = comm_dir
+    sandbox_cwd = vim.fn.tempname()
+    vim.fn.mkdir(sandbox_cwd, "p")
     permission.set_active_opts(HANDLE_ID, {
       permissions_allow = { "Read" },
       permissions_deny = { "Bash" },
       permission_mode = "acceptEdits",
+      cwd = sandbox_cwd,
     })
   end)
 
   after_each(function()
     permission.clear_active_opts(HANDLE_ID)
+    -- sandbox_cwd がgitの外である限りセッションは作られないが、ここは「作られていたら
+    -- 実リポジトリのrefを残さずに片付ける」ための保険。clearは冪等。
+    -- 下の `_capture_baselines` describe は git_snapshot を丸ごと差し替えるので、その復元より
+    -- こちらが先に走ると `clear` が存在しない。保険をspecの失敗にはしない
+    local GitSnapshot = require("vibing.core.utils.git_snapshot")
+    if GitSnapshot.clear then
+      GitSnapshot.clear(HANDLE_ID)
+    end
     vim.env.VIBING_HOOK_COMM_DIR = original_comm_dir
     vim.fn.delete(comm_dir, "rf")
+    vim.fn.delete(sandbox_cwd, "rf")
+  end)
+
+  it("takes no working-tree snapshot of the repository the suite runs in", function()
+    -- 決定パスを通しても、このspecがスナップショットを取らないことを固定する。`cwd` を
+    -- 実リポジトリに向け直すと、ここが落ちる
+    decide("req-no-snapshot", "Edit", { file_path = sandbox_cwd .. "/x.txt" })
+
+    assert.is_false(require("vibing.core.utils.git_snapshot").has_baseline(HANDLE_ID))
   end)
 
   it("grants vibing-nvim's own MCP tools outright", function()


### PR DESCRIPTION
## Summary

`#664` をマージした直後の cleanup 中に、**テストスイートが開発中のリポジトリにスナップショットを書き込む**ようになっていることに気付きました。`pnpm run test:lua` を1回流しただけで、実リポジトリに以下が残ります。

```console
$ git for-each-ref refs/worktree/
refs/worktree/vibing/decision-spec-handle 2026-09-02 15:36:02 +0900 af5420b
```

`permission_decision_spec.lua` の `active_opts` に `cwd` が無いため、許可された決定が通る `_capture_baselines` → `git_snapshot.ensure_baseline` が `worktree_root(nil)` = **Neovim のカレントディレクトリ = スイートを走らせている checkout そのもの** を対象にワーキングツリー全体のスナップショットを取り、ref とオブジェクトを置いていっていました。

**`#664` までは潜在バグでした。** それまでは `git add -A -- . ':(exclude).vibing'` が exit 1 で落ちていたため `snapshot()` が nil を返し、何も書かれていませんでした。スナップショット経路を直したことで、無害な no-op が「1 実行あたり1回、開発者のリポジトリへの副作用」に変わった、という形です。

## Changes

- `active_opts.cwd` を git の外の一時ディレクトリに向けた。`worktree_root` が nil を返すので **スナップショットがそもそも試みられない**
  - 「取ってから片付ける」ではなく「取らない」を選んだのは、前者だと example ごとに `git add -A` のフルスキャン（実測 9k ファイルで 20ms、80k で 63ms）を払い続けることになるため
- `after_each` に `GitSnapshot.clear(HANDLE_ID)` を保険として追加。ネストした `_capture_baselines` describe がモジュールを丸ごと差し替え、その復元がこちらより後に走ることがあるため、`clear` の存在を確認してから呼ぶ（無条件に呼ぶと `attempt to call field 'clear' (a nil value)` になる。実際に踏みました）
- 回帰テスト `"takes no working-tree snapshot of the repository the suite runs in"` を追加

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Ran `pnpm run test:lua`（全 spec 通過、exit 0）
- [x] Ran `pnpm run format:check`
- [x] Manual testing completed

追加テストが vacuous でないことを確認済み。`cwd` を実リポジトリに向け直すと落ちます。

```text
cwd = vim.fn.getcwd():   Fail || takes no working-tree snapshot of the repository the suite runs in
                         Success: 8   Failed : 1

cwd = sandbox_cwd:       Success: 9   Failed : 0   Errors : 0
```

スイート全体を流した後に ref が残らないことも確認しました。

```console
$ pnpm run test:lua; echo $?
0
$ git for-each-ref refs/worktree/ | wc -l
0
```

### Test Environment

- **Neovim version**: NVIM v0.11 系
- **Operating System**: macOS (Darwin 25.6.0)
- **git version**: 2.50.1 (Apple Git-155)

## Documentation

- [ ] README.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [x] Code comments added/updated (if applicable)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

#664 の follow-up です。

## Additional Context

`#664` をマージ済みの環境では、既に `refs/worktree/vibing/decision-spec-handle` が残っている可能性があります。手元では以下で掃除しました（ref を外したオブジェクトは dangling になり、通常の `gc --auto` が回収します）。

```console
$ git update-ref -d refs/worktree/vibing/decision-spec-handle
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved permission-handler test isolation by ensuring decisions run in controlled temporary directories.
  * Added assertions confirming that test runs do not capture unintended repository snapshots.
  * Expanded coverage to verify this behavior remains consistent after permission changes and subsequent decisions.
  * Strengthened test cleanup and state validation to detect leftover snapshot data between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->