### PR TITLE
feat(mcp): add nvim_chat_list to enumerate all open chats in one call

### DIFF
--- a/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
@@ -455,4 +455,46 @@ describe('chat tools (worktree redesign)', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe('no active chat');
   });
+
+  it('registers nvim_chat_list as a read, with no required arguments', () => {
+    const tool = allTools.find((t) => t.name === 'nvim_chat_list');
+    expect(tool).toBeDefined();
+    const inputSchema = tool?.inputSchema as {
+      required?: string[];
+      properties: Record<string, unknown>;
+    };
+    // A read, like nvim_list_buffers: rpc_port falls back to the instance registry rather than
+    // being required (see requireRpcPort's doc comment in ../tools/common.ts).
+    expect(inputSchema.required).toEqual([]);
+    expect(inputSchema.properties.rpc_port).toBeDefined();
+  });
+
+  it('has a handler for nvim_chat_list', () => {
+    expect(handlers.nvim_chat_list).toBeDefined();
+    expect(typeof handlers.nvim_chat_list).toBe('function');
+  });
+
+  it('nvim_chat_list forwards rpc_port and returns the chat list as JSON text', async () => {
+    const chats = [
+      { bufnr: 3, file_path: '/tmp/a.md', chat_status: 'idle', orchestrated_by: [] },
+      { bufnr: 7, file_path: '/tmp/b.md', chat_status: 'responding', orchestrated_by: ['/tmp/a.md'] },
+    ];
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ chats });
+
+    const result = await handlers.nvim_chat_list({ rpc_port: 9878 });
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith('list_chats', {}, 9878);
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.chats).toEqual(chats);
+  });
+
+  it('nvim_chat_list works without rpc_port, falling back to the instance registry', async () => {
+    vi.mocked(rpc.callNeovim).mockResolvedValue({ chats: [] });
+
+    const result = await handlers.nvim_chat_list({});
+
+    expect(rpc.callNeovim).toHaveBeenCalledWith('list_chats', {}, undefined);
+    expect(result.isError).toBeUndefined();
+  });
 });

--- a/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
@@ -477,7 +477,12 @@ describe('chat tools (worktree redesign)', () => {
   it('nvim_chat_list forwards rpc_port and returns the chat list as JSON text', async () => {
     const chats = [
       { bufnr: 3, file_path: '/tmp/a.md', chat_status: 'idle', orchestrated_by: [] },
-      { bufnr: 7, file_path: '/tmp/b.md', chat_status: 'responding', orchestrated_by: ['/tmp/a.md'] },
+      {
+        bufnr: 7,
+        file_path: '/tmp/b.md',
+        chat_status: 'responding',
+        orchestrated_by: ['/tmp/a.md'],
+      },
     ];
     vi.mocked(rpc.callNeovim).mockResolvedValue({ chats });
 

--- a/claude-plugin/mcp-server/src/__tests__/rpc-port-policy.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/rpc-port-policy.test.ts
@@ -25,6 +25,7 @@ const READ_ONLY_TOOLS = [
   'nvim_get_visual_selection',
   'nvim_get_window_info',
   'nvim_get_window_view',
+  'nvim_chat_list',
   'nvim_list_buffers',
   'nvim_list_tabpages',
   'nvim_list_windows',

--- a/claude-plugin/mcp-server/src/handlers/chat.ts
+++ b/claude-plugin/mcp-server/src/handlers/chat.ts
@@ -209,3 +209,18 @@ export async function handleChatAnswerApproval(args: any): Promise<any> {
     _meta: { bufnr: result?.bufnr ?? bufnr, tool: result?.tool, action },
   };
 }
+
+/**
+ * Handler for nvim_chat_list
+ *
+ * Enumerates every chat buffer `view.list_chat_buffers()` knows about on the Lua side — the same
+ * source `application/chat/concurrency.lua` reads to answer "how many chats are responding right
+ * now" — and reports each one's status in a single round trip. A read, so `rpc_port` stays
+ * optional and falls back to the instance registry like `nvim_list_buffers`.
+ */
+export async function handleChatList(args: any): Promise<any> {
+  const result = await callNeovim('list_chats', {}, args?.rpc_port);
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/claude-plugin/mcp-server/src/handlers/index.ts
+++ b/claude-plugin/mcp-server/src/handlers/index.ts
@@ -54,6 +54,7 @@ export const handlers: Record<string, (args: any) => Promise<any>> = {
   nvim_chat_send_message: chat.handleChatSendMessage,
   nvim_ask_user_question: chat.handleAskUserQuestion,
   nvim_chat_answer_approval: chat.handleChatAnswerApproval,
+  nvim_chat_list: chat.handleChatList,
 
   // Highlighting
   nvim_highlight_range: highlight.handleHighlightRange,

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -245,4 +245,22 @@ export const chatTools: Tool[] = [
       required: requireRpcPort(['action', 'from_bufnr']),
     },
   },
+  {
+    name: 'nvim_chat_list',
+    description:
+      'List every open vibing.nvim chat buffer with its status in one call, instead of polling ' +
+      'each with nvim_get_buffer one at a time. For each chat, reports bufnr, file_path, ' +
+      'chat_status (responding/idle/waiting_approval/asked_question/error), context_size (the ' +
+      "chat's last measured context size in tokens, or omitted if it has not completed a turn " +
+      'yet), updated_at (frontmatter timestamp of the last write), and orchestrated_by (the ' +
+      'chat file paths of this chat\'s orchestrator(s), if any). Use this to check on several ' +
+      'worker chats at once in a multi-agent workflow (see the vibing-orchestrate skill). Only ' +
+      'chats currently open in this Neovim session are listed — a chat file that was never ' +
+      'opened this session is not included.',
+    inputSchema: {
+      type: 'object',
+      properties: withRpcPort({}),
+      required: [],
+    },
+  },
 ];

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -253,7 +253,7 @@ export const chatTools: Tool[] = [
       'chat_status (responding/idle/waiting_approval/asked_question/error), context_size (the ' +
       "chat's last measured context size in tokens, or omitted if it has not completed a turn " +
       'yet), updated_at (frontmatter timestamp of the last write), and orchestrated_by (the ' +
-      'chat file paths of this chat\'s orchestrator(s), if any). Use this to check on several ' +
+      "chat file paths of this chat's orchestrator(s), if any). Use this to check on several " +
       'worker chats at once in a multi-agent workflow (see the vibing-orchestrate skill). Only ' +
       'chats currently open in this Neovim session are listed — a chat file that was never ' +
       'opened this session is not included.',

--- a/handbook/mcp-tools.md
+++ b/handbook/mcp-tools.md
@@ -70,7 +70,7 @@ Prefix each with whichever form matches how the server was registered (see above
 - **Annotations**: `nvim_annotate`, `nvim_clear_annotations`
 - **Chat**: `nvim_ask_user_question` (renders a choice list in the chat buffer — see
   `handbook/features/chat-ui.md`), `nvim_chat_send_message`, `nvim_chat_create`,
-  `nvim_chat_answer_approval`
+  `nvim_chat_answer_approval`, `nvim_chat_list`
 - **Instances**: `nvim_list_instances`
 - **Quickfix**: `nvim_set_qflist` (pushes a new list; the previous one survives under `:colder`)
 - **Debugger**: `nvim_dap_get_state`, `nvim_dap_get_stack_trace`, `nvim_dap_get_variables`,
@@ -142,6 +142,14 @@ what it buys is one agent clearing another agent's permission gate; `from_bufnr`
 the chosen option line into the worker's buffer instead of applying the decision directly, and why
 the watchdog's `waiting_approval` wording changes with the setting:
 `handbook/architecture/orchestration.md` → "Answering a worker's tool approval".
+
+`nvim_chat_list({ rpc_port? })` reports every chat buffer open in this Neovim session in one call —
+`bufnr`, `file_path`, `chat_status`, `context_size` (the last measured context in tokens, from the
+last turn's own `### Tokens` marker; absent until a turn has completed), `updated_at` (frontmatter
+timestamp; absent until something has written to frontmatter), and `orchestrated_by`. Use it
+instead of polling several worker chats one at a time with `nvim_get_buffer`. It is a read like
+`nvim_list_buffers`, so `rpc_port` stays optional; it only lists chats attached in this session —
+a chat file nobody has opened yet does not appear.
 
 The workflow is the bundled `vibing-orchestrate` skill. Why `position` defaults to `back`, why the
 chat file is written at creation, why the status is a field rather than a text heuristic, and what

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -100,6 +100,43 @@ function M.answer_approval(params)
   })
 end
 
+---直近ターンの `### Tokens <!-- context=N --> ` からcontextを読む
+---
+---`cache_expiry.read_last_turn` は `nvim_buf_get_lines(buf, 0, -1, false)` でバッファ全文を
+---Luaテーブルにコピーしてから末尾を探す。1チャットの送信時に1回だけ呼ぶ分にはそれで良いが、
+---`list_chats` は開いている全チャットぶんこれを呼ぶ — 「複数チャットを高頻度にポーリングする」
+---という新しい負荷パターンで、長いトランスクリプトのチャットが何本もあるとメインループを
+---縛る（`architecture.md` の git スナップショット実測値が示す同種の懸念）。
+---
+---末尾から倍々にチャンクを広げて読む手口は `infrastructure/rpc/handlers/buffer.lua` の
+---`read_last_section` と同じ。マーカーの完全一致だけを見て、`parse_context` のあいまい
+---フォールバック（`context 150k` のような地の文にも一致しうる）は使わない — こちらは
+---「直近ターンの範囲内」という境界を持たないので、あいまい一致まで許すと本文の引用に
+---誤って反応しかねない
+---@param bufnr number
+---@return number? context_size
+local function read_context_size(bufnr)
+  local TokenUsage = require("vibing.core.utils.token_usage")
+  local total_lines = vim.api.nvim_buf_line_count(bufnr)
+  local chunk_size = 500
+
+  while true do
+    local from = math.max(0, total_lines - chunk_size)
+    local chunk = vim.api.nvim_buf_get_lines(bufnr, from, total_lines, false)
+
+    for i = #chunk, 1, -1 do
+      if chunk[i]:match("^###%s+Tokens") then
+        return TokenUsage.parse_context(chunk[i])
+      end
+    end
+
+    if from == 0 then
+      return nil
+    end
+    chunk_size = chunk_size * 2
+  end
+end
+
 ---生きているチャットバッファをすべて列挙する（MCP tool `nvim_chat_list`）
 ---
 ---1チャットずつ `nvim_get_buffer` を叩くとNチャットでN往復かかる（#692の実走ではPythonの
@@ -110,7 +147,6 @@ end
 function M.list_chats(_)
   local view = require("vibing.presentation.chat.view")
   local ChatStatus = require("vibing.presentation.chat.modules.chat_status")
-  local CacheExpiry = require("vibing.application.chat.cache_expiry")
 
   local buffers = view.list_chat_buffers()
   local bufnrs = {}
@@ -123,15 +159,12 @@ function M.list_chats(_)
   for _, bufnr in ipairs(bufnrs) do
     local chat_buf = buffers[bufnr]
     local frontmatter = chat_buf:parse_frontmatter()
-    -- ターンの内訳（accumulator）はターンが終わると捨てられるので、直近ターンのサイズは
-    -- 書かれた `### Tokens` 見出しから読み戻すしかない（`token_usage.lua` のコメント参照）
-    local _, context_size = CacheExpiry.read_last_turn(bufnr)
 
     table.insert(chats, {
       bufnr = bufnr,
       file_path = chat_buf.file_path,
       chat_status = ChatStatus.get(bufnr),
-      context_size = context_size,
+      context_size = read_context_size(bufnr),
       updated_at = frontmatter.updated_at,
       orchestrated_by = chat_buf:get_frontmatter_list("orchestrated_by"),
       -- #692 3.8がfrontmatterに書くようになるまでは常にnil。防御的に読むだけにしておけば、

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -100,4 +100,48 @@ function M.answer_approval(params)
   })
 end
 
+---生きているチャットバッファをすべて列挙する（MCP tool `nvim_chat_list`）
+---
+---1チャットずつ `nvim_get_buffer` を叩くとNチャットでN往復かかる（#692の実走ではPythonの
+---RPCポーラーで迂回した）。列挙元は `view.list_chat_buffers()` 一択 — 「いま何本開いているか」
+---を知る手段はそれしかない（`application/chat/concurrency.lua` も同じものを読む）ので、
+---閉じたまま残っているチャットファイルはここには載らない
+---@return {chats: {bufnr: number, file_path: string?, chat_status: string?, context_size: number?, updated_at: string?, orchestrated_by: string[], task: string?, assignment: string?}[]}
+function M.list_chats(_)
+  local view = require("vibing.presentation.chat.view")
+  local ChatStatus = require("vibing.presentation.chat.modules.chat_status")
+  local CacheExpiry = require("vibing.application.chat.cache_expiry")
+
+  local buffers = view.list_chat_buffers()
+  local bufnrs = {}
+  for bufnr in pairs(buffers) do
+    table.insert(bufnrs, bufnr)
+  end
+  table.sort(bufnrs)
+
+  local chats = {}
+  for _, bufnr in ipairs(bufnrs) do
+    local chat_buf = buffers[bufnr]
+    local frontmatter = chat_buf:parse_frontmatter()
+    -- ターンの内訳（accumulator）はターンが終わると捨てられるので、直近ターンのサイズは
+    -- 書かれた `### Tokens` 見出しから読み戻すしかない（`token_usage.lua` のコメント参照）
+    local _, context_size = CacheExpiry.read_last_turn(bufnr)
+
+    table.insert(chats, {
+      bufnr = bufnr,
+      file_path = chat_buf.file_path,
+      chat_status = ChatStatus.get(bufnr),
+      context_size = context_size,
+      updated_at = frontmatter.updated_at,
+      orchestrated_by = chat_buf:get_frontmatter_list("orchestrated_by"),
+      -- #692 3.8がfrontmatterに書くようになるまでは常にnil。防御的に読むだけにしておけば、
+      -- そちらが着地した時点でここは自動で値を持つ
+      task = frontmatter.task,
+      assignment = frontmatter.assignment,
+    })
+  end
+
+  return { chats = chats }
+end
+
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -57,6 +57,7 @@ M.send_message = message.send_message
 
 M.create_chat = chat.create_chat
 M.answer_approval = chat.answer_approval
+M.list_chats = chat.list_chats
 
 M.check_tool_permission = permission.check_tool_permission
 M.ask_user_question = permission.ask_user_question

--- a/tests/lua/infrastructure/rpc/handlers/chat_list_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/chat_list_spec.lua
@@ -53,6 +53,39 @@ describe("rpc handlers: list_chats", function()
     assert.is_nil(result.chats[1].context_size)
   end)
 
+  it("reads context_size back from a written ### Tokens marker", function()
+    local created = handler.create_chat({})
+    vim.api.nvim_buf_set_lines(created.bufnr, -1, -1, false, {
+      "### Tokens <!-- context=12345 -->",
+      "",
+      "context 12.3k · 1 request · read 10k · new 2k",
+    })
+
+    local result = handler.list_chats({})
+
+    assert.equals(12345, result.chats[1].context_size)
+  end)
+
+  it("finds the marker even when the first (smallest) tail chunk misses it", function()
+    -- The chunked backward scan (#711 review) starts at a 500-line tail and doubles until it
+    -- finds the marker or covers the whole buffer -- it must not stop after the first miss.
+    local created = handler.create_chat({})
+    vim.api.nvim_buf_set_lines(created.bufnr, -1, -1, false, {
+      "### Tokens <!-- context=99999 -->",
+      "",
+      "context 100k · 1 request · read 90k · new 10k",
+    })
+    local filler = {}
+    for i = 1, 600 do
+      filler[i] = "filler line " .. i
+    end
+    vim.api.nvim_buf_set_lines(created.bufnr, -1, -1, false, filler)
+
+    local result = handler.list_chats({})
+
+    assert.equals(99999, result.chats[1].context_size)
+  end)
+
   it("reports the updated_at frontmatter timestamp once something has written it", function()
     -- A bare create_chat() writes only vibing.nvim/session_id/created_at (renderer.lua) --
     -- updated_at is stamped the first time any field actually updates (frontmatter_handler.lua),

--- a/tests/lua/infrastructure/rpc/handlers/chat_list_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/chat_list_spec.lua
@@ -1,0 +1,99 @@
+-- Tests for the `list_chats` RPC method backing the nvim_chat_list MCP tool (#695).
+-- An orchestrator driving several worker chats otherwise has to poll each one individually with
+-- nvim_get_buffer -- N chats, N round trips (#692's postmortem worked around exactly this with a
+-- hand-rolled Python RPC poller). list_chats answers for all of them in one call.
+
+local ChatBuffers = require("tests.helpers.chat_buffers")
+
+describe("rpc handlers: list_chats", function()
+  local handler
+
+  before_each(function()
+    ChatBuffers.setup()
+    handler = require("vibing.infrastructure.rpc.handlers.chat")
+  end)
+
+  after_each(ChatBuffers.reset)
+
+  it("returns an empty list when no chat is open", function()
+    local result = handler.list_chats({})
+
+    assert.same({}, result.chats)
+  end)
+
+  it("lists every open chat with its bufnr and file_path", function()
+    local first = handler.create_chat({})
+    local second = handler.create_chat({})
+
+    local result = handler.list_chats({})
+
+    assert.equals(2, #result.chats)
+    local bufnrs = { result.chats[1].bufnr, result.chats[2].bufnr }
+    table.sort(bufnrs)
+    assert.same({ first.bufnr, second.bufnr }, bufnrs)
+    for _, chat in ipairs(result.chats) do
+      assert.is_true(chat.file_path == first.file_path or chat.file_path == second.file_path)
+    end
+  end)
+
+  it("reports a freshly created chat as idle", function()
+    local created = handler.create_chat({})
+
+    local result = handler.list_chats({})
+
+    assert.equals("idle", result.chats[1].chat_status)
+    assert.equals(created.bufnr, result.chats[1].bufnr)
+  end)
+
+  it("reports no context_size for a chat that has not completed a turn", function()
+    handler.create_chat({})
+
+    local result = handler.list_chats({})
+
+    assert.is_nil(result.chats[1].context_size)
+  end)
+
+  it("reports the updated_at frontmatter timestamp once something has written it", function()
+    -- A bare create_chat() writes only vibing.nvim/session_id/created_at (renderer.lua) --
+    -- updated_at is stamped the first time any field actually updates (frontmatter_handler.lua),
+    -- which linking an orchestrator does.
+    local orchestrator = handler.create_chat({})
+    local worker = handler.create_chat({ from_bufnr = orchestrator.bufnr })
+
+    local result = handler.list_chats({})
+
+    local worker_entry
+    for _, chat in ipairs(result.chats) do
+      if chat.bufnr == worker.bufnr then
+        worker_entry = chat
+      end
+    end
+
+    assert.is_string(worker_entry.updated_at)
+  end)
+
+  it("reports orchestrated_by for a worker chat created with from_bufnr", function()
+    local orchestrator = handler.create_chat({})
+    local worker = handler.create_chat({ from_bufnr = orchestrator.bufnr })
+
+    local result = handler.list_chats({})
+
+    local worker_entry
+    for _, chat in ipairs(result.chats) do
+      if chat.bufnr == worker.bufnr then
+        worker_entry = chat
+      end
+    end
+
+    assert.is_not_nil(worker_entry)
+    assert.equals(1, #worker_entry.orchestrated_by)
+  end)
+
+  it("reports an empty orchestrated_by list for a chat with no orchestrator", function()
+    handler.create_chat({})
+
+    local result = handler.list_chats({})
+
+    assert.same({}, result.chats[1].orchestrated_by)
+  end)
+end)


### PR DESCRIPTION
Polling N chats' status one at a time cost N nvim_get_buffer round trips
(#692's postmortem worked around this with a hand-rolled Python RPC
poller). nvim_chat_list reports every open chat's bufnr, file_path,
chat_status, context_size, updated_at and orchestrated_by in a single
call.

task/assignment are read defensively from frontmatter so the field
picks up a value automatically once #692's 3.8 starts writing them,
without another change to this tool.

Closes #695.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NawkDtuBBQJDDaJ53C4Kjz