### PR TITLE
feat(mcp): add tail_lines / last_section to nvim_get_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@
 
 ### Added
 
+- **`nvim_get_buffer` (MCP): `tail_lines` and `last_section` read only part of a buffer.** A
+  vibing.nvim chat can run to hundreds of thousands of lines, and reading it all is effectively
+  the same as not being able to read it at all. `tail_lines: N` returns only the last N lines;
+  `last_section: true` cuts at the last `## User` / `## Assistant` / `## Request` / `## Report` /
+  `## Notice` heading; the two combine to take the last N lines of the last section. The result
+  reports the buffer's real total line count whenever the window actually truncated it, so a
+  caller that only saw the tail still learns the overall scale.
+
 - **`:VibingChatHandoff [position]` — continue a long chat in a new one that carries only its
   summary.** The current chat is summarized (the `## summary` stays in it, as with
   `:VibingSummarize`), and a new chat opens whose first, still unsent User message starts with

--- a/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
@@ -214,4 +214,29 @@ describe('nvim_get_buffer tail_lines / last_section', () => {
 
     expect(result.content).toHaveLength(2); // lines + chat status, no total-lines node
   });
+
+  it('forwards last_section alone and reports the total for it too', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      lines: ['## Assistant', 'reply'],
+      total_lines: 500,
+      chat_status: 'idle',
+    });
+
+    const result = await handlers.nvim_get_buffer({ bufnr: 3, last_section: true, rpc_port: 9878 });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'buf_get_lines',
+      {
+        bufnr: 3,
+        file_path: undefined,
+        include_chat_status: true,
+        tail_lines: undefined,
+        last_section: true,
+      },
+      9878
+    );
+    expect(result.content.map((c: { text: string }) => c.text)).toEqual(
+      expect.arrayContaining([expect.stringContaining('2 of 500 total lines')])
+    );
+  });
 });

--- a/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
@@ -149,3 +149,59 @@ describe('nvim_get_buffer chat status', () => {
     expect(result.content[0].text).toBe('old\nshape');
   });
 });
+
+/**
+ * tail_lines / last_section (#694): a chat buffer can run to hundreds of thousands of lines, and
+ * reading it all is the same as reading none of it. These let a caller ask for just the tail or
+ * just the last section, and the result still reports the buffer's real size.
+ */
+describe('nvim_get_buffer tail_lines / last_section', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards tail_lines and last_section to Neovim', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ lines: ['b'], total_lines: 2, chat_status: 'idle' });
+
+    await handlers.nvim_get_buffer({ bufnr: 3, tail_lines: 1, last_section: true, rpc_port: 9878 });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'buf_get_lines',
+      { bufnr: 3, file_path: undefined, include_chat_status: true, tail_lines: 1, last_section: true },
+      9878
+    );
+  });
+
+  it('rejects a non-integer tail_lines before calling Neovim', async () => {
+    await expect(
+      handlers.nvim_get_buffer({ bufnr: 3, tail_lines: 'all', rpc_port: 9878 })
+    ).rejects.toThrow();
+    expect(rpc.callNeovim).not.toHaveBeenCalled();
+  });
+
+  it('reports the total line count alongside a windowed result', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      lines: ['line 400000'],
+      total_lines: 400000,
+      chat_status: 'idle',
+    });
+
+    const result = await handlers.nvim_get_buffer({ bufnr: 3, tail_lines: 1, rpc_port: 9878 });
+
+    expect(result.content.map((c: { text: string }) => c.text)).toEqual(
+      expect.arrayContaining([expect.stringContaining('1 of 400000 total lines')])
+    );
+  });
+
+  it('does not add a total-lines node for a full, unwindowed read', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      lines: ['a', 'b'],
+      total_lines: 2,
+      chat_status: 'idle',
+    });
+
+    const result = await handlers.nvim_get_buffer({ bufnr: 3, rpc_port: 9878 });
+
+    expect(result.content).toHaveLength(2); // lines + chat status, no total-lines node
+  });
+});

--- a/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
@@ -189,6 +189,15 @@ describe('nvim_get_buffer tail_lines / last_section', () => {
     expect(rpc.callNeovim).not.toHaveBeenCalled();
   });
 
+  it('rejects a non-boolean last_section before calling Neovim', async () => {
+    // A review on PR #707 noted this was unvalidated: since Lua treats anything but nil/false as
+    // truthy, a string like "false" would silently take the last_section branch instead of erroring.
+    await expect(
+      handlers.nvim_get_buffer({ bufnr: 3, last_section: 'false', rpc_port: 9878 })
+    ).rejects.toThrow();
+    expect(rpc.callNeovim).not.toHaveBeenCalled();
+  });
+
   it('reports the total line count alongside a windowed result', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({
       lines: ['line 400000'],

--- a/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/buffer-tools.test.ts
@@ -161,13 +161,23 @@ describe('nvim_get_buffer tail_lines / last_section', () => {
   });
 
   it('forwards tail_lines and last_section to Neovim', async () => {
-    vi.mocked(rpc.callNeovim).mockResolvedValue({ lines: ['b'], total_lines: 2, chat_status: 'idle' });
+    vi.mocked(rpc.callNeovim).mockResolvedValue({
+      lines: ['b'],
+      total_lines: 2,
+      chat_status: 'idle',
+    });
 
     await handlers.nvim_get_buffer({ bufnr: 3, tail_lines: 1, last_section: true, rpc_port: 9878 });
 
     expect(rpc.callNeovim).toHaveBeenCalledWith(
       'buf_get_lines',
-      { bufnr: 3, file_path: undefined, include_chat_status: true, tail_lines: 1, last_section: true },
+      {
+        bufnr: 3,
+        file_path: undefined,
+        include_chat_status: true,
+        tail_lines: 1,
+        last_section: true,
+      },
       9878
     );
   });

--- a/claude-plugin/mcp-server/src/handlers/buffer.ts
+++ b/claude-plugin/mcp-server/src/handlers/buffer.ts
@@ -1,5 +1,6 @@
 import { callNeovim } from '../rpc.js';
 import {
+  validateBoolean,
   validateBufferParams,
   validateChatTarget,
   validateFilePath,
@@ -64,6 +65,9 @@ export async function handleGetBuffer(args: any) {
   }
   if (tail_lines !== undefined) {
     validatePositiveInteger(tail_lines, 'tail_lines');
+  }
+  if (last_section !== undefined) {
+    validateBoolean(last_section, 'last_section');
   }
   // Neither is fine here — it falls back to the current buffer, unlike a send.
   validateChatTarget({ bufnr, file_path });

--- a/claude-plugin/mcp-server/src/handlers/buffer.ts
+++ b/claude-plugin/mcp-server/src/handlers/buffer.ts
@@ -3,6 +3,7 @@ import {
   validateBufferParams,
   validateChatTarget,
   validateFilePath,
+  validatePositiveInteger,
   validateRequired,
 } from '../validation/schema.js';
 
@@ -39,31 +40,45 @@ const CHAT_STATUS_TEXT: Record<string, string> = {
  * bufnr only means anything in the session that issued it. The Lua side opens the chat if it is
  * closed (`application/chat/chat_locator.lua`).
  *
- * @param args - An object with `bufnr` or `file_path` naming what to retrieve, and optional
- *   `rpc_port`.
+ * A large buffer (a long-running chat, easily hundreds of thousands of lines) can be read as just
+ * its tail (`tail_lines`) or just its last section (`last_section`, cut at the last `## ...`
+ * heading) instead of in full — reading "all of it" is the same as "none of it" once it no longer
+ * fits (#694). Whichever way it was asked for, the result reports the buffer's real total line
+ * count so the caller still learns the overall scale even when it only saw the tail.
+ *
+ * @param args - An object with `bufnr` or `file_path` naming what to retrieve, optional
+ *   `tail_lines` / `last_section` to window a large buffer, and optional `rpc_port`.
  * @returns An object with `content` containing the buffer's contents (lines joined with `\n`),
- *   plus a chat-status node when the buffer is a vibing.nvim chat.
+ *   plus a chat-status node when the buffer is a vibing.nvim chat, plus a total-line-count node
+ *   when the result was windowed down from the buffer's full size.
  */
 export async function handleGetBuffer(args: any) {
   // Collapse an explicit null to "not given", matching nvim_chat_send_message.
   const bufnr = args?.bufnr ?? undefined;
   const file_path = args?.file_path ?? undefined;
+  const tail_lines = args?.tail_lines ?? undefined;
+  const last_section = args?.last_section ?? undefined;
 
   if (bufnr !== undefined) {
     validateBufferParams({ bufnr });
+  }
+  if (tail_lines !== undefined) {
+    validatePositiveInteger(tail_lines, 'tail_lines');
   }
   // Neither is fine here — it falls back to the current buffer, unlike a send.
   validateChatTarget({ bufnr, file_path });
   const result = await callNeovim(
     'buf_get_lines',
-    { bufnr, file_path, include_chat_status: true },
+    { bufnr, file_path, include_chat_status: true, tail_lines, last_section },
     args?.rpc_port
   );
 
-  // A Neovim running an older plugin version ignores include_chat_status and answers with the
-  // bare line array this tool used to get.
+  // A Neovim running an older plugin version ignores include_chat_status (and, with it,
+  // tail_lines/last_section/total_lines) and answers with the bare line array this tool used to
+  // get.
   const lines: string[] = Array.isArray(result) ? result : result.lines;
   const state: string | undefined = Array.isArray(result) ? undefined : result.chat_status;
+  const totalLines: number | undefined = Array.isArray(result) ? undefined : result.total_lines;
 
   // Refuse rather than hand back the wrong buffer's text. A Neovim too old to know `file_path`
   // ignores it and answers for `bufnr or 0` — the current buffer — which reads as a perfectly
@@ -77,6 +92,14 @@ export async function handleGetBuffer(args: any) {
   }
 
   const content = [{ type: 'text', text: lines.join('\n') }];
+  if (totalLines !== undefined && totalLines !== lines.length) {
+    // Only reported when the result was actually windowed down — a full read already says its
+    // own size, and repeating it would just be noise.
+    content.push({
+      type: 'text',
+      text: `Showing ${lines.length} of ${totalLines} total lines in this buffer.`,
+    });
+  }
   if (state) {
     // A status this server has no wording for still gets a line. Rendering nothing is the worst
     // available answer for `error` or `waiting_approval` — silence reads as a healthy chat, which

--- a/claude-plugin/mcp-server/src/tools/buffer.ts
+++ b/claude-plugin/mcp-server/src/tools/buffer.ts
@@ -7,7 +7,9 @@ export const bufferTools = [
       'Get current buffer content. For a vibing.nvim chat buffer the result also reports ' +
       'whether a reply is being streamed into it right now — poll this to tell whether a ' +
       'worker chat has finished. Read a chat by file_path rather than bufnr when you have one: ' +
-      'the path keeps working after a restart, and a chat that is not open is opened for you.',
+      'the path keeps working after a restart, and a chat that is not open is opened for you. ' +
+      'For a large buffer, use tail_lines or last_section instead of reading it all — the result ' +
+      'always reports the buffer\'s total line count so you know what you did not see.',
     inputSchema: {
       type: 'object' as const,
       properties: withRpcPort({
@@ -21,6 +23,19 @@ export const bufferTools = [
             'vibing.nvim chat file to read instead of a bufnr (git-root-relative, absolute, or ' +
             '~-prefixed). Opened in the background if it is not already open. Chat files only — ' +
             'use nvim_load_buffer for an ordinary file. Mutually exclusive with bufnr.',
+        },
+        tail_lines: {
+          type: 'number' as const,
+          description:
+            'Return only the last N lines instead of the whole buffer. Combine with ' +
+            'last_section to take the last N lines of the last section rather than of the ' +
+            'whole buffer.',
+        },
+        last_section: {
+          type: 'boolean' as const,
+          description:
+            'Return only the buffer\'s last section (cut at the last "## Assistant" / "## User" ' +
+            '/ "## Request" / "## Report" / "## Notice" heading) instead of the whole buffer.',
         },
       }),
       required: [],

--- a/claude-plugin/mcp-server/src/tools/buffer.ts
+++ b/claude-plugin/mcp-server/src/tools/buffer.ts
@@ -9,7 +9,7 @@ export const bufferTools = [
       'worker chat has finished. Read a chat by file_path rather than bufnr when you have one: ' +
       'the path keeps working after a restart, and a chat that is not open is opened for you. ' +
       'For a large buffer, use tail_lines or last_section instead of reading it all — the result ' +
-      'always reports the buffer\'s total line count so you know what you did not see.',
+      "always reports the buffer's total line count so you know what you did not see.",
     inputSchema: {
       type: 'object' as const,
       properties: withRpcPort({

--- a/claude-plugin/mcp-server/src/tools/buffer.ts
+++ b/claude-plugin/mcp-server/src/tools/buffer.ts
@@ -8,8 +8,9 @@ export const bufferTools = [
       'whether a reply is being streamed into it right now — poll this to tell whether a ' +
       'worker chat has finished. Read a chat by file_path rather than bufnr when you have one: ' +
       'the path keeps working after a restart, and a chat that is not open is opened for you. ' +
-      'For a large buffer, use tail_lines or last_section instead of reading it all — the result ' +
-      "always reports the buffer's total line count so you know what you did not see.",
+      'For a large buffer, use tail_lines or last_section instead of reading it all — when that ' +
+      "actually truncates the result, it also reports the buffer's total line count so you know " +
+      'what you did not see.',
     inputSchema: {
       type: 'object' as const,
       properties: withRpcPort({
@@ -26,6 +27,7 @@ export const bufferTools = [
         },
         tail_lines: {
           type: 'number' as const,
+          minimum: 0,
           description:
             'Return only the last N lines instead of the whole buffer. Combine with ' +
             'last_section to take the last N lines of the last section rather than of the ' +

--- a/claude-plugin/mcp-server/src/validation/schema.ts
+++ b/claude-plugin/mcp-server/src/validation/schema.ts
@@ -138,6 +138,12 @@ export function validateString(value: unknown, name: string): void {
   }
 }
 
+export function validateBoolean(value: unknown, name: string): void {
+  if (typeof value !== 'boolean') {
+    throw new ValidationError(`${name} must be a boolean`);
+  }
+}
+
 export function validateRequired<T>(value: T | undefined | null, name: string): asserts value is T {
   if (value === undefined || value === null) {
     throw new ValidationError(`${name} is required`);

--- a/handbook/mcp-tools.md
+++ b/handbook/mcp-tools.md
@@ -56,8 +56,10 @@ Prefix each with whichever form matches how the server was registered (see above
 `mcp__plugin_vibing-nvim_vibing-nvim__` in the normal self-hosted case,
 `mcp__vibing-nvim__` for a plain user-level entry.
 
-- **Buffer**: `nvim_get_buffer` (a chat can be named by `file_path` instead of `bufnr`),
-  `nvim_set_buffer`, `nvim_list_buffers`, `nvim_get_info`, `nvim_load_buffer`
+- **Buffer**: `nvim_get_buffer` (a chat can be named by `file_path` instead of `bufnr`; `tail_lines`
+  and/or `last_section` window a buffer too large to read in full, and the result always reports
+  the buffer's real total line count — #694), `nvim_set_buffer`, `nvim_list_buffers`,
+  `nvim_get_info`, `nvim_load_buffer`
 - **Cursor/Selection**: `nvim_get_cursor`, `nvim_set_cursor`, `nvim_get_visual_selection`
 - **Window/Pane**: `nvim_list_windows`, `nvim_get_window_info`, `nvim_get_window_view`,
   `nvim_list_tabpages`, `nvim_set_window_size`, `nvim_focus_window`, `nvim_win_set_buf`,

--- a/handbook/mcp-tools.md
+++ b/handbook/mcp-tools.md
@@ -57,8 +57,9 @@ Prefix each with whichever form matches how the server was registered (see above
 `mcp__vibing-nvim__` for a plain user-level entry.
 
 - **Buffer**: `nvim_get_buffer` (a chat can be named by `file_path` instead of `bufnr`; `tail_lines`
-  and/or `last_section` window a buffer too large to read in full, and the result always reports
-  the buffer's real total line count — #694), `nvim_set_buffer`, `nvim_list_buffers`,
+  and/or `last_section` window a buffer too large to read in full — the RPC response always
+  carries the buffer's real total line count, and the MCP tool surfaces it as text whenever the
+  window actually truncated the result — #694), `nvim_set_buffer`, `nvim_list_buffers`,
   `nvim_get_info`, `nvim_load_buffer`
 - **Cursor/Selection**: `nvim_get_cursor`, `nvim_set_cursor`, `nvim_get_visual_selection`
 - **Window/Pane**: `nvim_list_windows`, `nvim_get_window_info`, `nvim_get_window_view`,

--- a/lua/vibing/domain/chat/buffer_window.lua
+++ b/lua/vibing/domain/chat/buffer_window.lua
@@ -19,6 +19,24 @@ local function last_section_start(lines)
   return 1
 end
 
+---Normalize a `tail_lines` argument to a non-negative integer, or nil for "not given"/unusable.
+---
+---The MCP layer already rejects a negative or fractional value before it reaches Neovim
+---(`validatePositiveInteger` in `schema.ts`), but this primitive exists precisely so a future
+---direct Lua caller (#693) can skip that layer — so it has to defend the same ground itself
+---rather than silently misbehaving when handed a negative or fractional number (a caller asking
+---for a fractional tail is a bug in the caller, and a floor makes it a harmless one).
+---@param value any
+---@return integer?
+local function normalize_tail_lines(value)
+  if type(value) ~= "number" then
+    return nil
+  end
+  return math.max(0, math.floor(value))
+end
+
+M.normalize_tail_lines = normalize_tail_lines
+
 ---@class Vibing.Domain.Chat.BufferWindow.Opts
 ---@field tail_lines number? Keep only the last N lines (applied after `last_section`, if both given).
 ---@field last_section boolean? Keep only the buffer's last `## ...` section.
@@ -32,11 +50,12 @@ end
 function M.slice(lines, opts)
   local total_lines = #lines
   opts = opts or {}
+  local tail_lines = normalize_tail_lines(opts.tail_lines)
 
   local start = opts.last_section and last_section_start(lines) or 1
   local section_length = total_lines - start + 1
-  if type(opts.tail_lines) == "number" and opts.tail_lines >= 0 and opts.tail_lines < section_length then
-    start = total_lines - opts.tail_lines + 1
+  if tail_lines and tail_lines < section_length then
+    start = total_lines - tail_lines + 1
   end
 
   local windowed = start == 1 and lines or vim.list_slice(lines, start, total_lines)

--- a/lua/vibing/domain/chat/buffer_window.lua
+++ b/lua/vibing/domain/chat/buffer_window.lua
@@ -1,0 +1,51 @@
+---Slice a buffer's lines down to the window a caller asked for, for a buffer too large to read
+---in full (#694). One primitive so `nvim_get_buffer` and the orchestration notifier (#693) cannot
+---drift on what "the tail" or "the last section" means.
+---@class Vibing.Domain.Chat.BufferWindow
+local M = {}
+
+local Timestamp = require("vibing.core.utils.timestamp")
+
+---1-indexed start of the last section (the last `## <Kind> <!-- ... -->` header found scanning
+---from the end), or 1 when the buffer has no header at all — the whole buffer is one section.
+---@param lines string[]
+---@return integer
+local function last_section_start(lines)
+  for i = #lines, 1, -1 do
+    if Timestamp.is_header(lines[i]) then
+      return i
+    end
+  end
+  return 1
+end
+
+---@class Vibing.Domain.Chat.BufferWindow.Opts
+---@field tail_lines number? Keep only the last N lines (applied after `last_section`, if both given).
+---@field last_section boolean? Keep only the buffer's last `## ...` section.
+
+---Compute the windowed lines plus the buffer's real total, so a caller that only sees the tail
+---still learns the overall scale (the point of returning `total_lines` at all).
+---@param lines string[]
+---@param opts Vibing.Domain.Chat.BufferWindow.Opts?
+---@return string[] windowed
+---@return integer total_lines
+function M.slice(lines, opts)
+  local total_lines = #lines
+  opts = opts or {}
+  local windowed = lines
+
+  if opts.last_section then
+    local start = last_section_start(windowed)
+    if start > 1 then
+      windowed = vim.list_slice(windowed, start, #windowed)
+    end
+  end
+
+  if type(opts.tail_lines) == "number" and opts.tail_lines >= 0 and opts.tail_lines < #windowed then
+    windowed = vim.list_slice(windowed, #windowed - opts.tail_lines + 1, #windowed)
+  end
+
+  return windowed, total_lines
+end
+
+return M

--- a/lua/vibing/domain/chat/buffer_window.lua
+++ b/lua/vibing/domain/chat/buffer_window.lua
@@ -32,19 +32,14 @@ end
 function M.slice(lines, opts)
   local total_lines = #lines
   opts = opts or {}
-  local windowed = lines
 
-  if opts.last_section then
-    local start = last_section_start(windowed)
-    if start > 1 then
-      windowed = vim.list_slice(windowed, start, #windowed)
-    end
+  local start = opts.last_section and last_section_start(lines) or 1
+  local section_length = total_lines - start + 1
+  if type(opts.tail_lines) == "number" and opts.tail_lines >= 0 and opts.tail_lines < section_length then
+    start = total_lines - opts.tail_lines + 1
   end
 
-  if type(opts.tail_lines) == "number" and opts.tail_lines >= 0 and opts.tail_lines < #windowed then
-    windowed = vim.list_slice(windowed, #windowed - opts.tail_lines + 1, #windowed)
-  end
-
+  local windowed = start == 1 and lines or vim.list_slice(lines, start, total_lines)
   return windowed, total_lines
 end
 

--- a/lua/vibing/domain/chat/buffer_window.lua
+++ b/lua/vibing/domain/chat/buffer_window.lua
@@ -6,17 +6,28 @@ local M = {}
 
 local Timestamp = require("vibing.core.utils.timestamp")
 
----1-indexed start of the last section (the last `## <Kind> <!-- ... -->` header found scanning
----from the end), or 1 when the buffer has no header at all — the whole buffer is one section.
+---1-indexed index of the last `## <Kind> <!-- ... -->` header in `lines`, scanning from the end,
+---or nil if `lines` has none. Exported (unlike the section-start helper below, which folds "none"
+---into 1) so a caller reading a buffer incrementally — a suffix chunk, say — can tell "no header
+---in what I've read so far" apart from "the header is the first line I read", and keep reading
+---further back only in the first case (`infrastructure/rpc/handlers/buffer.lua`'s chunked scan).
 ---@param lines string[]
----@return integer
-local function last_section_start(lines)
+---@return integer?
+function M.find_last_header(lines)
   for i = #lines, 1, -1 do
     if Timestamp.is_header(lines[i]) then
       return i
     end
   end
-  return 1
+  return nil
+end
+
+---1-indexed start of the last section, or 1 when `lines` has no header at all — the whole thing
+---is one section.
+---@param lines string[]
+---@return integer
+local function last_section_start(lines)
+  return M.find_last_header(lines) or 1
 end
 
 ---Normalize a `tail_lines` argument to a non-negative integer, or nil for "not given"/unusable.

--- a/lua/vibing/infrastructure/rpc/handlers/buffer.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/buffer.lua
@@ -34,20 +34,21 @@ local BufferIdentifier = require("vibing.core.utils.buffer_identifier")
 --   needs no equivalent: it errors outright when it can find no target.
 function M.buf_get_lines(params)
   local bufnr = require("vibing.infrastructure.rpc.handlers.bufnr").resolve_chat_target(params) or 0
-  local tail_lines = params and params.tail_lines
+  local BufferWindow = require("vibing.domain.chat.buffer_window")
+  -- Normalized once, through the same primitive `BufferWindow.slice` uses below, so a negative or
+  -- fractional value cannot be read one way on this fast path and a different way on that one.
+  local tail_lines = BufferWindow.normalize_tail_lines(params and params.tail_lines)
   local last_section = params and params.last_section
 
   local windowed, total_lines
-  if type(tail_lines) == "number" and not last_section then
+  if tail_lines and not last_section then
     -- Read only the requested tail instead of the whole buffer: the entire point of asking for
     -- the last 40 lines of a 400k-line chat is to not pay for reading the other 399,960 (#694).
     total_lines = vim.api.nvim_buf_line_count(bufnr)
-    local n = math.max(0, tail_lines)
-    local from = n < total_lines and (total_lines - n) or 0
+    local from = tail_lines < total_lines and (total_lines - tail_lines) or 0
     windowed = vim.api.nvim_buf_get_lines(bufnr, from, total_lines, false)
   else
     local all_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-    local BufferWindow = require("vibing.domain.chat.buffer_window")
     windowed, total_lines = BufferWindow.slice(all_lines, { tail_lines = tail_lines, last_section = last_section })
   end
 

--- a/lua/vibing/infrastructure/rpc/handlers/buffer.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/buffer.lua
@@ -9,39 +9,51 @@ local BufferIdentifier = require("vibing.core.utils.buffer_identifier")
 --   not already (see `application/chat/chat_locator.lua`). Mutually exclusive with `bufnr`, and
 --   chat files only — an ordinary file has `nvim_load_buffer`, and this path opens and attaches
 --   a chat buffer, which is not what reading a source file should do.
--- @param params.include_chat_status? boolean Wrap the result and attach the buffer's chat status.
+-- @param params.include_chat_status? boolean Wrap the result and attach the buffer's chat status
+--   and its real total line count. Independent of `tail_lines`/`last_section` below — those
+--   window the lines either shape returns, so a caller that wants only a tail read and not the
+--   chat-status wrapper still gets one.
 -- @param params.tail_lines? number Keep only the last N lines of the (possibly `last_section`-cut)
---   result. Only applied inside the wrapped shape — see below.
+--   result.
 -- @param params.last_section? boolean Keep only the buffer's last `## ...` section (header
---   boundaries from `core/utils/timestamp.lua`). Only applied inside the wrapped shape.
+--   boundaries from `core/utils/timestamp.lua`).
 -- @return string[]|table Bare line array by default; `{ lines, total_lines, bufnr, chat_status }`
 --   when `include_chat_status` is set (`chat_status` is "responding"/"idle"/"waiting_approval"/
 --   "asked_question"/"error", or absent for a buffer that is not a vibing.nvim chat). An MCP
 --   server older than a value names it rather than dropping it, so a status added later reads as
 --   "go look" instead of as silence. The shape stays opt-in because the MCP server and this
 --   plugin are installed separately and can be at different versions: an older MCP server sends
---   no flag and must keep receiving the array it calls `.join()` on — which is also why
---   `tail_lines`/`last_section` are windows on that same wrapped shape rather than a third one:
---   a caller new enough to ask for a window is new enough to have sent `include_chat_status`.
+--   no flag and must keep receiving the array it calls `.join()` on. `total_lines` cannot be
+--   reported in that bare shape, which is exactly why it lives inside the wrapped one instead of
+--   next to the windowed lines themselves.
 --
 --   `bufnr` is what makes the *other* direction of that skew safe. A `file_path` reaching a
 --   Neovim too old to know the argument would be ignored, and the caller would be handed the
 --   current buffer's text as though it were the chat it named — silently, and reported `idle`.
 --   Answering with the buffer actually read lets the server tell that case apart. The send path
 --   needs no equivalent: it errors outright when it can find no target.
---
---   `total_lines` is the buffer's real line count, not the windowed one — the point of asking for
---   only the tail is to still learn the overall scale (#694).
 function M.buf_get_lines(params)
   local bufnr = require("vibing.infrastructure.rpc.handlers.bufnr").resolve_chat_target(params) or 0
-  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local tail_lines = params and params.tail_lines
+  local last_section = params and params.last_section
 
-  if not (params and params.include_chat_status) then
-    return lines
+  local windowed, total_lines
+  if type(tail_lines) == "number" and not last_section then
+    -- Read only the requested tail instead of the whole buffer: the entire point of asking for
+    -- the last 40 lines of a 400k-line chat is to not pay for reading the other 399,960 (#694).
+    total_lines = vim.api.nvim_buf_line_count(bufnr)
+    local n = math.max(0, tail_lines)
+    local from = n < total_lines and (total_lines - n) or 0
+    windowed = vim.api.nvim_buf_get_lines(bufnr, from, total_lines, false)
+  else
+    local all_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    local BufferWindow = require("vibing.domain.chat.buffer_window")
+    windowed, total_lines = BufferWindow.slice(all_lines, { tail_lines = tail_lines, last_section = last_section })
   end
 
-  local BufferWindow = require("vibing.domain.chat.buffer_window")
-  local windowed, total_lines = BufferWindow.slice(lines, params)
+  if not (params and params.include_chat_status) then
+    return windowed
+  end
 
   local ChatStatus = require("vibing.presentation.chat.modules.chat_status")
   return {

--- a/lua/vibing/infrastructure/rpc/handlers/buffer.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/buffer.lua
@@ -10,19 +10,28 @@ local BufferIdentifier = require("vibing.core.utils.buffer_identifier")
 --   chat files only — an ordinary file has `nvim_load_buffer`, and this path opens and attaches
 --   a chat buffer, which is not what reading a source file should do.
 -- @param params.include_chat_status? boolean Wrap the result and attach the buffer's chat status.
--- @return string[]|table Bare line array by default; `{ lines, bufnr, chat_status }` when
---   `include_chat_status` is set (`chat_status` is "responding"/"idle"/"waiting_approval"/
+-- @param params.tail_lines? number Keep only the last N lines of the (possibly `last_section`-cut)
+--   result. Only applied inside the wrapped shape — see below.
+-- @param params.last_section? boolean Keep only the buffer's last `## ...` section (header
+--   boundaries from `core/utils/timestamp.lua`). Only applied inside the wrapped shape.
+-- @return string[]|table Bare line array by default; `{ lines, total_lines, bufnr, chat_status }`
+--   when `include_chat_status` is set (`chat_status` is "responding"/"idle"/"waiting_approval"/
 --   "asked_question"/"error", or absent for a buffer that is not a vibing.nvim chat). An MCP
 --   server older than a value names it rather than dropping it, so a status added later reads as
 --   "go look" instead of as silence. The shape stays opt-in because the MCP server and this
 --   plugin are installed separately and can be at different versions: an older MCP server sends
---   no flag and must keep receiving the array it calls `.join()` on.
+--   no flag and must keep receiving the array it calls `.join()` on — which is also why
+--   `tail_lines`/`last_section` are windows on that same wrapped shape rather than a third one:
+--   a caller new enough to ask for a window is new enough to have sent `include_chat_status`.
 --
 --   `bufnr` is what makes the *other* direction of that skew safe. A `file_path` reaching a
 --   Neovim too old to know the argument would be ignored, and the caller would be handed the
 --   current buffer's text as though it were the chat it named — silently, and reported `idle`.
 --   Answering with the buffer actually read lets the server tell that case apart. The send path
 --   needs no equivalent: it errors outright when it can find no target.
+--
+--   `total_lines` is the buffer's real line count, not the windowed one — the point of asking for
+--   only the tail is to still learn the overall scale (#694).
 function M.buf_get_lines(params)
   local bufnr = require("vibing.infrastructure.rpc.handlers.bufnr").resolve_chat_target(params) or 0
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -31,9 +40,13 @@ function M.buf_get_lines(params)
     return lines
   end
 
+  local BufferWindow = require("vibing.domain.chat.buffer_window")
+  local windowed, total_lines = BufferWindow.slice(lines, params)
+
   local ChatStatus = require("vibing.presentation.chat.modules.chat_status")
   return {
-    lines = lines,
+    lines = windowed,
+    total_lines = total_lines,
     bufnr = bufnr == 0 and vim.api.nvim_get_current_buf() or bufnr,
     chat_status = ChatStatus.get(bufnr),
   }

--- a/lua/vibing/infrastructure/rpc/handlers/buffer.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/buffer.lua
@@ -2,6 +2,31 @@ local M = {}
 
 local BufferIdentifier = require("vibing.core.utils.buffer_identifier")
 
+-- Read only the buffer's last `## ...` section, by growing a backward-read chunk until a header
+-- turns up (or the chunk covers the whole buffer) — the `last_section` counterpart to the
+-- tail_lines-only fast path below. Doubling from a few hundred lines means an ordinary single
+-- turn (the overwhelmingly common case) is found in one or two reads instead of the full 400k
+-- lines a chat can run to (#694 follow-up flagged by review on PR #707).
+-- @param bufnr number
+-- @param tail_lines integer? Already normalized by `BufferWindow.normalize_tail_lines`.
+-- @return string[] windowed
+-- @return integer total_lines
+local function read_last_section(bufnr, tail_lines)
+  local BufferWindow = require("vibing.domain.chat.buffer_window")
+  local total_lines = vim.api.nvim_buf_line_count(bufnr)
+  local chunk_size = 500
+  local chunk, from
+
+  repeat
+    from = math.max(0, total_lines - chunk_size)
+    chunk = vim.api.nvim_buf_get_lines(bufnr, from, total_lines, false)
+    chunk_size = chunk_size * 2
+  until BufferWindow.find_last_header(chunk) or from == 0
+
+  local windowed = BufferWindow.slice(chunk, { tail_lines = tail_lines, last_section = true })
+  return windowed, total_lines
+end
+
 -- Retrieve all lines from the specified buffer.
 -- @param params? Table with optional fields.
 -- @param params.bufnr? number Buffer number to read from; defaults to 0 (current buffer).
@@ -41,15 +66,17 @@ function M.buf_get_lines(params)
   local last_section = params and params.last_section
 
   local windowed, total_lines
-  if tail_lines and not last_section then
+  if last_section then
+    windowed, total_lines = read_last_section(bufnr, tail_lines)
+  elseif tail_lines then
     -- Read only the requested tail instead of the whole buffer: the entire point of asking for
     -- the last 40 lines of a 400k-line chat is to not pay for reading the other 399,960 (#694).
     total_lines = vim.api.nvim_buf_line_count(bufnr)
     local from = tail_lines < total_lines and (total_lines - tail_lines) or 0
     windowed = vim.api.nvim_buf_get_lines(bufnr, from, total_lines, false)
   else
-    local all_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-    windowed, total_lines = BufferWindow.slice(all_lines, { tail_lines = tail_lines, last_section = last_section })
+    windowed = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    total_lines = #windowed
   end
 
   if not (params and params.include_chat_status) then

--- a/tests/lua/domain/chat/buffer_window_spec.lua
+++ b/tests/lua/domain/chat/buffer_window_spec.lua
@@ -109,4 +109,23 @@ describe("BufferWindow.slice", function()
       assert.equals(nil, BufferWindow.normalize_tail_lines(nil))
     end)
   end)
+
+  describe("find_last_header", function()
+    it("returns nil rather than 1 when there is no header, unlike the section-start fallback", function()
+      -- The chunked backward scan in infrastructure/rpc/handlers/buffer.lua needs to tell "no
+      -- header in what I've read so far, keep reading further back" apart from "the header is
+      -- right here" — a plain index can't carry that distinction when the header sits at index 1.
+      assert.equals(nil, BufferWindow.find_last_header({ "plain", "text" }))
+    end)
+
+    it("returns 1 when the header is the very first line, not nil", function()
+      assert.equals(1, BufferWindow.find_last_header({ "## Assistant", "reply" }))
+    end)
+
+    it("returns the last header's index when there are several", function()
+      local lines = { "## User <!-- 2026-01-01 00:00:00 -->", "a", "## Assistant <!-- 2026-01-01 00:00:01 -->", "b" }
+
+      assert.equals(3, BufferWindow.find_last_header(lines))
+    end)
+  end)
 end)

--- a/tests/lua/domain/chat/buffer_window_spec.lua
+++ b/tests/lua/domain/chat/buffer_window_spec.lua
@@ -1,0 +1,87 @@
+local BufferWindow = require("vibing.domain.chat.buffer_window")
+
+describe("BufferWindow.slice", function()
+  it("returns everything unchanged and the matching total when no option is given", function()
+    local lines = { "a", "b", "c" }
+
+    local windowed, total_lines = BufferWindow.slice(lines, nil)
+
+    assert.same({ "a", "b", "c" }, windowed)
+    assert.equals(3, total_lines)
+  end)
+
+  it("keeps only the last N lines with tail_lines", function()
+    local lines = { "a", "b", "c", "d", "e" }
+
+    local windowed, total_lines = BufferWindow.slice(lines, { tail_lines = 2 })
+
+    assert.same({ "d", "e" }, windowed)
+    assert.equals(5, total_lines)
+  end)
+
+  it("leaves a buffer shorter than tail_lines untouched", function()
+    local lines = { "a", "b" }
+
+    local windowed, total_lines = BufferWindow.slice(lines, { tail_lines = 40 })
+
+    assert.same({ "a", "b" }, windowed)
+    assert.equals(2, total_lines)
+  end)
+
+  it("cuts at the last '## ...' section boundary with last_section", function()
+    local lines = { "## User <!-- 2026-01-01 00:00:00 -->", "first", "## Assistant <!-- 2026-01-01 00:00:01 -->", "second", "reply" }
+
+    local windowed, total_lines = BufferWindow.slice(lines, { last_section = true })
+
+    assert.same({ "## Assistant <!-- 2026-01-01 00:00:01 -->", "second", "reply" }, windowed)
+    assert.equals(5, total_lines)
+  end)
+
+  it("returns the whole buffer for last_section when there is no header at all", function()
+    local lines = { "plain", "text", "no headers here" }
+
+    local windowed, total_lines = BufferWindow.slice(lines, { last_section = true })
+
+    assert.same({ "plain", "text", "no headers here" }, windowed)
+    assert.equals(3, total_lines)
+  end)
+
+  it("recognizes legacy headers with no timestamp comment", function()
+    local lines = { "## User", "first", "## Assistant", "second" }
+
+    local windowed = BufferWindow.slice(lines, { last_section = true })
+
+    assert.same({ "## Assistant", "second" }, windowed)
+  end)
+
+  it("applies tail_lines on top of last_section, not on the whole buffer", function()
+    local lines = {
+      "## User <!-- 2026-01-01 00:00:00 -->",
+      "one",
+      "two",
+      "## Assistant <!-- 2026-01-01 00:00:01 -->",
+      "three",
+      "four",
+      "five",
+    }
+
+    local windowed, total_lines = BufferWindow.slice(lines, { last_section = true, tail_lines = 2 })
+
+    assert.same({ "four", "five" }, windowed)
+    assert.equals(7, total_lines)
+  end)
+
+  it("treats tail_lines = 0 as an empty window", function()
+    local windowed = BufferWindow.slice({ "a", "b" }, { tail_lines = 0 })
+
+    assert.same({}, windowed)
+  end)
+
+  it("does not mutate the input", function()
+    local lines = { "a", "b", "c" }
+
+    BufferWindow.slice(lines, { tail_lines = 1 })
+
+    assert.same({ "a", "b", "c" }, lines)
+  end)
+end)

--- a/tests/lua/domain/chat/buffer_window_spec.lua
+++ b/tests/lua/domain/chat/buffer_window_spec.lua
@@ -84,4 +84,29 @@ describe("BufferWindow.slice", function()
 
     assert.same({ "a", "b", "c" }, lines)
   end)
+
+  describe("normalize_tail_lines (a defensive-coding review finding on PR #707)", function()
+    it("clamps a negative tail_lines to zero rather than ignoring it", function()
+      -- Unreachable through the MCP layer (validated non-negative there), but this primitive is
+      -- meant to be called directly by a future Lua caller (#693) that skips that validation.
+      assert.same({}, BufferWindow.slice({ "a", "b" }, { tail_lines = -1 }))
+    end)
+
+    it("clamps a negative tail_lines the same way whether or not last_section is also given", function()
+      local lines = { "## User <!-- 2026-01-01 00:00:00 -->", "one", "two" }
+
+      assert.same({}, BufferWindow.slice(lines, { tail_lines = -1, last_section = true }))
+    end)
+
+    it("floors a fractional tail_lines instead of producing a fractional slice bound", function()
+      local windowed = BufferWindow.slice({ "a", "b", "c" }, { tail_lines = 1.9 })
+
+      assert.same({ "c" }, windowed)
+    end)
+
+    it("treats a non-number tail_lines as not given", function()
+      assert.equals(nil, BufferWindow.normalize_tail_lines("3"))
+      assert.equals(nil, BufferWindow.normalize_tail_lines(nil))
+    end)
+  end)
 end)

--- a/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
@@ -178,5 +178,15 @@ describe("rpc handlers.buffer.buf_get_lines target resolution", function()
 
       assert.same({ "1", "2", "3" }, BufferHandler.buf_get_lines({ bufnr = target }))
     end)
+
+    it("clamps a negative tail_lines the same way on the fast path and the last_section path", function()
+      -- A PR #707 review caught these two branches disagreeing on a negative tail_lines: the fast
+      -- path (no last_section) clamped to an empty result, the other silently ignored tail_lines
+      -- and returned the whole buffer. Both now clamp through BufferWindow.normalize_tail_lines.
+      local target = make_buffer({ "1", "2", "3" })
+
+      assert.same({}, BufferHandler.buf_get_lines({ bufnr = target, tail_lines = -1 }))
+      assert.same({}, BufferHandler.buf_get_lines({ bufnr = target, tail_lines = -1, last_section = true }))
+    end)
   end)
 end)

--- a/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
@@ -155,6 +155,54 @@ describe("rpc handlers.buffer.buf_get_lines target resolution", function()
       assert.equals(4, result.total_lines)
     end)
 
+    it("finds a last_section header beyond the first backward-scan chunk by doubling", function()
+      -- last_section alone used to fall back to reading the whole buffer (a review finding on PR
+      -- #707); this pins the chunked backward scan that replaced it. The header sits far enough
+      -- back that the first 500-line chunk misses it and a second, doubled read is required.
+      local lines = {}
+      for i = 1, 599 do
+        lines[i] = "filler " .. i
+      end
+      lines[600] = "## Assistant <!-- 2026-01-01 00:00:00 -->"
+      for i = 601, 1200 do
+        lines[i] = "reply " .. i
+      end
+      local target = make_buffer(lines)
+
+      local result = BufferHandler.buf_get_lines({
+        bufnr = target,
+        include_chat_status = true,
+        last_section = true,
+      })
+
+      assert.equals(1200, result.total_lines)
+      assert.equals(601, #result.lines)
+      assert.equals("## Assistant <!-- 2026-01-01 00:00:00 -->", result.lines[1])
+      assert.equals("reply 1200", result.lines[#result.lines])
+    end)
+
+    it("combines a doubled last_section scan with tail_lines", function()
+      local lines = {}
+      for i = 1, 599 do
+        lines[i] = "filler " .. i
+      end
+      lines[600] = "## Assistant <!-- 2026-01-01 00:00:00 -->"
+      for i = 601, 1200 do
+        lines[i] = "reply " .. i
+      end
+      local target = make_buffer(lines)
+
+      local result = BufferHandler.buf_get_lines({
+        bufnr = target,
+        include_chat_status = true,
+        last_section = true,
+        tail_lines = 2,
+      })
+
+      assert.same({ "reply 1199", "reply 1200" }, result.lines)
+      assert.equals(1200, result.total_lines)
+    end)
+
     it("reports total_lines even when the whole buffer was read", function()
       local target = make_buffer({ "a", "b" })
 

--- a/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
@@ -164,10 +164,19 @@ describe("rpc handlers.buffer.buf_get_lines target resolution", function()
       assert.equals(2, result.total_lines)
     end)
 
-    it("ignores tail_lines/last_section in the bare-array shape an older MCP server asks for", function()
+    it("windows even in the bare-array shape, since only the response shape is opt-in", function()
+      -- include_chat_status and tail_lines/last_section are independent: an older MCP server
+      -- that never sends tail_lines is unaffected, but a caller that does ask for a window gets
+      -- one whether or not it also asked to be wrapped with chat status.
       local target = make_buffer({ "1", "2", "3" })
 
-      assert.same({ "1", "2", "3" }, BufferHandler.buf_get_lines({ bufnr = target, tail_lines = 1 }))
+      assert.same({ "3" }, BufferHandler.buf_get_lines({ bufnr = target, tail_lines = 1 }))
+    end)
+
+    it("still returns the untouched bare array when no window was asked for", function()
+      local target = make_buffer({ "1", "2", "3" })
+
+      assert.same({ "1", "2", "3" }, BufferHandler.buf_get_lines({ bufnr = target }))
     end)
   end)
 end)

--- a/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/buffer_spec.lua
@@ -122,4 +122,52 @@ describe("rpc handlers.buffer.buf_get_lines target resolution", function()
       assert.same({ "x" }, BufferHandler.buf_get_lines({ bufnr = target }))
     end)
   end)
+
+  describe("tail_lines / last_section / total_lines (#694)", function()
+    it("windows to the last N lines and reports the buffer's real total", function()
+      local target = make_buffer({ "1", "2", "3", "4", "5" })
+
+      local result = BufferHandler.buf_get_lines({
+        bufnr = target,
+        include_chat_status = true,
+        tail_lines = 2,
+      })
+
+      assert.same({ "4", "5" }, result.lines)
+      assert.equals(5, result.total_lines)
+    end)
+
+    it("windows to the last '## ...' section", function()
+      local target = make_buffer({
+        "## User <!-- 2026-01-01 00:00:00 -->",
+        "first",
+        "## Assistant <!-- 2026-01-01 00:00:01 -->",
+        "second",
+      })
+
+      local result = BufferHandler.buf_get_lines({
+        bufnr = target,
+        include_chat_status = true,
+        last_section = true,
+      })
+
+      assert.same({ "## Assistant <!-- 2026-01-01 00:00:01 -->", "second" }, result.lines)
+      assert.equals(4, result.total_lines)
+    end)
+
+    it("reports total_lines even when the whole buffer was read", function()
+      local target = make_buffer({ "a", "b" })
+
+      local result = BufferHandler.buf_get_lines({ bufnr = target, include_chat_status = true })
+
+      assert.same({ "a", "b" }, result.lines)
+      assert.equals(2, result.total_lines)
+    end)
+
+    it("ignores tail_lines/last_section in the bare-array shape an older MCP server asks for", function()
+      local target = make_buffer({ "1", "2", "3" })
+
+      assert.same({ "1", "2", "3" }, BufferHandler.buf_get_lines({ bufnr = target, tail_lines = 1 }))
+    end)
+  end)
 end)


### PR DESCRIPTION
A chat buffer can run to hundreds of thousands of lines, and reading it all
via nvim_get_buffer is effectively unreadable. tail_lines returns only the
last N lines, and last_section cuts at the last "## ..." heading boundary;
both can be combined. The result always reports the buffer's real total
line count so a caller that only saw a window still learns the overall
scale.

The windowing itself lives in one domain primitive
(domain/chat/buffer_window.lua) rather than in the RPC handler, since #693
needs the same "read only the tail" logic from the orchestration notifier.

Closes #694.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bftqc1z7sKegAd4mA92VWz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional buffer windowing to read only the last N lines or the final section.
  * Windowed results now report the buffer’s total line count and indicate when content is truncated.
  * Added support for identifying chats by file path in the buffer tool documentation.

* **Documentation**
  * Expanded guidance for buffer windowing options and total-line reporting.

* **Tests**
  * Added coverage for windowing, validation, truncation metadata, and compatibility with older response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->