### PR TITLE
feat(orchestration): inject a vibing-worker skill into orchestrated_by chats

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -171,6 +171,12 @@ One chat can create and drive others: `nvim_chat_create` (MCP) → `rpc/handlers
 - **Reporting is the worker's job; the notification is a watchdog.** `agent.chat_notifications`
   gates only the watchdog — a stop the chat cannot leave on its own (`asked_question`,
   `waiting_approval`, `error`) is delivered whatever the setting is.
+- **The report protocol is injected, not left to the brief or to skill auto-trigger** (#706). A
+  chat with `orchestrated_by` gets the orchestrator's `file_path` and the report protocol appended
+  to its system prompt on every turn (`cli_command_builder.lua`), pointing at the
+  `claude-plugin/skills/vibing-worker/SKILL.md` skill for the rest. Skill discovery by description
+  match is probabilistic, so this line — not the orchestrator's brief text — is the one place a
+  worker is guaranteed to be told where and how to report.
 - **A worker's tool-approval prompt is the user's to clear unless the user says otherwise**
   (`agent.orchestration.delegated_approval`, default `false`).
 - **A message delivered from another chat gets its own section kind** — `## Request`, `## Report`

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -71,45 +71,17 @@ request, not the files already discussed, not the decisions already made. Write 
 someone who just walked in — goal, the files or directories involved, the constraints, and what
 "done" looks like. A brief that says "do the refactor we discussed" produces nothing useful.
 
-### The brief must tell the worker to report back
+### The brief does not need to teach the worker to report back
 
-This is not optional decoration — it is how the fan-out finishes without you polling. Every brief
-carries three things beyond the task:
-
-1. **Where to report** — this chat's `file_path`. The worker is told it in its own system prompt
-   too, but a brief is read on its own and should not depend on that.
-2. **How to report** — `nvim_chat_send_message` with the worker's own chat buffer number as
-   `from_bufnr` and **`queue_if_busy: true`**. Without that flag the send is refused outright
-   whenever you happen to be mid-turn, and the report is simply lost.
-3. **What to report** — the conclusion, what failed, and what needs your action, **briefly**. The
-   summary must stand on its own — "Done, read my chat" costs you a `nvim_get_buffer` and pulls
-   that worker's entire transcript into this conversation, once per worker — but the opposite
-   failure wastes tokens twice: a report that replays the whole working log is paid for once when
-   the worker writes it and again when you read it, while that log already sits in the worker's
-   transcript for free. Tell the worker to keep the report to the points you will act on; read its
-   transcript yourself on the rare occasion you need the detail.
-
-Add that if it gets stuck or the brief turns out to be ambiguous, it should ask you the same way
-rather than guess. A question costs one turn; a worker guessing wrong costs the whole task.
-
-A closing paragraph you can paste into a brief:
-
-```text
-終わったら、次の呼び出しで報告してから止まってください。
-
-  nvim_chat_send_message({
-    rpc_port,
-    file_path: "<このチャットの file_path>",
-    from_bufnr: <あなた自身の chat buffer 番号>,
-    queue_if_busy: true,
-    message: "<結果の要約>",
-  })
-
-要約だけで判断できる内容にしてください（何を変えたか・何が失敗したか・何が残っているか）。
-作業過程の詳細は書かず、要点だけを短く。詳細が必要なときはこちらからあなたの transcript を
-読みに行きます。
-詰まったとき、ブリーフが曖昧なときも、推測せず同じ方法で聞いてください。
-```
+That used to be your job to write into every brief; it is not anymore (#706). Creating the worker
+with `from_bufnr` records `orchestrated_by` on it, and vibing.nvim reads that frontmatter on every
+turn to inject the report protocol into the worker's own system prompt — this chat's `file_path`
+already resolved in, the call shape (`nvim_chat_send_message`, `from_bufnr`, `queue_if_busy: true`),
+the report shape (conclusion → what changed → what's unresolved → what's needed next), and what not
+to do. The full version is the `vibing-worker` skill, bundled for exactly this purpose. Your brief
+only needs to be the task itself, as below — writing the reporting instructions into it too is
+redundant, not more reliable, since the injected line does not depend on the worker having read the
+brief carefully or at all.
 
 ## 4. End your turn — the workers come back to you
 
@@ -242,7 +214,9 @@ there.
 ## 7. If you are also someone else's worker
 
 A chat can be a worker and an orchestrator at once: briefed by a parent, and splitting its own task
-across workers of its own. Everything above still applies — plus one rule.
+across workers of its own. Your own reporting duty to that parent is the injected line in your
+system prompt plus the `vibing-worker` skill it points to — read that for the report protocol.
+Everything above still applies to how you run your own workers — plus one rule.
 
 **Report to your parent only once every worker of yours has reported.** Nothing enforces this;
 there is no barrier in vibing.nvim, and a message sent early is delivered normally. The whole

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -218,9 +218,12 @@ across workers of its own. Your own reporting duty to that parent is the injecte
 system prompt plus the `vibing-worker` skill it points to — read that for the report protocol.
 Everything above still applies to how you run your own workers — plus one rule.
 
-**Report to your parent only once every worker of yours has reported.** Nothing enforces this;
-there is no barrier in vibing.nvim, and a message sent early is delivered normally. The whole
-fan-in is this convention, so keeping it is on you.
+**Report your own completion to your parent only once every worker of yours has reported.**
+Nothing enforces this; there is no barrier in vibing.nvim, and a message sent early is delivered
+normally. The whole fan-in is this convention, so keeping it is on you. It covers only the
+completion report — the immediate reports the `vibing-worker` skill obligates you to send your own
+parent (a heads-up before an approval-prone action, or the moment you find you yourself cannot
+proceed) still fire right away, whether or not your own workers have finished.
 
 - While workers are outstanding, end each turn with a line naming which ones you are still waiting
   on. That text is the only place the count survives — you are a fresh process every turn, and

--- a/claude-plugin/skills/vibing-worker/SKILL.md
+++ b/claude-plugin/skills/vibing-worker/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: vibing-worker
+description: Use when this chat's system prompt states it was started by another vibing.nvim chat (an orchestrator). Covers where and when to report back, the report's shape, and what not to do — the full version of the protocol summarized in that system-prompt line.
+user-invocable: false
+---
+
+# vibing-worker
+
+This chat is a worker: some other vibing.nvim chat (its orchestrator) created it and is waiting to
+hear back. Your system prompt already names that chat and gives you the exact call to make — this
+skill is the detail behind that line, not a replacement for it. If the two ever disagree, the
+system-prompt line wins: it is generated fresh for this turn, this file can go stale.
+
+## Where and how to report
+
+Call `nvim_chat_send_message` with:
+
+- `file_path`: the orchestrator's path, exactly as given in your system prompt.
+- `from_bufnr`: your own chat buffer number, also given in your system prompt.
+- `queue_if_busy: true`. Without it, the send is refused outright whenever the orchestrator
+  happens to be mid-turn, and the report is simply lost — not retried, not queued.
+- `message`: the report itself (shape below).
+
+This is the only path that reaches the orchestrator. Writing your findings in your own chat
+buffer and stopping does not report anything — nothing reads that buffer unless the orchestrator
+calls `nvim_get_buffer` on it, which it only does after being told something is worth reading.
+
+## When to report
+
+**When the task is done.** The ordinary case: finish the work, then send the report before ending
+your turn.
+
+**Before you act on something you expect will need approval.** A tool-approval prompt kills your
+turn on the spot — you cannot report _after_ hitting one, because there is no turn left to send
+from. If you can see one coming (a destructive command, an edit outside what the brief covers),
+send a heads-up first, in the same turn, before making that call. The orchestrator (or the user,
+depending on `agent.orchestration.delegated_approval`) is who clears it either way; a heads-up
+just means they aren't finding out from a cold watchdog notice with no context.
+
+**The moment you find you cannot proceed.** Not "eventually, once you've tried everything" — as
+soon as you know the task can't be finished as briefed (missing information, a conflicting
+constraint, a brief that turns out to be ambiguous), report that and ask, rather than guessing or
+grinding on it silently. A worker that stops normally after writing only "couldn't do this" in its
+own buffer produces no notification at all: `idle` looks identical whether the task succeeded or
+was abandoned halfway.
+
+## Report shape
+
+Conclusion → what changed → what's unresolved → what you need next. Briefly — the orchestrator can
+read your transcript for detail it actually wants; a report that replays the working log is paid
+for twice (once when you write it, once when it's read) for content that already sits in your
+transcript for free.
+
+- **Conclusion**: done, partially done, or blocked — one line.
+- **What changed**: the files or state you touched, not how you got there.
+- **What's unresolved**: anything left undone or uncertain.
+- **What's needed next**: a decision, a missing input, or nothing (task fully closed).
+
+## Do not
+
+- **End your turn with only a prose report in your own chat buffer.** That is not a report; it is
+  a transcript nobody was told to read. If you wrote something worth knowing, send it.
+- **Edit `.claude/rules/**`** even if the task seems to call for it. Those files are this
+  project's own invariants, kept deliberately small and reviewed as such — a worker changing them
+  mid-task bypasses that review. Note the need in your report instead and let the orchestrator (or
+  the user) decide.
+- **Forward your own subagent- or worker-launch calls to the orchestrator as if they were your
+  report.** If you dispatch a subagent or create worker chats of your own (see `vibing-orchestrate`
+  for that case), "I launched X" is not an outcome — it tells the orchestrator what you did, not
+  what happened. Wait for the outcome and report that, holding your own report until your own
+  workers have reported back to you.

--- a/claude-plugin/skills/vibing-worker/SKILL.md
+++ b/claude-plugin/skills/vibing-worker/SKILL.md
@@ -15,7 +15,11 @@ system-prompt line wins: it is generated fresh for this turn, this file can go s
 
 Call `nvim_chat_send_message` with:
 
-- `file_path`: the orchestrator's path, exactly as given in your system prompt.
+- `rpc_port`: this turn's value, exactly as given in your system prompt — required on every
+  vibing-nvim MCP call, not just this one (see the `nvim-context` skill).
+- `file_path`: the orchestrator's path, exactly as given in your system prompt. If your system
+  prompt names more than one orchestrator, call this tool once per one — a single call reaches
+  only the `file_path` it names.
 - `from_bufnr`: your own chat buffer number, also given in your system prompt.
 - `queue_if_busy: true`. Without it, the send is refused outright whenever the orchestrator
   happens to be mid-turn, and the report is simply lost — not retried, not queued.
@@ -67,5 +71,8 @@ transcript for free.
 - **Forward your own subagent- or worker-launch calls to the orchestrator as if they were your
   report.** If you dispatch a subagent or create worker chats of your own (see `vibing-orchestrate`
   for that case), "I launched X" is not an outcome — it tells the orchestrator what you did, not
-  what happened. Wait for the outcome and report that, holding your own report until your own
-  workers have reported back to you.
+  what happened. Wait for the outcome and report that, holding your own **completion** report
+  until your own workers have reported back to you. That hold applies only to the completion
+  report — a heads-up before an approval-prone action, or a report that you yourself are blocked,
+  still goes out immediately under "When to report" above, whether or not your own workers have
+  finished.

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -358,19 +358,29 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
             and string.format("%s (currently buffer %d)", orchestrator.path, orchestrator.bufnr)
           or orchestrator.path
       end, opts.orchestrators)
+      -- Usually one path, but `orchestrated_by` is a list: a second chat that later messages this
+      -- one via nvim_chat_send_message is appended too (orchestration_link.lua), so a worker can
+      -- have more than one orchestrator to report to. nvim_chat_send_message addresses exactly one
+      -- file_path per call, so "that file_path" (singular) only holds for the one-name case.
+      local target_clause = #named == 1
+          and ("This chat was started by vibing.nvim chat " .. named[1] .. ". Report to it")
+        or (
+          "This chat was started by more than one vibing.nvim chat: "
+          .. table.concat(named, ", ")
+          .. ". Report to each of them separately, once per file_path"
+        )
       table.insert(
         system_prompt_lines,
-        "This chat was started by vibing.nvim chat "
-          .. table.concat(named, ", ")
-          .. ". Report to it — when the task is done, before you act on something you expect will "
-          .. "need approval, and the moment you find you cannot proceed — by calling "
+        target_clause
+          .. " — when the task is done, before you act on something you expect will need "
+          .. "approval, and the moment you find you cannot proceed — by calling "
           .. "nvim_chat_send_message with that file_path, your own chat buffer number as "
-          .. "from_bufnr, and queue_if_busy: true. State the conclusion, what changed, what is "
-          .. "unresolved, and what input you need next, briefly: it can read this transcript for "
-          .. "the rest, and can be asked the same way if the brief is ambiguous or you get stuck. "
-          .. "Do not stop with only a prose report in your own chat buffer — that report is never "
-          .. "read unless you also send it. See the vibing-worker skill for the full protocol, "
-          .. "including what not to touch."
+          .. "from_bufnr, this turn's rpc_port, and queue_if_busy: true. State the conclusion, "
+          .. "what changed, what is unresolved, and what input you need next, briefly: it can "
+          .. "read this transcript for the rest, and can be asked the same way if the brief is "
+          .. "ambiguous or you get stuck. Do not stop with only a prose report in your own chat "
+          .. "buffer — that report is never read unless you also send it. See the vibing-worker "
+          .. "skill for the full protocol, including what not to touch."
       )
     end
 

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -342,11 +342,16 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
     -- dispatch, so it would move the prefix on a normal turn rather than an unusual one — and the
     -- completion notification already names the chat it wants read.
     --
-    -- Reporting back is stated as an obligation rather than an option (#643). The brief the
-    -- orchestrator writes says the same thing, but a brief is prose the worker may skim; this
-    -- line is the one place the rule is always present. It is also what the watchdog notice now
+    -- Reporting back is stated as an obligation rather than an option (#643, #706). The brief the
+    -- orchestrator writes no longer has to spell this out — see #706 — because a worker cannot be
+    -- trusted to have loaded the vibing-worker skill on its own (skill auto-trigger is
+    -- probabilistic); this line is the one place the report protocol is always present, with the
+    -- orchestrator's file_path already resolved into it. It is also what the watchdog notice
     -- assumes — a stop with no report reads as a failure, a question, or an approval prompt, so a
-    -- worker that finishes silently is reported to its orchestrator as suspect.
+    -- worker that finishes silently is reported to its orchestrator as suspect. The line stays
+    -- short by design: it states the target, the call shape and the report shape, and points at
+    -- the vibing-worker skill for everything else (full "don't"s, the fan-in rule, examples)
+    -- rather than inlining it and growing this cached prefix.
     if opts.orchestrators and #opts.orchestrators > 0 then
       local named = vim.tbl_map(function(orchestrator)
         return orchestrator.bufnr
@@ -357,15 +362,15 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         system_prompt_lines,
         "This chat was started by vibing.nvim chat "
           .. table.concat(named, ", ")
-          .. ". When your task is done, report the result to it by calling nvim_chat_send_message "
-          .. "with that file_path, your own chat buffer number as from_bufnr, queue_if_busy: true, "
-          .. "and a summary that stands on its own — it should not have to read this transcript to "
-          .. "learn what happened. Keep it brief: the conclusion, anything that failed, and "
-          .. "anything that needs its action. Leave the working detail in this transcript, which "
-          .. "it can read when it wants more. Ask it the same way if the brief turns out to be ambiguous or "
-          .. "you get stuck, rather than guessing. Address it by file_path rather than by buffer "
-          .. "number: the path keeps working after a restart, and the chat is opened for you if it "
-          .. "is closed."
+          .. ". Report to it — when the task is done, before you act on something you expect will "
+          .. "need approval, and the moment you find you cannot proceed — by calling "
+          .. "nvim_chat_send_message with that file_path, your own chat buffer number as "
+          .. "from_bufnr, and queue_if_busy: true. State the conclusion, what changed, what is "
+          .. "unresolved, and what input you need next, briefly: it can read this transcript for "
+          .. "the rest, and can be asked the same way if the brief is ambiguous or you get stuck. "
+          .. "Do not stop with only a prose report in your own chat buffer — that report is never "
+          .. "read unless you also send it. See the vibing-worker skill for the full protocol, "
+          .. "including what not to touch."
       )
     end
 

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -114,6 +114,23 @@ describe("cli_command_builder", function()
       assert.is_nil(prompt_text:find("This chat was started by", 1, true))
     end)
 
+    it("tells the model to report to each orchestrator separately when there is more than one", function()
+      -- A worker's `orchestrated_by` can gain a second entry when another chat later messages it
+      -- (orchestration_link.lua) — one nvim_chat_send_message call only reaches one file_path, so
+      -- "that file_path" (singular) would be wrong here.
+      local cmd = cli_command_builder.build(
+        "hello",
+        { orchestrators = { { path = ".vibing/chat/boss.md" }, { path = ".vibing/chat/other.md" } } },
+        nil,
+        {},
+        nil
+      )
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+      assert.is_true(prompt_text:find(".vibing/chat/boss.md", 1, true) ~= nil)
+      assert.is_true(prompt_text:find(".vibing/chat/other.md", 1, true) ~= nil)
+      assert.is_true(prompt_text:find("Report to each of them separately", 1, true) ~= nil)
+    end)
+
     it("keeps the system prompt byte-identical when only the chat file path changes", function()
       local before = cli_command_builder.build("hello", { chat_bufnr = 12, chat_file_path = "/tmp/a.md" }, nil, {}, nil)
       local after = cli_command_builder.build(


### PR DESCRIPTION
Closes #706.

The report protocol used to depend on the orchestrator manually pasting
boilerplate into every worker's brief — a step that got skipped, which was
the root cause behind #692's lost reports. Move the contract from the brief
into the plugin: a chat with `orchestrated_by` already gets a per-turn
system-prompt line (cli_command_builder.lua) naming its orchestrator; that
line now also states when to report (turn end, before an approval-prone
action, the moment the task can't proceed), the report shape (conclusion →
changes → unresolved → next input), and what not to do, then points at the
new claude-plugin/skills/vibing-worker/SKILL.md for the full version.

vibing-orchestrate's SKILL.md no longer tells the orchestrator to write the
report protocol into each brief, since it's now injected regardless of
whether the brief mentions it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EQm6aPngZ2DZyRWE8WFov8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worker chats now automatically receive clear instructions for reporting progress, completion, approval needs, and blockers to the orchestrating chat.
  - Reports include the outcome, completed changes, unresolved issues, and required next steps.
  - Reports are queued when the orchestrator is busy, helping preserve important updates.

- **Documentation**
  - Updated orchestration guidance so task briefs can focus on the work itself rather than repeating reporting instructions.
  - Added guidance for nested workers and their reporting responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->