### PR TITLE
fix(auto-resume): write one line to the chat when max_retries is exhausted

### DIFF
--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -16,6 +16,13 @@ Read the linked file before changing that path.
 - **Every field of the three rate-limit signals is optional.** None of the payload shapes is
   documented, so a schema change must degrade the feature, not break the stream.
 - Both features spend tokens unattended, so `auto_resume_on_limit.enabled` defaults to `false`.
+- **Giving up on the retry budget writes one line into the chat's own buffer, and that write is
+  not a send.** `auto_resume.announce_gave_up` edits the buffer directly and saves it; it must
+  never route through `ProgrammaticSender.send` / `ChatBuffer:send_message()`, which would start a
+  new CLI turn and spend tokens exactly where the budget exists to stop that. Forwarding the same
+  line to `orchestrated_by` is the one exception, and deliberately unconditional on
+  `chat_notifications.enabled`: a chat auto-resume gave up on will never resume itself, the same
+  "cannot leave this stop on its own" shape as `asked_question` / `waiting_approval` / `error`.
 
 ## Subagent Output Visibility
 

--- a/handbook/features/usage-limits.md
+++ b/handbook/features/usage-limits.md
@@ -21,6 +21,32 @@ limit hit, never overwriting an unsent `## User` message, and an 8-day sanity ce
 timestamp. Concurrently parked chats all fire at once by design. See `handbook/configuration.md` →
 "Auto-Resume on Usage Limit".
 
+### Giving Up
+
+Before #698, a chat whose retry budget ran out just vanished from `.vibing/pending-resume.json`
+with a `vim.notify` nobody was watching — the only way to learn why it had stopped was to go read
+that file by hand (#692's postmortem hit this in a live parallel run: a chat sat with an unsent
+message and no timer, and nothing in the buffer said so).
+
+Both places that give up (`on_rate_limited`'s normal gate, and `fire()`'s defence-in-depth check
+for a stale entry that outlives a restart) now call `auto_resume.announce_gave_up`, which:
+
+- Appends `> auto-resume: retry budget exhausted (max_retries=N). Not resuming automatically.`
+  directly into the chat's buffer, right before its trailing header, and saves the file. This is
+  **not** a new request — nothing here calls `ChatBuffer:send_message()`, since that would spend
+  a token exactly where the retry budget exists to stop that.
+- Reads the chat's `orchestrated_by` frontmatter and, for each entry, forwards the identical line
+  to that chat by path through `infrastructure/rpc/handlers/message.lua`'s `send_message`
+  (`from_bufnr` = the gave-up chat, `queue_if_busy = true`), the same function
+  `nvim_chat_send_message` uses. That forwarded delivery **does** start a turn on the orchestrator,
+  deliberately: a chat that has given up on its own resume will never restart itself, which is the
+  same "cannot leave this stop on its own" shape `completion_notifier` already delivers
+  unconditionally for `asked_question` / `waiting_approval` / `error` — gating it behind
+  `chat_notifications.enabled` would leave an orchestrated worker parked forever with nothing
+  saying so. A chat with no `orchestrated_by` entries only gets its own buffer line.
+- Fails soft per orchestrator: an unreachable parent path warns rather than raising, so one bad
+  entry does not stop the chat's own notice line from being written.
+
 **Implementation:** `application/chat/auto_resume.lua` (scheduler),
 `infrastructure/storage/pending_resume.lua` (persistence),
 `infrastructure/rpc/handlers/rate_limit.lua` (StopFailure receiver), `bin/hooks/stop-failure.sh`.

--- a/lua/vibing/application/chat/auto_resume.lua
+++ b/lua/vibing/application/chat/auto_resume.lua
@@ -173,8 +173,19 @@ end
 --- @param chat_file_path string
 --- @param max_retries number
 local function announce_gave_up(chat_file_path, max_retries)
-  local chat_buf = resolve_chat_buffer(chat_file_path)
+  local chat_buf, err = resolve_chat_buffer(chat_file_path)
   if not chat_buf then
+    -- The one place in this module that gave up silently before #698's own fix — a chat file
+    -- deleted out from under a parked entry, or a buffer that failed to attach, would otherwise
+    -- leave no notice anywhere, which is exactly the failure this function exists to remove.
+    vim.notify(
+      string.format(
+        "[vibing] Could not write the auto-resume give-up notice for %s: %s",
+        vim.fn.fnamemodify(chat_file_path, ":t"),
+        err
+      ),
+      vim.log.levels.WARN
+    )
     return
   end
 
@@ -185,7 +196,13 @@ local function announce_gave_up(chat_file_path, max_retries)
 
   local bufnr = chat_buf:get_buffer()
   append_gave_up_notice(bufnr, message)
-  require("vibing.presentation.chat.modules.file_manager").save_buffer(bufnr)
+  local saved, save_err = require("vibing.presentation.chat.modules.file_manager").save_buffer(bufnr)
+  if not saved then
+    vim.notify(
+      string.format("[vibing] Auto-resume give-up notice written but not saved: %s", save_err),
+      vim.log.levels.WARN
+    )
+  end
 
   local parents = chat_buf:get_frontmatter_list("orchestrated_by")
   if not parents or #parents == 0 then

--- a/lua/vibing/application/chat/auto_resume.lua
+++ b/lua/vibing/application/chat/auto_resume.lua
@@ -140,6 +140,75 @@ local function trim_empty_trailing_user_section(bufnr)
   vim.api.nvim_buf_set_lines(bufnr, header_idx - 1, -1, false, {})
 end
 
+--- Append one line noting that auto-resume gave up, placed right before the trailing header so
+--- whatever that section already holds (an empty draft, or a parked continuation) is untouched.
+--- Not a new request: this only edits the buffer text, since starting a turn here would be
+--- exactly the unattended token spend the retry budget exists to bound (#698).
+--- @param bufnr number
+--- @param text string
+local function append_gave_up_notice(bufnr, text)
+  local Timestamp = require("vibing.core.utils.timestamp")
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+  local header_idx = nil
+  for i = #lines, 1, -1 do
+    if Timestamp.is_header(lines[i]) then
+      header_idx = i
+      break
+    end
+  end
+
+  local insert_at = header_idx and (header_idx - 1) or #lines
+  vim.api.nvim_buf_set_lines(bufnr, insert_at, insert_at, false, { "", text, "" })
+end
+
+--- Tell a chat, and its orchestrator if it has one, that auto-resume gave up on it (#698).
+---
+--- The chat's own line is the buffer edit above, not a new request. The orchestrator side does
+--- start a turn on it, and deliberately so: a chat auto-resume has given up on will never resume
+--- itself, which is the same "cannot leave this stop on its own" shape `completion_notifier`
+--- already delivers unconditionally for `asked_question` / `waiting_approval` / `error` — holding
+--- it behind `chat_notifications.enabled` would leave an orchestrated worker parked forever with
+--- nothing saying so.
+--- @param chat_file_path string
+--- @param max_retries number
+local function announce_gave_up(chat_file_path, max_retries)
+  local chat_buf = resolve_chat_buffer(chat_file_path)
+  if not chat_buf then
+    return
+  end
+
+  local message = string.format(
+    "> auto-resume: retry budget exhausted (max_retries=%d). Not resuming automatically.",
+    max_retries
+  )
+
+  local bufnr = chat_buf:get_buffer()
+  append_gave_up_notice(bufnr, message)
+  require("vibing.presentation.chat.modules.file_manager").save_buffer(bufnr)
+
+  local parents = chat_buf:get_frontmatter_list("orchestrated_by")
+  if not parents or #parents == 0 then
+    return
+  end
+
+  local MessageHandler = require("vibing.infrastructure.rpc.handlers.message")
+  for _, parent_path in ipairs(parents) do
+    local ok, err = pcall(MessageHandler.send_message, {
+      file_path = parent_path,
+      message = message,
+      from_bufnr = bufnr,
+      queue_if_busy = true,
+    })
+    if not ok then
+      vim.notify(
+        string.format("[vibing] Could not notify orchestrator %s: %s", parent_path, tostring(err)),
+        vim.log.levels.WARN
+      )
+    end
+  end
+end
+
 --- Whether a due scheduled request should actually go out.
 --- Split from fire_scheduled so the rules are testable without a live chat buffer.
 --- @param body string|nil The chat's unsent `## User` body
@@ -255,6 +324,7 @@ local function fire(chat_file_path, entry)
   -- here straight from restore(), which never consults it.
   if (current.retry_count or 0) >= (opts.max_retries or 1) then
     PendingResume.remove(chat_file_path)
+    announce_gave_up(chat_file_path, opts.max_retries or 1)
     return
   end
 
@@ -484,6 +554,7 @@ function M.on_rate_limited(chat_file_path, info)
       ),
       vim.log.levels.WARN
     )
+    announce_gave_up(chat_file_path, max_retries)
     return
   end
 

--- a/tests/lua/application/chat/auto_resume_spec.lua
+++ b/tests/lua/application/chat/auto_resume_spec.lua
@@ -322,6 +322,66 @@ describe("auto_resume", function()
       assert.equals(1, #calls)
       assert.equals("parent.md", calls[1].file_path)
     end)
+
+    it("writes its own line via fire() too when it has no orchestrator to tell", function()
+      -- The "no orchestrator" case above only exercised on_rate_limited(). announce_gave_up is a
+      -- function shared by both give-up paths, but sharing it is not itself a test: this pins
+      -- fire()'s own defence-in-depth branch reaches the no-parents early return too.
+      local worker_bufnr, worker_path = open_chat("stale-solo.md", {})
+
+      local entry = {
+        chat_file_path = worker_path,
+        resets_at = os.time() - 10,
+        retry_count = 1,
+        recorded_at = os.time(),
+        state = "waiting",
+      }
+      PendingResume.put(entry)
+
+      assert.has_no.errors(function()
+        AutoResume._fire(worker_path, entry)
+      end)
+
+      local lines = vim.api.nvim_buf_get_lines(worker_bufnr, 0, -1, false)
+      assert.is_true(
+        vim.tbl_contains(lines, EXPECTED_MESSAGE),
+        "expected the notice line from fire() with no orchestrator; got: " .. vim.inspect(lines)
+      )
+    end)
+
+    it("warns, rather than silently doing nothing, when the chat buffer cannot be resolved", function()
+      -- Regression guard for the review finding on #713: resolve_chat_buffer's error reason used
+      -- to be discarded here, which reproduced the exact "gave up and nobody was told" failure
+      -- #698 exists to fix — just one layer further in, for a chat file deleted out from under a
+      -- parked entry.
+      local missing_path = dir .. "/does-not-exist.md"
+      PendingResume.put({
+        chat_file_path = missing_path,
+        resets_at = os.time() + 60,
+        retry_count = 1,
+        recorded_at = os.time(),
+        state = "in_flight",
+      })
+
+      local original_notify = vim.notify
+      local messages = {}
+      vim.notify = function(msg, ...)
+        table.insert(messages, msg)
+      end
+
+      local ok, err =
+        pcall(AutoResume.on_rate_limited, missing_path, { rejected = true, resets_at = os.time() + 3600, source = "test" })
+      vim.notify = original_notify
+      assert.is_true(ok, err)
+
+      local found = false
+      for _, msg in ipairs(messages) do
+        if msg:match("Could not write the auto%-resume give%-up notice") then
+          found = true
+        end
+      end
+      assert.is_true(found, "expected a warning naming the unresolved chat; got: " .. vim.inspect(messages))
+    end)
   end)
 
   describe("format_duration", function()

--- a/tests/lua/application/chat/auto_resume_spec.lua
+++ b/tests/lua/application/chat/auto_resume_spec.lua
@@ -175,6 +175,155 @@ describe("auto_resume", function()
     end)
   end)
 
+  describe("announce_gave_up (#698)", function()
+    local AutoResume = require("vibing.application.chat.auto_resume")
+    local Config = require("vibing.config")
+    local ChatFiles = require("tests.helpers.chat_files")
+    local view = require("vibing.presentation.chat.view")
+    local original_get
+    local original_send_message
+    local dir
+    local buffers
+
+    local EXPECTED_MESSAGE = "> auto-resume: retry budget exhausted (max_retries=1). Not resuming automatically."
+
+    ---@param name string
+    ---@param frontmatter table?
+    ---@return number bufnr
+    ---@return string path
+    local function open_chat(name, frontmatter)
+      local path = ChatFiles.write(dir, name, frontmatter)
+      local bufnr = vim.fn.bufadd(path)
+      vim.fn.bufload(bufnr)
+      if not view.get_chat_buffer(bufnr) then
+        view.attach_to_buffer(bufnr, path)
+      end
+      table.insert(buffers, bufnr)
+      return bufnr, path
+    end
+
+    before_each(function()
+      original_get = Config.get
+      Config.get = function()
+        return { agent = { auto_resume_on_limit = { enabled = true, max_retries = 1 } } }
+      end
+
+      -- Symlink-resolved, matching the pattern orchestration_link_spec.lua uses: nvim_buf_get_name
+      -- returns a resolved path, and comparing against an unresolved tempname would leave
+      -- vim.fn.bufnr(chat_file_path) unable to find the buffer this test just opened.
+      dir = vim.fn.resolve(vim.fn.tempname())
+      vim.fn.mkdir(dir, "p")
+      buffers = {}
+      original_send_message = nil
+    end)
+
+    after_each(function()
+      Config.get = original_get
+      if original_send_message then
+        require("vibing.infrastructure.rpc.handlers.message").send_message = original_send_message
+      end
+      for _, bufnr in ipairs(buffers) do
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          vim.api.nvim_buf_delete(bufnr, { force = true })
+        end
+      end
+      vim.fn.delete(dir, "rf")
+    end)
+
+    it("appends one line to the chat and forwards it to the orchestrator", function()
+      local worker_bufnr, worker_path = open_chat("worker.md", { orchestrated_by = { "parent.md" } })
+
+      PendingResume.put({
+        chat_file_path = worker_path,
+        resets_at = os.time() + 60,
+        retry_count = 1,
+        recorded_at = os.time(),
+        state = "in_flight",
+      })
+
+      -- Stubbed rather than exercised for real: a real send would spawn the `claude` CLI. What
+      -- this test owns is that auto_resume asks the right module for the right delivery, not
+      -- whether that module can actually deliver it (message_handler_spec.lua covers that).
+      local MessageHandler = require("vibing.infrastructure.rpc.handlers.message")
+      original_send_message = MessageHandler.send_message
+      local calls = {}
+      MessageHandler.send_message = function(params)
+        table.insert(calls, params)
+        return { success = true, bufnr = 0 }
+      end
+
+      AutoResume.on_rate_limited(worker_path, { rejected = true, resets_at = os.time() + 3600, source = "test" })
+
+      local lines = vim.api.nvim_buf_get_lines(worker_bufnr, 0, -1, false)
+      assert.is_true(
+        vim.tbl_contains(lines, EXPECTED_MESSAGE),
+        "expected the notice line in the worker buffer; got: " .. vim.inspect(lines)
+      )
+      assert.is_false(vim.bo[worker_bufnr].modified, "the notice must be saved to disk, not left as an edit")
+
+      assert.equals(1, #calls)
+      assert.equals("parent.md", calls[1].file_path)
+      assert.equals(EXPECTED_MESSAGE, calls[1].message)
+      assert.equals(worker_bufnr, calls[1].from_bufnr)
+      assert.is_true(calls[1].queue_if_busy)
+    end)
+
+    it("writes its own line even when it has no orchestrator to tell", function()
+      local worker_bufnr, worker_path = open_chat("solo.md", {})
+
+      PendingResume.put({
+        chat_file_path = worker_path,
+        resets_at = os.time() + 60,
+        retry_count = 1,
+        recorded_at = os.time(),
+        state = "in_flight",
+      })
+
+      assert.has_no.errors(function()
+        AutoResume.on_rate_limited(worker_path, { rejected = true, resets_at = os.time() + 3600, source = "test" })
+      end)
+
+      local lines = vim.api.nvim_buf_get_lines(worker_bufnr, 0, -1, false)
+      assert.is_true(
+        vim.tbl_contains(lines, EXPECTED_MESSAGE),
+        "expected the notice line even with no orchestrator; got: " .. vim.inspect(lines)
+      )
+    end)
+
+    it("also fires from fire()'s defence-in-depth budget check", function()
+      -- The usual gate is on_rate_limited(); this covers the second guard inside fire(), reached
+      -- when a stale entry outlives a restart (M._fire is the documented test seam for it).
+      local worker_bufnr, worker_path = open_chat("stale.md", { orchestrated_by = { "parent.md" } })
+
+      local MessageHandler = require("vibing.infrastructure.rpc.handlers.message")
+      original_send_message = MessageHandler.send_message
+      local calls = {}
+      MessageHandler.send_message = function(params)
+        table.insert(calls, params)
+        return { success = true, bufnr = 0 }
+      end
+
+      local entry = {
+        chat_file_path = worker_path,
+        resets_at = os.time() - 10,
+        retry_count = 1,
+        recorded_at = os.time(),
+        state = "waiting",
+      }
+      PendingResume.put(entry)
+
+      AutoResume._fire(worker_path, entry)
+
+      local lines = vim.api.nvim_buf_get_lines(worker_bufnr, 0, -1, false)
+      assert.is_true(
+        vim.tbl_contains(lines, EXPECTED_MESSAGE),
+        "expected the notice line from fire()'s own budget check; got: " .. vim.inspect(lines)
+      )
+      assert.equals(1, #calls)
+      assert.equals("parent.md", calls[1].file_path)
+    end)
+  end)
+
   describe("format_duration", function()
     local AutoResume = require("vibing.application.chat.auto_resume")
 


### PR DESCRIPTION
A chat whose retry budget ran out used to just vanish from
pending-resume.json with a vim.notify nobody was watching, leaving an
unsent message parked with no timer and nothing in the buffer saying
why. Both give-up paths (on_rate_limited's normal gate and fire()'s
defence-in-depth check for a stale entry) now append a one-line notice
directly into the chat's buffer, and forward the same line to its
orchestrator if it has one, via the existing send_message path.

Closes #698

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FUN4Q3cHkpiqwYxZzogCnf