### PR TITLE
feat(orchestration): let an orchestrator answer a worker's tool approval

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -371,6 +371,10 @@ there is no command and no scheduler.
 - **Reporting is the worker's job; the notification is a watchdog.** `agent.chat_notifications`
   gates only the watchdog — a stop the chat cannot leave on its own (`asked_question`,
   `waiting_approval`, `error`) is delivered whatever the setting is.
+- **A worker's tool-approval prompt is the user's to clear, unless the user says otherwise.**
+  `agent.orchestration.delegated_approval` (default `false`) is what lets the orchestrator answer
+  it with `nvim_chat_answer_approval`; the answer takes the human path
+  (`ChatBuffer:send_message()`) rather than a second implementation of what an approval means.
 - **A message delivered from another chat gets its own section kind** — `## Request`, `## Report`
   or `## Notice`. `extract_role` still answers `user` for all three; only the display splits.
 

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -63,7 +63,8 @@ Prefix with `mcp__vibing-nvim__`:
 - **Highlighting**: `nvim_highlight_range`, `nvim_clear_highlight` (see "Showing Code" below)
 - **Annotations**: `nvim_annotate`, `nvim_clear_annotations` (see "Inline Review Notes" below)
 - **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
-  `features.md`), `nvim_chat_send_message`, `nvim_chat_create` (see "Orchestration" below)
+  `features.md`), `nvim_chat_send_message`, `nvim_chat_create`, `nvim_chat_answer_approval`
+  (see "Orchestration" below)
 - **Instances**: `nvim_list_instances`
 - **Quickfix**: `nvim_set_qflist` (pushes a new list; the previous one survives under `:colder`)
 - **Debugger**: `nvim_dap_get_state`, `nvim_dap_get_stack_trace`, `nvim_dap_get_variables`,
@@ -126,6 +127,15 @@ happened, and "queued" means no request has started yet — an orchestrator that
 would poll a transcript that has not moved. Why it is not gated on `chat_notifications`, why the
 frontmatter link is written at delivery rather than when the message is queued, and why the queue
 is capped: `handbook/architecture/orchestration.md`.
+
+`nvim_chat_answer_approval({ rpc_port, file_path|bufnr, action, from_bufnr })` answers another
+chat's pending tool-approval prompt with one of `allow_once` / `deny_once` / `allow_for_session` /
+`deny_for_session`. **It is refused unless `agent.orchestration.delegated_approval` is set**, since
+what it buys is one agent clearing another agent's permission gate; `from_bufnr` is required here
+(unlike on the other two) so the answer is always recorded as somebody's decision. Why it writes
+the chosen option line into the worker's buffer instead of applying the decision directly, and why
+the watchdog's `waiting_approval` wording changes with the setting:
+`handbook/architecture/orchestration.md` → "Answering a worker's tool approval".
 
 The workflow is the bundled `vibing-orchestrate` skill. Why `position` defaults to `back`, why the
 chat file is written at creation, why the status is a field rather than a text heuristic, and what

--- a/.claude/rules/permissions.md
+++ b/.claude/rules/permissions.md
@@ -120,6 +120,21 @@ The user deletes unwanted options with standard Vim commands (`dd`, etc.) and se
 one with `<CR>`. `allow_once`/`deny_once` apply to this call only; `allow_for_session`/
 `deny_for_session` persist for the rest of the chat session.
 
+**Another chat can answer it only when the user opted in.** A worker chat that hits this prompt is
+`waiting_approval`: its turn was killed, so it can neither continue nor report that it is stuck,
+and in an orchestration run the user has to find each blocked worker by hand. With
+`agent.orchestration.delegated_approval = true` the orchestrator answers instead, via the MCP tool
+`nvim_chat_answer_approval` → `application/chat/approval_delegate.lua`. The default is off because
+what it buys is an agent clearing another agent's permission gate, not because of anything in the
+implementation.
+
+The delegated answer takes **exactly the human path**: it writes the chosen option line into the
+worker's pending unsent section (replacing the prompt) and calls `ChatBuffer:send_message()`, so
+`update_session_permissions`, the `:once` bookkeeping and the retry-message substitution all run
+once, in one place. A second implementation of "what an approval means" is the failure this shape
+exists to prevent. What differs is the section header — `## Request <!-- … from <orchestrator> -->`
+— which is how the worker's transcript records who granted it.
+
 **An answer belongs to the chat that was asked, and to no other** (#667). The four decisions are
 recorded on that `ChatBuffer` (`update_session_permissions`), handed to the next request as
 `permissions_session_allow` / `permissions_session_deny`, and reach the hook through

--- a/.claude/rules/self-testing.md
+++ b/.claude/rules/self-testing.md
@@ -54,6 +54,39 @@ The one case neither the exit code nor a summary count catches is a spec file th
 tests (a `describe` that stopped being reached): plenary exits 0 without printing a summary, which
 is also how the E2E specs opt out via `should_run()`.
 
+## A Spec Cannot Outlast Its Harness
+
+`PlenaryBustedDirectory` runs one child Neovim per spec **file** and joins it with a single
+timeout — 50000ms unless the invocation says otherwise. A spec still inside a `vim.wait` when that
+expires is killed mid-wait: no summary, no failure, no test count. Only the exit code moves, which
+is the zero-tests shape above arriving by a different route.
+
+Three E2E specs sat in exactly that state, each budgeting `ASSISTANT_RESPONSE = 60000` against the
+50000ms default: they died at 50.2s every run and printed nothing at all. `test:e2e` now passes
+`timeout = 240000`, and `tests/e2e-timeout-gate.test.mjs` keeps the two numbers in agreement — it
+reads the budget out of the `test:e2e` command itself (so it cannot pass against a command the
+project no longer runs) and sums every wait each spec file can perform. The sum is deliberately an
+over-estimate; over-counting only ever asks for a larger budget, and an exact model is what would
+let the silent case back in. The bound is **per file**, not per test, because the timeout is on
+the job.
+
+## An Assertion That a Failed Turn Satisfies Is Not an Assertion
+
+`## .* Assistant` is written into the buffer whether the turn produced an answer or died on the
+first line — `send_message.lua` appends `**Error:** …` under the same header. So a spec waiting
+for that header passes with the CLI never having worked, which is what `chat_basic_flow_spec`'s
+"should send message and receive response" was doing.
+
+Anything asserting a turn ran uses `helper.wait_for_response`, not `wait_for_buffer_content`. It
+waits for text only the model can produce (a marker word the prompt asks for) and **gives up the
+moment `**Error:**` appears**, returning the reason as a second value for the assertion message.
+Both halves matter: waiting on real output stops a dead turn from passing, and aborting on the
+error stops a dead turn from being misreported — `plugin_dir_spec` would otherwise spend its full
+budget and then blame `--plugin-dir` for a failure that was the CLI refusing to start.
+
+The error pattern lives once, in `e2e_helper.lua`. Copied into each spec, the day that wording
+changes is the day every spec quietly decides no turn ever fails.
+
 ## Vim Help Verification
 
 `npm run check:doc` (`scripts/check-help.lua`, run by the "Verify Vim help files" CI step) is the

--- a/.claude/rules/self-testing.md
+++ b/.claude/rules/self-testing.md
@@ -73,19 +73,45 @@ the job.
 ## An Assertion That a Failed Turn Satisfies Is Not an Assertion
 
 `## .* Assistant` is written into the buffer whether the turn produced an answer or died on the
-first line — `send_message.lua` appends `**Error:** …` under the same header. So a spec waiting
-for that header passes with the CLI never having worked, which is what `chat_basic_flow_spec`'s
-"should send message and receive response" was doing.
+first line — `send_message.lua` appends `**Error:** …` under that same header. So a spec waiting
+for it passes with the CLI never having worked, which is what `chat_basic_flow_spec`'s "should
+send message and receive response" was doing.
 
-Anything asserting a turn ran uses `helper.wait_for_response`, not `wait_for_buffer_content`. It
-waits for text only the model can produce (a marker word the prompt asks for) and **gives up the
-moment `**Error:**` appears**, returning the reason as a second value for the assertion message.
-Both halves matter: waiting on real output stops a dead turn from passing, and aborting on the
-error stops a dead turn from being misreported — `plugin_dir_spec` would otherwise spend its full
-budget and then blame `--plugin-dir` for a failure that was the CLI refusing to start.
+Anything that depends on a turn goes through one of three helpers, never `wait_for_buffer_content`.
+All three abort the moment `**Error:**` appears and hand the reason back as a second value for the
+assertion message — without that, a dead turn is not just missed but **misreported**:
+`plugin_dir_spec` used to spend its whole budget and then blame `--plugin-dir` for a CLI that had
+refused to start.
+
+- `wait_for_assistant_turns(instance, n, timeout)` — "a turn ran and did not fail". The right
+  default, because it does not depend on the model choosing to say any particular thing.
+- `wait_for_assistant_text(instance, pattern, timeout)` — for content only the model could have
+  produced. Matches **only after the last `## … Assistant` header**, which is the half that is
+  easy to get wrong: a whole-buffer match lets a marker word the prompt itself asks for satisfy
+  the assertion from the `## User` section, with the turn never having returned a byte. That
+  mistake was made and caught here.
+- `wait_for_response(instance, pattern, timeout)` — whole buffer, for what the chat UI renders
+  into the _user_ section as a result of a turn: the approval prompt, the question choice list.
 
 The error pattern lives once, in `e2e_helper.lua`. Copied into each spec, the day that wording
 changes is the day every spec quietly decides no turn ever fails.
+
+## The Child CLI Cannot Run as Root Without Being Told It Is Sandboxed
+
+`tests/e2e_init.lua` pins `permissions.mode = "bypassPermissions"`, and it has to — under
+`acceptEdits` the CLI refuses vibing.nvim's own MCP tool and `--allowedTools` does not clear it
+(see that file). But the CLI turns that mode into `--dangerously-skip-permissions`, which it
+refuses outright when the process is running as root:
+
+```text
+--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
+```
+
+Containers — CI, Claude Code on the web, devcontainers — are uid 0, so every spec that needs a
+real turn failed there and nowhere else. `spawn_nvim_instance` sets `IS_SANDBOX=1` in the child's
+environment, which is the CLI's own escape hatch for that check, **only when `getuid()` is 0**.
+Setting it unconditionally would silently drop a safety check on a developer's own machine, where
+there is nothing to drop in the first place.
 
 ## Vim Help Verification
 

--- a/.claude/skills/self-testing/SKILL.md
+++ b/.claude/skills/self-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-testing
-description: E2E self-testing workflow for vibing.nvim using a separate Neovim instance controlled over RPC. Use when writing or debugging E2E tests, running `npm run test:e2e`, or executing the 3-try auto-fix rule after implementing a feature. Covers the spawn_nvim_instance/send_keys/wait_for_buffer_content/cleanup_instance helper API, test scenario checklist, and troubleshooting for hangs, "Job not found", and cross-test state pollution.
+description: E2E self-testing workflow for vibing.nvim using a separate Neovim instance controlled over RPC. Use when writing or debugging E2E tests, running `npm run test:e2e`, or executing the 3-try auto-fix rule after implementing a feature. Covers the spawn_nvim_instance/send_keys/wait_for_buffer_content/wait_for_response/cleanup_instance helper API, test scenario checklist, and troubleshooting for hangs, "Job not found", and cross-test state pollution.
 ---
 
 # Self-Testing for vibing.nvim
@@ -16,6 +16,8 @@ Test Runner (Current Nvim)
   │   ├─ spawn_nvim_instance()  - Launch child Nvim via jobstart(rpc=true)
   │   ├─ send_keys()             - Send key input via rpcrequest
   │   ├─ wait_for_buffer_content() - Poll buffer TEXT until pattern matches
+  │   ├─ wait_for_response()      - Same, but for output only a real turn produces:
+  │   │                             aborts with the reason when the turn errors
   │   ├─ wait_for_buffer_name()    - Poll buffer NAME (use this for a filename)
   │   └─ cleanup_instance()      - Stop job
   │
@@ -100,11 +102,40 @@ Send a key sequence via `rpcrequest`, e.g. `":VibingChat<CR>"`, `"G"`, `"iHello<
 ### `wait_for_buffer_content(instance, pattern, timeout)`
 
 Poll buffer content until `pattern` (Lua pattern) matches or `timeout` (ms) elapses. Returns
-`true`/`false`.
+`true`/`false`. Use it for buffer state vibing.nvim writes on its own — frontmatter, a rendered
+prompt, a slash command's confirmation. **Not** for anything that depends on a CLI turn.
+
+### `wait_for_response(instance, pattern, timeout)`
+
+The one to use when a real turn has to have run. Returns `ok, reason`; pass `reason` straight into
+the assertion message.
+
+```lua
+local ok, reason = helper.wait_for_response(nvim_instance, MARKER, 30000)
+assert.is_true(ok, reason or "the model should have answered")
+```
+
+Two things it does that `wait_for_buffer_content` does not:
+
+- It gives up as soon as the turn writes `**Error:**`, with that line as `reason`. Without it a
+  failed turn burns the whole budget and then reports whatever the spec happened to be waiting
+  for — `plugin_dir_spec` blamed `--plugin-dir` for a CLI that never started.
+- It makes you name what the model produced. Waiting for `## .* Assistant` asserts nothing: that
+  header is written above the error text too, so the spec passes with the CLI broken.
+
+Ask the prompt for a marker word the model cannot produce otherwise, and wait for that.
 
 ### `cleanup_instance(instance)`
 
 Stop the Neovim instance job. Always call this in `after_each()`.
+
+## Budget: a spec cannot outlast its harness
+
+plenary joins each spec **file** with one timeout — `timeout = 240000` in the `test:e2e` script.
+A spec still inside a `vim.wait` when that expires is killed mid-wait and prints **nothing**: no
+summary, no failure, no test count. So the sum of every wait a file can perform has to fit inside
+that budget, and `tests/e2e-timeout-gate.test.mjs` fails the build when it does not. Raise the
+script's `timeout` rather than trimming a wait that a real turn needs.
 
 ## Test Scenarios to Cover
 
@@ -171,12 +202,12 @@ it("should export chat to markdown file via /export", function()
 
   helper.send_keys(nvim_instance, "G")
   helper.send_keys(nvim_instance, "i")
-  helper.send_keys(nvim_instance, "Test message")
+  helper.send_keys(nvim_instance, "Reply with ONLY the word " .. MARKER .. ".")
   helper.send_keys(nvim_instance, "<Esc>")
   helper.send_keys(nvim_instance, "<CR>")
 
-  local ok = helper.wait_for_buffer_content(nvim_instance, "## .* Assistant", 30000)
-  assert.is_true(ok, "Assistant should respond")
+  local ok, reason = helper.wait_for_response(nvim_instance, MARKER, 30000)
+  assert.is_true(ok, reason or "Assistant should respond")
 
   helper.send_keys(nvim_instance, "G")
   helper.send_keys(nvim_instance, "i")

--- a/.claude/skills/self-testing/SKILL.md
+++ b/.claude/skills/self-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-testing
-description: E2E self-testing workflow for vibing.nvim using a separate Neovim instance controlled over RPC. Use when writing or debugging E2E tests, running `npm run test:e2e`, or executing the 3-try auto-fix rule after implementing a feature. Covers the spawn_nvim_instance/send_keys/wait_for_buffer_content/wait_for_response/cleanup_instance helper API, test scenario checklist, and troubleshooting for hangs, "Job not found", and cross-test state pollution.
+description: E2E self-testing workflow for vibing.nvim using a separate Neovim instance controlled over RPC. Use when writing or debugging E2E tests, running `npm run test:e2e`, or executing the 3-try auto-fix rule after implementing a feature. Covers the spawn_nvim_instance/send_keys/wait_for_buffer_content/wait_for_assistant_turns/cleanup_instance helper API, test scenario checklist, and troubleshooting for hangs, "Job not found", and cross-test state pollution.
 ---
 
 # Self-Testing for vibing.nvim
@@ -16,8 +16,9 @@ Test Runner (Current Nvim)
   │   ├─ spawn_nvim_instance()  - Launch child Nvim via jobstart(rpc=true)
   │   ├─ send_keys()             - Send key input via rpcrequest
   │   ├─ wait_for_buffer_content() - Poll buffer TEXT until pattern matches
-  │   ├─ wait_for_response()      - Same, but for output only a real turn produces:
-  │   │                             aborts with the reason when the turn errors
+  │   ├─ wait_for_assistant_turns() - A turn ran and did not fail (start here)
+  │   ├─ wait_for_assistant_text()  - Output only the model could produce
+  │   ├─ wait_for_response()        - Whole buffer, but aborts when the turn errors
   │   ├─ wait_for_buffer_name()    - Poll buffer NAME (use this for a filename)
   │   └─ cleanup_instance()      - Stop job
   │
@@ -105,29 +106,49 @@ Poll buffer content until `pattern` (Lua pattern) matches or `timeout` (ms) elap
 `true`/`false`. Use it for buffer state vibing.nvim writes on its own — frontmatter, a rendered
 prompt, a slash command's confirmation. **Not** for anything that depends on a CLI turn.
 
-### `wait_for_response(instance, pattern, timeout)`
+### Waits that depend on a CLI turn
 
-The one to use when a real turn has to have run. Returns `ok, reason`; pass `reason` straight into
-the assertion message.
+Three helpers, all returning `ok, reason` — pass `reason` straight into the assertion message —
+and all giving up the moment the turn writes `**Error:**`. Never use `wait_for_buffer_content`
+for something a turn has to produce: that error text lands under a normal `## … Assistant`
+header, so waiting for the header asserts nothing at all.
+
+#### `wait_for_assistant_turns(instance, count, timeout)`
+
+"A turn ran and did not fail." **Start here.** It does not depend on the model choosing to say any
+particular thing, so it cannot go flaky on a rewording.
 
 ```lua
-local ok, reason = helper.wait_for_response(nvim_instance, MARKER, 30000)
-assert.is_true(ok, reason or "the model should have answered")
+local ok, reason = helper.wait_for_assistant_turns(nvim_instance, 1, 30000)
+assert.is_true(ok, reason or "the assistant should have answered")
 ```
 
-Two things it does that `wait_for_buffer_content` does not:
+#### `wait_for_assistant_text(instance, pattern, timeout)`
 
-- It gives up as soon as the turn writes `**Error:**`, with that line as `reason`. Without it a
-  failed turn burns the whole budget and then reports whatever the spec happened to be waiting
-  for — `plugin_dir_spec` blamed `--plugin-dir` for a CLI that never started.
-- It makes you name what the model produced. Waiting for `## .* Assistant` asserts nothing: that
-  header is written above the error text too, so the spec passes with the CLI broken.
+For content only the model could have produced — the marker word in `plugin_dir_spec`, proving a
+skill's description reached it. Matches **only the text after the last `## … Assistant` header**.
 
-Ask the prompt for a marker word the model cannot produce otherwise, and wait for that.
+That scoping is the whole point. Match the whole buffer instead and a marker word your own prompt
+asks for is satisfied by the `## User` section, so the spec passes with the turn never having
+returned a byte. Put the marker somewhere the prompt does not repeat — a skill description, a
+file the model has to read.
+
+#### `wait_for_response(instance, pattern, timeout)`
+
+Whole buffer, for what the chat UI renders into the **user** section as a result of a turn: the
+tool-approval prompt, the `nvim_ask_user_question` choice list.
 
 ### `cleanup_instance(instance)`
 
 Stop the Neovim instance job. Always call this in `after_each()`.
+
+### Running as root
+
+`spawn_nvim_instance` sets `IS_SANDBOX=1` for the child when `getuid()` is 0. The E2E init pins
+`permissions.mode = "bypassPermissions"`, which becomes `--dangerously-skip-permissions`, and the
+CLI refuses that under root — so in a container every spec needing a real turn fails without it.
+It is gated on uid rather than set unconditionally: on a developer's own machine there is no root
+check to clear, only a safety check to lose.
 
 ## Budget: a spec cannot outlast its harness
 
@@ -202,11 +223,11 @@ it("should export chat to markdown file via /export", function()
 
   helper.send_keys(nvim_instance, "G")
   helper.send_keys(nvim_instance, "i")
-  helper.send_keys(nvim_instance, "Reply with ONLY the word " .. MARKER .. ".")
+  helper.send_keys(nvim_instance, "Test message")
   helper.send_keys(nvim_instance, "<Esc>")
   helper.send_keys(nvim_instance, "<CR>")
 
-  local ok, reason = helper.wait_for_response(nvim_instance, MARKER, 30000)
+  local ok, reason = helper.wait_for_assistant_turns(nvim_instance, 1, 30000)
   assert.is_true(ok, reason or "Assistant should respond")
 
   helper.send_keys(nvim_instance, "G")

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -238,6 +238,18 @@ The MCP server exposes the following tools to Claude:
     relationship in both chat files' frontmatter (`orchestrated` / `orchestrated_by`), so it
     outlives the buffer numbers and file names it was built from
 
+- **nvim_chat_answer_approval** - Answer another chat's pending tool-approval prompt, the stop
+  that leaves it at status `waiting_approval` unable to continue or report. **Refused unless the
+  user set `agent.orchestration.delegated_approval`** — by default only the user can clear that
+  prompt, and the error says so
+  - `file_path` / `bufnr` (exactly one): The blocked chat, addressed as above
+  - `action` (required): `allow_once` / `deny_once` / `allow_for_session` / `deny_for_session` —
+    the same four options the prompt offers the user. The `_for_session` pair is written into that
+    chat's frontmatter and applies to every later call in it
+  - `from_bufnr` (**required**, unlike on the two tools above): The answering chat's buffer
+    number. The answer is recorded in the blocked chat as coming from it, so a call that cannot
+    say whose decision it was is refused
+
 - **nvim_ask_user_question** - Render a multiple-choice question in the chat buffer. This cancels
   the in-flight turn; the user's answer arrives as the next turn's message
   - `chat_bufnr` (required): Chat buffer number

--- a/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { allTools } from '../tools/index.js';
-import { CHAT_POSITIONS } from '../tools/chat.js';
+import { APPROVAL_ACTIONS, CHAT_POSITIONS } from '../tools/chat.js';
 import { handlers } from '../handlers/index.js';
 import * as rpc from '../rpc.js';
 
@@ -286,6 +286,102 @@ describe('chat tools (worktree redesign)', () => {
     expect(inputSchema.required).not.toContain('bufnr');
     expect(inputSchema.required).not.toContain('file_path');
     expect(inputSchema.required).toContain('message');
+  });
+
+  it('registers nvim_chat_answer_approval with action and from_bufnr required', () => {
+    const tool = allTools.find((t) => t.name === 'nvim_chat_answer_approval');
+    const inputSchema = tool?.inputSchema as {
+      required?: string[];
+      properties: Record<string, any>;
+    };
+
+    expect(tool).toBeDefined();
+    expect(inputSchema.required).toContain('rpc_port');
+    expect(inputSchema.required).toContain('action');
+    // Unlike the other two chat tools, this one cannot be called anonymously: it removes a
+    // permission gate, so the answer has to be attributable to a chat.
+    expect(inputSchema.required).toContain('from_bufnr');
+    // Same "name the target once" rule as nvim_chat_send_message.
+    expect(inputSchema.required).not.toContain('bufnr');
+    expect(inputSchema.required).not.toContain('file_path');
+    expect(inputSchema.properties.action.enum).toEqual([...APPROVAL_ACTIONS]);
+  });
+
+  it('nvim_chat_answer_approval forwards the action and reports the tool it answered', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      success: true,
+      bufnr: 21,
+      tool: 'Bash',
+      action: 'allow_once',
+    });
+
+    const result = await handlers.nvim_chat_answer_approval({
+      rpc_port: 9878,
+      file_path: '.vibing/chat/worker.md',
+      action: 'allow_once',
+      from_bufnr: 12,
+    });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'answer_approval',
+      {
+        bufnr: undefined,
+        file_path: '.vibing/chat/worker.md',
+        action: 'allow_once',
+        from_bufnr: 12,
+      },
+      9878
+    );
+    expect(result.content[0].text).toContain('Bash');
+    expect(result._meta.bufnr).toBe(21);
+  });
+
+  it('nvim_chat_answer_approval refuses an action outside the four the prompt offers', async () => {
+    await expect(
+      handlers.nvim_chat_answer_approval({
+        rpc_port: 9878,
+        bufnr: 21,
+        action: 'allow',
+        from_bufnr: 12,
+      })
+    ).rejects.toThrow();
+    expect(rpc.callNeovim).not.toHaveBeenCalled();
+  });
+
+  it('nvim_chat_answer_approval refuses a call that names no chat as the answerer', async () => {
+    await expect(
+      handlers.nvim_chat_answer_approval({ rpc_port: 9878, bufnr: 21, action: 'allow_once' })
+    ).rejects.toThrow();
+    expect(rpc.callNeovim).not.toHaveBeenCalled();
+  });
+
+  it('nvim_chat_answer_approval refuses a call that names the target twice, or not at all', async () => {
+    await expect(
+      handlers.nvim_chat_answer_approval({
+        rpc_port: 9878,
+        bufnr: 21,
+        file_path: '.vibing/chat/worker.md',
+        action: 'allow_once',
+        from_bufnr: 12,
+      })
+    ).rejects.toThrow();
+
+    await expect(
+      handlers.nvim_chat_answer_approval({ rpc_port: 9878, action: 'allow_once', from_bufnr: 12 })
+    ).rejects.toThrow();
+
+    expect(rpc.callNeovim).not.toHaveBeenCalled();
+  });
+
+  it('tells the model the delegated-approval gate exists, so a refusal is not a surprise', () => {
+    // The Lua side refuses unless agent.orchestration.delegated_approval is on. A description
+    // that does not say so turns every blocked worker into one wasted call before the model does
+    // the right thing anyway.
+    const description =
+      allTools.find((t) => t.name === 'nvim_chat_answer_approval')?.description ?? '';
+
+    expect(description).toContain('delegated_approval');
+    expect(description).toContain('waiting_approval');
   });
 
   it('nvim_chat_create forwards from_bufnr so a worker is linked at creation', async () => {

--- a/claude-plugin/mcp-server/src/handlers/chat.ts
+++ b/claude-plugin/mcp-server/src/handlers/chat.ts
@@ -1,6 +1,6 @@
 import { callNeovim } from '../rpc.js';
 import { z } from 'zod';
-import { CHAT_POSITIONS } from '../tools/chat.js';
+import { APPROVAL_ACTIONS, CHAT_POSITIONS } from '../tools/chat.js';
 import { validateChatTarget } from '../validation/schema.js';
 
 const chatCreateArgsSchema = z.object({
@@ -154,5 +154,58 @@ export async function handleAskUserQuestion(args: any): Promise<any> {
 
   return {
     content: [{ type: 'text', text: 'Question presented to the user in the chat buffer.' }],
+  };
+}
+
+const chatAnswerApprovalArgsSchema = z.object({
+  bufnr: z.number().nullish(),
+  file_path: z.string().nullish(),
+  action: z.enum(APPROVAL_ACTIONS),
+  from_bufnr: z.number(),
+  rpc_port: z.number(),
+});
+
+/**
+ * Handler for nvim_chat_answer_approval
+ *
+ * A chat that hit a tool in its `ask` list has had its turn killed and the approval prompt drawn
+ * into its buffer (`rpc/handlers/permission.lua`). It cannot continue, and it cannot report that
+ * it is stuck — so until someone answers, it simply never moves again. By default that someone is
+ * the user; `agent.orchestration.delegated_approval` lets an orchestrator stand in.
+ *
+ * The gate lives on the Lua side rather than here, so the model gets one answer whichever route
+ * it takes and the setting cannot be read stale by a server process that started before it
+ * changed. That is also why a disabled call comes back as an error with the wording the model
+ * should act on ("tell the user which chat is blocked") instead of a bare refusal.
+ *
+ * `from_bufnr` is required here although the other chat tools keep it optional: this call removes
+ * a permission gate, and one that cannot record whose decision it was should not be made at all.
+ * Version skew is not an argument for softening it — a Neovim without the `answer_approval` RPC
+ * method rejects the call outright.
+ */
+export async function handleChatAnswerApproval(args: any): Promise<any> {
+  const parsed = chatAnswerApprovalArgsSchema.parse(args);
+  const { action, from_bufnr, rpc_port } = parsed;
+  const bufnr = parsed.bufnr ?? undefined;
+  const file_path = parsed.file_path ?? undefined;
+
+  validateChatTarget({ bufnr, file_path }, { required: true });
+
+  const result = await callNeovim(
+    'answer_approval',
+    { bufnr, file_path, action, from_bufnr },
+    rpc_port
+  );
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          `Answered ${result?.tool ?? 'the'} tool approval with ${action}. That chat has started ` +
+          'a new turn; it will come back to you when it stops.',
+      },
+    ],
+    _meta: { bufnr: result?.bufnr ?? bufnr, tool: result?.tool, action },
   };
 }

--- a/claude-plugin/mcp-server/src/handlers/index.ts
+++ b/claude-plugin/mcp-server/src/handlers/index.ts
@@ -53,6 +53,7 @@ export const handlers: Record<string, (args: any) => Promise<any>> = {
   nvim_chat_create: chat.handleChatCreate,
   nvim_chat_send_message: chat.handleChatSendMessage,
   nvim_ask_user_question: chat.handleAskUserQuestion,
+  nvim_chat_answer_approval: chat.handleChatAnswerApproval,
 
   // Highlighting
   nvim_highlight_range: highlight.handleHighlightRange,

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -12,6 +12,18 @@ import { withRpcPort, requireRpcPort } from './common.js';
  */
 export const CHAT_POSITIONS = ['back', 'current', 'right', 'left', 'top', 'bottom'] as const;
 
+/**
+ * The four answers a tool-approval prompt accepts, mirroring `APPROVAL_OPTIONS` in
+ * `lua/vibing/infrastructure/rpc/handlers/permission.lua` and the vocabulary
+ * `presentation/chat/modules/approval_parser.lua` reads back out of the buffer.
+ */
+export const APPROVAL_ACTIONS = [
+  'allow_once',
+  'deny_once',
+  'allow_for_session',
+  'deny_for_session',
+] as const;
+
 export const chatTools: Tool[] = [
   {
     name: 'nvim_chat_create',
@@ -178,6 +190,59 @@ export const chatTools: Tool[] = [
         },
       }),
       required: requireRpcPort(['chat_bufnr', 'questions']),
+    },
+  },
+  {
+    name: 'nvim_chat_answer_approval',
+    description:
+      "Answer another chat's pending tool-approval prompt — the one that leaves it stuck at " +
+      'status waiting_approval, unable to continue or even to report back. Read what it is ' +
+      'stuck on with nvim_get_buffer first; the prompt names the tool and its input. ' +
+      'This is off unless the user turned it on ' +
+      '(agent.orchestration.delegated_approval), and the call fails with an explanation when it ' +
+      'is off — then the only thing to do is tell the user which chat is blocked and on what. ' +
+      'When it is on, you are standing in for the user on a decision they asked to be consulted ' +
+      'about: answer only when the tool is plainly within the task you briefed that chat with, ' +
+      'and put anything else to the user instead. Your answer is recorded in that chat as coming ' +
+      'from you. It can only be answered once, and only while it is pending.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({
+        file_path: {
+          type: 'string',
+          description:
+            'Chat file of the blocked chat (git-root-relative, absolute, or ~-prefixed). ' +
+            'Opened in the background if it is not already open. Prefer this over bufnr.',
+        },
+        bufnr: {
+          type: 'number',
+          description:
+            'Buffer number of the blocked chat. Only valid within this Neovim session — use ' +
+            'file_path instead when you have one.',
+        },
+        action: {
+          type: 'string',
+          enum: [...APPROVAL_ACTIONS],
+          description:
+            'Which of the four options to choose. The "_once" pair applies to this one call; ' +
+            'the "_for_session" pair is written into that chat\'s frontmatter and applies to ' +
+            'every later call in it, so prefer allow_once unless the chat will clearly need the ' +
+            'tool repeatedly.',
+        },
+        from_bufnr: {
+          type: 'number',
+          description:
+            'Your own chat: the exact "Current vibing.nvim chat buffer number" from your ' +
+            'system prompt THIS turn — never a number remembered from earlier in the ' +
+            'conversation, which a Neovim restart silently invalidates. Required here (unlike ' +
+            'on the other chat tools): answering an approval is recorded as your decision, and ' +
+            'a call that cannot say whose decision it was is refused.',
+        },
+      }),
+      // bufnr/file_path stay out of the required list for the same reason as on
+      // nvim_chat_send_message: the handler enforces that exactly one arrives, and listing both
+      // as required would read as "pass both".
+      required: requireRpcPort(['action', 'from_bufnr']),
     },
   },
 ];

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -165,8 +165,10 @@ Alongside the transcript the result carries a chat-status line, in the same voca
 - `status: asked_question` — the worker stopped to ask something and is waiting for an answer.
   Read the question and reply with `nvim_chat_send_message` (passing `from_bufnr`), or put it to
   the user if only they can decide. It will not move until someone answers.
-- `status: waiting_approval` — the worker stopped on a tool-approval prompt. Only the user can
-  clear that one; say which worker is blocked and on what.
+- `status: waiting_approval` — the worker stopped on a tool-approval prompt. By default only the
+  user can clear that one: say which worker is blocked and on what. If the user turned on
+  `agent.orchestration.delegated_approval`, you can answer it yourself — see "Answering a worker's
+  tool approval" below.
 - `status: error` — the last turn ended with an error. Read the tail of the transcript for the
   message and decide whether to re-brief the worker or report the failure.
 
@@ -196,6 +198,43 @@ still needs the user. Point at each worker's `file_path` so the user can open th
 `waiting_approval` will never reach `idle` on its own, so waiting for it is waiting forever.
 Report it as blocked and say what it needs.
 
+### Answering a worker's tool approval
+
+A worker that reaches a tool in its `ask` list has its turn killed and the approval prompt drawn
+into its own buffer. It cannot continue and cannot report that it is stuck. **By default the only
+one who can clear that is the user** — name the worker and the tool in your reply and end the turn.
+
+If the user set `agent.orchestration.delegated_approval`, you can answer it instead:
+
+```text
+nvim_get_buffer({ rpc_port, file_path: "<worker file_path>" })    # read what it is stuck on
+nvim_chat_answer_approval({
+  rpc_port,
+  file_path: "<worker file_path>",
+  action: "allow_once",
+  from_bufnr: <this chat's bufnr>,
+})
+```
+
+Four things about it:
+
+- **You are standing in for the user on a decision they asked to be consulted about.** Answer only
+  when the tool and its input are plainly within the brief you wrote for that worker. Anything
+  else — a command touching files outside the task, anything destructive, anything you cannot
+  place — goes to the user, with the worker and the tool named.
+- **Read the prompt before answering.** The buffer names the tool and its input. Approving a tool
+  you have not looked at is not delegation, it is a rubber stamp.
+- **Prefer `allow_once`.** `allow_for_session` is written into that worker's frontmatter and
+  applies to every later call in it, so it outlives the one call you actually judged. Use it only
+  when the brief obviously needs the tool repeatedly. `deny_once` / `deny_for_session` are the
+  other two; a denial sends the worker back with "use a different approach", so say why in a
+  follow-up message if the reason matters.
+- **The call fails with an explanation when the setting is off.** Read it and put the approval to
+  the user; don't call it again to check.
+
+Answering starts a new turn in that worker, so it will come back to you when it stops — exactly
+like a brief. Do not poll it.
+
 If you used worktrees, offer the `vibing-worktree-finish` skill for each branch once its work has
 been merged or abandoned. Don't remove a worktree on your own initiative; unmerged work lives
 there.
@@ -216,8 +255,9 @@ fan-in is this convention, so keeping it is on you.
   worker: your parent's job is the same as yours, and forwarding raw worker output makes it pay for
   a transcript twice.
 - **Do not wait forever.** A worker that stops `asked_question`, `waiting_approval` or `error` is
-  not going to report on its own. Deal with it if you can (answer the question, re-brief it); if
-  you cannot, report to your parent now with that worker's state named, rather than holding the
-  whole tree open for something only the user can clear.
+  not going to report on its own. Deal with it if you can (answer the question, answer the tool
+  approval if that is enabled, re-brief it); if you cannot, report to your parent now with that
+  worker's state named, rather than holding the whole tree open for something only the user can
+  clear.
 - If your own brief turns out to be ambiguous, ask your parent before dispatching. Splitting a
   misunderstood task fans the misunderstanding out across several chats.

--- a/handbook/architecture/orchestration.md
+++ b/handbook/architecture/orchestration.md
@@ -1,9 +1,10 @@
 # Multi-Agent Orchestration
 
 Detail behind `.claude/rules/architecture.md` → "Multi-Agent Orchestration". One chat can create
-and drive other chats. The whole feature is three MCP calls and a skill; nothing new was needed
-to keep the workers apart, since parallel workers are the existing concurrency guarantee being
-used rather than extended.
+and drive other chats. The whole feature is three MCP calls and a skill — plus a fourth call,
+off unless the user opts in, that answers a worker's tool-approval prompt ("Answering a worker's
+tool approval", last section). Nothing new was needed to keep the workers apart, since parallel
+workers are the existing concurrency guarantee being used rather than extended.
 
 The long middle of this file is the completion-notification machinery, and it is long because
 almost every rule in it exists to stop a specific silent failure — a worker that stopped and told
@@ -13,8 +14,7 @@ One chat can create and drive other chats: `nvim_chat_create` (MCP) →
 `infrastructure/rpc/handlers/chat.lua` → `application/chat/use_cases/create_chat.lua` →
 `view.render`. The orchestrator briefs each worker with `nvim_chat_send_message` and polls it with
 `nvim_get_buffer`. The workflow is the bundled
-`claude-plugin/skills/vibing-orchestrate/SKILL.md`; there is no command and no scheduler — the
-whole feature is three MCP calls and a skill.
+`claude-plugin/skills/vibing-orchestrate/SKILL.md`; there is no command and no scheduler.
 
 Nothing new was needed to keep the workers apart. Each chat buffer already owns its own session
 id and handle id (see `handbook/architecture/chat-lineage.md`), so parallel workers are the
@@ -666,3 +666,57 @@ target twice.
 asked for, reported `idle`. So `buf_get_lines` reports the buffer it actually read, and the MCP
 handler refuses an answer that omits it whenever a `file_path` was passed. The send path needs no
 equivalent: it errors outright when it can find no target.
+
+## Answering a worker's tool approval
+
+A worker that reaches a tool in its `ask` list is the one stop in this machine that nothing in it
+can clear. `cancel_and_deny` kills the turn before drawing the prompt (`rpc/handlers/permission.lua`),
+so the worker cannot continue and cannot report; the watchdog delivers `status: waiting_approval`
+to whoever messaged it, and — by default — the only thing that orchestrator can do with that is
+name the worker and the tool and hand it to the user. With a fan of five workers all hitting the
+same `Bash` prompt, that is five buffers the user has to find by hand.
+
+`agent.orchestration.delegated_approval` (default `false`) lets the orchestrator answer instead,
+through the MCP tool `nvim_chat_answer_approval` →`rpc/handlers/chat.lua:answer_approval` →
+`application/chat/approval_delegate.lua`.
+
+**The default is off for what it buys, not for what it costs to build.** The `ask` list is the
+user asking to be consulted; an agent that can clear it for another agent has changed the
+permission model, and that is a decision to make once, deliberately, in `setup()` — not something
+to acquire by installing an update. The refusal is worded for the model that will read it: it says
+what to do instead (name the blocked chat and the tool) and names the setting, so a chat running
+without it does not spend a turn probing.
+
+Four things about the implementation:
+
+- **The answer takes exactly the human path.** `approval_delegate` writes the chosen option line —
+  the same `1. allow_once - Allow this execution only` the renderer drew — into the worker's
+  buffer and calls `ChatBuffer:send_message()`. Everything that decides what an approval _means_
+  (`update_session_permissions`, the `:once` bookkeeping, dropping `_pending_approval`, the
+  substitution to `I approved the Bash tool (command: …)`) stays in the one block that already
+  did it. A second implementation of that, reachable only through orchestration, is precisely the
+  kind of divergence that shows up as "the delegated grant did not survive the retry" months
+  later.
+- **The prompt is replaced, not left behind.** `ProgrammaticSender.send` normally drops the
+  trailing unsent section only when it is empty, because that section is also where the approval
+  prompt and the question list are drawn. Delegated answers pass `replace_unsent`, the one case
+  where that section _is_ the thing being answered; without it an answered prompt sits in the
+  transcript forever and every later `extract_conversation` re-sends it to the CLI.
+- **The section header is what records who granted it.** A delegated answer lands as
+  `## Request <!-- <ts> from .vibing/chat/orchestrator.md -->`, so the substituted first-person
+  body ("I approved the Bash tool") resolves to the chat the header names. That is also why
+  `from_bufnr` is **required** on this tool while it stays optional on `nvim_chat_create` and
+  `nvim_chat_send_message`: a call that cannot say whose decision it was should not be made, and
+  the compatibility argument does not apply to an RPC method older Neovims do not have at all.
+- **The watchdog's wording follows the setting.** `delivery_message.notification_section` asks
+  `approval_delegate.enabled()` and swaps the `waiting_approval` bullet between "only the user can
+  clear that one" and "answer it with `nvim_chat_answer_approval` when the tool is plainly within
+  the brief". Telling the model to answer while the setting is off would buy one guaranteed failed
+  call per blocked worker before it did the right thing anyway.
+
+What it deliberately does not do: decide on the orchestrator's behalf. Nothing inspects the tool
+input, and there is no allow list of "safe" tools to delegate — the judgement lives in the skill's
+prose (`vibing-orchestrate` → "Answering a worker's tool approval"), which tells the orchestrator
+to read the prompt, answer only what its own brief plainly covers, and prefer `allow_once` over
+the frontmatter-persisting `allow_for_session`. A mechanical rule here would have to guess at the
+task, which is the one thing the orchestrator knows and this module does not.

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -205,6 +205,18 @@ agent = {
                             -- that hits the limit is refused unless it passed queue_if_busy,
                             -- in which case it is queued and delivered the moment one of the
                             -- running chats finishes
+    delegated_approval = false,
+                            -- Let one chat answer another chat's tool-approval prompt. A worker
+                            -- that hits a tool in its `ask` list has its turn killed and the
+                            -- prompt drawn into its own buffer: it cannot continue and cannot
+                            -- report that it is stuck, so with this off you have to find each
+                            -- blocked worker and answer it yourself. On, the orchestrator
+                            -- answers instead (nvim_chat_answer_approval), choosing among the
+                            -- same four options you would. Off by default because that is an
+                            -- agent clearing another agent's permission gate — a change to the
+                            -- permission model, not a convenience. The answer is written into
+                            -- the worker's transcript as `## Request ... from <that chat>`, so
+                            -- who granted what is readable afterwards
   },
 
   codex_provider_notice = {

--- a/lua/vibing/application/chat/approval_delegate.lua
+++ b/lua/vibing/application/chat/approval_delegate.lua
@@ -1,0 +1,182 @@
+---@class Vibing.Application.Chat.ApprovalDelegate
+---ワーカーの `waiting_approval` に、別のチャットが代理で答える。
+---
+---承認プロンプトはターンを殺してから描かれる（`rpc/handlers/permission.lua` の
+---`cancel_and_deny`）。止まったチャットは自分では何もできず、報告する手段も残っていないので、
+---誰かが外から答えるまで動かない。既定でその「誰か」はユーザーだけで、オーケストレーターは
+---「どのチャットが何で止まっているか」を言うところまでしかできない
+---（`delivery_message.lua` の `waiting_approval` の説明文）。
+---
+---`agent.orchestration.delegated_approval` を true にすると、オーケストレーターが4択に代理で
+---答えられるようになる。**opt-in なのは、買っているのが「エージェントが別のエージェントの
+---承認ゲートを外せる」状態そのものだから**で、実装上の都合ではない。
+---
+---答えは人間の `<CR>` とまったく同じ経路を通る。選んだ選択肢の行をワーカーのバッファに
+---書いてから `ChatBuffer:send_message()` を呼ぶだけで、承認の消費
+---（`update_session_permissions` → `_pending_approval` の破棄 → 再試行文への差し替え）は
+---既存の承認ブロックが行う。判断ロジックを2本持たないための形で、代理応答だけが
+---`:once` の扱いやセッションリストの更新で人間の経路と食い違う、という壊れ方をしない。
+---
+---人間の経路と違うのは書かれるセクション見出しだけ: 代理応答は
+---`## Request <!-- <時刻> from .vibing/chat/orchestrator.md -->` として残るので、
+---「誰が許可したのか」がワーカーの transcript から読める。差し替え後の本文が
+---「I approved the Bash tool ...」と一人称なのはそのままでよく、その "I" は見出しが
+---名指ししているチャットを指す。
+local M = {}
+
+---代理で答えられる4択。`rpc/handlers/permission.lua` の `APPROVAL_OPTIONS` と同じ語彙で、
+---`presentation/chat/modules/approval_parser.lua` がバッファから読み戻す側
+---@type string[]
+M.ACTIONS = { "allow_once", "deny_once", "allow_for_session", "deny_for_session" }
+
+---@param action any
+---@return boolean
+local function is_valid_action(action)
+  return type(action) == "string" and vim.tbl_contains(M.ACTIONS, action)
+end
+
+---この機能が有効か
+---
+---`concurrency.limit()` と同じ理由で型を見る: `orchestration = true` のような壊れた設定で、
+---`setup()` 後のあらゆる代理応答が落ちるのではなく「無効」に倒れてほしい
+---@return boolean
+function M.enabled()
+  local config = require("vibing.config").get()
+  local orchestration = config.agent and config.agent.orchestration
+  if type(orchestration) ~= "table" then
+    return false
+  end
+  return orchestration.delegated_approval == true
+end
+
+---承認プロンプトに描かれたのと同じ行を組み立てる
+---
+---`approval_parser` が読むのは番号付きリストの行（`1. allow_once - ...`）なので、番号もラベルも
+---レンダラーが描いたものに合わせる。番号の採り方（空ラベルを飛ばす）を
+---`renderer.lua` と揃えてあるのは、バッファに残る行が「ユーザーが選んだ場合に残るはずの行」と
+---一字一句同じであってほしいため — transcript を読む人間が、代理応答かどうかを見分けるのに
+---見出し以外の手がかりを要らなくする
+---@param options table? `_pending_approval.options`
+---@param action string
+---@return string
+function M.option_line(options, action)
+  local index = 1
+  for _, opt in ipairs(options or {}) do
+    local label = (opt.label and opt.label ~= "") and opt.label or ""
+    if label ~= "" then
+      if opt.value == action then
+        return string.format("%d. %s", index, label)
+      end
+      index = index + 1
+    end
+  end
+
+  -- 選択肢を読み取れなかったときの逃げ道。`- ` の後ろまで含めて書くのは、パターンが
+  -- ハイフンまでを要求するため（`approval_parser.APPROVAL_PATTERNS`）
+  return string.format("1. %s - answered by another chat", action)
+end
+
+---ワーカーの承認プロンプトに代理で答える
+---@param params {bufnr: number, action: string, from_bufnr: number}
+---@return {success: boolean, bufnr: number, tool: string, action: string}
+function M.answer(params)
+  if not M.enabled() then
+    error(
+      "Delegated tool approval is disabled. Only the user can answer this chat's tool-approval "
+        .. "prompt: say which chat is blocked and on which tool, and let the user answer it in "
+        .. "that chat. (The user can enable it with "
+        .. "agent.orchestration.delegated_approval = true in their vibing.nvim setup.)"
+    )
+  end
+
+  if not is_valid_action(params.action) then
+    error(
+      string.format(
+        "Invalid action: %s (expected one of: %s)",
+        tostring(params.action),
+        table.concat(M.ACTIONS, ", ")
+      )
+    )
+  end
+
+  local bufnr, from_bufnr = params.bufnr, params.from_bufnr
+
+  -- 自分自身の承認に答えるのは通せない。答えるチャットは止まっていなければならないが、
+  -- この呼び出しをしているチャットは走っている。`send_message` の同じガードに揃える
+  if from_bufnr == bufnr then
+    error("A chat cannot answer its own tool-approval prompt")
+  end
+
+  local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+  local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(bufnr)
+  if not chat_buf then
+    error("Buffer is not a vibing chat buffer")
+  end
+
+  local pending = chat_buf:get_pending_approval()
+  if not pending then
+    -- 状態を名乗る。「承認待ちではない」だけだと、呼び出し元は `nvim_get_buffer` を1往復して
+    -- 同じことを知りに行くしかない。語彙は watchdog の通知や `nvim_get_buffer` と同じ
+    local status = require("vibing.presentation.chat.modules.chat_status").get(bufnr) or "unknown"
+    error(
+      string.format(
+        "That chat is not waiting on a tool approval (status: %s). "
+          .. "A tool-approval prompt can only be answered once, and only while it is pending.",
+        status
+      )
+    )
+  end
+
+  local line = M.option_line(pending.options, params.action)
+
+  -- 送れる状態かを先に確かめる。この後の `link_or_warn` は宛先のバッファを直接編集し、
+  -- `replace_unsent` は承認プロンプトそのものを消すので、送信が弾かれるならその前に止まって
+  -- ほしい（`rpc/handlers/message.lua` が同じ順序を取っている理由と同じ）
+  ProgrammaticSender.validate(bufnr, line)
+
+  -- 承認に答えると、そのワーカーは新しいターンを始める。並列度の上限は「機械が始める送信」に
+  -- かかるものなので、ここも見る。ただし `at_capacity_message` は使わない — あれは
+  -- `queue_if_busy` を勧める文面で、このツールにその引数は無い。承認は溜めて後で配るような
+  -- ものでもない（プロンプトは1回しか消費できず、待つ側は止まったままでいる）ので、
+  -- 断って呼び直させる
+  local Concurrency = require("vibing.application.chat.concurrency")
+  if Concurrency.at_capacity() then
+    error(
+      string.format(
+        "%d chats are already responding, which is the configured limit "
+          .. "(agent.orchestration.max_concurrent = %d). The approval prompt is still pending — "
+          .. "answer it again once one of them finishes.",
+        Concurrency.responding_count(),
+        Concurrency.limit()
+      )
+    )
+  end
+
+  local OrchestrationLink = require("vibing.application.chat.orchestration_link")
+  OrchestrationLink.link_or_warn(from_bufnr, bufnr)
+
+  -- 向きは `link_or_warn` の後で聞く。配布側からの応答ならリンクは今書かれたばかりで
+  -- `Request` を返し、逆向き（ワーカーが親の承認に答える）なら `Report` になる
+  local from_name = vim.api.nvim_buf_is_valid(from_bufnr) and vim.api.nvim_buf_get_name(from_bufnr) or ""
+  local section = {
+    kind = OrchestrationLink.direction(from_bufnr, bufnr),
+    from = from_name ~= "" and require("vibing.core.utils.git").to_display_path(from_name) or nil,
+  }
+
+  local result = ProgrammaticSender.send(bufnr, line, nil, section, { replace_unsent = true })
+
+  -- 送信と同じく、答えたという事実を購読の登録として扱う。代理で答えたなら、その結果として
+  -- ワーカーが動き出し、また止まる。止まったことを知りたいのは答えた側
+  if result and result.success then
+    require("vibing.application.chat.completion_notifier").on_sent(from_bufnr, bufnr)
+  end
+
+  return {
+    success = result and result.success or false,
+    bufnr = bufnr,
+    tool = pending.tool,
+    action = params.action,
+  }
+end
+
+return M

--- a/lua/vibing/application/chat/delivery_message.lua
+++ b/lua/vibing/application/chat/delivery_message.lua
@@ -74,21 +74,39 @@ local function notification_section(items, cache)
       and "The following chat(s) you sent a message to have stopped and cannot continue on their own:"
     or "The following chat(s) you sent a message to have stopped without reporting back:"
 
-  local explanation = any_blocked
+  -- `waiting_approval` の行だけ設定で変わる。既定では外せるのはユーザーだけなので
+  -- 「誰が何で止まっているか言え」で終わりだが、`delegated_approval` が有効なら
+  -- 読み手自身が答えられる。無効なまま「答えろ」と書くと、モデルは必ず失敗する呼び出しを
+  -- 1回してからユーザーに回すことになる（`approval_delegate.answer` が断る）
+  local waiting_approval_lines = require("vibing.application.chat.approval_delegate").enabled()
       and {
-        "A chat with a status above will not move again until someone acts on it:",
-        "",
-        "- asked_question — it is waiting for an answer. Read the question with",
-        "  nvim_get_buffer({ rpc_port, file_path }) and answer it with nvim_chat_send_message",
-        "  (passing from_bufnr), or put it to the user if only they can decide.",
-        "- waiting_approval — it is sitting on a tool-approval prompt. Only the user can clear that",
-        "  one, so say which chat is blocked and on what.",
-        "- error — its last turn failed. Read the tail of the transcript and decide whether to",
-        "  re-brief it or report the failure.",
-        "",
-        "A chat listed without a status stopped without reporting back; read it the same way and do",
-        "not treat its task as done.",
+        "- waiting_approval — it is sitting on a tool-approval prompt. Read what it is stuck on",
+        "  with nvim_get_buffer, then answer it with nvim_chat_answer_approval({ rpc_port,",
+        "  file_path, action, from_bufnr }) if the tool is plainly within the task you briefed it",
+        "  with. If it is not, say which chat is blocked and on what, and let the user decide.",
       }
+    or {
+      "- waiting_approval — it is sitting on a tool-approval prompt. Only the user can clear that",
+      "  one, so say which chat is blocked and on what.",
+    }
+
+  local blocked_explanation = {
+    "A chat with a status above will not move again until someone acts on it:",
+    "",
+    "- asked_question — it is waiting for an answer. Read the question with",
+    "  nvim_get_buffer({ rpc_port, file_path }) and answer it with nvim_chat_send_message",
+    "  (passing from_bufnr), or put it to the user if only they can decide.",
+  }
+  vim.list_extend(blocked_explanation, waiting_approval_lines)
+  vim.list_extend(blocked_explanation, {
+    "- error — its last turn failed. Read the tail of the transcript and decide whether to",
+    "  re-brief it or report the failure.",
+    "",
+    "A chat listed without a status stopped without reporting back; read it the same way and do",
+    "not treat its task as done.",
+  })
+
+  local explanation = any_blocked and blocked_explanation
     or {
       "A chat that finishes its task is expected to report the result to you itself, so a stop with",
       "no report is more likely to be something else: it failed, it stopped to ask a question, or it",

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -97,6 +97,10 @@
 ---チャット網の走らせ方に関する設定
 ---@field max_concurrent number 同時に応答中にできるチャットの本数。0で無制限（デフォルト: 0）。
 ---  見るのは機械が始める送信（`nvim_chat_send_message`とキューの配達）だけで、人間の<CR>は止めない
+---@field delegated_approval boolean? 別のチャットが`nvim_chat_answer_approval`でツール承認
+---  プロンプトに代理で答えられるようにするか（デフォルト: false）。承認ゲートはユーザーのために
+---  あるので、エージェントが別のエージェントのゲートを外せる状態は権限モデルそのものの変更であり、
+---  既定にはしない
 
 ---@class Vibing.AgentConfig
 ---エージェント設定
@@ -336,6 +340,17 @@ M.defaults = {
       -- 上限に当たった送信は捨てられずキューに残り、枠が空いた完了イベントで配り直される。
       -- 人間の<CR>はこの上限を見ない。
       max_concurrent = 0,
+      -- ワーカーが `ask` 対象のツールに当たると、そのチャットは `waiting_approval` で止まり、
+      -- 自力では抜けられない。既定ではそれを外せるのはユーザーだけで、オーケストレーターは
+      -- 「どのチャットが何で止まっているか」を言うところまでしかできない。
+      --
+      -- true にすると、オーケストレーターは `nvim_chat_answer_approval` で4択
+      -- （allow_once / deny_once / allow_for_session / deny_for_session）に代理で答えられる。
+      -- 扇の全員が同じ承認で止まる運用ではこれが唯一の現実解だが、買っているのは
+      -- 「エージェントが別のエージェントの承認ゲートを外せる」状態そのものなので、
+      -- opt-in にしてある。答えは配達セクション（`## Request <!-- ... from ... -->`）として
+      -- ワーカーのtranscriptに残るので、誰が許可したかは後から読める。
+      delegated_approval = false,
     },
     -- codexの軽量呼び出しは --ignore-user-config で走るので、ユーザーの model_provider が落ちて
     -- 既定のOpenAIエンドポイントに向く。それを1セッション1回だけ警告する。

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -71,4 +71,33 @@ function M.create_chat(params)
   }
 end
 
+---別のチャットのツール承認プロンプトに代理で答える（MCP tool `nvim_chat_answer_approval`）
+---
+---宛先の指し方は `nvim_chat_send_message` と同じ（`file_path` か `bufnr` のどちらか一方）。
+---違うのは `from_bufnr` が**必須**なこと: 承認ゲートを外す呼び出しなので、誰が外したのかを
+---記録できない形は通さない。互換のために任意にしておく理由も無い — このRPCメソッドを持たない
+---古いNeovimは、呼び出しそのものが届かない
+---@param params {bufnr?: number, file_path?: string, action: string, from_bufnr: number}
+---@return {success: boolean, bufnr: number, tool: string, action: string}
+function M.answer_approval(params)
+  params = params or {}
+
+  local Bufnr = require("vibing.infrastructure.rpc.handlers.bufnr")
+  local bufnr = Bufnr.resolve_chat_target(params)
+  if not bufnr then
+    error("Missing bufnr or file_path parameter")
+  end
+
+  local from_bufnr = Bufnr.resolve_from_bufnr(params.from_bufnr)
+  if not from_bufnr then
+    error("Missing from_bufnr parameter (the chat answering the prompt must name itself)")
+  end
+
+  return require("vibing.application.chat.approval_delegate").answer({
+    bufnr = bufnr,
+    action = params.action,
+    from_bufnr = from_bufnr,
+  })
+end
+
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -56,6 +56,7 @@ M.clear_annotations = annotations.clear_annotations
 M.send_message = message.send_message
 
 M.create_chat = chat.create_chat
+M.answer_approval = chat.answer_approval
 
 M.check_tool_permission = permission.check_tool_permission
 M.ask_user_question = permission.ask_user_question

--- a/lua/vibing/presentation/chat/buffer.lua
+++ b/lua/vibing/presentation/chat/buffer.lua
@@ -868,6 +868,19 @@ function ChatBuffer:update_session_permissions(approval)
   end
 end
 
+---いま答えを待っているツール承認要求（無ければ nil）
+---
+---コピーを返す。呼び出し側（`approval_delegate`）が必要とするのは「何について止まっているか」
+---を読むことだけで、`_pending_approval` を消してよいのは承認が実際に消費されたときだけ
+---（`send_message` の承認ブロック）。参照を渡すと、その1箇所という保証が外から崩せてしまう
+---@return {tool: string, input: table?, options: table?}?
+function ChatBuffer:get_pending_approval()
+  if not self._pending_approval then
+    return nil
+  end
+  return vim.deepcopy(self._pending_approval)
+end
+
 ---セッションレベルの許可リストを取得
 ---@return table
 function ChatBuffer:get_session_allow()

--- a/lua/vibing/presentation/chat/modules/programmatic_sender.lua
+++ b/lua/vibing/presentation/chat/modules/programmatic_sender.lua
@@ -70,7 +70,7 @@ function M.validate(bufnr, message)
   return chat_buf
 end
 
----末尾の空の未送信セクションを落とす
+---末尾の未送信セクションを落とす（既定では中身が空のときだけ）
 ---
 ---ターンが終わるたび `add_user_section()` が空の `## User <!-- unsent -->` を置く。人間はそこに
 ---打ち込むのでセクションは1つのままだが、配達はその下に**もう1つ**足していたので、配達された
@@ -78,9 +78,13 @@ end
 ---1ターンにつき1つ増えるのを確認）。
 ---
 ---落とすのは中身が空のときだけ。承認プロンプトや質問の選択肢は同じ未送信セクションに
----描かれるので、それらは「空でない」として残る
+---描かれるので、それらは「空でない」として残る（`replace_unsent` を渡した呼び出しを除く）。
+---
 ---@param buf number
-local function drop_empty_trailing_section(buf)
+---@param replace_unsent boolean? true なら中身があっても末尾の未送信セクションを落とす。
+---  承認への代理応答（`approval_delegate`）専用で、そこでは承認プロンプトそのものが
+---  「置き換える対象」になる。残すと、答え終わったプロンプトがバッファに永久に居座る
+local function drop_trailing_unsent_section(buf, replace_unsent)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 
   -- 末尾から空行を飛ばして最初に当たった行がヘッダーなら、それが最後のセクションで、かつ
@@ -91,8 +95,23 @@ local function drop_empty_trailing_section(buf)
     last = last - 1
   end
 
-  if last == 0 or not Timestamp.is_unsent_header(lines[last]) then
+  if last == 0 then
     return
+  end
+
+  if not Timestamp.is_unsent_header(lines[last]) then
+    if not replace_unsent then
+      return
+    end
+    -- 中身のある未送信セクションを落とす経路。末尾から**最初に当たったヘッダー**まで戻り、
+    -- それが未送信でなければ何もしない。「未送信ヘッダーを見つけるまで遡る」にすると、
+    -- 送信済みセクションを飛び越えて上のほうの未送信セクションを消しうる
+    repeat
+      last = last - 1
+    until last == 0 or Timestamp.is_header(lines[last])
+    if last == 0 or not Timestamp.is_unsent_header(lines[last]) then
+      return
+    end
   end
 
   -- ヘッダーの手前の空行も一緒に落とす。残しても `addUserSection` が末尾の空行を畳むが、
@@ -109,8 +128,11 @@ end
 ---@param sender string?
 ---@param delivery Vibing.Application.DeliveryMessage.Section? 他のチャットからの配達なら、
 ---  そのセクション見出しに使う種別と送信元。省略すると通常の `## User` セクションになる
-function M.send(bufnr, message, sender, delivery)
+---@param opts {replace_unsent: boolean?}? `replace_unsent` で、中身のある末尾の未送信
+---  セクションも落としてから書く（承認プロンプトへの代理応答）
+function M.send(bufnr, message, sender, delivery, opts)
   sender = sender or "User"
+  opts = opts or {}
 
   local chat_buf = M.validate(bufnr, message)
 
@@ -127,7 +149,7 @@ function M.send(bufnr, message, sender, delivery)
 
     -- Add user section and send
     local header = delivery and Timestamp.create_header(delivery.kind, nil, delivery.from) or nil
-    drop_empty_trailing_section(bufnr)
+    drop_trailing_unsent_section(bufnr, opts.replace_unsent)
     Renderer.addUserSection(bufnr, nil, nil, nil, message, header)
     sent = chat_buf:send_message()
 

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -143,16 +143,87 @@ local function wait_for(instance, pattern, timeout, label, read)
   return false
 end
 
+---現在のバッファの本文を1回読む。`wait_for` の `read` と同じ形（job_id, bufnr）
+---@param job_id number
+---@param bufnr number
+---@return boolean ok
+---@return string text_or_error
+local function read_content(job_id, bufnr)
+  local ok, lines = pcall(vim.fn.rpcrequest, job_id, "nvim_buf_get_lines", bufnr, 0, -1, false)
+  return ok, ok and table.concat(lines, "\n") or lines
+end
+
 ---バッファ「本文」が条件に一致するまで待機
 ---@param instance table インスタンスハンドル
 ---@param pattern string パターン（Luaパターン）
 ---@param timeout number タイムアウト（ミリ秒）
 ---@return boolean 成功したかどうか
 function M.wait_for_buffer_content(instance, pattern, timeout)
-  return wait_for(instance, pattern, timeout, "content", function(job_id, bufnr)
-    local ok, lines = pcall(vim.fn.rpcrequest, job_id, "nvim_buf_get_lines", bufnr, 0, -1, false)
-    return ok, ok and table.concat(lines, "\n") or lines
-  end)
+  return wait_for(instance, pattern, timeout, "content", read_content)
+end
+
+---失敗したターンがチャットに書く行（`application/chat/send_message.lua`）。
+---
+---パターンをここに1つだけ置いてあるのは、これが「ターンが動いたか」を判定する唯一の手掛かり
+---だから。specごとに書くと、文言が変わった日にすべてのspecが黙って「エラーなし」に倒れる
+local TURN_ERROR_PATTERN = "%*%*Error:%*%* [^\n]*"
+
+---モデルの応答を待つ。**ターンがエラーで終わったらそこで待つのをやめる。**
+---
+---`wait_for_buffer_content` との違いはそこだけだが、差は大きい。`## .* Assistant` のような
+---構造だけを待つと、CLIが即座に失敗したターンでも見出しは書かれるので spec は緑になる
+---（このリポジトリで実際にそうなっていた）。かといってモデルの実出力を待つようにすると、
+---今度はターンが失敗したときに「モデルがマーカーを返さなかった」という**嘘の診断**で
+---タイムアウトまで待つことになる。
+---
+---だから待つのは実出力にし、`**Error:**` が出た時点で理由ごと打ち切る。呼び出し側は
+---第2返り値をそのままアサーションメッセージに渡せばよい
+---@param instance table インスタンスハンドル
+---@param pattern string 応答本文に期待するLuaパターン
+---@param timeout number タイムアウト（ミリ秒）
+---@return boolean ok
+---@return string? reason 失敗した理由（成功時は nil）
+function M.wait_for_response(instance, pattern, timeout)
+  if not instance or not instance.job_id then
+    return false, "Invalid instance: instance or job_id is nil"
+  end
+
+  local deadline = vim.loop.hrtime() + timeout * 1000000
+  local last_seen = ""
+
+  while vim.loop.hrtime() < deadline do
+    local ok, bufnr = pcall(vim.fn.rpcrequest, instance.job_id, "nvim_get_current_buf")
+    if not ok then
+      return false, string.format("RPC failed to get buffer: %s", tostring(bufnr))
+    end
+
+    local ok2, text = read_content(instance.job_id, bufnr)
+    if not ok2 then
+      return false, string.format("RPC failed to read buffer: %s", tostring(text))
+    end
+
+    last_seen = text or ""
+    if last_seen:match(pattern) then
+      return true
+    end
+
+    -- エラーの判定はパターン一致の**後**。エラー行と期待した出力が同じターンに並ぶことは
+    -- 原理的にありうるので、先に見ると成功を失敗として報告しうる
+    local turn_error = last_seen:match(TURN_ERROR_PATTERN)
+    if turn_error then
+      return false, string.format("The turn failed before producing '%s': %s", pattern, turn_error)
+    end
+
+    vim.loop.sleep(100)
+  end
+
+  return false,
+    string.format(
+      "Timed out after %dms waiting for '%s'. Last 500 chars of the chat:\n%s",
+      timeout,
+      pattern,
+      last_seen:sub(-500)
+    )
 end
 
 ---バッファ「名」が条件に一致するまで待機

--- a/lua/vibing/testing/e2e_helper.lua
+++ b/lua/vibing/testing/e2e_helper.lua
@@ -13,6 +13,32 @@ function M.should_run()
   return vim.env.VIBING_E2E == "1"
 end
 
+---子Neovim（とそれが起動するCLI）に渡す環境変数
+---
+---`tests/e2e_init.lua` は `permissions.mode = "bypassPermissions"` を決め打ちしており、
+---それ自体は必要（同ファイルのコメント参照: acceptEdits ではCLIが vibing-nvim の MCP ツールを
+---拒否し、`--allowedTools` でも解けない）。ところがそのモードは CLI 内部で
+---`--dangerously-skip-permissions` になり、**root で走っているとCLIが起動を拒否する**：
+---
+---  --dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
+---
+---コンテナ（CI、Claude Code on the web、devcontainer）は uid 0 で走るのが普通なので、そこでは
+---実ターンに依存するE2Eが1本も通らない。`IS_SANDBOX=1` はCLIが用意しているそのための逃げ道で、
+---root チェックだけを外す。
+---
+---**uid 0 のときにしか渡さない。** 無条件に立てると、開発者が自分のマシンで
+---`npm run test:e2e` を叩いたときにも安全確認を1つ黙って外すことになる。そこでは root で
+---走っていないので、そもそも外すものが無い
+---@param chat_dir string
+---@return table<string, string>
+local function child_env(chat_dir)
+  local env = { VIBING_E2E_CHAT_DIR = chat_dir }
+  if vim.loop.getuid and vim.loop.getuid() == 0 then
+    env.IS_SANDBOX = "1"
+  end
+  return env
+end
+
 ---別Neovimインスタンスを起動
 ---@param config? { headless?: boolean, init_script?: string, cwd?: string }
 ---@return table インスタンスハンドル { job_id: number, chat_dir: string }
@@ -45,7 +71,7 @@ function M.spawn_nvim_instance(config)
     job_id = vim.fn.jobstart(cmd, {
       cwd = config.cwd or vim.fn.getcwd(),
       rpc = true,
-      env = { VIBING_E2E_CHAT_DIR = chat_dir },
+      env = child_env(chat_dir),
       on_exit = function(_, code)
         if code ~= 0 then
           vim.notify("[E2E] Nvim instance exited with code: " .. code, vim.log.levels.WARN)
@@ -168,22 +194,23 @@ end
 ---だから。specごとに書くと、文言が変わった日にすべてのspecが黙って「エラーなし」に倒れる
 local TURN_ERROR_PATTERN = "%*%*Error:%*%* [^\n]*"
 
----モデルの応答を待つ。**ターンがエラーで終わったらそこで待つのをやめる。**
+---Assistantセクションの見出し（タイムスタンプ付き・レガシーの両方）
+local ASSISTANT_HEADER_PATTERN = "\n## [^\n]*Assistant[^\n]*"
+
+---チャット本文を条件が満たされるまでポーリングする。**ターンがエラーで書いた行を見つけたら
+---そこで打ち切る。**
 ---
----`wait_for_buffer_content` との違いはそこだけだが、差は大きい。`## .* Assistant` のような
----構造だけを待つと、CLIが即座に失敗したターンでも見出しは書かれるので spec は緑になる
----（このリポジトリで実際にそうなっていた）。かといってモデルの実出力を待つようにすると、
----今度はターンが失敗したときに「モデルがマーカーを返さなかった」という**嘘の診断**で
----タイムアウトまで待つことになる。
----
----だから待つのは実出力にし、`**Error:**` が出た時点で理由ごと打ち切る。呼び出し側は
----第2返り値をそのままアサーションメッセージに渡せばよい
+---打ち切りが要点。待つ対象を「モデルが実際に出したもの」にすると、ターンが失敗したときに
+---「モデルが期待した出力を返さなかった」という**嘘の診断**でタイムアウトまで待つことになる
+---（`plugin_dir_spec` が実際に、CLIが起動を拒否しただけの失敗を `--plugin-dir` のせいだと
+---60秒かけて報告していた）。
 ---@param instance table インスタンスハンドル
----@param pattern string 応答本文に期待するLuaパターン
 ---@param timeout number タイムアウト（ミリ秒）
+---@param done fun(text: string): boolean 本文を見て満たされたか
+---@param what string タイムアウトメッセージでの呼び名
 ---@return boolean ok
 ---@return string? reason 失敗した理由（成功時は nil）
-function M.wait_for_response(instance, pattern, timeout)
+local function poll_chat(instance, timeout, done, what)
   if not instance or not instance.job_id then
     return false, "Invalid instance: instance or job_id is nil"
   end
@@ -203,15 +230,15 @@ function M.wait_for_response(instance, pattern, timeout)
     end
 
     last_seen = text or ""
-    if last_seen:match(pattern) then
+    -- 条件の判定はエラー判定の**前**。エラー行と期待した出力が同じ本文に並ぶことは原理的に
+    -- ありうるので、逆にすると成功を失敗として報告しうる
+    if done(last_seen) then
       return true
     end
 
-    -- エラーの判定はパターン一致の**後**。エラー行と期待した出力が同じターンに並ぶことは
-    -- 原理的にありうるので、先に見ると成功を失敗として報告しうる
     local turn_error = last_seen:match(TURN_ERROR_PATTERN)
     if turn_error then
-      return false, string.format("The turn failed before producing '%s': %s", pattern, turn_error)
+      return false, string.format("The turn failed before producing %s: %s", what, turn_error)
     end
 
     vim.loop.sleep(100)
@@ -219,11 +246,91 @@ function M.wait_for_response(instance, pattern, timeout)
 
   return false,
     string.format(
-      "Timed out after %dms waiting for '%s'. Last 500 chars of the chat:\n%s",
+      "Timed out after %dms waiting for %s. Last 500 chars of the chat:\n%s",
       timeout,
-      pattern,
+      what,
       last_seen:sub(-500)
     )
+end
+
+---最後の `## ... Assistant` 見出しより後ろ（＝直近の応答本文）
+---@param text string
+---@return string? nil なら応答がまだ1つも無い
+local function assistant_tail(text)
+  local last_end, from = nil, 1
+  while true do
+    local s, e = text:find(ASSISTANT_HEADER_PATTERN, from)
+    if not s then
+      break
+    end
+    last_end, from = e, e + 1
+  end
+  return last_end and text:sub(last_end + 1) or nil
+end
+
+---@param text string
+---@return number
+local function count_assistant_headers(text)
+  local count, from = 0, 1
+  while true do
+    local s, e = text:find(ASSISTANT_HEADER_PATTERN, from)
+    if not s then
+      return count
+    end
+    count, from = count + 1, e + 1
+  end
+end
+
+---**モデルが実際に出した文字列**を待つ。ターンがエラーで死んだら理由ごと打ち切る。
+---
+---照合するのは最後の `## ... Assistant` 見出しより後ろだけで、バッファ全体ではない。
+---全体を見ると、プロンプトに書いた語がそのまま `## User` セクションで一致してしまい、
+---ターンが1バイトも返していなくても spec が緑になる（マーカー語を頼む書き方をした瞬間に
+---そうなる）。
+---
+---逆に、チャットUIがユーザーセクションに描くもの（承認プロンプト、質問の選択肢）を待つのは
+---`wait_for_response` のほう
+---@param instance table インスタンスハンドル
+---@param pattern string 応答本文に期待するLuaパターン
+---@param timeout number タイムアウト（ミリ秒）
+---@return boolean ok
+---@return string? reason
+function M.wait_for_assistant_text(instance, pattern, timeout)
+  return poll_chat(instance, timeout, function(text)
+    local tail = assistant_tail(text)
+    return tail ~= nil and tail:match(pattern) ~= nil
+  end, string.format("assistant output matching '%s'", pattern))
+end
+
+---ターンが走った結果としてバッファに現れるものを待つ。ターンがエラーで死んだら打ち切る。
+---
+---`wait_for_buffer_content` との違いは打ち切りだけ。CLIが失敗したターンでも
+---`## ... Assistant` の見出しは書かれるので、ターンに依存する待ちは全部こちらを通す
+---@param instance table インスタンスハンドル
+---@param pattern string Luaパターン（バッファ全体に対して）
+---@param timeout number タイムアウト（ミリ秒）
+---@return boolean ok
+---@return string? reason
+function M.wait_for_response(instance, pattern, timeout)
+  return poll_chat(instance, timeout, function(text)
+    return text:match(pattern) ~= nil
+  end, string.format("'%s'", pattern))
+end
+
+---Assistantの応答が `count` 本になるまで待つ。
+---
+---「ターンが1本走って、しかも失敗しなかった」を言うのに、モデルが特定の語を返してくれることに
+---賭けずに済む形。`## .* Assistant` を `wait_for_buffer_content` で待つのとは違い、
+---エラーで死んだターンはここで打ち切られる
+---@param instance table インスタンスハンドル
+---@param count number 期待する応答の本数
+---@param timeout number タイムアウト（ミリ秒）
+---@return boolean ok
+---@return string? reason
+function M.wait_for_assistant_turns(instance, count, timeout)
+  return poll_chat(instance, timeout, function(text)
+    return count_assistant_headers(text) >= count
+  end, string.format("%d assistant turn(s)", count))
 end
 
 ---バッファ「名」が条件に一致するまで待機

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "npm run test:lua && npm run test:node",
     "test:node": "find tests -name '*.test.mjs' -exec node --test {} +",
     "test:lua": "nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/ { minimal_init = 'tests/minimal_init.lua' }\"",
-    "test:e2e": "VIBING_E2E=1 nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/e2e/ { minimal_init = 'tests/minimal_init.lua' }\"",
+    "test:e2e": "VIBING_E2E=1 nvim --headless -u tests/minimal_init.lua -c \"PlenaryBustedDirectory tests/e2e/ { minimal_init = 'tests/minimal_init.lua', timeout = 240000 }\"",
     "test:eval": "nvim --headless -u tests/minimal_init.lua -l tests/evals/run.lua",
     "check": "find lua -name '*.lua' -exec luac -p {} +",
     "check:lua": "luac -p lua/vibing/init.lua",

--- a/tests/e2e-timeout-gate.test.mjs
+++ b/tests/e2e-timeout-gate.test.mjs
@@ -1,0 +1,127 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A spec that budgets more time than the harness gives it cannot report anything.
+ *
+ * `PlenaryBustedDirectory` runs one child Neovim per spec **file** and joins it with a single
+ * timeout (`plenary/test_harness.lua`, default 50000ms). A spec still inside a `vim.wait` when
+ * that expires is killed mid-wait: it prints no summary, no failure, no test count — only the
+ * suite's exit code moves. That is the same dead-gate shape `.claude/rules/self-testing.md`
+ * documents for a spec file that runs zero tests, and it is how three E2E specs (each budgeting
+ * 60000ms against the 50000ms default) sat silently broken.
+ *
+ * The number that has to hold is per file, not per test, because the timeout is on the job. So
+ * this sums every wait a file can perform and requires the total to fit.
+ *
+ * It reads both sides out of the repository rather than restating them: the harness budget comes
+ * from the actual `test:e2e` command, so the check cannot pass against a command the project no
+ * longer runs (the same reasoning as `lua-syntax-gate.test.mjs`).
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** plenary's own default when `PlenaryBustedDirectory` is given no `timeout` (test_harness.lua). */
+const PLENARY_DEFAULT_TIMEOUT_MS = 50000;
+
+function harnessTimeoutMs() {
+  const { scripts } = JSON.parse(readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const command = scripts['test:e2e'];
+  assert.ok(command, 'package.json must still define a test:e2e script');
+  assert.match(
+    command,
+    /PlenaryBusted/,
+    'test:e2e no longer runs plenary; this gate encodes plenary’s per-file job timeout'
+  );
+
+  const explicit = command.match(/timeout\s*=\s*(\d+)/);
+  return explicit ? Number(explicit[1]) : PLENARY_DEFAULT_TIMEOUT_MS;
+}
+
+/** `local TIMEOUTS = { KEY = 1234, ... }` → { KEY: 1234 } */
+function parseTimeoutTable(source) {
+  const table = source.match(/local TIMEOUTS = \{([\s\S]*?)\n\}/);
+  if (!table) return {};
+
+  const values = {};
+  for (const [, key, ms] of table[1].matchAll(/(\w+)\s*=\s*(\d+)/g)) {
+    values[key] = Number(ms);
+  }
+  return values;
+}
+
+/**
+ * The worst case a file can spend waiting: every `TIMEOUTS.KEY` reference at its declared value,
+ * plus every `vim.wait(<literal>)`.
+ *
+ * Deliberately an over-estimate — a reference inside a comment or an assertion message counts
+ * too. Over-counting only ever asks for a larger harness budget, which is the safe direction; a
+ * clever exact model would be the thing that lets the silent case back in.
+ */
+function worstCaseWaitMs(source) {
+  const values = parseTimeoutTable(source);
+  const body = source.replace(/local TIMEOUTS = \{[\s\S]*?\n\}/, '');
+
+  let total = 0;
+  for (const [, key] of body.matchAll(/TIMEOUTS\.(\w+)/g)) {
+    total += values[key] ?? 0;
+  }
+  for (const [, ms] of body.matchAll(/vim\.wait\(\s*(\d+)\s*\)/g)) {
+    total += Number(ms);
+  }
+  return total;
+}
+
+function specFiles() {
+  const dir = path.join(ROOT, 'tests', 'e2e');
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.lua'))
+    .map((name) => path.join(dir, name));
+}
+
+test('every E2E spec can spend its whole budget without the harness killing it first', () => {
+  const budget = harnessTimeoutMs();
+  const over = [];
+
+  for (const file of specFiles()) {
+    const worstCase = worstCaseWaitMs(readFileSync(file, 'utf8'));
+    if (worstCase >= budget) {
+      over.push(
+        `${path.relative(ROOT, file)}: waits up to ${worstCase}ms, harness allows ${budget}ms`
+      );
+    }
+  }
+
+  assert.deepEqual(
+    over,
+    [],
+    'These specs would be killed mid-wait and report nothing at all — no summary, no failure, ' +
+      'only the exit code. Either lower the spec’s own timeouts or raise `timeout` in the ' +
+      'test:e2e script:\n' +
+      over.join('\n')
+  );
+});
+
+test('the gate reads a real budget, not a placeholder', () => {
+  // A `test:e2e` that lost its explicit timeout silently falls back to plenary's 50s, which is
+  // below what these specs need. Catch that here rather than in a run that prints nothing.
+  const budget = harnessTimeoutMs();
+  assert.ok(
+    budget > PLENARY_DEFAULT_TIMEOUT_MS,
+    `test:e2e must set an explicit timeout; got ${budget}ms`
+  );
+});
+
+test('the parser actually finds the numbers it is gating on', () => {
+  // Without this, a rename of the TIMEOUTS table would make every file measure 0ms and the gate
+  // would pass by seeing nothing — the failure mode it exists to prevent, one level up.
+  const measured = specFiles().map((file) => worstCaseWaitMs(readFileSync(file, 'utf8')));
+
+  assert.ok(
+    measured.filter((ms) => ms > 0).length >= 5,
+    `expected most E2E specs to declare waits; measured ${JSON.stringify(measured)}`
+  );
+});

--- a/tests/e2e/ask_user_question_spec.lua
+++ b/tests/e2e/ask_user_question_spec.lua
@@ -69,9 +69,12 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     helper.send_keys(nvim_instance, "<Esc>")
     helper.send_keys(nvim_instance, "<CR>")
 
-    -- Wait for question prompt
-    ok = helper.wait_for_buffer_content(nvim_instance, "\n1%. A\n", TIMEOUTS.ASSISTANT_RESPONSE)
-    assert.is_true(ok, "Choice list should be rendered into the buffer")
+    -- Wait for question prompt. `wait_for_response` gives up as soon as the turn writes an
+    -- error, so a CLI that never ran reports itself instead of looking like a model that
+    -- declined to use the tool
+    local reason
+    ok, reason = helper.wait_for_response(nvim_instance, "\n1%. A\n", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, reason or "Choice list should be rendered into the buffer")
 
     -- Verify prompt appears exactly once (regression: was duplicated before the fix)
     local count = count_lines_matching(nvim_instance, "^1%. A$")
@@ -96,15 +99,21 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     helper.send_keys(nvim_instance, "<CR>")
 
     -- Wait for question prompt to appear
-    ok = helper.wait_for_buffer_content(nvim_instance, "\n1%. Red\n", TIMEOUTS.ASSISTANT_RESPONSE)
-    assert.is_true(ok, "Choice list should be rendered into the buffer")
+    local reason
+    ok, reason = helper.wait_for_response(nvim_instance, "\n1%. Red\n", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, reason or "Choice list should be rendered into the buffer")
 
     -- Send an answer by pressing <CR> (all options remain — Claude understands)
     helper.send_keys(nvim_instance, "<CR>")
 
-    -- Wait for Claude to process the answer and produce a follow-up response
-    ok = helper.wait_for_buffer_content(nvim_instance, "## .* Assistant", TIMEOUTS.ASSISTANT_RESPONSE)
-    assert.is_true(ok, "Claude should respond after the answer is sent")
+    -- 答えを送った**あとの**応答を待つ。`## .* Assistant` の見出し数で待つのは、質問を出した
+    -- 1本目のターンの見出しが既にあるので最初から一致してしまう。2本目の見出しが増えることを
+    -- 待ち、かつターンがエラーで死んだらそこで打ち切る
+    -- Luaパターンの `.` は改行にも一致するので、これは「Assistantの見出しが2つある」
+    -- という意味になる
+    ok, reason =
+      helper.wait_for_response(nvim_instance, "## .* Assistant.*## .* Assistant", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, reason or "Claude should respond after the answer is sent")
 
     -- Verify prompt still appears only once (not re-inserted after answering)
     local count = count_lines_matching(nvim_instance, "^1%. Red$")

--- a/tests/e2e/ask_user_question_spec.lua
+++ b/tests/e2e/ask_user_question_spec.lua
@@ -106,13 +106,9 @@ describe("E2E: AskUserQuestion - no repeated questions", function()
     -- Send an answer by pressing <CR> (all options remain — Claude understands)
     helper.send_keys(nvim_instance, "<CR>")
 
-    -- 答えを送った**あとの**応答を待つ。`## .* Assistant` の見出し数で待つのは、質問を出した
-    -- 1本目のターンの見出しが既にあるので最初から一致してしまう。2本目の見出しが増えることを
-    -- 待ち、かつターンがエラーで死んだらそこで打ち切る
-    -- Luaパターンの `.` は改行にも一致するので、これは「Assistantの見出しが2つある」
-    -- という意味になる
-    ok, reason =
-      helper.wait_for_response(nvim_instance, "## .* Assistant.*## .* Assistant", TIMEOUTS.ASSISTANT_RESPONSE)
+    -- 答えを送った**あとの**応答を待つ。`## .* Assistant` を待つのでは、質問を出した1本目の
+    -- 見出しが既にあるので最初から一致してしまい、何も待っていないのと同じだった
+    ok, reason = helper.wait_for_assistant_turns(nvim_instance, 2, TIMEOUTS.ASSISTANT_RESPONSE)
     assert.is_true(ok, reason or "Claude should respond after the answer is sent")
 
     -- Verify prompt still appears only once (not re-inserted after answering)

--- a/tests/e2e/chat_basic_flow_spec.lua
+++ b/tests/e2e/chat_basic_flow_spec.lua
@@ -8,6 +8,10 @@ if not helper.should_run() then
 end
 
 -- Timeout constants
+-- プロンプトにしか現れない語。モデルが本当に答えたときにしかバッファに現れないので、
+-- 「応答が来た」と「ターンの見出しが書かれた」を取り違えずに済む
+local MARKER = "VBGXKQ"
+
 local TIMEOUTS = {
   CHAT_CREATION = 2000, -- Time for chat buffer creation and rendering
   BUFFER_READY = 5000, -- Time for buffer to be ready with .md extension
@@ -66,15 +70,19 @@ describe("E2E: Chat basic flow", function()
     vim.wait(TIMEOUTS.CURSOR_MOVE)
 
     -- Insert modeでメッセージ入力
-    helper.send_keys(nvim_instance, 'i')
-    helper.send_keys(nvim_instance, 'Say "test"')
+    helper.send_keys(nvim_instance, "i")
+    helper.send_keys(nvim_instance, "Reply with ONLY the word " .. MARKER .. ". Do not use any tools.")
     helper.send_keys(nvim_instance, "<Esc>")
 
     -- <CR>でメッセージ送信
     helper.send_keys(nvim_instance, "<CR>")
 
-    -- Assistantレスポンス待機
-    ok = helper.wait_for_buffer_content(nvim_instance, "## .* Assistant", TIMEOUTS.ASSISTANT_RESPONSE)
-    assert.is_true(ok, "Assistant response should appear within timeout")
+    -- **モデルが実際に答えたこと**を待つ。`## .* Assistant` の見出しだけを待っていたころは、
+    -- CLIが即座に失敗したターンでも見出しは書かれるのでこのspecは緑のままだった
+    -- （root環境で `--dangerously-skip-permissions` が拒否されるケースで実際に起きた）。
+    -- マーカーはプロンプトからしか出てこない語にしてある
+    local reason
+    ok, reason = helper.wait_for_response(nvim_instance, MARKER, TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, reason or "Assistant response should appear within timeout")
   end)
 end)

--- a/tests/e2e/chat_basic_flow_spec.lua
+++ b/tests/e2e/chat_basic_flow_spec.lua
@@ -8,10 +8,6 @@ if not helper.should_run() then
 end
 
 -- Timeout constants
--- プロンプトにしか現れない語。モデルが本当に答えたときにしかバッファに現れないので、
--- 「応答が来た」と「ターンの見出しが書かれた」を取り違えずに済む
-local MARKER = "VBGXKQ"
-
 local TIMEOUTS = {
   CHAT_CREATION = 2000, -- Time for chat buffer creation and rendering
   BUFFER_READY = 5000, -- Time for buffer to be ready with .md extension
@@ -71,18 +67,22 @@ describe("E2E: Chat basic flow", function()
 
     -- Insert modeでメッセージ入力
     helper.send_keys(nvim_instance, "i")
-    helper.send_keys(nvim_instance, "Reply with ONLY the word " .. MARKER .. ". Do not use any tools.")
+    helper.send_keys(nvim_instance, 'Say "test"')
     helper.send_keys(nvim_instance, "<Esc>")
 
     -- <CR>でメッセージ送信
     helper.send_keys(nvim_instance, "<CR>")
 
-    -- **モデルが実際に答えたこと**を待つ。`## .* Assistant` の見出しだけを待っていたころは、
-    -- CLIが即座に失敗したターンでも見出しは書かれるのでこのspecは緑のままだった
-    -- （root環境で `--dangerously-skip-permissions` が拒否されるケースで実際に起きた）。
-    -- マーカーはプロンプトからしか出てこない語にしてある
+    -- 「ターンが1本走って、しかも失敗しなかった」を待つ。`wait_for_buffer_content` で
+    -- `## .* Assistant` を待っていたころは、CLIが即座に失敗したターンでも見出しは書かれるので
+    -- このspecは緑のままだった（root環境で `--dangerously-skip-permissions` が拒否される
+    -- ケースで実際に起きた）。
+    --
+    -- マーカー語を頼んでそれを待つ形は採らない。モデルが従うことに賭ける必要があるうえ、
+    -- バッファ全体を見る待ち方だとプロンプトに書いたマーカーが `## User` セクションで
+    -- 即座に一致してしまい、同じ穴が別の形で開く
     local reason
-    ok, reason = helper.wait_for_response(nvim_instance, MARKER, TIMEOUTS.ASSISTANT_RESPONSE)
+    ok, reason = helper.wait_for_assistant_turns(nvim_instance, 1, TIMEOUTS.ASSISTANT_RESPONSE)
     assert.is_true(ok, reason or "Assistant response should appear within timeout")
   end)
 end)

--- a/tests/e2e/nvim_ask_user_question_spec.lua
+++ b/tests/e2e/nvim_ask_user_question_spec.lua
@@ -71,8 +71,9 @@ describe("E2E: nvim_ask_user_question MCP tool", function()
     helper.send_keys(nvim_instance, "<CR>")
 
     -- Wait for question prompt (same UI as AskUserQuestion)
-    ok = helper.wait_for_buffer_content(nvim_instance, "\n1%. A\n", TIMEOUTS.ASSISTANT_RESPONSE)
-    assert.is_true(ok, "Choice-list prompt should appear")
+    local reason
+    ok, reason = helper.wait_for_response(nvim_instance, "\n1%. A\n", TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, reason or "Choice-list prompt should appear")
 
     local count = count_lines_matching(nvim_instance, "^1%. A$")
     assert.equals(1, count, "The question must be rendered exactly once — no duplicate UI insertion")

--- a/tests/e2e/plugin_dir_spec.lua
+++ b/tests/e2e/plugin_dir_spec.lua
@@ -88,7 +88,7 @@ describe("E2E: .vibing/plugins is loaded via --plugin-dir", function()
     -- 失敗したターンで打ち切る。そうしないと、ターンがCLIのエラーで死んだだけの場合にも
     -- 「skillが読まれなかった」という嘘の診断が60秒後に出る（`reason` がそれを言い分ける）
     local reason
-    ok, reason = helper.wait_for_response(nvim_instance, MARKER, TIMEOUTS.ASSISTANT_RESPONSE)
+    ok, reason = helper.wait_for_assistant_text(nvim_instance, MARKER, TIMEOUTS.ASSISTANT_RESPONSE)
     assert.is_true(
       ok,
       (reason or "")

--- a/tests/e2e/plugin_dir_spec.lua
+++ b/tests/e2e/plugin_dir_spec.lua
@@ -85,10 +85,14 @@ describe("E2E: .vibing/plugins is loaded via --plugin-dir", function()
     helper.send_keys(nvim_instance, "<Esc>")
     helper.send_keys(nvim_instance, "<CR>")
 
-    ok = helper.wait_for_buffer_content(nvim_instance, MARKER, TIMEOUTS.ASSISTANT_RESPONSE)
+    -- 失敗したターンで打ち切る。そうしないと、ターンがCLIのエラーで死んだだけの場合にも
+    -- 「skillが読まれなかった」という嘘の診断が60秒後に出る（`reason` がそれを言い分ける）
+    local reason
+    ok, reason = helper.wait_for_response(nvim_instance, MARKER, TIMEOUTS.ASSISTANT_RESPONSE)
     assert.is_true(
       ok,
-      "The probe skill's description never reached the model — `--plugin-dir` did not load "
+      (reason or "")
+        .. "\nThe probe skill's description never reached the model — `--plugin-dir` did not load "
         .. project_root
         .. "/.vibing/plugins/"
         .. PLUGIN_NAME

--- a/tests/lua/application/chat/approval_delegate_integration_spec.lua
+++ b/tests/lua/application/chat/approval_delegate_integration_spec.lua
@@ -1,0 +1,170 @@
+--- 代理承認を、本物の `ChatBuffer` で端から端まで通す統合spec。
+---
+--- `approval_delegate_spec.lua` は `ProgrammaticSender.send` を差し替えて「何を書こうとしたか」
+--- だけを見る。つまりこの機能の**後半** — 書いた行を `ChatBuffer:send_message()` が承認応答と
+--- して読み、`update_session_permissions` を走らせ、`_pending_approval` を捨て、CLIに渡す本文を
+--- 再試行文に差し替える — は、そちらでは1行も実行されない。
+---
+--- この機能の設計は「承認の意味を自前で持たず、人間の `<CR>` と同じ経路に流す」ことなので、
+--- 検証すべきものはまさにその接続部にある。書く側と読む側が食い違えば、代理応答は黙って
+--- ただのユーザーメッセージになり、承認は消費されないままワーカーが再試行してまた止まる —
+--- エラーはどこにも出ない。だからここでは本物のバッファに本物の承認プロンプトを描かせ、
+--- 止めるのは `SendMessage.execute`（ここから先は本物のCLIターン）だけにする。
+local ApprovalDelegate = require("vibing.application.chat.approval_delegate")
+local Config = require("vibing.config")
+local vibing = require("vibing")
+local view = require("vibing.presentation.chat.view")
+local CreateChat = require("vibing.application.chat.use_cases.create_chat")
+local SendMessage = require("vibing.application.chat.send_message")
+
+-- `rpc/handlers/permission.lua` の APPROVAL_OPTIONS そのもの
+local OPTIONS = {
+  { value = "allow_once", label = "allow_once - Allow this execution only" },
+  { value = "deny_once", label = "deny_once - Deny this execution only" },
+  { value = "allow_for_session", label = "allow_for_session - Allow for this session" },
+  { value = "deny_for_session", label = "deny_for_session - Deny for this session" },
+}
+
+describe("delegated approval, end to end", function()
+  local originals = {}
+  local save_dir
+  local chats
+  local requests
+
+  ---@param enabled boolean
+  local function configure(enabled)
+    local cfg = vim.tbl_deep_extend("force", vim.deepcopy(Config.defaults), {
+      chat = { save_location_type = "custom", save_dir = save_dir },
+      agent = { orchestration = { delegated_approval = enabled } },
+    })
+    Config.get = function()
+      return cfg
+    end
+    vibing.get_config = function()
+      return cfg
+    end
+  end
+
+  ---@return Vibing.ChatBuffer
+  local function open_chat()
+    local chat_buf = view.render(CreateChat.execute({}), "back", { background = true })
+    table.insert(chats, chat_buf)
+    return chat_buf
+  end
+
+  ---@param chat_buf Vibing.ChatBuffer
+  ---@return string
+  local function buffer_text(chat_buf)
+    return table.concat(vim.api.nvim_buf_get_lines(chat_buf.buf, 0, -1, false), "\n")
+  end
+
+  ---承認待ちで止まったワーカーを1つ作る（`permission.lua` がやるのと同じ2手）
+  ---@return Vibing.ChatBuffer
+  local function blocked_worker()
+    local worker = open_chat()
+    worker:insert_approval_request("Bash", { command = "npm install" }, OPTIONS, "req-1")
+    worker:add_user_section()
+    return worker
+  end
+
+  before_each(function()
+    originals.config_get = Config.get
+    originals.get_config = vibing.get_config
+    originals.get_adapter = vibing.get_adapter
+    originals.execute = SendMessage.execute
+
+    save_dir = vim.fn.tempname()
+    vim.fn.mkdir(save_dir, "p")
+    chats = {}
+    requests = {}
+    configure(true)
+
+    vibing.get_adapter = function()
+      return { name = "fake" }
+    end
+    -- ここから先は本物のCLIターン。何が送られようとしたかだけ読む
+    SendMessage.execute = function(_, _, message)
+      table.insert(requests, message)
+    end
+  end)
+
+  after_each(function()
+    Config.get = originals.config_get
+    vibing.get_config = originals.get_config
+    vibing.get_adapter = originals.get_adapter
+    SendMessage.execute = originals.execute
+
+    for _, chat_buf in ipairs(chats) do
+      if vim.api.nvim_buf_is_valid(chat_buf.buf) then
+        vim.api.nvim_buf_delete(chat_buf.buf, { force = true })
+      end
+    end
+    vim.fn.delete(save_dir, "rf")
+  end)
+
+  it("consumes the approval and restarts the worker with the retry instruction", function()
+    local orchestrator, worker = open_chat(), blocked_worker()
+    assert.equals("waiting_approval", worker:get_stop_reason())
+
+    ApprovalDelegate.answer({ bufnr = worker.buf, action = "allow_once", from_bufnr = orchestrator.buf })
+
+    -- 承認が消費されたことの3つの現れ。どれか1つでも欠けると、ワーカーは同じ壁にまた当たる
+    assert.is_nil(worker:get_pending_approval(), "the prompt must be marked consumed")
+    assert.is_true(vim.tbl_contains(worker:get_session_allow(), "Bash:once"), "the grant must be recorded")
+    assert.equals(1, #requests)
+    assert.is_truthy(requests[1]:match("^I approved the Bash tool"), requests[1])
+    -- 入力の要約まで渡すのは、モデルに同じ操作をやり直させるため
+    assert.is_truthy(requests[1]:match("npm install"), requests[1])
+  end)
+
+  it("replaces the prompt in the transcript with a section naming who answered", function()
+    local orchestrator, worker = open_chat(), blocked_worker()
+    assert.is_truthy(buffer_text(worker):match("Tool approval required"))
+
+    ApprovalDelegate.answer({ bufnr = worker.buf, action = "allow_once", from_bufnr = orchestrator.buf })
+
+    local text = buffer_text(worker)
+    -- 残すと、答え終わったプロンプトが以後の `extract_conversation` に毎回乗る
+    assert.is_nil(text:match("Tool approval required"), text)
+    assert.is_truthy(text:match("## Request <!%-%- %d%d%d%d%-%d%d%-%d%d "), text)
+    assert.is_truthy(text:match("1%. allow_once %- Allow this execution only"), text)
+  end)
+
+  it("records a denial as a denial, and tells the worker to take another route", function()
+    local orchestrator, worker = open_chat(), blocked_worker()
+
+    ApprovalDelegate.answer({ bufnr = worker.buf, action = "deny_for_session", from_bufnr = orchestrator.buf })
+
+    assert.is_true(vim.tbl_contains(worker:get_session_deny(), "Bash"))
+    assert.is_truthy(requests[1]:match("^I denied the Bash tool"), requests[1])
+  end)
+
+  it("leaves the prompt untouched when the feature is off", function()
+    configure(false)
+    local orchestrator, worker = open_chat(), blocked_worker()
+
+    assert.has_error(function()
+      ApprovalDelegate.answer({ bufnr = worker.buf, action = "allow_once", from_bufnr = orchestrator.buf })
+    end)
+
+    -- 断るだけでなく、ユーザーが答えられる状態のまま残っていること
+    assert.is_truthy(worker:get_pending_approval())
+    assert.equals("waiting_approval", worker:get_stop_reason())
+    assert.is_truthy(buffer_text(worker):match("Tool approval required"))
+    assert.equals(0, #requests)
+  end)
+
+  it("refuses a second answer to a prompt that was already consumed", function()
+    local orchestrator, worker = open_chat(), blocked_worker()
+
+    ApprovalDelegate.answer({ bufnr = worker.buf, action = "allow_once", from_bufnr = orchestrator.buf })
+    -- 1回目の応答でワーカーは新しいターンに入っている。`SendMessage.execute` を差し替えて
+    -- いるので `_is_sending` はそのまま立っており、2回目は「応答中」で弾かれる。承認が
+    -- 消費済みであることも同じく理由になる — どちらでも通ってはいけない
+    assert.has_error(function()
+      ApprovalDelegate.answer({ bufnr = worker.buf, action = "deny_once", from_bufnr = orchestrator.buf })
+    end)
+
+    assert.equals(1, #requests)
+  end)
+end)

--- a/tests/lua/application/chat/approval_delegate_spec.lua
+++ b/tests/lua/application/chat/approval_delegate_spec.lua
@@ -1,0 +1,213 @@
+--- `approval_delegate` — オーケストレーターがワーカーの承認プロンプトに代理で答える経路。
+---
+--- ここで固定したいのは3つ。既定で**断る**こと（承認ゲートを外せる状態は opt-in であって、
+--- 有効化を忘れた設定で黙って通ってはいけない）、答えがバッファに書く行が
+--- `approval_parser` の読む形と一字一句合うこと、そして代理応答が承認プロンプトのセクションを
+--- 置き換えること。
+---
+--- 2つ目が肝心で、この機能は「承認の意味」を自前で持たない設計になっている
+--- （選択肢の行を書いて `ChatBuffer:send_message()` に読ませるだけ）。その代わり、書く側と
+--- 読む側が食い違った瞬間に代理応答は黙って**ただのユーザーメッセージ**になり、承認は
+--- 消費されないままワーカーが再試行してまた止まる。片方だけを直しても気づけないので、
+--- 両方をこのファイルで突き合わせる。
+local ApprovalDelegate = require("vibing.application.chat.approval_delegate")
+local ApprovalParser = require("vibing.presentation.chat.modules.approval_parser")
+local ProgrammaticSender = require("vibing.presentation.chat.modules.programmatic_sender")
+local OrchestrationLink = require("vibing.application.chat.orchestration_link")
+local Notifier = require("vibing.application.chat.completion_notifier")
+local Config = require("vibing.config")
+local view = require("vibing.presentation.chat.view")
+
+-- `rpc/handlers/permission.lua` の APPROVAL_OPTIONS と同じ形。ハンドラから渡ってくるものを
+-- そのまま模す
+local OPTIONS = {
+  { value = "allow_once", label = "allow_once - Allow this execution only" },
+  { value = "deny_once", label = "deny_once - Deny this execution only" },
+  { value = "allow_for_session", label = "allow_for_session - Allow for this session" },
+  { value = "deny_for_session", label = "deny_for_session - Deny for this session" },
+}
+
+describe("ApprovalDelegate", function()
+  local originals = {}
+  local worker, orchestrator
+  local sends
+  local pending
+  local stop_reason
+
+  ---@param enabled boolean
+  local function configure(enabled)
+    local cfg = vim.tbl_deep_extend("force", vim.deepcopy(Config.defaults), {
+      agent = { orchestration = { delegated_approval = enabled } },
+    })
+    Config.get = function()
+      return cfg
+    end
+  end
+
+  before_each(function()
+    originals.config_get = Config.get
+    originals.get_chat_buffer = view.get_chat_buffer
+    originals.send = ProgrammaticSender.send
+    originals.validate = ProgrammaticSender.validate
+    originals.link_or_warn = OrchestrationLink.link_or_warn
+    originals.direction = OrchestrationLink.direction
+    originals.on_sent = Notifier.on_sent
+
+    worker = vim.api.nvim_create_buf(false, true)
+    orchestrator = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(orchestrator, vim.fn.tempname() .. "-orchestrator.md")
+
+    sends = {}
+    pending = { tool = "Bash", input = { command = "npm install" }, options = OPTIONS }
+    stop_reason = "waiting_approval"
+
+    configure(true)
+
+    view.get_chat_buffer = function(target)
+      if target ~= worker and target ~= orchestrator then
+        return nil
+      end
+      return {
+        is_responding = function()
+          return false
+        end,
+        get_pending_approval = function()
+          return pending
+        end,
+        get_stop_reason = function()
+          return stop_reason
+        end,
+      }
+    end
+
+    -- 本物を通すとCLIターンが走る。何が書かれようとしたかだけ読む
+    ProgrammaticSender.validate = function() end
+    ProgrammaticSender.send = function(bufnr, message, sender, delivery, opts)
+      table.insert(sends, { bufnr = bufnr, message = message, delivery = delivery, opts = opts })
+      return { success = true, bufnr = bufnr }
+    end
+    OrchestrationLink.link_or_warn = function() end
+    OrchestrationLink.direction = function()
+      return "Request"
+    end
+    Notifier.on_sent = function() end
+  end)
+
+  after_each(function()
+    Config.get = originals.config_get
+    view.get_chat_buffer = originals.get_chat_buffer
+    ProgrammaticSender.send = originals.send
+    ProgrammaticSender.validate = originals.validate
+    OrchestrationLink.link_or_warn = originals.link_or_warn
+    OrchestrationLink.direction = originals.direction
+    Notifier.on_sent = originals.on_sent
+
+    for _, buf in ipairs({ worker, orchestrator }) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end
+  end)
+
+  ---@param action string
+  local function answer(action)
+    return ApprovalDelegate.answer({ bufnr = worker, action = action, from_bufnr = orchestrator })
+  end
+
+  it("refuses by default, and says what to do instead", function()
+    configure(false)
+
+    local ok, err = pcall(answer, "allow_once")
+
+    assert.is_false(ok)
+    -- 文面まで見るのは、これを読むのがモデルだから。「無効です」だけだと、次の一手が
+    -- 「もう一度呼ぶ」になりうる
+    assert.is_truthy(tostring(err):match("Only the user can answer"), tostring(err))
+    assert.is_truthy(tostring(err):match("delegated_approval"), tostring(err))
+    assert.equals(0, #sends, "nothing may be written into the worker while the gate is closed")
+  end)
+
+  it("writes a line the approval parser reads back as the same action", function()
+    -- この spec の主眼。書く側（ここ）と読む側（`ChatBuffer:send_message` が使う
+    -- `approval_parser`）が食い違うと、代理応答は黙ってただのユーザーメッセージになる
+    for _, opt in ipairs(OPTIONS) do
+      sends = {}
+      answer(opt.value)
+
+      local line = sends[1].message
+      assert.is_true(ApprovalParser.is_approval_response(line), line)
+      assert.equals(opt.value, ApprovalParser.parse_approval_response(line).action)
+    end
+  end)
+
+  it("reproduces the numbering the renderer drew, so the transcript reads like a human answer", function()
+    answer("allow_for_session")
+
+    assert.equals("3. allow_for_session - Allow for this session", sends[1].message)
+  end)
+
+  it("still produces a parseable line when the options are missing", function()
+    -- 選択肢を読み取れなかったときの逃げ道も、パターンに合っていなければ意味がない
+    local line = ApprovalDelegate.option_line(nil, "deny_once")
+
+    assert.is_true(ApprovalParser.is_approval_response(line), line)
+    assert.equals("deny_once", ApprovalParser.parse_approval_response(line).action)
+  end)
+
+  it("replaces the prompt section and names the answering chat in the header", function()
+    answer("allow_once")
+
+    assert.is_true(sends[1].opts.replace_unsent, "the answered prompt must not stay in the buffer")
+    assert.equals("Request", sends[1].delivery.kind)
+    assert.is_truthy(sends[1].delivery.from, "the worker's transcript must record who answered")
+  end)
+
+  it("refuses an action that is not one of the four", function()
+    assert.has_error(function()
+      answer("allow")
+    end)
+    assert.has_error(function()
+      ApprovalDelegate.answer({ bufnr = worker, action = nil, from_bufnr = orchestrator })
+    end)
+    assert.equals(0, #sends)
+  end)
+
+  it("refuses a chat that is not waiting on an approval, and names its actual status", function()
+    pending = nil
+    stop_reason = nil
+
+    local ok, err = pcall(answer, "allow_once")
+
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):match("idle"), tostring(err))
+    assert.equals(0, #sends)
+  end)
+
+  it("refuses a chat answering its own prompt", function()
+    local ok = pcall(function()
+      ApprovalDelegate.answer({ bufnr = worker, action = "allow_once", from_bufnr = worker })
+    end)
+
+    assert.is_false(ok)
+    assert.equals(0, #sends)
+  end)
+
+  it("subscribes the answering chat to the turn its answer starts", function()
+    local subscribed = {}
+    Notifier.on_sent = function(from_bufnr, to_bufnr)
+      table.insert(subscribed, { from_bufnr, to_bufnr })
+    end
+
+    answer("allow_once")
+
+    assert.same({ { orchestrator, worker } }, subscribed)
+  end)
+
+  it("reports which tool it answered, so the caller need not re-read the buffer", function()
+    local result = answer("deny_for_session")
+
+    assert.equals("Bash", result.tool)
+    assert.equals("deny_for_session", result.action)
+    assert.is_true(result.success)
+  end)
+end)

--- a/tests/lua/presentation/chat/modules/programmatic_sender_spec.lua
+++ b/tests/lua/presentation/chat/modules/programmatic_sender_spec.lua
@@ -87,6 +87,48 @@ describe("ProgrammaticSender.send", function()
     assert.is_true(vim.tbl_contains(lines, "1. PostgreSQL"), table.concat(lines, "\n"))
   end)
 
+  it("replaces a trailing section with something in it when asked to", function()
+    -- 承認への代理応答（`approval_delegate`）だけがこれを渡す。そこでは承認プロンプトそのものが
+    -- 「答える対象」なので、残すと答え終わったプロンプトがバッファに永久に居座る
+    vim.api.nvim_buf_set_lines(bufnr, -1, -1, false, {
+      "## User <!-- unsent -->",
+      "",
+      "⚠️  Tool approval required",
+      "",
+      "1. allow_once - Allow this execution only",
+      "",
+    })
+
+    ProgrammaticSender.send(bufnr, "1. allow_once - Allow this execution only", nil, {
+      kind = "Request",
+      from = ".vibing/chat/orchestrator.md",
+    }, { replace_unsent = true })
+
+    local lines = buffer_lines()
+    assert.is_false(vim.tbl_contains(lines, "⚠️  Tool approval required"), table.concat(lines, "\n"))
+
+    local headers = vim.tbl_filter(function(line)
+      return line:match("^## ")
+    end, lines)
+    assert.same({ "## Request <!-- unsent from .vibing/chat/orchestrator.md -->" }, headers)
+  end)
+
+  it("leaves an already-committed trailing section alone even with replace_unsent", function()
+    -- 「未送信ヘッダーが見つかるまで遡る」実装だと、送信済みセクションを飛び越えて上のほうの
+    -- 未送信セクションを消しうる。末尾から最初に当たったヘッダーだけを見る
+    vim.api.nvim_buf_set_lines(bufnr, -1, -1, false, {
+      "## User <!-- 2026-09-03 10:00:00 -->",
+      "",
+      "already sent",
+      "",
+    })
+
+    ProgrammaticSender.send(bufnr, "hello", nil, { kind = "Request" }, { replace_unsent = true })
+
+    local lines = buffer_lines()
+    assert.is_true(vim.tbl_contains(lines, "already sent"), table.concat(lines, "\n"))
+  end)
+
   it("refuses a chat that is already responding, before touching the buffer", function()
     -- 追加してから巻き戻すのではなく追加する前に断る。`ChatBuffer:send_message()` は
     -- 応答中なら黙って return するので、先に append すると送られない `## User` が残り、


### PR DESCRIPTION
A worker chat that reaches a tool in its `ask` list has its turn killed
before the approval prompt is drawn, so it can neither continue nor report
that it is stuck. Until now the only one who could clear that was the user:
the watchdog notice and the `vibing-orchestrate` skill both told the
orchestrator to name the blocked chat and stop there. With a fan of workers
all hitting the same prompt, that is one buffer per worker for the user to
find by hand.

`agent.orchestration.delegated_approval` (default `false`) lets the
orchestrator answer instead, through the new MCP tool
`nvim_chat_answer_approval` -> `rpc/handlers/chat.lua:answer_approval` ->
`application/chat/approval_delegate.lua`, choosing among the same four
options the prompt offers the user.

Off by default for what it buys, not for what it costs to build: the `ask`
list is the user asking to be consulted, and an agent that can clear it for
another agent has changed the permission model. The refusal is worded for
the model that reads it, so a chat running without the setting spends no
turn probing.

The answer takes exactly the human path. `approval_delegate` writes the
chosen option line -- the same one the renderer drew -- into the worker's
buffer and calls `ChatBuffer:send_message()`, so `update_session_permissions`,
the `:once` bookkeeping and the retry-message substitution all stay in the
one block that already did them. A second implementation of what an
approval means, reachable only through orchestration, is the divergence
this shape exists to prevent.

Three supporting changes:

- `ProgrammaticSender.send` takes `replace_unsent`, the one case where the
  trailing unsent section *is* the thing being answered. Without it an
  answered prompt sits in the transcript forever and every later
  `extract_conversation` re-sends it to the CLI.
- The delegated answer lands as `## Request <!-- ... from <orchestrator> -->`,
  which is how the worker's transcript records who granted it. That is also
  why `from_bufnr` is required on this tool while it stays optional on the
  other two.
- `delivery_message`'s `waiting_approval` bullet follows the setting.
  Telling the model to answer while it is off would buy one guaranteed
  failed call per blocked worker.

Tested by a unit spec pinning the write/read seam against `approval_parser`
(a mismatch turns a delegated answer silently into an ordinary user message)
and an integration spec driving a real `ChatBuffer` from prompt to consumed
grant.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Piss8Vm82HL3qxGKpza2ZH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in delegated tool-approval handling for orchestrated chats.
  * Orchestrators can approve or deny a worker’s pending tool request using four available actions.
  * Added configuration to enable delegated approvals, disabled by default.
  * Approval decisions are recorded in the worker’s chat transcript and permissions.

* **Documentation**
  * Updated orchestration, configuration, MCP tool, and skill documentation with delegated-approval guidance.

* **Tests**
  * Added coverage for approval validation, delegation workflows, transcript updates, and configuration safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->