### PR TITLE
chore: add SessionStart hook so web sessions can run the test suite

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook for Claude Code on the web.
+#
+# The remote container ships node and git but neither Neovim nor a Lua compiler, so four of
+# this repository's five gates cannot even start there: `test:lua`, `test:e2e` and `check:doc`
+# invoke `nvim`, and `check` invokes `luac`. This installs what they need, mirroring the
+# "Setup Neovim" / "Install plenary.nvim" / "Install Lua" steps of .github/workflows/ci.yml so
+# a web session passes and fails on the same things CI does.
+#
+# It is deliberately synchronous: the first thing a session here typically does is run the
+# suite, and an async hook would let that start against a half-installed environment.
+set -euo pipefail
+
+# A local machine already has the developer's own Neovim, package manager and Lua. Touching
+# /opt and /usr/local there would be rude and is never what is wanted.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# CI pins `version: stable` via rhysd/action-setup-vim, so this tracks the same tag rather than
+# a number that would silently drift away from it. Override to reproduce a version-specific bug.
+NVIM_VERSION="${VIBING_NVIM_VERSION:-stable}"
+NVIM_PREFIX="${VIBING_NVIM_PREFIX:-/opt/nvim}"
+
+# tests/minimal_init.lua resolves plenary from `vim.fn.stdpath("data")`, which honours
+# XDG_DATA_HOME — so this has to as well, or the clone lands where nothing looks for it.
+PLENARY_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/nvim/site/pack/vendor/start/plenary.nvim"
+
+# Progress goes to stderr. A SessionStart hook's stdout is prepended to the session as context,
+# and none of this is worth the tokens; stderr is still surfaced when the hook fails.
+log() { printf '[session-start] %s\n' "$*" >&2; }
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+elif command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+install_neovim() {
+  if command -v nvim >/dev/null 2>&1; then
+    log "neovim present: $(nvim --version | head -1)"
+    return
+  fi
+
+  local arch
+  case "$(uname -m)" in
+    x86_64 | amd64) arch="x86_64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *)
+      log "ERROR: no Neovim release for $(uname -m)"
+      return 1
+      ;;
+  esac
+
+  local tarball="nvim-linux-${arch}.tar.gz"
+  local tmp
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '${tmp}'" RETURN
+
+  log "downloading ${tarball} (${NVIM_VERSION})"
+  curl -fsSL --retry 3 --retry-delay 2 -o "${tmp}/${tarball}" \
+    "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/${tarball}"
+
+  $SUDO mkdir -p "${NVIM_PREFIX}"
+  $SUDO tar -xzf "${tmp}/${tarball}" -C "${NVIM_PREFIX}" --strip-components=1
+  $SUDO ln -sf "${NVIM_PREFIX}/bin/nvim" /usr/local/bin/nvim
+
+  log "installed $(nvim --version | head -1)"
+}
+
+install_plenary() {
+  if [ -d "${PLENARY_DIR}/.git" ]; then
+    log "plenary.nvim present"
+    return
+  fi
+  # A directory that exists without a .git is a half-finished clone from an interrupted run;
+  # git clone would refuse it, so clear it rather than fail every session from here on.
+  rm -rf "${PLENARY_DIR}"
+  mkdir -p "$(dirname "${PLENARY_DIR}")"
+  log "cloning plenary.nvim"
+  git clone --depth 1 --quiet https://github.com/nvim-lua/plenary.nvim "${PLENARY_DIR}"
+}
+
+install_luac() {
+  if command -v luac >/dev/null 2>&1; then
+    log "luac present: $(luac -v 2>&1 | head -1)"
+    return
+  fi
+  if ! command -v apt-get >/dev/null 2>&1; then
+    log "ERROR: no apt-get; cannot install lua5.3"
+    return 1
+  fi
+
+  export DEBIAN_FRONTEND=noninteractive
+  # The image usually carries usable package lists already, so try the install first and pay
+  # for `apt-get update` only when it is actually needed.
+  $SUDO apt-get install -y -qq lua5.3 >/dev/null 2>&1 || {
+    log "refreshing package lists"
+    $SUDO apt-get update -qq >/dev/null
+    $SUDO apt-get install -y -qq lua5.3 >/dev/null
+  }
+
+  # Debian's alternatives normally provide a bare `luac`, which is the name package.json's
+  # `check` script calls. Link it directly if they did not.
+  command -v luac >/dev/null 2>&1 || $SUDO ln -sf /usr/bin/luac5.3 /usr/local/bin/luac
+
+  log "installed $(luac -v 2>&1 | head -1)"
+}
+
+install_node_deps() {
+  [ -f "${PROJECT_DIR}/package.json" ] || return 0
+  log "npm install"
+  # `install`, not `ci`: the container image is cached after this hook completes, and install
+  # reuses an existing node_modules where ci deletes and refetches it every time.
+  (cd "${PROJECT_DIR}" && npm install --no-audit --no-fund --loglevel=error >&2)
+}
+
+install_neovim
+install_plenary
+install_luac
+install_node_deps
+
+# Verify rather than assume. A hook that reports success over a half-installed environment is
+# the exact failure this one exists to prevent — the session would then blame the repository
+# for an error that belongs to its own setup.
+missing=()
+command -v nvim >/dev/null 2>&1 || missing+=("nvim")
+command -v luac >/dev/null 2>&1 || missing+=("luac")
+[ -d "${PLENARY_DIR}" ] || missing+=("plenary.nvim")
+[ -d "${PROJECT_DIR}/node_modules" ] || missing+=("node_modules")
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  log "ERROR: setup incomplete, still missing: ${missing[*]}"
+  exit 1
+fi
+
+log "ready: npm run check / check:doc / test:lua / test:node are all runnable"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -25,6 +25,10 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &
 NVIM_VERSION="${VIBING_NVIM_VERSION:-stable}"
 NVIM_PREFIX="${VIBING_NVIM_PREFIX:-/opt/nvim}"
 
+# The Lua the `check` gate must compile with. CI installs lua5.3; see install_luac for why the
+# version is checked rather than assumed.
+LUA_VERSION="5.3"
+
 # tests/minimal_init.lua resolves plenary from `vim.fn.stdpath("data")`, which honours
 # XDG_DATA_HOME — so this has to as well, or the clone lands where nothing looks for it.
 PLENARY_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/nvim/site/pack/vendor/start/plenary.nvim"
@@ -42,8 +46,14 @@ else
 fi
 
 install_neovim() {
-  if command -v nvim >/dev/null 2>&1; then
-    log "neovim present: $(nvim --version | head -1)"
+  # Keyed on *this hook's own* installation, not on whatever `nvim` happens to be first on
+  # PATH. Accepting any nvim would let a build the image ships — an older one, or a distro
+  # package — decide what `test:lua` and `check:doc` run against, so the web session would
+  # pass and fail on different things than CI, which is the one thing this hook exists to
+  # prevent. The link below then puts the managed build ahead of any other.
+  if "${NVIM_PREFIX}/bin/nvim" --version >/dev/null 2>&1; then
+    log "neovim present: $("${NVIM_PREFIX}/bin/nvim" --version | head -1) (managed)"
+    link_neovim
     return
   fi
 
@@ -67,11 +77,35 @@ install_neovim() {
   curl -fsSL --retry 3 --retry-delay 2 -o "${tmp}/${tarball}" \
     "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/${tarball}"
 
-  $SUDO mkdir -p "${NVIM_PREFIX}"
-  $SUDO tar -xzf "${tmp}/${tarball}" -C "${NVIM_PREFIX}" --strip-components=1
-  $SUDO ln -sf "${NVIM_PREFIX}/bin/nvim" /usr/local/bin/nvim
+  # The `stable` tag publishes no digest of its own (shasum.txt and the per-asset
+  # .sha256sum names are all 404), so there is nothing authoritative to compare against and
+  # baking one in would break the hook every time upstream moves the tag. Certificate
+  # verification on the HTTPS fetch is therefore the integrity boundary here. Pin
+  # VIBING_NVIM_VERSION to a real release and set VIBING_NVIM_SHA256 to check a digest.
+  if [ -n "${VIBING_NVIM_SHA256:-}" ]; then
+    log "verifying sha256"
+    printf '%s  %s\n' "${VIBING_NVIM_SHA256}" "${tmp}/${tarball}" | sha256sum -c - >/dev/null
+  fi
 
-  log "installed $(nvim --version | head -1)"
+  # Unpack to a staging directory and smoke-test it before it becomes ${NVIM_PREFIX}. A
+  # truncated download extracted in place would leave a prefix that looks managed, and every
+  # later run would take the branch above and skip repairing it.
+  $SUDO rm -rf "${tmp}/stage"
+  mkdir -p "${tmp}/stage"
+  tar -xzf "${tmp}/${tarball}" -C "${tmp}/stage" --strip-components=1
+  "${tmp}/stage/bin/nvim" --version >/dev/null 2>&1 \
+    || { log "ERROR: the downloaded Neovim does not run"; return 1; }
+
+  $SUDO rm -rf "${NVIM_PREFIX}"
+  $SUDO mkdir -p "$(dirname "${NVIM_PREFIX}")"
+  $SUDO mv "${tmp}/stage" "${NVIM_PREFIX}"
+  link_neovim
+
+  log "installed $("${NVIM_PREFIX}/bin/nvim" --version | head -1)"
+}
+
+link_neovim() {
+  $SUDO ln -sf "${NVIM_PREFIX}/bin/nvim" /usr/local/bin/nvim
 }
 
 install_plenary() {
@@ -87,38 +121,81 @@ install_plenary() {
   git clone --depth 1 --quiet https://github.com/nvim-lua/plenary.nvim "${PLENARY_DIR}"
 }
 
+luac_is_required_version() {
+  command -v luac >/dev/null 2>&1 || return 1
+  luac -v 2>&1 | head -1 | grep -q "Lua ${LUA_VERSION}\b"
+}
+
 install_luac() {
-  if command -v luac >/dev/null 2>&1; then
+  # The version matters, so `command -v luac` is not enough on its own. CI installs lua5.3,
+  # and 5.4 accepts syntax 5.3 rejects — `local x <const> = 1` compiles under 5.4 — so a
+  # container whose bare `luac` is 5.4 would let `npm run check` pass here and fail in CI.
+  # That is the same divergence the version check above guards against.
+  if luac_is_required_version; then
     log "luac present: $(luac -v 2>&1 | head -1)"
     return
   fi
+  if command -v luac >/dev/null 2>&1; then
+    log "luac is $(luac -v 2>&1 | head -1), but CI uses Lua ${LUA_VERSION}; installing it"
+  fi
   if ! command -v apt-get >/dev/null 2>&1; then
-    log "ERROR: no apt-get; cannot install lua5.3"
+    log "ERROR: no apt-get; cannot install lua${LUA_VERSION}"
     return 1
   fi
 
   export DEBIAN_FRONTEND=noninteractive
   # The image usually carries usable package lists already, so try the install first and pay
   # for `apt-get update` only when it is actually needed.
-  $SUDO apt-get install -y -qq lua5.3 >/dev/null 2>&1 || {
+  $SUDO apt-get install -y -qq "lua${LUA_VERSION}" >/dev/null 2>&1 || {
     log "refreshing package lists"
     $SUDO apt-get update -qq >/dev/null
-    $SUDO apt-get install -y -qq lua5.3 >/dev/null
+    $SUDO apt-get install -y -qq "lua${LUA_VERSION}" >/dev/null
   }
 
-  # Debian's alternatives normally provide a bare `luac`, which is the name package.json's
-  # `check` script calls. Link it directly if they did not.
-  command -v luac >/dev/null 2>&1 || $SUDO ln -sf /usr/bin/luac5.3 /usr/local/bin/luac
+  # Debian's alternatives provide a bare `luac`, which is the name package.json's `check`
+  # script calls — but it may point at another installed version. Name the compiler we want
+  # explicitly, in /usr/local/bin so it wins over /usr/bin.
+  luac_is_required_version \
+    || $SUDO ln -sf "/usr/bin/luac${LUA_VERSION}" /usr/local/bin/luac
 
   log "installed $(luac -v 2>&1 | head -1)"
 }
 
 install_node_deps() {
   [ -f "${PROJECT_DIR}/package.json" ] || return 0
-  log "npm install"
-  # `install`, not `ci`: the container image is cached after this hook completes, and install
-  # reuses an existing node_modules where ci deletes and refetches it every time.
-  (cd "${PROJECT_DIR}" && npm install --no-audit --no-fund --loglevel=error >&2)
+
+  # `npm ci`, matching CI, because `npm install` **rewrites package-lock.json** when it
+  # disagrees with package.json. Two things go wrong when it does: the drift that CI's
+  # `npm ci` would reject is silently repaired here instead, so the session passes on a
+  # dependency tree CI will refuse; and the rewritten lockfile is a working-tree change, which
+  # this repository's per-turn git tree snapshot picks up and lists under `### Modified Files`
+  # for whatever turn happens to be running.
+  local lock="${PROJECT_DIR}/package-lock.json"
+  if [ ! -f "$lock" ]; then
+    log "ERROR: no package-lock.json; npm ci needs one (CI uses it too)"
+    return 1
+  fi
+
+  # `ci` deletes node_modules and refetches every time, which would throw away the container
+  # image's cache on every resume. So keep the cache benefit a different way: stamp the
+  # lockfile's digest inside node_modules and skip the install entirely while it still
+  # matches. The stamp lives in node_modules precisely so `ci` wiping the tree invalidates it.
+  local stamp="${PROJECT_DIR}/node_modules/.vibing-session-start-lock"
+  local digest
+  digest="$(sha256sum "$lock" | cut -d' ' -f1)"
+  if [ -d "${PROJECT_DIR}/node_modules" ] && [ "$(cat "$stamp" 2>/dev/null)" = "$digest" ]; then
+    log "node_modules already matches package-lock.json"
+    return
+  fi
+
+  log "npm ci"
+  if ! (cd "${PROJECT_DIR}" && npm ci --no-audit --no-fund --loglevel=error >&2); then
+    log "ERROR: npm ci failed. If it reports a lockfile mismatch, package.json and"
+    log "       package-lock.json disagree — run 'npm install' locally and commit the"
+    log "       updated lockfile. CI would reject this too."
+    return 1
+  fi
+  printf '%s\n' "$digest" > "$stamp"
 }
 
 install_neovim
@@ -129,9 +206,20 @@ install_node_deps
 # Verify rather than assume. A hook that reports success over a half-installed environment is
 # the exact failure this one exists to prevent — the session would then blame the repository
 # for an error that belongs to its own setup.
+#
+# Presence is not the whole check: `nvim` and `luac` must be the builds this hook installed,
+# or the gates run against something CI never saw.
 missing=()
-command -v nvim >/dev/null 2>&1 || missing+=("nvim")
-command -v luac >/dev/null 2>&1 || missing+=("luac")
+if ! command -v nvim >/dev/null 2>&1; then
+  missing+=("nvim")
+elif [ "$(readlink -f "$(command -v nvim)")" != "$(readlink -f "${NVIM_PREFIX}/bin/nvim")" ]; then
+  missing+=("nvim (PATH resolves to $(command -v nvim), not the managed ${NVIM_PREFIX})")
+fi
+if ! command -v luac >/dev/null 2>&1; then
+  missing+=("luac")
+elif ! luac_is_required_version; then
+  missing+=("luac Lua ${LUA_VERSION} (PATH resolves to $(luac -v 2>&1 | head -1))")
+fi
 [ -d "${PLENARY_DIR}" ] || missing+=("plenary.nvim")
 [ -d "${PROJECT_DIR}/node_modules" ] || missing+=("node_modules")
 

--- a/.claude/rules/web-workflow.md
+++ b/.claude/rules/web-workflow.md
@@ -12,7 +12,7 @@ Neovim `stable` to `/opt/nvim`, plenary.nvim, `lua5.3`, `npm install` — mirror
 corresponding steps of `.github/workflows/ci.yml` so a web session fails and passes on the same
 things CI does. It is registered as a `SessionStart` hook in `.claude/settings.json`.
 
-Three things about it are decisions rather than details:
+Five things about it are decisions rather than details:
 
 - **It no-ops unless `CLAUDE_CODE_REMOTE=true`.** A local machine has the developer's own
   Neovim, and writing to `/opt` and `/usr/local` there is never what is wanted.
@@ -22,9 +22,31 @@ Three things about it are decisions rather than details:
   success over a broken environment makes the next failure look like the repository's, which is
   the whole failure it exists to prevent. For the same reason its progress output goes to
   **stderr**: a `SessionStart` hook's stdout is prepended to the session as context.
+- **It checks which `nvim` and `luac` it got, not merely that one exists.** Both are keyed on
+  the build the hook itself manages, because a tool the image happens to ship would otherwise
+  decide what the gates run against. `luac` is the sharp case: 5.4 compiles syntax 5.3 rejects
+  (`local x <const> = 1`), so a container whose bare `luac` is 5.4 would let `npm run check`
+  pass here and fail in CI.
+- **It installs Node dependencies with `npm ci`, like CI.** `npm install` **rewrites
+  `package-lock.json`** when it disagrees with `package.json`, which both hides drift CI would
+  reject and leaves a working-tree change the per-turn git tree snapshot reports under
+  `### Modified Files`. The container-cache benefit that argued for `npm install` is kept
+  another way: the hook stamps the lockfile's digest inside `node_modules` and skips the
+  install entirely while it still matches.
 
 `plenary.nvim` goes under `vim.fn.stdpath("data")` (honouring `XDG_DATA_HOME`), because that is
 where `tests/minimal_init.lua` looks for it.
+
+The `stable` Neovim tag publishes no checksum of its own, so certificate verification on the
+HTTPS fetch is the integrity boundary; the tarball is unpacked to a staging directory and
+smoke-tested before it becomes `/opt/nvim`, so a truncated download cannot leave a prefix that
+later runs mistake for a good install. Set `VIBING_NVIM_SHA256` alongside a pinned
+`VIBING_NVIM_VERSION` to check a digest.
+
+**The hook has no automated test, and that is deliberate rather than an oversight.** It installs
+system packages into a throwaway container, so exercising it means being in one. It is verified
+by running it against a fully torn-down container and reading the result — do that after
+changing it, rather than looking for a spec that does not exist.
 
 ## Git Push Requirements
 

--- a/.claude/rules/web-workflow.md
+++ b/.claude/rules/web-workflow.md
@@ -3,6 +3,29 @@
 When developing with Claude Code on the web, there are specific Git push constraints that require
 special handling.
 
+## Environment Setup (SessionStart Hook)
+
+The web container ships node and git but **neither Neovim nor a Lua compiler**, so four of the
+five CI gates cannot start there: `test:lua`, `test:e2e` and `check:doc` invoke `nvim`, and
+`check` invokes `luac`. `.claude/hooks/session-start.sh` installs them —
+Neovim `stable` to `/opt/nvim`, plenary.nvim, `lua5.3`, `npm install` — mirroring the
+corresponding steps of `.github/workflows/ci.yml` so a web session fails and passes on the same
+things CI does. It is registered as a `SessionStart` hook in `.claude/settings.json`.
+
+Three things about it are decisions rather than details:
+
+- **It no-ops unless `CLAUDE_CODE_REMOTE=true`.** A local machine has the developer's own
+  Neovim, and writing to `/opt` and `/usr/local` there is never what is wanted.
+- **It is synchronous.** The first thing a web session usually does is run the suite; an async
+  hook would let that start against a half-installed environment.
+- **It verifies at the end and exits non-zero on anything missing.** A hook that reports
+  success over a broken environment makes the next failure look like the repository's, which is
+  the whole failure it exists to prevent. For the same reason its progress output goes to
+  **stderr**: a `SessionStart` hook's stdout is prepended to the session as context.
+
+`plenary.nvim` goes under `vim.fn.stdpath("data")` (honouring `XDG_DATA_HOME`), because that is
+where `tests/minimal_init.lua` looks for it.
+
 ## Git Push Requirements
 
 **Branch Naming:** branch names MUST start with `claude/` and end with a matching session ID

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/remote-screenshot/SKILL.md
+++ b/.claude/skills/remote-screenshot/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: remote-screenshot
+description:
+  Take a real screenshot of a running Neovim from inside the Claude Code on the web container,
+  which has no X server. Use when asked to show what a UI change looks like, or to attach an
+  image of the chat buffer, a split layout, an approval prompt or a picker. Requires
+  CLAUDE_CODE_REMOTE=true — on a local machine there is nothing to do here, since the developer
+  is already looking at their editor.
+---
+
+# Screenshotting Neovim in the web container
+
+**Applies only to Claude Code on the web.** `CLAUDE_CODE_REMOTE` must be `true`; the script
+refuses to run otherwise and that refusal is correct, not an obstacle to work around. If you are
+on a local machine, stop and say so — the user can see their own editor, and starting a hidden
+second Neovim to photograph it helps nobody.
+
+## The sequence
+
+```bash
+S=scripts/screenshot
+$S/capture.sh start --cols 150 --rows 40 lua/vibing/core/utils/git_snapshot.lua
+$S/capture.sh keys ':VibingChat right' Enter
+$S/capture.sh shoot /tmp/shot.png
+python3 $S/pxbox.py /tmp/shot.png --expect-height 798   # (rows - 2) * 21
+$S/capture.sh stop
+```
+
+Then hand the PNG to the user with `SendUserFile`.
+
+`capture.sh shoot` prints the exact `pxbox.py` command to run. **Run it.** A capture whose
+bottom rows were clipped is a plausible-looking screenshot of a slightly different screen, and
+the difference between 21px and 1px of painted height does not survive downscaling — you will
+not catch it by looking, and you will describe a statusline that is not in the image. `pxbox.py`
+exits non-zero when the painted region is short.
+
+`scripts/screenshot/README.md` has the mechanism, the `headless_shell` trap, and why each
+terminal cell is its own element. Read it if something renders wrong.
+
+## Do not fabricate the contents
+
+`capture-pane` returns the actual screen buffer, which is the whole point: the frontmatter,
+statusline path and highlighting in the image are Neovim's own output. Two ways to throw that
+away, both of which produce an image that lies:
+
+- **Writing a transcript into the chat buffer to make it look busy.** Text you typed is not the
+  renderer's output. If a screenshot needs a real assistant turn — tool headers,
+  `### Modified Files`, streaming — that costs real tokens, so ask first and say that is what
+  the image shows.
+- **Describing what the screenshot shows without reading it back.** Open the PNG and look
+  before you narrate it.
+
+Typing an **unsent** `## User` message is fine and authentic — that is a real editor state a
+user reaches by typing.
+
+## Housekeeping
+
+`start` writes a chat into the project's real `.vibing/chat/`, which is git-ignored, so nothing
+lands in a commit. Still run `git status` before committing, and `capture.sh stop` when done —
+a forgotten session keeps a Neovim alive for the rest of the container's life.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Detailed documentation is organized in `.claude/rules/`:
 | `features.md`           | Auto-resume on usage limit, message timestamps, AskUserQuestion support    |
 | `configuration.md`      | Full configuration examples, window positions, daily summary               |
 | `commands-reference.md` | User commands, slash commands                                              |
-| `web-workflow.md`       | Claude Code on the Web git push requirements                               |
+| `web-workflow.md`       | Claude Code on the Web: SessionStart env setup, git push reqs              |
 
 All `.md` files in `.claude/rules/` are automatically loaded into Claude Code's context. **だから
 `.claude/rules/` に置くのは「放っておくと破る不変条件」と「どこに何があるかの地図」だけにする。**

--- a/scripts/screenshot/README.md
+++ b/scripts/screenshot/README.md
@@ -1,0 +1,73 @@
+# Screenshotting Neovim from a headless container
+
+Takes a real screenshot of a real, running Neovim in an environment with no X server — the
+Claude Code on the web container. Used to show what a change looks like, rather than describing
+it.
+
+**This is for that container only.** `capture.sh` refuses to run unless
+`CLAUDE_CODE_REMOTE=true`; on a local machine you are already looking at your editor, and the
+script would start a second hidden one and leave a tmux session behind. Nothing here is loaded
+into a session's context automatically — the instructions live in
+`.claude/skills/remote-screenshot/SKILL.md`, which is read only when invoked.
+
+## How it works
+
+```text
+tmux (pty)          holds nvim at a fixed COLS x ROWS
+  |  capture-pane -e     the visible screen, with its truecolor SGR sequences
+ansi2html.py        one absolutely positioned element per terminal cell
+  |
+headless_shell      --screenshot at 2x
+```
+
+Nothing is intercepted or reconstructed. `capture-pane` returns the screen buffer, so whatever
+Neovim actually drew is what lands in the PNG — real syntax highlighting, real statusline, real
+cursor position.
+
+## Usage
+
+```bash
+S=scripts/screenshot
+$S/capture.sh start --cols 150 --rows 40 lua/vibing/core/utils/git_snapshot.lua
+$S/capture.sh keys ':VibingChat right' Enter
+$S/capture.sh keys 'G' 'o' 'なぜこの順序なのか？' Escape
+$S/capture.sh shoot /tmp/nvim.png
+$S/capture.sh stop
+```
+
+`shoot` prints the `pxbox.py` command to verify the result with. Run it — see below.
+
+## Two things that cost an hour each
+
+**Use `headless_shell`, never `chrome --headless`.** The full browser subtracts its
+(nonexistent) window UI from `--window-size`, so the page is silently clipped from the bottom.
+The symptom is that Neovim's statusline is absent while every row above it looks perfect — which
+reads as a CSS bug, not a viewport one. `getComputedStyle` and `getBoundingClientRect` both
+reported the cells at their correct `9x21`; the layout was right the whole time.
+
+**Verify by measuring, not by looking.** A clipped capture is a plausible-looking screenshot of
+a slightly different screen, and 21px versus 1px of painted height is not something the eye
+catches in a downscaled image. `pxbox.py` decodes the PNG with `zlib` alone and reports the
+bounding box of everything that is not page background:
+
+```bash
+python3 scripts/screenshot/pxbox.py /tmp/nvim.png --expect-height 798
+```
+
+It exits non-zero when the painted region is shorter than expected. `--expect-height` should be
+about `(rows - 2) * 21`: the bottom row is usually the message line, which is blank.
+
+## Why one element per cell
+
+This repository's source is Japanese-heavy, and no font in the container renders DejaVu Sans
+Mono's Latin advance and a CJK glyph at exactly a 1:2 ratio. A flowed `<pre>` therefore drifts a
+little further out of alignment on every wide character, until the two window splits no longer
+line up and the screenshot misrepresents the layout. Positioning each cell at a multiple of the
+Latin advance, with `unicodedata.east_asian_width` deciding whether it occupies one column or
+two, makes the grid exact by construction.
+
+## Requirements in the container
+
+`tmux`, `nvim` (installed by `.claude/hooks/session-start.sh`), `python3`, DejaVu Sans Mono plus
+a CJK monospace fallback, and Playwright's Chromium under `/opt/pw-browsers`. Override the
+browser with `VIBING_SHOT_BROWSER` and the scratch directory with `VIBING_SHOT_DIR`.

--- a/scripts/screenshot/README.md
+++ b/scripts/screenshot/README.md
@@ -71,3 +71,16 @@ two, makes the grid exact by construction.
 `tmux`, `nvim` (installed by `.claude/hooks/session-start.sh`), `python3`, DejaVu Sans Mono plus
 a CJK monospace fallback, and Playwright's Chromium under `/opt/pw-browsers`. Override the
 browser with `VIBING_SHOT_BROWSER` and the scratch directory with `VIBING_SHOT_DIR`.
+
+## What is tested, and what is not
+
+No repository gate reads `.py` or `.sh`: `check` compiles `lua/` only, eslint matches
+`js`/`mjs`/`ts`, and prettier matches `js`/`ts`/`json`/`md`/`yml`. So the two Python tools carry
+their own regression tests in `tests/screenshot-tools.test.mjs`, which `npm run test:node` picks
+up — the SGR parser, the wide-character grid, the explicit cell height, and pxbox's five PNG row
+filters and clipping verdict. They shell out to `python3`, which is therefore a requirement of
+`test:node` as well.
+
+`capture.sh` itself is not covered: driving it means starting tmux and a browser, which is the
+whole environment it exists for. Verify a change to it by taking a screenshot and running
+`pxbox.py` on the result.

--- a/scripts/screenshot/ansi2html.py
+++ b/scripts/screenshot/ansi2html.py
@@ -44,6 +44,7 @@ def xterm256(n):
 
 
 def css_rgb(t):
+    """An (r, g, b) triple as a CSS hex colour."""
     return "#%02x%02x%02x" % t
 
 
@@ -64,12 +65,14 @@ class Pen:
         self.reverse = False
 
     def copy(self):
+        """A snapshot of this pen, since one Pen is mutated across a whole line."""
         p = Pen.__new__(Pen)
         for s in Pen.__slots__:
             setattr(p, s, getattr(self, s))
         return p
 
     def apply(self, params):
+        """Fold one SGR sequence's parameters into this pen. Unknown codes are ignored."""
         if not params:
             params = [0]
         i = 0
@@ -116,6 +119,7 @@ class Pen:
             i += 1
 
     def style(self):
+        """This pen as an inline CSS declaration, omitting anything left at its default."""
         fg, bg = self.fg or FG_DEFAULT, self.bg or BG_DEFAULT
         if self.reverse:
             fg, bg = bg, fg
@@ -172,7 +176,19 @@ def cells(line):
     return out
 
 
+def page_size(cols, rows, font_px, line_px, pad_px):
+    """The browser viewport this grid needs, in CSS pixels.
+
+    `render` and `--print-size` both go through here so the caller sizing the screenshot
+    cannot disagree with the page it is screenshotting. capture.sh used to compute the same
+    formula itself, which put CHAR_ADVANCE in two places — and a mismatch there is precisely
+    the silent clipping pxbox.py exists to catch.
+    """
+    return round(cols * font_px * CHAR_ADVANCE) + 2 * pad_px, rows * line_px + 2 * pad_px
+
+
 def render(text, cols, font_px, line_px, pad_px):
+    """The whole capture as a standalone HTML page, one positioned element per painted cell."""
     cw = font_px * CHAR_ADVANCE
     lines = text.rstrip("\n").split("\n")
     rows = len(lines)
@@ -200,12 +216,23 @@ def render(text, cols, font_px, line_px, pad_px):
 
 
 def main():
+    """Render stdin, or answer --print-size."""
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--cols", type=int, required=True, help="pane width the dump was taken at")
     ap.add_argument("--font-px", type=int, default=15)
     ap.add_argument("--line-px", type=int, default=21)
     ap.add_argument("--pad-px", type=int, default=14)
+    ap.add_argument("--print-size", action="store_true",
+                    help="print '<width> <height>' for --window-size and exit, reading no input")
+    ap.add_argument("--rows", type=int, help="pane height; required by --print-size")
     a = ap.parse_args()
+
+    if a.print_size:
+        if a.rows is None:
+            ap.error("--print-size requires --rows")
+        print("%d %d" % page_size(a.cols, a.rows, a.font_px, a.line_px, a.pad_px))
+        return
+
     sys.stdout.write(render(sys.stdin.read(), a.cols, a.font_px, a.line_px, a.pad_px))
 
 

--- a/scripts/screenshot/ansi2html.py
+++ b/scripts/screenshot/ansi2html.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Render a `tmux capture-pane -e` dump as an HTML page a headless browser can screenshot.
+
+Each terminal cell becomes its own absolutely positioned element. That is far more markup than
+a <pre> needs, but it is the only way to guarantee the grid survives: this repository's source
+is Japanese-heavy, and no font in the container renders DejaVu Sans Mono's Latin advance and a
+CJK glyph at exactly a 1:2 ratio, so a flowed <pre> drifts a little further out of alignment on
+every wide character until the two window splits no longer line up.
+
+Reads the dump on stdin, writes HTML on stdout.
+"""
+
+import argparse
+import html
+import sys
+import unicodedata
+
+# DejaVu Sans Mono's advance width, in em. Every cell's x position is a multiple of this, so the
+# grid is exact rather than accumulated from glyph metrics.
+CHAR_ADVANCE = 0.6023
+
+FG_DEFAULT = "#e2e2ea"
+BG_DEFAULT = "#14161b"
+
+# The xterm base-16 palette, for the 30-37/90-97 and 40-47/100-107 forms.
+BASE16 = [
+    (0, 0, 0), (205, 0, 0), (0, 205, 0), (205, 205, 0),
+    (0, 0, 238), (205, 0, 205), (0, 205, 205), (229, 229, 229),
+    (127, 127, 127), (255, 0, 0), (0, 255, 0), (255, 255, 0),
+    (92, 92, 255), (255, 0, 255), (0, 255, 255), (255, 255, 255),
+]
+
+
+def xterm256(n):
+    """Colour n of the 256-colour cube, generated rather than tabulated."""
+    if n < 16:
+        return BASE16[n]
+    if n < 232:
+        n -= 16
+        levels = (0, 95, 135, 175, 215, 255)
+        return levels[n // 36], levels[(n // 6) % 6], levels[n % 6]
+    v = 8 + (n - 232) * 10
+    return v, v, v
+
+
+def css_rgb(t):
+    return "#%02x%02x%02x" % t
+
+
+class Pen:
+    """The SGR state that applies to the cell about to be emitted."""
+
+    __slots__ = ("fg", "bg", "bold", "italic", "underline", "reverse")
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.fg = None
+        self.bg = None
+        self.bold = False
+        self.italic = False
+        self.underline = False
+        self.reverse = False
+
+    def copy(self):
+        p = Pen.__new__(Pen)
+        for s in Pen.__slots__:
+            setattr(p, s, getattr(self, s))
+        return p
+
+    def apply(self, params):
+        if not params:
+            params = [0]
+        i = 0
+        while i < len(params):
+            p = params[i]
+            if p == 0:
+                self.reset()
+            elif p == 1:
+                self.bold = True
+            elif p == 3:
+                self.italic = True
+            elif p == 4:
+                self.underline = True
+            elif p == 7:
+                self.reverse = True
+            elif p == 22:
+                self.bold = False
+            elif p == 23:
+                self.italic = False
+            elif p == 24:
+                self.underline = False
+            elif p == 27:
+                self.reverse = False
+            elif 30 <= p <= 37:
+                self.fg = css_rgb(BASE16[p - 30])
+            elif 90 <= p <= 97:
+                self.fg = css_rgb(BASE16[p - 90 + 8])
+            elif 40 <= p <= 47:
+                self.bg = css_rgb(BASE16[p - 40])
+            elif 100 <= p <= 107:
+                self.bg = css_rgb(BASE16[p - 100 + 8])
+            elif p == 39:
+                self.fg = None
+            elif p == 49:
+                self.bg = None
+            elif p in (38, 48):
+                target = "fg" if p == 38 else "bg"
+                if i + 1 < len(params) and params[i + 1] == 2:
+                    setattr(self, target, css_rgb(tuple(params[i + 2 : i + 5])))
+                    i += 4
+                elif i + 1 < len(params) and params[i + 1] == 5:
+                    setattr(self, target, css_rgb(xterm256(params[i + 2])))
+                    i += 2
+            i += 1
+
+    def style(self):
+        fg, bg = self.fg or FG_DEFAULT, self.bg or BG_DEFAULT
+        if self.reverse:
+            fg, bg = bg, fg
+        out = ["color:%s" % fg]
+        if bg != BG_DEFAULT:
+            out.append("background:%s" % bg)
+        if self.bold:
+            out.append("font-weight:700")
+        if self.italic:
+            out.append("font-style:italic")
+        if self.underline:
+            out.append("text-decoration:underline")
+        return ";".join(out)
+
+
+def cells(line):
+    """Expand one captured line into (char, pen, columns) triples.
+
+    Escape sequences other than SGR are dropped here rather than in a pre-pass, so a stray OSC
+    title or cursor-visibility sequence cannot swallow the `m` of a colour that follows it.
+    """
+    pen, out, pos, n = Pen(), [], 0, len(line)
+    while pos < n:
+        ch = line[pos]
+        if ch == "\x1b" and pos + 1 < n:
+            intro = line[pos + 1]
+            if intro == "[":  # CSI: parameters, then a final byte
+                end = pos + 2
+                while end < n and (line[end].isdigit() or line[end] in ";:?<>!"):
+                    end += 1
+                if end < n:
+                    if line[end] == "m":
+                        params = [int(x) if x.isdigit() else 0
+                                  for x in line[pos + 2 : end].split(";")]
+                        pen.apply(params)
+                    pos = end + 1
+                    continue
+            elif intro == "]":  # OSC: runs to BEL or ST
+                end = pos + 2
+                while end < n and line[end] != "\x07":
+                    if line[end] == "\x1b" and end + 1 < n and line[end + 1] == "\\":
+                        end += 1
+                        break
+                    end += 1
+                pos = min(end + 1, n)
+                continue
+            pos += 2
+            continue
+        pos += 1
+        if ch == "\x1b":
+            continue
+        width = 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+        out.append((ch, pen.copy(), width))
+    return out
+
+
+def render(text, cols, font_px, line_px, pad_px):
+    cw = font_px * CHAR_ADVANCE
+    lines = text.rstrip("\n").split("\n")
+    rows = len(lines)
+    body = []
+    for row, line in enumerate(lines):
+        col = 0
+        for ch, pen, width in cells(line):
+            # A blank cell only needs an element if it paints a background.
+            if ch != " " or pen.bg is not None or pen.reverse:
+                body.append(
+                    '<i style="left:%.2fpx;top:%dpx;width:%.2fpx;%s">%s</i>'
+                    % (col * cw, row * line_px, width * cw, pen.style(), html.escape(ch))
+                )
+            col += width
+    return f"""<!doctype html><meta charset="utf-8"><title>terminal capture</title><style>
+  html,body{{margin:0;background:{BG_DEFAULT}}}
+  #t{{position:relative;width:{cols * cw:.0f}px;height:{rows * line_px}px;padding:{pad_px}px;
+     font-family:"DejaVu Sans Mono","WenQuanYi Zen Hei Mono","IPAGothic",monospace;
+     font-size:{font_px}px;line-height:{line_px}px}}
+  /* Each cell states its own height and line-height. Leaving them to the line box let the
+     statusline row's descenders fall outside the box and get clipped by overflow:hidden. */
+  #t i{{position:absolute;display:block;overflow:hidden;font-style:normal;white-space:pre;
+        height:{line_px}px;line-height:{line_px}px;text-align:left}}
+</style><div id="t">{"".join(body)}</div>"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cols", type=int, required=True, help="pane width the dump was taken at")
+    ap.add_argument("--font-px", type=int, default=15)
+    ap.add_argument("--line-px", type=int, default=21)
+    ap.add_argument("--pad-px", type=int, default=14)
+    a = ap.parse_args()
+    sys.stdout.write(render(sys.stdin.read(), a.cols, a.font_px, a.line_px, a.pad_px))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/screenshot/capture.sh
+++ b/scripts/screenshot/capture.sh
@@ -63,10 +63,18 @@ cmd_start() {
   need nvim
   mkdir -p "$WORK"
   tmux kill-session -t "$SESSION" 2>/dev/null || true
+  # tmux takes a *shell command string*, so every argument has to be quoted into it: an
+  # unquoted "$*" splits a path containing a space into two filenames, and an apostrophe in one
+  # ends the quoting early and runs the remainder as shell.
+  local cmd
+  cmd="TERM=xterm-256color nvim -u $(printf '%q' "$HERE/nvim_init.lua")"
+  local arg
+  for arg in "$@"; do
+    cmd+=" $(printf '%q' "$arg")"
+  done
   # A dedicated init so the screenshot shows vibing.nvim actually set up (`:Vibing*` commands
   # present), rather than the plugin merely on runtimepath.
-  tmux new-session -d -s "$SESSION" -x "$COLS" -y "$ROWS" -c "$REPO_ROOT" \
-    "TERM=xterm-256color nvim -u '$HERE/nvim_init.lua' $*"
+  tmux new-session -d -s "$SESSION" -x "$COLS" -y "$ROWS" -c "$REPO_ROOT" "$cmd"
   printf '%s %s\n' "$COLS" "$ROWS" > "$(geometry_path)"
   # Neovim needs to finish drawing before the first capture; a capture taken too early shows a
   # blank pane, which looks exactly like a broken renderer.
@@ -91,9 +99,13 @@ cmd_shoot() {
     read -r COLS ROWS < "$(geometry_path)"
   fi
 
+  # Ask the renderer for the viewport rather than recomputing it. The character advance used to
+  # be hardcoded here as well as in ansi2html.py, so changing one left the screenshot sized for
+  # a page of a different width — the same silent-clipping class of bug as the browser trap.
   local width height
-  width=$(python3 -c "print(round($COLS * $FONT_PX * 0.6023) + 2*$PAD_PX)")
-  height=$(python3 -c "print($ROWS * $LINE_PX + 2*$PAD_PX)")
+  read -r width height < <(python3 "$HERE/ansi2html.py" --print-size \
+    --cols "$COLS" --rows "$ROWS" --font-px "$FONT_PX" \
+    --line-px "$LINE_PX" --pad-px "$PAD_PX")
 
   tmux capture-pane -e -p -t "$SESSION" > "$WORK/pane.ansi"
   python3 "$HERE/ansi2html.py" --cols "$COLS" --font-px "$FONT_PX" \

--- a/scripts/screenshot/capture.sh
+++ b/scripts/screenshot/capture.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Screenshot a real, running Neovim from a container that has no X server.
+#
+#   capture.sh start [--cols N] [--rows N] [--session NAME] [--] [nvim args...]
+#   capture.sh keys  [--session NAME] <tmux send-keys arguments...>
+#   capture.sh shoot [--session NAME] [--scale N] <out.png>
+#   capture.sh stop  [--session NAME]
+#
+# tmux holds the pty, `capture-pane -e` returns the visible screen with its truecolor SGR
+# sequences, ansi2html.py lays that grid out as positioned cells, and headless Chromium paints
+# it. Nothing is intercepted or reconstructed: what is on the screen is what lands in the PNG.
+#
+# THIS IS FOR THE CLAUDE CODE ON THE WEB CONTAINER ONLY. It refuses to run anywhere else, on
+# purpose — see the guard below.
+set -euo pipefail
+
+# A developer on their own machine is looking at Neovim already, and this would start a second
+# hidden one, install nothing it needs, and leave a tmux session behind. There is no case where
+# it is the right tool locally, so it does not run there.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  cat >&2 <<'MSG'
+capture.sh: refusing to run outside Claude Code on the web.
+
+This script screenshots a headless Neovim because the remote container has no display. On a
+local machine, look at your editor — or drive it directly if you want an image.
+
+Set CLAUDE_CODE_REMOTE=true only if you genuinely have this container's tmux, DejaVu Sans Mono
+and Playwright Chromium at the paths below.
+MSG
+  exit 2
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+WORK="${VIBING_SHOT_DIR:-${TMPDIR:-/tmp}/vibing-screenshot}"
+
+# `chrome --headless`, NOT headless_shell, is the trap here: the full browser subtracts its
+# (nonexistent) window UI from --window-size, so the page is silently clipped from the bottom.
+# The Neovim statusline disappears while every row above it still looks correct, which reads as
+# a CSS bug rather than a viewport one. headless_shell honours the size exactly.
+BROWSER="${VIBING_SHOT_BROWSER:-}"
+if [ -z "$BROWSER" ]; then
+  BROWSER="$(find /opt/pw-browsers -maxdepth 3 -type f -name headless_shell -print -quit 2>/dev/null || true)"
+fi
+
+SESSION="vibing-shot"
+COLS=150
+ROWS=40
+SCALE="${SCALE:-2}"
+FONT_PX=15
+LINE_PX=21
+PAD_PX=14
+
+die() { printf 'capture.sh: %s\n' "$*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "$1 is not installed"; }
+
+geometry_path() { printf '%s/%s.geometry' "$WORK" "$SESSION"; }
+
+cmd_start() {
+  need tmux
+  need nvim
+  mkdir -p "$WORK"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  # A dedicated init so the screenshot shows vibing.nvim actually set up (`:Vibing*` commands
+  # present), rather than the plugin merely on runtimepath.
+  tmux new-session -d -s "$SESSION" -x "$COLS" -y "$ROWS" -c "$REPO_ROOT" \
+    "TERM=xterm-256color nvim -u '$HERE/nvim_init.lua' $*"
+  printf '%s %s\n' "$COLS" "$ROWS" > "$(geometry_path)"
+  # Neovim needs to finish drawing before the first capture; a capture taken too early shows a
+  # blank pane, which looks exactly like a broken renderer.
+  sleep 3
+  printf 'started tmux session %s (%sx%s)\n' "$SESSION" "$COLS" "$ROWS" >&2
+}
+
+cmd_keys() {
+  need tmux
+  tmux send-keys -t "$SESSION" "$@"
+  sleep 1
+}
+
+cmd_shoot() {
+  local out="${1:?usage: capture.sh shoot <out.png>}"
+  need tmux
+  [ -n "$BROWSER" ] || die "no headless_shell found under /opt/pw-browsers (set VIBING_SHOT_BROWSER)"
+  [ -x "$BROWSER" ] || die "$BROWSER is not executable"
+  mkdir -p "$WORK"
+
+  if [ -r "$(geometry_path)" ]; then
+    read -r COLS ROWS < "$(geometry_path)"
+  fi
+
+  local width height
+  width=$(python3 -c "print(round($COLS * $FONT_PX * 0.6023) + 2*$PAD_PX)")
+  height=$(python3 -c "print($ROWS * $LINE_PX + 2*$PAD_PX)")
+
+  tmux capture-pane -e -p -t "$SESSION" > "$WORK/pane.ansi"
+  python3 "$HERE/ansi2html.py" --cols "$COLS" --font-px "$FONT_PX" \
+    --line-px "$LINE_PX" --pad-px "$PAD_PX" < "$WORK/pane.ansi" > "$WORK/pane.html"
+  "$BROWSER" --headless --no-sandbox --disable-gpu --hide-scrollbars \
+    --force-device-scale-factor="$SCALE" --window-size="$width,$height" \
+    --screenshot="$out" "file://$WORK/pane.html" 2>/dev/null
+
+  [ -s "$out" ] || die "the browser wrote no image"
+  printf '%s  (%sx%s grid, %sx%s css, %sx scale)\n' "$out" "$COLS" "$ROWS" \
+    "$width" "$height" "$SCALE" >&2
+  printf 'verify with: python3 %s/pxbox.py %s --expect-height %s\n' \
+    "$HERE" "$out" "$(( (ROWS - 2) * LINE_PX ))" >&2
+}
+
+cmd_stop() {
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  printf 'stopped %s\n' "$SESSION" >&2
+}
+
+[ $# -gt 0 ] || die "usage: capture.sh {start|keys|shoot|stop} ..."
+action="$1"; shift
+
+# Options common to every subcommand are consumed first so `keys` and `start` can still take
+# arbitrary trailing arguments.
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --session) SESSION="$2"; shift 2 ;;
+    --cols) COLS="$2"; shift 2 ;;
+    --rows) ROWS="$2"; shift 2 ;;
+    --scale) SCALE="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+done
+
+case "$action" in
+  start) cmd_start "$@" ;;
+  keys) cmd_keys "$@" ;;
+  shoot) cmd_shoot "$@" ;;
+  stop) cmd_stop ;;
+  *) die "unknown subcommand: $action" ;;
+esac

--- a/scripts/screenshot/nvim_init.lua
+++ b/scripts/screenshot/nvim_init.lua
@@ -1,0 +1,29 @@
+-- init.lua for the Neovim a screenshot is taken of.
+--
+-- Not tests/minimal_init.lua (that one wires up plenary for the parent test process and never
+-- calls setup(), so no `:Vibing*` command would exist) and not tests/e2e_init.lua (that one
+-- redirects chats to a throwaway temp directory, which then shows up in the statusline as a
+-- path no reader can make sense of).
+--
+-- Chats land in the project's real .vibing/chat/, which is already git-ignored.
+
+local repo_root = vim.fs.root(debug.getinfo(1, "S").source:sub(2), "package.json")
+  or vim.fn.getcwd()
+vim.opt.runtimepath:append(repo_root)
+
+vim.opt.swapfile = false
+vim.opt.backup = false
+-- Every capture starts a fresh Neovim in the same container; sharing one ShaDa file across them
+-- risks the same "read a half-written file" failure the test suite disables it for.
+vim.opt.shadafile = "NONE"
+
+vim.opt.termguicolors = true
+vim.opt.number = true
+-- One statusline for the whole editor rather than one per split: at these widths a per-window
+-- statusline spends most of its room on a truncated path.
+vim.opt.laststatus = 3
+
+require("vibing").setup({
+  mcp = { enabled = true },
+  permissions = { mode = "acceptEdits" },
+})

--- a/scripts/screenshot/pxbox.py
+++ b/scripts/screenshot/pxbox.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Report the bounding box of everything painted in a PNG, ignoring the page background.
+
+This exists because the failure it catches is invisible to the eye. A capture whose bottom rows
+are silently clipped looks like a correct screenshot of a slightly different screen — the
+statusline is simply absent, and every row above it is right. Measuring the painted region turns
+that into a number you can compare against `rows x line-height`.
+
+Decodes the PNG with nothing but zlib, so it needs no image library.
+"""
+
+import argparse
+import struct
+import sys
+import zlib
+
+
+def read_png(path):
+    data = open(path, "rb").read()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        sys.exit(f"{path}: not a PNG")
+    pos, idat, ihdr = 8, bytearray(), None
+    while pos + 8 <= len(data):
+        length = struct.unpack(">I", data[pos : pos + 4])[0]
+        kind = data[pos + 4 : pos + 8]
+        body = data[pos + 8 : pos + 8 + length]
+        if kind == b"IHDR":
+            ihdr = struct.unpack(">IIBBBBB", body)
+        elif kind == b"IDAT":
+            idat += body
+        elif kind == b"IEND":
+            break
+        pos += 12 + length
+    width, height, depth, ctype = ihdr[0], ihdr[1], ihdr[2], ihdr[3]
+    if depth != 8 or ctype not in (2, 6):
+        sys.exit(f"{path}: only 8-bit RGB/RGBA is supported (depth={depth} type={ctype})")
+    channels = 3 if ctype == 2 else 4
+    raw = zlib.decompress(bytes(idat))
+    stride = width * channels
+    rows, prev, p = [], bytearray(stride), 0
+    for _ in range(height):
+        filt = raw[p]
+        line = bytearray(raw[p + 1 : p + 1 + stride])
+        p += 1 + stride
+        if filt == 1:
+            for i in range(channels, stride):
+                line[i] = (line[i] + line[i - channels]) & 255
+        elif filt == 2:
+            for i in range(stride):
+                line[i] = (line[i] + prev[i]) & 255
+        elif filt == 3:
+            for i in range(stride):
+                left = line[i - channels] if i >= channels else 0
+                line[i] = (line[i] + ((left + prev[i]) >> 1)) & 255
+        elif filt == 4:
+            for i in range(stride):
+                a = line[i - channels] if i >= channels else 0
+                b = prev[i]
+                c = prev[i - channels] if i >= channels else 0
+                pa, pb, pc = abs(b - c), abs(a - c), abs(a + b - 2 * c)
+                pred = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[i] = (line[i] + pred) & 255
+        rows.append(bytes(line))
+        prev = line
+    return width, height, channels, rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("png")
+    ap.add_argument("--tolerance", type=int, default=12,
+                    help="per-channel distance from the background that counts as painted")
+    ap.add_argument("--expect-height", type=int, default=None,
+                    help="fail if the painted region is shorter than this many pixels")
+    a = ap.parse_args()
+
+    width, height, channels, rows = read_png(a.png)
+    # Sample the background from a far corner rather than assuming a constant: the page
+    # background is whatever the captured terminal's default was.
+    bg = tuple(rows[height // 2][(width - 2) * channels : (width - 2) * channels + 3])
+
+    x0, y0, x1, y1, painted = width, height, -1, -1, 0
+    for y, row in enumerate(rows):
+        for x in range(width):
+            px = row[x * channels : x * channels + 3]
+            if max(abs(px[i] - bg[i]) for i in range(3)) > a.tolerance:
+                painted += 1
+                x0, y0, x1, y1 = min(x0, x), min(y0, y), max(x1, x), max(y1, y)
+
+    print(f"{a.png}: {width}x{height}px  bg={bg}  painted={painted}px")
+    if not painted:
+        print("  nothing painted")
+        sys.exit(1)
+    box_h = y1 - y0 + 1
+    print(f"  x {x0}..{x1} (w={x1 - x0 + 1})   y {y0}..{y1} (h={box_h})")
+    if a.expect_height is not None and box_h < a.expect_height:
+        sys.exit(f"  painted height {box_h} < expected {a.expect_height}: the capture is clipped")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/screenshot/pxbox.py
+++ b/scripts/screenshot/pxbox.py
@@ -16,6 +16,7 @@ import zlib
 
 
 def read_png(path):
+    """Decode an 8-bit RGB/RGBA PNG to (width, height, channels, rows-as-bytes)."""
     data = open(path, "rb").read()
     if data[:8] != b"\x89PNG\r\n\x1a\n":
         sys.exit(f"{path}: not a PNG")
@@ -65,7 +66,33 @@ def read_png(path):
     return width, height, channels, rows
 
 
+def background_colour(width, height, channels, rows):
+    """The page background, taken as the most common colour along the image border.
+
+    The page ansi2html.py renders carries padding on all four sides, so its outermost pixels are
+    background whatever the terminal drew. Reading a single pixel instead — the earlier version
+    sampled one at the right edge, half way down — inverts the whole measurement the moment that
+    pixel lands on something painted, such as a full-width statusline in a two-pane layout: the
+    tool then reports the background as the painted region and can call a clipped capture fine,
+    which is the one answer it must never give.
+    """
+    counts = {}
+
+    def tally(x, y):
+        key = bytes(rows[y][x * channels : x * channels + 3])
+        counts[key] = counts.get(key, 0) + 1
+
+    for x in range(width):
+        tally(x, 0)
+        tally(x, height - 1)
+    for y in range(height):
+        tally(0, y)
+        tally(width - 1, y)
+    return tuple(max(counts, key=counts.get))
+
+
 def main():
+    """Report the painted bounding box, and fail if --expect-height is not reached."""
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("png")
     ap.add_argument("--tolerance", type=int, default=12,
@@ -75,9 +102,7 @@ def main():
     a = ap.parse_args()
 
     width, height, channels, rows = read_png(a.png)
-    # Sample the background from a far corner rather than assuming a constant: the page
-    # background is whatever the captured terminal's default was.
-    bg = tuple(rows[height // 2][(width - 2) * channels : (width - 2) * channels + 3])
+    bg = background_colour(width, height, channels, rows)
 
     x0, y0, x1, y1, painted = width, height, -1, -1, 0
     for y, row in enumerate(rows):

--- a/tests/screenshot-tools.test.mjs
+++ b/tests/screenshot-tools.test.mjs
@@ -1,0 +1,333 @@
+// scripts/screenshot/ is reached by no other gate: `check` compiles lua/ only, eslint matches
+// js/mjs/ts, and prettier matches js/ts/json/md/yml — none of them touch .py or .sh. So the two
+// Python tools there could break without a word, and one of them is the safety net that catches
+// a silently clipped screenshot. This pins what each is relied on for.
+//
+// The fixtures are built here rather than committed, so a change to the renderer's output cannot
+// be "fixed" by regenerating a golden file that no longer describes anything.
+
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { crc32, deflateSync } from 'node:zlib';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const ANSI2HTML = path.join(ROOT, 'scripts/screenshot/ansi2html.py');
+const PXBOX = path.join(ROOT, 'scripts/screenshot/pxbox.py');
+
+// python3 is a hard requirement of both tools, so a missing interpreter is a real failure rather
+// than a reason to skip: a test that quietly runs nothing is the exact dead gate this file exists
+// to prevent.
+const PYTHON = 'python3';
+
+const FONT_PX = 15;
+const LINE_PX = 21;
+const PAD_PX = 14;
+
+function ansi2html(dump, cols, extra = []) {
+  return execFileSync(
+    PYTHON,
+    [
+      ANSI2HTML,
+      '--cols',
+      String(cols),
+      '--font-px',
+      String(FONT_PX),
+      '--line-px',
+      String(LINE_PX),
+      '--pad-px',
+      String(PAD_PX),
+      ...extra,
+    ],
+    { input: dump, encoding: 'utf8' }
+  );
+}
+
+/** Every `<i>` cell in the rendered page, as {left, top, width, style, char}. */
+function cellsOf(html) {
+  return [...html.matchAll(/<i style="([^"]*)">([^<]*)<\/i>/g)].map(([, style, char]) => {
+    const num = (name) => {
+      const m = style.match(new RegExp(`(?:^|;)${name}:(-?[0-9.]+)px`));
+      return m ? Number(m[1]) : null;
+    };
+    return { left: num('left'), top: num('top'), width: num('width'), style, char };
+  });
+}
+
+const SGR = (...params) => `[${params.join(';')}m`;
+
+test('ansi2html --print-size is the single source of the viewport geometry', () => {
+  // capture.sh sizes the browser window from this. It used to compute the character advance
+  // itself, so the two could disagree and the screenshot would be cut off with no error.
+  const out = execFileSync(
+    PYTHON,
+    [
+      ANSI2HTML,
+      '--print-size',
+      '--cols',
+      '150',
+      '--rows',
+      '40',
+      '--font-px',
+      String(FONT_PX),
+      '--line-px',
+      String(LINE_PX),
+      '--pad-px',
+      String(PAD_PX),
+    ],
+    { encoding: 'utf8' }
+  );
+  const [width, height] = out.trim().split(/\s+/).map(Number);
+
+  assert.equal(height, 40 * LINE_PX + 2 * PAD_PX);
+  // The width must match what the page itself lays out, whatever the advance happens to be.
+  const html = ansi2html('x'.repeat(150), 150);
+  const page = html.match(/#t\{[^}]*width:([0-9.]+)px/);
+  assert.ok(page, 'the page should declare its own width');
+  assert.equal(width, Math.round(Number(page[1])) + 2 * PAD_PX);
+});
+
+test('ansi2html --print-size refuses to guess a missing --rows', () => {
+  const r = spawnSync(PYTHON, [ANSI2HTML, '--print-size', '--cols', '80'], { encoding: 'utf8' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--rows/);
+});
+
+test('ansi2html carries truecolor foreground and background onto the cell', () => {
+  const html = ansi2html(`${SGR(38, 2, 224, 226, 234)}${SGR(48, 2, 79, 82, 88)}A`, 10);
+  const [cell] = cellsOf(html);
+  assert.equal(cell.char, 'A');
+  assert.match(cell.style, /color:#e0e2ea/);
+  assert.match(cell.style, /background:#4f5258/);
+});
+
+test('ansi2html resolves the 256-colour and base-16 forms too', () => {
+  // 196 is the pure red of the colour cube; 31 is base-16 red.
+  const cube = cellsOf(ansi2html(`${SGR(38, 5, 196)}A`, 10))[0];
+  assert.match(cube.style, /color:#ff0000/);
+  const base = cellsOf(ansi2html(`${SGR(31)}A`, 10))[0];
+  assert.match(base.style, /color:#cd0000/);
+});
+
+test('ansi2html gives a wide character two columns', () => {
+  // A CJK glyph advances the grid by two cells. Getting this wrong is what made a flowed <pre>
+  // drift out of alignment on Japanese-heavy source and misrepresent the window layout.
+  const cells = cellsOf(ansi2html('あA', 10));
+  assert.equal(cells.length, 2);
+  const [wide, narrow] = cells;
+  assert.equal(wide.char, 'あ');
+  // Compared with a tolerance because the page carries the positions rounded to 1/100 px: the
+  // advance is 9.0345px, so doubling the *printed* 9.03 gives 18.06 where the wide cell prints
+  // 18.07. Each value can be off by half a hundredth, and doubling one doubles its share.
+  assert.ok(
+    Math.abs(wide.width - 2 * narrow.width) <= 0.02,
+    `wide cell ${wide.width} should be twice ${narrow.width}`
+  );
+  // This one is exact, and is the property that actually keeps the grid aligned: the next cell
+  // begins where the wide one ends, not one narrow column in.
+  assert.equal(narrow.left, wide.left + wide.width);
+});
+
+test('ansi2html states an explicit cell height, so descenders are not clipped', () => {
+  // Leaving the height to the line box let the statusline row's descenders fall outside the
+  // box and get cut by overflow:hidden — visible only on that one row.
+  const html = ansi2html('A', 10);
+  const rule = html.match(/#t i\{[^}]*\}/s);
+  assert.ok(rule, 'the page should carry a cell rule');
+  assert.match(rule[0], new RegExp(`height:${LINE_PX}px`));
+  assert.match(rule[0], new RegExp(`line-height:${LINE_PX}px`));
+});
+
+test('ansi2html emits a blank cell only when it paints something', () => {
+  // Most of a terminal screen is unstyled spaces; an element each would multiply the page size
+  // for nothing. A space with a background is the statusline, and must survive.
+  assert.equal(cellsOf(ansi2html('   ', 10)).length, 0);
+  const painted = cellsOf(ansi2html(`${SGR(48, 2, 79, 82, 88)}   `, 10));
+  assert.equal(painted.length, 3);
+  assert.match(painted[0].style, /background:#4f5258/);
+});
+
+test('ansi2html swaps colours for reverse video', () => {
+  const [cell] = cellsOf(ansi2html(`${SGR(38, 2, 0, 0, 0)}${SGR(48, 2, 255, 0, 0)}${SGR(7)}A`, 10));
+  assert.match(cell.style, /color:#ff0000/);
+  assert.match(cell.style, /background:#000000/);
+});
+
+test('ansi2html drops a non-SGR escape without swallowing the colour after it', () => {
+  // The scanner has to know where a CSI or OSC sequence ends. A regex that stripped escapes in
+  // a pre-pass could eat the `m` that terminates the colour that follows, silently losing every
+  // subsequent style on the line.
+  const dump = `]0;a title[?25l${SGR(38, 2, 1, 2, 3)}A`;
+  const cells = cellsOf(ansi2html(dump, 20));
+  assert.equal(cells.length, 1);
+  assert.equal(cells[0].char, 'A');
+  assert.match(cells[0].style, /color:#010203/);
+});
+
+test('ansi2html escapes markup coming from the terminal', () => {
+  const html = ansi2html('<&>', 10);
+  assert.match(html, /&lt;/);
+  assert.match(html, /&amp;/);
+  assert.equal(cellsOf(html).length, 3);
+});
+
+// --- pxbox.py -----------------------------------------------------------------------------
+
+const BPP = 3; // 8-bit RGB
+
+/**
+ * PNG scanlines with a chosen filter per row.
+ *
+ * Encoding the filters here rather than always writing type 0 is what makes the decoder test
+ * worth anything: a real browser screenshot is filtered per row, and pxbox.py reverses all five
+ * types by hand.
+ */
+function encodeScanlines(width, height, paint, filterFor) {
+  const stride = width * BPP;
+  const parts = [];
+  let prev = Buffer.alloc(stride);
+  for (let y = 0; y < height; y++) {
+    const line = Buffer.alloc(stride);
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = paint(x, y);
+      line[x * BPP] = r;
+      line[x * BPP + 1] = g;
+      line[x * BPP + 2] = b;
+    }
+    const filter = filterFor(y);
+    const encoded = Buffer.alloc(stride);
+    for (let i = 0; i < stride; i++) {
+      const left = i >= BPP ? line[i - BPP] : 0;
+      const up = prev[i];
+      const upLeft = i >= BPP ? prev[i - BPP] : 0;
+      let predictor = 0;
+      if (filter === 1) {
+        predictor = left;
+      } else if (filter === 2) {
+        predictor = up;
+      } else if (filter === 3) {
+        predictor = (left + up) >> 1;
+      } else if (filter === 4) {
+        const p = left + up - upLeft;
+        const pa = Math.abs(p - left);
+        const pb = Math.abs(p - up);
+        const pc = Math.abs(p - upLeft);
+        predictor = pa <= pb && pa <= pc ? left : pb <= pc ? up : upLeft;
+      }
+      encoded[i] = (line[i] - predictor) & 0xff;
+    }
+    parts.push(Buffer.from([filter]), encoded);
+    prev = line;
+  }
+  return Buffer.concat(parts);
+}
+
+/** A minimal 8-bit RGB PNG, so the fixture does not come from the decoder under test. */
+function png(width, height, paint, filterFor = () => 0) {
+  const raw = encodeScanlines(width, height, paint, filterFor);
+  const chunk = (type, body) => {
+    const head = Buffer.alloc(8);
+    head.writeUInt32BE(body.length, 0);
+    head.write(type, 4, 'ascii');
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(Buffer.concat([Buffer.from(type, 'ascii'), body])), 0);
+    return Buffer.concat([head, body, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // colour type: RGB
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+const BG = [20, 22, 27];
+const INK = [224, 226, 234];
+
+function writePng(name, width, height, paint, filterFor) {
+  const file = path.join(mkdtempSync(path.join(tmpdir(), 'vibing-pxbox-')), name);
+  writeFileSync(file, png(width, height, paint, filterFor));
+  return file;
+}
+
+function pxbox(file, expectHeight) {
+  const args = [PXBOX, file];
+  if (expectHeight !== undefined) args.push('--expect-height', String(expectHeight));
+  return spawnSync(PYTHON, args, { encoding: 'utf8' });
+}
+
+test('pxbox reports the exact bounding box of what was painted', () => {
+  // x 10..19, y 5..24 — deliberately not touching any edge, so an off-by-one in the row filter
+  // or stride would move it.
+  const file = writePng('box.png', 40, 30, (x, y) =>
+    x >= 10 && x <= 19 && y >= 5 && y <= 24 ? INK : BG
+  );
+  const r = pxbox(file);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /x 10\.\.19 \(w=10\)/);
+  assert.match(r.stdout, /y 5\.\.24 \(h=20\)/);
+});
+
+test('pxbox fails when the painted region is shorter than the grid implies', () => {
+  // This is the whole point of the tool: a capture clipped from the bottom is a plausible
+  // screenshot of a slightly different screen, and the eye does not catch it.
+  //
+  // Both fixtures leave a margin, because the page being measured always has one — ansi2html.py
+  // pads the grid — and content that ran to the very edge would be a different image than this
+  // tool is ever pointed at.
+  const band = (from, to) => (x, y) => (y >= from && y <= to && x >= 4 && x <= 35 ? INK : BG);
+
+  const clipped = writePng('clipped.png', 40, 60, band(4, 13));
+  const short = pxbox(clipped, 40);
+  assert.notEqual(short.status, 0);
+  assert.match(short.stdout + short.stderr, /clipped/);
+
+  const full = writePng('full.png', 40, 60, band(4, 53));
+  assert.equal(pxbox(full, 40).status, 0);
+});
+
+test('pxbox fails rather than reports an empty box on a blank capture', () => {
+  const blank = writePng('blank.png', 20, 20, () => BG);
+  const r = pxbox(blank);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stdout, /nothing painted/);
+});
+
+test('pxbox reverses every PNG row filter', () => {
+  // A browser screenshot is filtered per row, and pxbox.py undoes all five types by hand. A
+  // wrong Paeth or Average reconstruction corrupts the image and moves the box, so the same
+  // rectangle has to come back whichever filter carried it.
+  const paint = (x, y) => (x >= 8 && x <= 31 && y >= 4 && y <= 19 ? INK : BG);
+  for (const filter of [0, 1, 2, 3, 4]) {
+    const file = writePng(`filter${filter}.png`, 64, 40, paint, () => filter);
+    const r = pxbox(file);
+    assert.equal(r.status, 0, `filter ${filter}: ${r.stderr}`);
+    assert.match(r.stdout, /x 8\.\.31 \(w=24\)/, `filter ${filter} moved the box`);
+    assert.match(r.stdout, /y 4\.\.19 \(h=16\)/, `filter ${filter} moved the box`);
+  }
+
+  // Mixed filters exercise the "previous row" state the reconstruction carries between rows.
+  const mixed = writePng('mixed.png', 64, 40, paint, (y) => y % 5);
+  const r = pxbox(mixed);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /x 8\.\.31 \(w=24\)/);
+  assert.match(r.stdout, /y 4\.\.19 \(h=16\)/);
+});
+
+test('pxbox takes the background from the border, not from one pixel', () => {
+  // The regression this guards: a full-width painted band crossing the middle of the image used
+  // to be read as the background, because the sample point sat inside it.
+  const file = writePng('midband.png', 40, 60, (x, y) => (y >= 25 && y <= 34 ? INK : BG));
+  const r = pxbox(file);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /y 25\.\.34 \(h=10\)/);
+  assert.match(r.stdout, new RegExp(`bg=\\(${BG.join(', ')}\\)`));
+});


### PR DESCRIPTION
The Claude Code on the web container ships node and git but neither Neovim
nor a Lua compiler, so four of the five CI gates could not start there:
test:lua, test:e2e and check:doc invoke `nvim`, and check invokes `luac`.
Every web session had to rebuild that environment by hand first.

.claude/hooks/session-start.sh installs Neovim stable to /opt/nvim,
plenary.nvim under stdpath("data"), lua5.3 and the npm dependencies —
mirroring the corresponding steps of .github/workflows/ci.yml so a web
session fails and passes on the same things CI does. Registered as a
SessionStart hook in .claude/settings.json.

Three properties are deliberate:

- It no-ops unless CLAUDE_CODE_REMOTE=true. A local machine already has the
  developer's own Neovim, and writing to /opt and /usr/local there is never
  what is wanted.
- It is synchronous. The first thing a web session usually does is run the
  suite, and an async hook would let that start against a half-installed
  environment.
- It verifies at the end and exits non-zero on anything still missing, and
  keeps all progress output on stderr — a SessionStart hook's stdout is
  prepended to the session as context, and a hook that reports success over
  a broken environment makes the next failure look like the repository's.

Verified from a fully torn-down container: 6.4s cold, idempotent on re-run,
0 bytes on stdout, then check / check:doc / lint / format:check / test:node
all exit 0 and test:lua reports 1610 assertions with 0 failures and 0
errors. The E2E child-Neovim harness was exercised with the one spec that
sends no CLI request (tests/e2e/chat_jump_user_spec.lua, 3/3).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mzi7YPY7Mu1nb1e3EEAV9z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automatic environment setup for remote development sessions.
  - Required development tools and dependencies are installed and verified before the session proceeds.
  - Local development sessions remain unaffected.
  - Setup progress and validation errors are reported clearly.

- **Documentation**
  - Documented the remote session setup process, required tooling, validation behavior, and workflow requirements.
  - Updated project guidance to reflect the expanded web workflow coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->