### PR TITLE
fix(mcp-server): keep the self-build inside Claude Code's MCP startup deadline

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -123,11 +123,17 @@ fi
 # empty-value guard is needed around it.
 echo "$(command -v "$NODE_EXECUTABLE")" > "${MCP_DIR}/bin/.node-path"
 
+# npm's audit and funding requests are pure registry round-trips that say nothing about whether
+# the install succeeded, and against a warm cache they are most of what `npm install` spends here.
+# claude-plugin/mcp-server/bin/run.mjs turns them off for the same reason, where it matters far
+# more: that path runs under Claude Code's 30s MCP startup deadline.
+readonly NPM_QUIET_FLAGS=(--no-audit --no-fund --silent)
+
 # Install root dependencies. Nothing at the root is bundled any more -- the only build left is
 # the MCP server's, below -- but the MCP server imports `zod` from here.
 echo "[vibing.nvim] Installing root dependencies..."
 cd "$SCRIPT_DIR"
-npm install --silent
+npm install "${NPM_QUIET_FLAGS[@]}"
 
 # One-shot cleanup for checkouts that predate the mote removal. The integration is
 # gone (diffs come from a per-request git tree snapshot now), so these downloaded
@@ -138,7 +144,7 @@ rm -f bin/mote-darwin-arm64 bin/mote-darwin-x64 bin/mote-linux-arm64 bin/mote-li
 cd "$MCP_DIR"
 
 echo "[vibing.nvim] Installing MCP server dependencies..."
-npm install --silent
+npm install "${NPM_QUIET_FLAGS[@]}"
 
 echo "[vibing.nvim] Building TypeScript..."
 npm run build --silent

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -64,6 +64,14 @@ it. By hand:
 `dist/.build-fingerprint` (or the whole `dist/` directory) and relaunch, or just run
 `npm ci && npm run build` directly in this directory.
 
+That rebuild happens inside the 30 seconds Claude Code allows a plugin's MCP server to start, so
+the install runs with `--prefer-offline --no-audit --no-fund` — npm's registry round-trips alone
+are 31s against a warm cache and would blow the deadline every time, leaving the tools silently
+absent from the session. A **cold** cache still takes minutes and no flag helps; run `./build.sh`
+once after a dependency bump, which does the same install under no deadline and stamps the
+fingerprint so the next launch skips the build. See
+`handbook/architecture/plugin-and-commands.md` → "The MCP server's own startup budget".
+
 ### 1. Build the MCP Server
 
 **Option 1: Using build script (simplest)**

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -65,12 +65,13 @@ it. By hand:
 `npm ci && npm run build` directly in this directory.
 
 That rebuild happens inside the 30 seconds Claude Code allows a plugin's MCP server to start, so
-the install runs with `--prefer-offline --no-audit --no-fund` — npm's registry round-trips alone
-are 31s against a warm cache and would blow the deadline every time, leaving the tools silently
-absent from the session. A **cold** cache still takes minutes and no flag helps; run `./build.sh`
-once after a dependency bump, which does the same install under no deadline and stamps the
-fingerprint so the next launch skips the build. See
-`handbook/architecture/plugin-and-commands.md` → "The MCP server's own startup budget".
+the install runs with `--prefer-offline --no-audit --no-fund`. npm's registry round-trips are not
+a fixed cost — the same `npm ci` on the same warm cache was measured at 31.1s once and ~1.5s hours
+later — and blowing the deadline leaves the tools silently absent from the session, so the flags
+are there to keep the step bounded by local work rather than by registry latency. A **cold** cache
+still takes minutes and no flag helps; run `./build.sh` once after a dependency bump, which does
+the same install under no deadline and stamps the fingerprint so the next launch skips the build.
+See `handbook/architecture/plugin-and-commands.md` → "The MCP server's own startup budget".
 
 ### 1. Build the MCP Server
 

--- a/claude-plugin/mcp-server/bin/run.mjs
+++ b/claude-plugin/mcp-server/bin/run.mjs
@@ -28,6 +28,17 @@ const distEntry = join(mcpDir, 'dist', 'index.js');
 const nodeModulesDir = join(mcpDir, 'node_modules');
 const fingerprintFile = fingerprintFilePath(mcpDir);
 
+// Claude Code gives a plugin's MCP server 30s to come up, and this launcher
+// spends that budget before the server is even spawned. `npm ci` defaults to an
+// audit request and a funding request against the registry, and revalidates
+// package metadata it already has cached — measured against a warm cache on
+// macOS, that is the entire cost of the step: 31s with these flags off, 1.3s
+// with them on. So the default makes every self-build here miss the deadline,
+// and the whole vibing-nvim tool set silently disappears from the session.
+// (A genuinely cold cache still fetches tarballs and still takes minutes; only
+// `./build.sh`, which is under no such deadline, can fix that case.)
+const OFFLINE_FIRST_FLAGS = ['--prefer-offline', '--no-audit', '--no-fund'];
+
 function isBuildStale(fingerprint) {
   if (!existsSync(distEntry) || !existsSync(nodeModulesDir) || !existsSync(fingerprintFile)) {
     return true;
@@ -56,7 +67,7 @@ if (isBuildStale(fingerprint)) {
   // stale fingerprint behind that would make a later, unrelated source
   // state look "already built" against a corrupted dist/.
   rmSync(fingerprintFile, { force: true });
-  run('npm', ['ci', '--silent']);
+  run('npm', ['ci', ...OFFLINE_FIRST_FLAGS, '--silent']);
   run('npm', ['run', 'build', '--silent']);
   writeFileSync(fingerprintFile, fingerprint);
 }

--- a/claude-plugin/mcp-server/bin/run.mjs
+++ b/claude-plugin/mcp-server/bin/run.mjs
@@ -31,10 +31,12 @@ const fingerprintFile = fingerprintFilePath(mcpDir);
 // Claude Code gives a plugin's MCP server 30s to come up, and this launcher
 // spends that budget before the server is even spawned. `npm ci` defaults to an
 // audit request and a funding request against the registry, and revalidates
-// package metadata it already has cached — measured against a warm cache on
-// macOS, that is the entire cost of the step: 31s with these flags off, 1.3s
-// with them on. So the default makes every self-build here miss the deadline,
-// and the whole vibing-nvim tool set silently disappears from the session.
+// package metadata it already has cached — so how long it takes depends on the
+// registry rather than on this machine. Measured against the same warm cache on
+// macOS, plain `npm ci` ran 31.1s once and ~1.5s hours later; these flags held
+// it at ~1.3s throughout. The point is not the average, it is that without them
+// the step can exceed the deadline at a moment nothing here controls, and the
+// whole vibing-nvim tool set then silently disappears from the session.
 // (A genuinely cold cache still fetches tarballs and still takes minutes; only
 // `./build.sh`, which is under no such deadline, can fix that case.)
 const OFFLINE_FIRST_FLAGS = ['--prefer-offline', '--no-audit', '--no-fund'];

--- a/handbook/architecture/plugin-and-commands.md
+++ b/handbook/architecture/plugin-and-commands.md
@@ -167,3 +167,38 @@ Two pieces were therefore moved off that path, taking a measured ~32ms `setup()`
 
 A scan moved to first use also reads `vim.fn.getcwd()` at first use, which is the more accurate
 cwd for picking up a project's `.claude/commands/` anyway.
+
+### The MCP server's own startup budget is 30 seconds, and the launcher spends it first
+
+That is a different clock from `setup()`: it starts when the CLI spawns
+`claude-plugin/mcp-server/bin/run.sh` for a turn, and it runs out before the server has said
+anything. `run.mjs` sits inside it, and rebuilds whenever the source fingerprint moved — which is
+every first turn after a `git pull` that touched `src/`.
+
+Overrunning it does not look like a failure. The server simply never connects, so
+`mcp__plugin_vibing-nvim_vibing-nvim__*` is absent from the model's tool list for the whole
+session while the skills and the `nvim-navigator` agent — which come from the same
+`--plugin-dir` and need no process — load normally. Nothing logs, and the model is left to
+conclude the tools do not exist.
+
+Measured on macOS with node 22, against the tree as of TypeScript 7:
+
+| Step                          | Wall time | CPU  |
+| ----------------------------- | --------- | ---- |
+| `npm ci --silent`, warm cache | 31.1s     | 9%   |
+| `+ --prefer-offline`          | 5.0s      | 58%  |
+| `+ --no-audit --no-fund`      | 1.3s      | 212% |
+| `npm ci --silent`, cold cache | 7m 01s    | 0%   |
+| `npm run build` (`tsc`)       | 0.19s     | 259% |
+
+So the compile is not the cost and never was — `typescript@7` is the native compiler. The cost is
+npm's registry chatter: an audit request, a funding request, and metadata revalidation, none of
+which say anything about whether the install worked. At the default that is 31s against a 30s
+deadline, which is why the self-build failed **every** time rather than intermittently.
+`OFFLINE_FIRST_FLAGS` in `run.mjs` turns all three off, and
+`tests/mcp-server-launcher.test.mjs` runs the real launcher against a fake `npm` to keep them
+there.
+
+A cold cache is still minutes, and no flag fixes that — the tarballs genuinely have to arrive.
+`./build.sh` is the escape hatch: it runs the same install under no deadline and stamps the
+fingerprint (`bin/write-fingerprint.mjs`), so the next launch skips the build entirely.

--- a/handbook/architecture/plugin-and-commands.md
+++ b/handbook/architecture/plugin-and-commands.md
@@ -181,24 +181,32 @@ session while the skills and the `nvim-navigator` agent — which come from the 
 `--plugin-dir` and need no process — load normally. Nothing logs, and the model is left to
 conclude the tools do not exist.
 
-Measured on macOS with node 22, against the tree as of TypeScript 7:
+The compile is not the cost and never was — `typescript@7` is the native compiler, and
+`npm run build` is 0.19s. The whole budget goes to `npm ci`, and **what it costs is not a
+constant**. Measured on macOS with node 22, against the tree as of TypeScript 7:
 
-| Step                          | Wall time | CPU  |
-| ----------------------------- | --------- | ---- |
-| `npm ci --silent`, warm cache | 31.1s     | 9%   |
-| `+ --prefer-offline`          | 5.0s      | 58%  |
-| `+ --no-audit --no-fund`      | 1.3s      | 212% |
-| `npm ci --silent`, cold cache | 7m 01s    | 0%   |
-| `npm run build` (`tsc`)       | 0.19s     | 259% |
+| `npm ci --silent` under                      | Wall time | CPU   |
+| -------------------------------------------- | --------- | ----- |
+| a cold cache (right after a dependency bump) | 7m 01s    | 0%    |
+| a warm cache, registry slow                  | 31.1s     | 9%    |
+| a warm cache, registry responsive            | ~1.5s     | ~200% |
 
-So the compile is not the cost and never was — `typescript@7` is the native compiler. The cost is
-npm's registry chatter: an audit request, a funding request, and metadata revalidation, none of
-which say anything about whether the install worked. At the default that is 31s against a 30s
-deadline, which is why the self-build failed **every** time rather than intermittently.
-`OFFLINE_FIRST_FLAGS` in `run.mjs` turns all three off, and
-`tests/mcp-server-launcher.test.mjs` runs the real launcher against a fake `npm` to keep them
+The spread is npm's registry chatter — an audit request, a funding request, and metadata
+revalidation, none of which say anything about whether the install worked. The 31.1s and the
+~1.5s rows are the _same command on the same tree_, hours apart; the flags were A/B'd against
+each other within that slow window (`--prefer-offline` alone 5.0s, `--no-audit --no-fund` alone
+1.3s) and again later, when plain `npm ci` had become as fast as the flagged form.
+
+So `OFFLINE_FIRST_FLAGS` does not remove a fixed 31s. What it removes is **the dependency on
+registry latency inside a deadline that cannot absorb it**: with the flags the step is bounded by
+local work, and end-to-end `run.sh` → `initialize` measures 1.8–2.2s from a stale fingerprint.
+`tests/mcp-server-launcher.test.mjs` runs the real launcher against a fake `npm` to keep the flags
 there.
 
-A cold cache is still minutes, and no flag fixes that — the tarballs genuinely have to arrive.
-`./build.sh` is the escape hatch: it runs the same install under no deadline and stamps the
-fingerprint (`bin/write-fingerprint.mjs`), so the next launch skips the build entirely.
+**A cold cache is the case this does not fix**, and it is the one that most likely caused the
+incident that prompted the change (#679 bumped typescript, vitest and @types/node together, so
+the next launch had to fetch everything). 7 minutes is so far past 30s that every turn's build was
+killed partway, leaving a half-installed `node_modules` and no fingerprint — so the next turn
+tried again from the same place. `./build.sh` is the escape hatch: it runs the same install under
+no deadline and stamps the fingerprint (`bin/write-fingerprint.mjs`), so the next launch skips the
+build entirely. Run it after a dependency bump.

--- a/tests/mcp-server-launcher.test.mjs
+++ b/tests/mcp-server-launcher.test.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * claude-plugin/mcp-server/bin/run.mjs runs before the MCP server exists, inside the 30s Claude
+ * Code allows a plugin's server to start. Everything it spends there comes out of that budget.
+ *
+ * A plain `npm ci` does not fit in it. Measured against a warm cache on macOS, the audit and
+ * funding round-trips plus metadata revalidation take 31s on their own — so any commit that
+ * leaves the build stale (a `git pull` touching src/, say) makes the launcher time out on every
+ * turn, and the whole vibing-nvim tool set vanishes from the session with no error anywhere.
+ * Nothing else in the project notices: the failure is a missing tool, not a failing command.
+ *
+ * These tests run the real launcher against a throwaway mcp-server tree with a fake `npm` first on
+ * PATH, so they assert on the argv it actually passes rather than on the text of the file.
+ */
+
+import { strict as assert } from 'assert';
+import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, copyFile, writeFile, chmod, rm } from 'fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const launcherDir = join(repoRoot, 'claude-plugin/mcp-server/bin');
+
+/**
+ * A stand-in for npm that records its argv and, for `run build`, produces the dist/ output the
+ * launcher goes on to require. Exiting 0 without it would make the launcher fail for a reason
+ * these tests are not about.
+ */
+const FAKE_NPM = `#!/bin/sh
+printf '%s\\n' "$*" >> "$NPM_LOG"
+if [ "$1" = "run" ]; then
+  mkdir -p dist
+  echo 'process.exit(0)' > dist/index.js
+fi
+exit 0
+`;
+
+/** Build a throwaway tree shaped like claude-plugin/mcp-server/, with the real launcher in it. */
+async function makeTree() {
+  const dir = await mkdtemp(join(tmpdir(), 'vibing-launcher-'));
+  await mkdir(join(dir, 'mcp/bin'), { recursive: true });
+  await mkdir(join(dir, 'mcp/src'), { recursive: true });
+  await mkdir(join(dir, 'fakebin'), { recursive: true });
+
+  for (const file of ['run.mjs', 'build-fingerprint.mjs']) {
+    await copyFile(join(launcherDir, file), join(dir, 'mcp/bin', file));
+  }
+  await writeFile(join(dir, 'mcp/package.json'), '{ "name": "stub", "version": "0.0.0" }\n');
+  await writeFile(join(dir, 'mcp/src/index.ts'), 'export const x = 1;\n');
+
+  const npm = join(dir, 'fakebin/npm');
+  await writeFile(npm, FAKE_NPM);
+  await chmod(npm, 0o755);
+
+  return dir;
+}
+
+/** Run the launcher in `dir`, and return its exit code plus one entry per npm invocation. */
+function runLauncher(dir) {
+  const log = join(dir, 'npm.log');
+  const result = spawnSync(process.execPath, [join(dir, 'mcp/bin/run.mjs')], {
+    env: { ...process.env, PATH: `${join(dir, 'fakebin')}:${process.env.PATH}`, NPM_LOG: log },
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  assert.notEqual(result.status, null, `launcher did not exit: ${result.error ?? 'unknown'}`);
+  const calls = existsSync(log)
+    ? readFileSync(log, 'utf8')
+        .split('\n')
+        .filter((line) => line.length > 0)
+    : [];
+  return { code: result.status, stderr: result.stderr, calls };
+}
+
+test('the self-build keeps npm off the registry', async () => {
+  const dir = await makeTree();
+  try {
+    const { calls } = runLauncher(dir);
+    const install = calls.find((call) => call.startsWith('ci'));
+    assert.ok(install, `no \`npm ci\` was run; calls were ${JSON.stringify(calls)}`);
+    for (const flag of ['--prefer-offline', '--no-audit', '--no-fund']) {
+      assert.ok(
+        install.includes(flag),
+        `\`npm ${install}\` is missing ${flag}; a self-build that talks to the registry ` +
+          `overruns Claude Code's 30s MCP startup deadline and the tools never appear`
+      );
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a stale tree is rebuilt and the compiled server is launched', async () => {
+  const dir = await makeTree();
+  try {
+    const { code, calls, stderr } = runLauncher(dir);
+    assert.equal(code, 0, `launcher failed: ${stderr}`);
+    assert.equal(calls.length, 2, `expected an install and a build, got ${JSON.stringify(calls)}`);
+    assert.ok(calls[1].startsWith('run build'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a tree already built for this source is launched without touching npm', async () => {
+  const dir = await makeTree();
+  try {
+    // node_modules/ is one of the three things isBuildStale checks for; the fake npm does not
+    // create it, so without this the second run would rebuild for a reason unrelated to the
+    // fingerprint.
+    await mkdir(join(dir, 'mcp/node_modules'), { recursive: true });
+    runLauncher(dir);
+    await rm(join(dir, 'npm.log'));
+
+    const { code, calls } = runLauncher(dir);
+    assert.equal(code, 0);
+    assert.deepEqual(calls, [], 'an unchanged tree spent a build it did not need');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/mcp-server-launcher.test.mjs
+++ b/tests/mcp-server-launcher.test.mjs
@@ -80,7 +80,7 @@ test('the self-build keeps npm off the registry', async () => {
   const dir = await makeTree();
   try {
     const { calls } = runLauncher(dir);
-    const install = calls.find((call) => call.startsWith('ci'));
+    const install = calls.find((call) => call.startsWith('ci '));
     assert.ok(install, `no \`npm ci\` was run; calls were ${JSON.stringify(calls)}`);
     for (const flag of ['--prefer-offline', '--no-audit', '--no-fund']) {
       assert.ok(
@@ -113,7 +113,11 @@ test('a tree already built for this source is launched without touching npm', as
     // create it, so without this the second run would rebuild for a reason unrelated to the
     // fingerprint.
     await mkdir(join(dir, 'mcp/node_modules'), { recursive: true });
-    runLauncher(dir);
+    // Assert the priming run worked. A first run that died leaves no dist/ and no fingerprint,
+    // so the second run would rebuild — and this test would then report "spent a build it did
+    // not need" for a build it did need, blaming the fingerprint for a broken launcher.
+    const primed = runLauncher(dir);
+    assert.equal(primed.code, 0, `priming run failed: ${primed.stderr}`);
     await rm(join(dir, 'npm.log'));
 
     const { code, calls } = runLauncher(dir);


### PR DESCRIPTION
# Pull Request

## Summary

vibing-nvim の MCP ツール (`mcp__plugin_vibing-nvim_vibing-nvim__*`) がセッションから丸ごと消える問題を修正します。

原因は MCP サーバー本体ではなく、その起動ランチャー `claude-plugin/mcp-server/bin/run.mjs` が
**Claude Code の MCP サーバー起動タイムアウト（30秒）を超えていた** ことでした。

`run.mjs` は `package.json` / `package-lock.json` / `tsconfig.json` / `src/**` のフィンガープリントが
`dist/.build-fingerprint` と食い違うとセルフビルドを走らせます。そのビルドが 30 秒に収まらないと、
サーバーは接続されないまま終わります。

厄介なのは失敗の見え方です。同じ `--plugin-dir` から来るスキルと `nvim-navigator` エージェントは
プロセスを必要としないので普通にロードされ、MCP ツールだけが無言で消えます。ログにも何も出ません。

## Changes

- `run.mjs` のセルフビルドに `--prefer-offline --no-audit --no-fund` を追加（`OFFLINE_FIRST_FLAGS`）
- `build.sh` の 2 箇所の `npm install` にも `--no-audit --no-fund` を適用（`NPM_QUIET_FLAGS`）
- `tests/mcp-server-launcher.test.mjs` を追加。実物の `run.mjs` を偽 `npm` を先頭に置いた PATH で
  一時ツリーに対して走らせ、**実際に渡した argv** を検証する（ファイルの文字列 grep ではない）
- 実測値を `handbook/architecture/plugin-and-commands.md` に、利用者向けの説明を
  `claude-plugin/mcp-server/README.md` に記載

## 実測（macOS / node 22 / TypeScript 7 時点のツリー）

コンパイルは犯人ではありません。`typescript@7` はネイティブコンパイラで `npm run build` は 0.19 秒。
予算はすべて `npm ci` が使っており、**その値は定数ではありませんでした**。

| `npm ci --silent` の条件               | Wall time |
| -------------------------------------- | --------- |
| コールドキャッシュ（依存バンプ直後）   | 7m 01s    |
| ウォーム、レジストリが遅かったとき     | 31.1s     |
| ウォーム、レジストリが応答良好のとき   | 約 1.5s   |

31.1s と約 1.5s は**同じツリーに対する同じコマンド**を数時間あけて測ったものです。フラグの A/B は
その遅い時間帯に取りました（`--prefer-offline` 単独 5.0s、`--no-audit --no-fund` 単独 1.3s）。
のちに素の `npm ci` がフラグ付きと同程度まで速くなったことも確認しています。

つまりこの PR は固定の 31 秒を削るものではありません。削っているのは**「吸収できない期限の内側に
レジストリ遅延への依存があること」**そのものです。フラグを付けた状態では所要時間はローカル作業に
律速されます。

### 実機のエンドツーエンド計測（`bin/run.sh` → `initialize` 応答）

`git pull` 直後に相当する stale 状態（`dist/.build-fingerprint` を削除）から、`plugin.json` が実際に
起動するのと同じ `sh bin/run.sh` を叩き、`initialize` のレスポンス行が返るまでを計測:

| 条件                       | 実測                          |
| -------------------------- | ----------------------------- |
| 修正あり（本 PR）          | **1.8 / 2.0 / 2.2 秒**（3回） |
| 修正なし（同一環境・同時刻） | 2.0 / 1.9 / 2.2 / 2.9 / 2.3 秒（5回） |

いずれも `initialize` 応答は正常。**この時間帯にはレジストリが速く、修正なしでも期限内に収まりました。**
つまりこの計測は「修正しないと必ず落ちる」ことを示すものではなく、「修正すると期限に対する依存が
ローカル作業だけになる」ことを示すものです。31.1 秒を踏んだ条件はこの時点では再現していません。

## コールドキャッシュは直りません（既知の限界）

そしておそらく**今回の実際の発生原因はそちら**です。#679 が typescript / vitest / @types/node を
まとめて上げたため、次の起動は全部を取り直す必要がありました。7 分は 30 秒から桁が違うので、毎ターン
ビルドが途中で kill され、`node_modules` は中途半端なまま・フィンガープリントは書かれないまま残り、
次のターンも同じところからやり直す、という状態になります。

フラグではこれは解決しません。解決するのは `./build.sh`（期限なしで同じインストールを行い
`bin/write-fingerprint.mjs` でフィンガープリントを打つ）を依存バンプ後に1回走らせることです。
その旨を README と handbook の両方に明記しました。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition or update
- [x] Documentation update

## Testing

- [x] Tested locally in Neovim
- [x] `pnpm run test:node` — 58 passed / 0 failed（新規 3 件を含む）
- [x] `pnpm run test:lua` — 54 passed / 0 failed、exit 0
- [x] `pnpm run check` / `check:doc` / `lint` / `format:check` — すべて green
- [x] `pnpm run test:e2e` — 全スペック pass（`plugin_dir_spec` を含む）
- [x] 新規テストが**落ちること**を確認（フラグを外すと 1 件 fail、戻すと pass）
- [x] `./build.sh` を bash 3.2 / 5.x 両方で構文チェック（`readonly ARR=(...)` は 3.2 でも動作）
- [x] `bin/run.sh` 経由の実機起動計測（上記）

初回の通し E2E では `ask_user_question_spec` の 1 件が落ちましたが、原因はコードではなくアカウントの
利用上限（`**Error:** You've hit your session limit`）でターンが死んだためでした。上限リセット後に
再実行して **2/2 pass** を確認済みです。

### Test Environment

- **Neovim version**: local (stable)
- **Operating System**: macOS (Darwin 25.6.0, arm64)
- **Node.js version**: v22 (mise)

## Documentation

- [x] `handbook/architecture/plugin-and-commands.md` — 「The MCP server's own startup budget」節を追加
- [x] `claude-plugin/mcp-server/README.md` — Auto-build mechanism の説明に追記

`.claude/rules/architecture.md` への 1 行の不変条件追記は、Claude Code の組み込み sensitive-file
ガードで編集できないため入っていません。#685 が `.claude/rules/` を全面改稿するため、全 PR マージ後の
単独 PR にまとめる方針です（オーケストレータ側の判断）。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes

## Related Issues

紐づく issue はありません（このセッション中に発見した不具合）。

## Additional Context

`--prefer-offline` を `build.sh` 側には入れていないのは意図的です。`build.sh` は期限に縛られない
「ちゃんと入れ直す」経路なので、ネットワークに出て最新を取るのが正しい。共有しているのは audit /
funding の 2 フラグだけで、これらはどちらの経路でも純粋な無駄です。
