### PR TITLE
fix(agent): disable the CLI's per-process git status block by default

### DIFF
--- a/handbook/architecture/cli-integration.md
+++ b/handbook/architecture/cli-integration.md
@@ -53,6 +53,76 @@ it is accepted rather than solved.
 its owning Neovim is gone: it cross-checks `registry.list()`, which already filters to live PIDs,
 so a concurrent instance's in-flight `.req`/`.res` files are never deleted.
 
+## What the System Prompt May Not Contain
+
+vibing.nvim starts a fresh CLI process for every turn and re-attaches it to the session with
+`--resume`. That is the one structural difference from every other way the CLI is run, and it has
+a consequence that only shows up on the bill: **anything the CLI computes once at process start
+and places in the system prompt is re-computed on every turn.** The system prompt is the first
+thing in the prefix, so a value that moves invalidates the cache for it _and_ the whole
+conversation behind it — floor plus history, re-written at cache-creation price, which is 12.5× the
+read price. A long-lived process pays that once per session; here it is once per change.
+
+`agent.git_instructions` is the case that was found (#681). The CLI embeds a block like
+
+```text
+This is the git status at the start of the conversation. ...
+Current branch: ...
+Status: <git status --short>
+Recent commits: <git log --oneline -10>
+```
+
+computed once per session id and cached in memory (`refreshReason: "session_start"`). One edit,
+one commit or one untracked file changes those bytes. Measured against 2.1.231 on a 128k-token
+session, the turn following a one-line edit reports `new=128,456 / read=144,076` with the block on
+and `new=9 / read=272,424` with it off — the same input volume, 6.4× the input cost. The
+fixed prefix ahead of the block stays cached, so what misses is exactly the conversation, which is
+why the loss grows with `context` (`handbook/configuration.md` → "Token Usage").
+
+Read out of the 2.1.231 binary, the gate is:
+
+```js
+function () {
+  let e = process.env.CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS
+  if (isTruthy(e)) return false
+  if (isFalsy(e)) return true
+  return settings().includeGitInstructions ?? true
+}
+// ... and at the call site:
+let n = env.CLAUDE_CODE_REMOTE || !includeGitInstructions() ? null : await gitStatus(e)
+```
+
+So Claude Code on the web has never carried the block at all — its process is long-lived, and the
+block was still judged not worth it. `claude_cli.lua` therefore sets
+`CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` in the child environment by default. Three things about
+that shape:
+
+- **The environment, not the `--settings` file.** `includeGitInstructions` is a real settings key,
+  but `--settings` is written per cwd by `settings_generator.lua` and is skipped entirely on the
+  lightweight path, which would leave title generation and `/summarize` carrying a block that
+  changes under them. The environment is the one channel every call goes through.
+- **Both settings write the variable**, because the CLI reads it as a tri-state: `"1"` suppresses,
+  `"0"` forces on, unset defers to `includeGitInstructions` — which
+  `--setting-sources user,project,local` still loads. So `agent.git_instructions = true` writes
+  `"0"` rather than nothing; writing nothing would leave the opt-in unable to deliver what it
+  promises to a user who has that key set to `false`. Verified against the CLI: `0` and `false`
+  both put the block back, `1` removes it.
+- **A value already in the environment wins over both.** Setting `CLAUDE_CODE_REMOTE` instead is
+  not an option: it changes other behaviour (this repository's own `SessionStart` hook keys on
+  it), and a variable that means "you are in a container" is not a variable to lie about.
+- **What is lost is small and recoverable.** The model no longer starts a turn knowing the branch,
+  the recent commits or the changed files, and the CLI's built-in "match the style of recent
+  commits" instruction goes with them. One `git status` or `git log` call buys that back, and one
+  tool call is orders of magnitude cheaper than re-writing the prefix. Commit-message conventions
+  belong in `.claude/rules/` or `.vibing/system-prompt.md`, where they are part of the stable
+  prefix rather than re-derived.
+
+The invariant generalises past this one block: **a per-turn process makes every startup-time
+computation a prefix variable.** The CLI version string, the date and the cache-breaker phrase are
+the other candidates; none has been measured moving, and #674's re-write detection is what is meant
+to catch the next one rather than a hand-maintained list here. vibing.nvim's own
+`--append-system-prompt` was byte-stabilised for the same reason in #469.
+
 ## Backend Seams
 
 These are the seams that stop backend identity leaking into shared code. The rule they encode:

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -32,6 +32,7 @@ require("vibing").setup({
     default_model = "sonnet",
     utility_model = "sonnet",
     setting_sources = { "user", "project", "local" },
+    git_instructions = false,
     subagent = { enabled = false, show_prefix = false },
     auto_resume_on_limit = { enabled = false, max_retries = 1 },
     scheduled_requests = { enabled = true, max_retries = 3 },
@@ -157,6 +158,15 @@ agent = {
                             -- Drop "user" to skip loading your global CLAUDE.md on
                             -- every chat, reducing fixed per-session token cost.
                             -- Note: does not affect MCP server loading.
+
+  git_instructions = false, -- Claude backend only. The CLI's own git status block (branch,
+                            -- `git status --short`, recent commits) plus its built-in commit/PR
+                            -- workflow instructions. Off because the CLI computes that block
+                            -- once per process and vibing.nvim starts one per turn — see
+                            -- "Token Usage" below. Set true to get the old behaviour back —
+                            -- which also overrides includeGitInstructions in your settings.json,
+                            -- since both values are written through the CLI's env var.
+                            -- An already-set CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS wins either way.
 
   subagent = {              -- What a subagent (Task/Agent tool) says in the chat
     enabled = false,        -- Opt-in: passes --forward-subagent-text to the CLI so the
@@ -428,6 +438,36 @@ would then stay in every later one. See `handbook/architecture/chat-lineage.md` 
 `/summarize` is **not** the tool for this, despite the name. It opens a summary in a floating
 window and never touches the session, so the turn after it re-reads exactly as much as the turn
 before.
+
+**A re-write is not always the conversation's fault.** The prefix starts with the system prompt,
+so anything the CLI computes _at process start_ and puts there is re-computed on every turn —
+vibing.nvim restarts the CLI per turn, where an interactive session or Claude Code on the web keeps
+one process for the whole conversation. If that value changes, the miss is total: floor plus the
+entire history, at creation price. The known case is the CLI's git status block (branch,
+`git status --short`, recent commits), which is why `agent.git_instructions` defaults to `false`
+(#681).
+
+Measured on a 128k-token session, comparing the turn right after a one-line edit to `README.md`:
+
+| `git_instructions` | `new`   | `read`  |
+| ------------------ | ------- | ------- |
+| `true`             | 128,456 | 144,076 |
+| `false`            | 9       | 272,424 |
+
+The turn processes the same ~272k of input either way; what moves is the **price tier** it is
+processed at. Priced in base-input-token equivalents (creation 1.25×, read 0.10×) that turn costs
+174,978 against 27,254 — the block-on turn pays 6.4× as much for the same conversation. Note that
+the CLI's fixed system prefix (the 144,076 read in both rows) stays cached: the block sits between
+it and the conversation, so what misses is everything the chat has accumulated. That is what makes
+the loss proportional to `context`.
+
+The saving applies only to a turn that changed the tree, and one `git status` the model runs
+because the block is gone costs one extra request over the whole context at read price — 27k
+equivalents here, so it would take about five such calls per turn to give the saving back.
+
+The same shape can come from anything else startup-computed; the invariant to apply when touching
+this path is in `handbook/architecture/cli-integration.md` → "What the System Prompt May Not
+Contain".
 
 One more thing the numbers depend on: **a chat has a floor it can never go below**, made of the
 system prompt, the tool schemas, and whatever `CLAUDE.md` and `.claude/rules/` the project loads.

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -111,6 +111,11 @@
 ---@field default_effort ("low"|"medium"|"high"|"xhigh"|"max")? 推論量の既定値（未指定ならCLIの既定に任せる）
 ---@field utility_effort ("low"|"medium"|"high"|"xhigh"|"max")? タイトル生成・要約等の軽量呼び出しの推論量（デフォルト: "low"）
 ---@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）
+---@field git_instructions boolean? trueでClaude CLI組み込みのgitステータスブロック（ブランチ名・
+---  直近コミット・`git status --short`）とcommit/PRワークフロー指示をsystem promptに載せる
+---  （デフォルト: false）。どちらの値でも`CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS`を明示的に書く
+---  （true→"0"、false→"1"）ので settings.json の`includeGitInstructions`より優先される。
+---  ただしユーザーが既に環境変数を立てている場合はそちらを尊重して触らない
 ---@field subagent Vibing.SubagentConfig? subagent（Task/Agentツール）の出力表示設定
 ---@field auto_resume_on_limit Vibing.AutoResumeOnLimitConfig 使用量リミット自動継続設定
 ---@field scheduled_requests Vibing.ScheduledRequestsConfig 予約リクエスト設定
@@ -275,6 +280,11 @@ M.defaults = {
     default_effort = nil,
     utility_effort = "low",
     setting_sources = { "user", "project", "local" },
+    -- CLIはプロセス起動ごとにgitステータスブロックを1回計算してsystem promptの先頭に埋める。
+    -- vibing.nvimはターンごとにCLIを起動し直すので、tree を触ったターンの次はそのバイト列が
+    -- 変わり、system prompt以降＝全履歴がキャッシュミスになる。既定でoffにする理由はそれで、
+    -- ブランチ名や直近コミットが要るときはモデルに `git status` / `git log` を1回呼ばせれば済む。
+    git_instructions = false,
     subagent = {
       enabled = false,
       show_prefix = false,

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -143,6 +143,23 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   -- chats don't cross-wire each other's AskUserQuestion/approval UI (see ActiveStreamRegistry).
   env.VIBING_HANDLE_ID = handle_id
 
+  -- The CLI computes a git status block (branch, `git status --short`, recent commits) once per
+  -- process and puts it at the top of the system prompt, ahead of the whole conversation. A
+  -- long-lived process pays for that once; vibing.nvim starts a new one every turn, so any turn
+  -- that touched the tree changes those bytes and the entire prefix is re-written at
+  -- cache-creation price. The CLI drops the block itself under CLAUDE_CODE_REMOTE for the same
+  -- reason.
+  --
+  -- Both settings write the variable, because the CLI reads it as a tri-state: "1" suppresses the
+  -- block, "0" forces it on, and unset falls through to `includeGitInstructions` in the user's
+  -- settings.json — which `--setting-sources user,project,local` still loads. Writing nothing on
+  -- the opt-in path would leave `git_instructions = true` unable to deliver what it promises for
+  -- a user who has that key set to false. A value already in the environment wins over both.
+  if env.CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS == nil then
+    local git_instructions = self.config.agent and self.config.agent.git_instructions
+    env.CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS = git_instructions and "0" or "1"
+  end
+
   ActiveStreamRegistry.register({
     handle_id = handle_id,
     chat_bufnr = opts.chat_bufnr,

--- a/tests/lua/infrastructure/adapter/claude_cli_spec.lua
+++ b/tests/lua/infrastructure/adapter/claude_cli_spec.lua
@@ -1,0 +1,63 @@
+---@diagnostic disable: undefined-field
+--- Covers the part of the child environment only `claude_cli` decides: whether the CLI computes
+--- its own git status block.
+---
+--- It is an environment assertion rather than an argv one because the CLI has no flag for it, and
+--- it belongs here rather than in `stream_options_spec` because no other backend reads the
+--- variable. What it protects is a cache property, so nothing downstream fails loudly when it
+--- lapses -- the turns simply cost more.
+
+local helper = require("tests.helpers.adapter_stream")
+local claude = require("vibing.infrastructure.adapter.claude_cli")
+
+local CONFIG = { agent = { default_model = "sonnet" } }
+local VAR = "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS"
+
+describe("claude_cli git instructions", function()
+  local system, ambient
+
+  before_each(function()
+    system = helper.stub_system()
+    -- The adapter reads the real process environment, so a developer who exports this variable
+    -- would otherwise be asserted against instead of the code -- and "0" is exactly the value the
+    -- feature documents as their escape hatch. Saved rather than dropped, so the suite leaves the
+    -- process as it found it.
+    ambient = vim.env[VAR]
+    vim.env[VAR] = nil
+  end)
+
+  after_each(function()
+    system.restore()
+    vim.env[VAR] = ambient
+  end)
+
+  --- @param agent table? overrides merged into CONFIG.agent
+  local function env_for(agent, opts)
+    local config = { agent = vim.tbl_extend("force", CONFIG.agent, agent or {}) }
+    helper.run_stream(claude:new(config), opts)
+    return system.only_call().opts.env
+  end
+
+  it("disables the block by default", function()
+    assert.equals("1", env_for().CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+  end)
+
+  it("disables it on lightweight calls too", function()
+    -- `--setting-sources ""` does not reach this: the block comes from the CLI's own startup, not
+    -- from project settings, so a title generation would otherwise carry a per-turn prefix as well.
+    assert.equals("1", env_for(nil, { lightweight = true }).CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+  end)
+
+  it("forces the block back on when git_instructions is set", function()
+    -- "0", not unset: unset falls through to `includeGitInstructions` in the user's settings.json,
+    -- so a user who has that key set to false would ask for the block and not get it.
+    assert.equals("0", env_for({ git_instructions = true }).CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+  end)
+
+  it("does not overwrite a value the user set", function()
+    -- "0" is the CLI's own way of forcing the block back on, so overwriting it would take away
+    -- the escape hatch rather than merely duplicating the setting.
+    vim.env[VAR] = "0"
+    assert.equals("0", env_for().CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

Claude CLI は system prompt の先頭に git ステータスブロック（ブランチ名 / `git status --short` / 直近コミット）を埋める。これは**プロセス起動時に1回**計算される値で、常駐プロセス（対話モード）なら1セッション1回の負担で済む。

vibing.nvim はターンごとに `claude -p --resume` を起動し直すので、この計算が**毎ターン**走る。tree を触ったターンの次はバイト列が変わり、system prompt 以降＝全履歴がキャッシュミスになって作成価格（読み取りの12.5倍）で払い直しになる。

既定で `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` を立ててこれを止め、`agent.git_instructions = true` で従来の挙動に戻せるようにした。

## Changes

- `claude_cli.lua`: 子プロセスの env に `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` を明示的に書く（既定 `"1"`、`agent.git_instructions = true` なら `"0"`）。ユーザーが既に環境変数を立てていればそちらを尊重して触らない
- `config.lua`: `agent.git_instructions`（既定 `false`）を追加
- `tests/lua/infrastructure/adapter/claude_cli_spec.lua`: 新規。既定 / lightweight / opt-in / ユーザー環境変数の非上書き の4件
- `handbook/configuration.md`: Agent 節・Defaults・Token Usage 節に追記
- `handbook/architecture/cli-integration.md`: 新節 "What the System Prompt May Not Contain"

### 設計上の判断

**`--settings` の `includeGitInstructions` ではなく環境変数にした。** `--settings` は lightweight 呼び出し（タイトル生成・`/summarize`・日報）では渡されない（`claude_cli.lua` が `settings_path` を nil にする）ので、そちらだけブロックを抱えたままになる。env は全経路が通る唯一のチャネル。

**opt-in 側も明示的に書く（`"0"`）。** CLI はこの変数を三値で読む — `"1"` で抑制、`"0"` で強制ON、未設定なら settings.json の `includeGitInstructions` にフォールバックする。`--setting-sources user,project,local` はその settings を読むので、opt-in で「何も書かない」にすると `includeGitInstructions: false` を持つユーザーは `git_instructions = true` にしてもブロックが出ない。

**`CLAUDE_CODE_REMOTE` を真似るのは不可。** CLI 側は `CLAUDE_CODE_REMOTE || !includeGitInstructions() ? null : gitStatus()` でこのブロックを落としているが、この変数は他の挙動も変える（本リポジトリの `SessionStart` フックもこれを見る）。

### 副作用

モデルがブランチ名・直近コミット・変更ファイル一覧を最初から知らなくなり、CLI 内蔵の「直近コミットのスタイルに合わせろ」指示も消える。必要なら `git status` / `git log` を1回呼ばせれば済み、そのツール呼び出し1回は全 prefix の再書き込みより桁違いに安い。コミットメッセージの規約は `.claude/rules` か `.vibing/system-prompt.md` に書けば安定 prefix の一部になる。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement
- [x] Documentation update
- [x] Test addition or update

## Testing

- [x] Tested locally in Neovim
- [x] Ran `npm run format:check`
- [x] Manual testing completed

### 1. CLI 単体：ブロックの有無

system prompt に `Current branch:` 行があるか直接聞いた結果（`claude 2.1.231`）:

| `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` | 応答 |
| --- | --- |
| 未設定 | YES |
| `1` | NO |
| `0` | YES |
| `false` | YES |

三値であることを実測で確認。

### 2. キャッシュ実測（issue の再現手順、128k コンテキスト）

一時 git repo で `--resume` を使いターンごと再起動を再現し、`README.md` を1行変更した直後のターンの `usage` を読んだ結果:

| | tree 変更なしのターン | **tree 変更後のターン** |
| --- | --- | --- |
| block ON | new=128,447 / read=144,076 | **new=128,456** / read=144,076 |
| block OFF | new=128,348 / read=144,076 | **new=9** / read=272,424 |

処理される入力トークンの総量はどちらも約 272k で同じで、**変わるのは価格帯**。block ON では会話履歴 128k 全体が作成価格（基本の1.25倍）に落ち、block OFF では読み取り価格（0.1倍）のまま維持される。

基本入力トークン換算でその1ターンの入力コストを出すと:

```
block ON  : 128,456 × 1.25 + 144,076 × 0.10 = 174,978
block OFF :       9 × 1.25 + 272,424 × 0.10 =  27,254
差分      : 147,724 （そのターンの入力コストの 84%、6.4倍の差）
```

前半 144k が両方で read のままなのは、git ブロックが「CLI 基本 system prompt」と「会話履歴」の間に入るため。ミスするのはブロック以降＝会話全体なので、損失はコンテキストサイズに比例する。

**測っていないこと:** ブロックを外したぶんモデルが `git status` / `git log` を余計に呼ぶ可能性は実測していない。算術的な上限は出せて、ツール呼び出し1回は「全コンテキストをもう1リクエスト、読み取り価格で」なので、このセッションなら 27,200 換算/回 — 節約分 147,724 を食い潰すには tree を触るターンごとに約5回の余計な呼び出しが要る。また節約が効くのは tree が変わったターンだけで、読み取りだけのターンには効かない。

### 3. vibing.nvim の adapter 経由（実 config で実ターン）

```
default (agent.git_instructions unset)     -> NO
agent.git_instructions = true              -> YES
```

### 4. ゲート

`pnpm run check` / `format:check` / `test:lua`（exit 0）/ `lint:md` すべて通過。`lint:md` の既存エラーは今回触っていないファイルのみ。

### Test Environment

- **Neovim version**: NVIM v0.11
- **Operating System**: macOS 15 (Darwin 25.6.0)
- **Claude CLI version**: 2.1.231

## Documentation

- [x] Code comments added/updated

`doc/vibing.txt` と `README.md` は `agent.*` の個別オプションを列挙していないため変更なし。

## Related Issues

Fixes #681

## Additional Context

`.claude/rules/architecture.md` にも同じ不変条件（「ターンごと再起動では起動時計算がすべて prefix 変動になる」＋ handbook への1行ポインタ）を足したいが、ローカルの権限フックで編集がブロックされたため未反映。レビューでも routing convention 上の指摘として挙がっている。

同じ性質の起動時変動は他にもありうる（CLI バージョン、日付、`cacheBreakerPhrase`）。本 PR は git ブロックだけを扱い、残りは #674 の再書き込み検知で拾う想定。関連: #469 / #669 / #674 / #676
