### PR TITLE
Replace @claude-mention issue trigger with claude:in-progress label

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   claude-review:
-    # Only run when shabaraba attaches the "review" label to the PR
-    if: github.event.label.name == 'review' && github.event.sender.login == 'shabaraba'
+    # Only run when shabaraba attaches the "claude:in-review" label to the PR
+    if: github.event.label.name == 'claude:in-review' && github.event.sender.login == 'shabaraba'
 
     runs-on: ubuntu-latest
     permissions:
@@ -54,9 +54,9 @@ jobs:
             Post the ENTIRE review as a SINGLE PR comment: call `gh pr comment` exactly once.
             Do not split the review across multiple comments.
 
-            After the comment is posted, remove the "review" label so this workflow does not
-            fire again until it is re-attached:
-            gh pr edit ${{ github.event.pull_request.number }} --remove-label review
+            After the comment is posted, remove the "claude:in-review" label so this workflow does
+            not fire again until it is re-attached:
+            gh pr edit ${{ github.event.pull_request.number }} --remove-label "claude:in-review"
 
             IMPORTANT: All prose MUST be in Japanese. Keep the priority headings themselves in
             English (Critical/High/Medium/Low) so they match the repository's priority scheme.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,12 +54,24 @@ jobs:
             Post the ENTIRE review as a SINGLE PR comment: call `gh pr comment` exactly once.
             Do not split the review across multiple comments.
 
-            After the comment is posted, remove the "claude:in-review" label so this workflow does
-            not fire again until it is re-attached:
-            gh pr edit ${{ github.event.pull_request.number }} --remove-label "claude:in-review"
-
             IMPORTANT: All prose MUST be in Japanese. Keep the priority headings themselves in
             English (Critical/High/Medium/Low) so they match the repository's priority scheme.
 
-          # Minimum required tools for code review + removing the trigger label
-          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr edit:*)"'
+          # Minimum required tools for code review; label transitions are handled by the workflow
+          # step below, not by Claude, so no gh-edit access is needed here.
+          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
+
+      # Runs regardless of whether the step above succeeded, so a crashed or timed-out run still
+      # gets reflected on the PR instead of leaving "claude:in-review" stuck forever.
+      - name: Reflect the run outcome on the PR label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ steps.claude-review.outcome }}" = "success" ] && [ "${{ steps.claude-review.outputs.conclusion }}" = "success" ]; then
+            gh pr edit "${{ github.event.pull_request.number }}" -R "${{ github.repository }}" \
+              --remove-label "claude:in-review"
+          else
+            gh pr edit "${{ github.event.pull_request.number }}" -R "${{ github.repository }}" \
+              --remove-label "claude:in-review" --add-label "claude:failed"
+          fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,7 +49,6 @@ jobs:
             EVENT_TYPE: ${{ github.event_name }}
             ISSUE_NUMBER: ${{ github.event.issue.number }}
             PR_NUMBER: ${{ github.event.pull_request.number }}
-            LABEL_NAME: ${{ github.event.label.name }}
 
             ## FIRST STEP: Gather Context
             Before starting any work, you MUST gather complete context by running the appropriate commands:
@@ -76,15 +75,24 @@ jobs:
                - Create a descriptive PR title in English using semantic commit format
                - Write the PR body in Japanese with clear description of changes
                - Include "fixes #<issue-number>" if there's a related issue
-            5. If EVENT_TYPE is "issues" (LABEL_NAME is set), remove the triggering label from the
-               issue once you are done — whether you succeeded in opening a PR or have to stop and
-               report a blocker instead — so the label stops showing the issue as being processed:
-               ```bash
-               gh issue edit $ISSUE_NUMBER --remove-label "$LABEL_NAME"
-               ```
 
           # Allow file operations and git/gh commands for implementation tasks
           claude_args: '--allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"'
 
           # Show full output for debugging
           show_full_output: true
+
+      # Runs regardless of whether the step above succeeded, so a crashed or timed-out run still
+      # gets reflected on the issue instead of leaving "claude:in-progress" stuck forever.
+      - name: Reflect the run outcome on the issue label
+        if: always() && github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ steps.claude.outcome }}" = "success" ] && [ "${{ steps.claude.outputs.conclusion }}" = "success" ]; then
+            gh issue edit "${{ github.event.issue.number }}" -R "${{ github.repository }}" \
+              --remove-label "claude:in-progress"
+          else
+            gh issue edit "${{ github.event.issue.number }}" -R "${{ github.repository }}" \
+              --remove-label "claude:in-progress" --add-label "claude:failed"
+          fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve the issue/PR number for this thread
+        id: thread
+        run: |
+          echo "number=${{ github.event.issue.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      # Finds the session_id this same job stored in a previous run on this thread (see
+      # "Persist the session id" below), so a follow-up "@claude ..." comment continues that
+      # conversation with --resume instead of starting from a blank one every time. Only a
+      # marker posted by this workflow's own token counts, so a comment from anyone else cannot
+      # forge one and redirect --resume at an unrelated session.
+      - name: Look up a previous Claude session for this thread
+        id: lookup-session
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # --paginate concatenates one JSON array per page to stdout; -s (slurp) folds all of
+          # those into one array-of-arrays so `.[][]` and `last` see every page as a single list
+          # instead of picking the last match of whichever page happened to contain one.
+          SESSION_ID="$(gh api "repos/${{ github.repository }}/issues/${{ steps.thread.outputs.number }}/comments" --paginate \
+            | jq -sr '[.[][] | select(.user.login == "github-actions[bot]" and (.body | test("<!-- claude-session-id: ")))] | (last // {}) | .body // empty' \
+            | sed -n 's/.*<!-- claude-session-id: \([a-zA-Z0-9_-]*\) -->.*/\1/p')"
+          echo "session_id=$SESSION_ID" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         id: claude
         # Pin to specific commit SHA for security (v1.0.216)
@@ -76,8 +99,11 @@ jobs:
                - Write the PR body in Japanese with clear description of changes
                - Include "fixes #<issue-number>" if there's a related issue
 
-          # Allow file operations and git/gh commands for implementation tasks
-          claude_args: '--allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"'
+          # Allow file operations and git/gh commands for implementation tasks. --resume is
+          # appended when lookup-session found a prior session_id for this thread.
+          claude_args: >-
+            --allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"
+            ${{ steps.lookup-session.outputs.session_id != '' && format('--resume {0}', steps.lookup-session.outputs.session_id) || '' }}
 
           # Show full output for debugging
           show_full_output: true
@@ -95,4 +121,17 @@ jobs:
           else
             gh issue edit "${{ github.event.issue.number }}" -R "${{ github.repository }}" \
               --remove-label "claude:in-progress" --add-label "claude:failed"
+          fi
+
+      # Runs regardless of outcome: a failed run can still be worth resuming from where it
+      # stopped, and this is what "Look up a previous Claude session" reads back next time.
+      - name: Persist the session id for future --resume
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SESSION_ID="${{ steps.claude.outputs.session_id }}"
+          if [ -n "$SESSION_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/${{ steps.thread.outputs.number }}/comments" \
+              -f body="<!-- claude-session-id: ${SESSION_ID} -->" >/dev/null
           fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened]
+    types: [labeled]
   pull_request_review:
     types: [submitted]
 
@@ -18,7 +18,7 @@ jobs:
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issues' && github.event.label.name == 'claude:in-progress')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -49,6 +49,7 @@ jobs:
             EVENT_TYPE: ${{ github.event_name }}
             ISSUE_NUMBER: ${{ github.event.issue.number }}
             PR_NUMBER: ${{ github.event.pull_request.number }}
+            LABEL_NAME: ${{ github.event.label.name }}
 
             ## FIRST STEP: Gather Context
             Before starting any work, you MUST gather complete context by running the appropriate commands:
@@ -75,6 +76,12 @@ jobs:
                - Create a descriptive PR title in English using semantic commit format
                - Write the PR body in Japanese with clear description of changes
                - Include "fixes #<issue-number>" if there's a related issue
+            5. If EVENT_TYPE is "issues" (LABEL_NAME is set), remove the triggering label from the
+               issue once you are done — whether you succeeded in opening a PR or have to stop and
+               report a blocker instead — so the label stops showing the issue as being processed:
+               ```bash
+               gh issue edit $ISSUE_NUMBER --remove-label "$LABEL_NAME"
+               ```
 
           # Allow file operations and git/gh commands for implementation tasks
           claude_args: '--allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"'


### PR DESCRIPTION
Attaching the "claude:in-progress" label to an issue now kicks off the
same full-development job (context gathering, implementation, PR
creation) that previously required "@claude" in the issue title or
body. The label is removed once the run finishes, whether it opened a
PR or had to stop and report a blocker, so its presence always reflects
whether Claude is currently working the issue.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MNw4ZqnBuiP1Caje84Jbcu