### PR TITLE
fix(queue): persist message_queue and never silently drop it (#697)

### DIFF
--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -12,10 +12,15 @@
 ---- 通知 — 「あのチャットが止まった、読みに行け」（`completion_notifier` の watchdog）
 ---- 本文 — 送信元のテキストそのもの（`nvim_chat_send_message` の `queue_if_busy`）
 ---
----キューは**インメモリのみ**。Neovim が落ちればワーカーチャットも道連れなので、永続化に意味がない。
+---生きた待ち合わせはインメモリの `pending` が唯一の実体。ただし宛先が使用量リミットで
+---数時間パークされている間（`pending_resume.lua` が前提にしている状況そのもの）に Neovim が
+---再起動されると、このテーブルは道連れで消える。`message_queue_store` へは変更のたびに
+---書き出し、`M.restore()` が起動時にそこから作り直す — キューが「待てば解ける」契約を
+---Neovim の寿命ではなく相手チャットの寿命に合わせるための、後付けの複製でしかない
 local M = {}
 
 local notify = require("vibing.core.utils.notify")
+local Store = require("vibing.infrastructure.storage.message_queue_store")
 
 ---1バッファに溜められる上限。超えたら**捨てずに拒否する**: 捨てると報告が黙って消え、
 ---それはこのモジュールが防ぐために存在しているものそのものになる
@@ -34,6 +39,71 @@ local WARN_TITLE = "Chat Delivery"
 ---@type table<number, Vibing.Application.MessageQueue.Item[]>
 local pending = {}
 
+---@param bufnr number?
+---@return string?
+local function file_path_of(bufnr)
+  if not (type(bufnr) == "number" and vim.api.nvim_buf_is_valid(bufnr)) then
+    return nil
+  end
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  return name ~= "" and name or nil
+end
+
+---`to_bufnr` のキューをディスクに書く（空/nilなら消す）
+---
+---宛先に名前が無ければ書けない（再起動後に開き直す先が無い）。それは即配達できるチャット
+---（`:VibingChat` で作った直後、まだ保存前）が普通に持つ状態なので、警告はしない
+---@param to_bufnr number
+local function persist(to_bufnr)
+  local to_path = file_path_of(to_bufnr)
+  if not to_path then
+    return
+  end
+
+  local queue = pending[to_bufnr]
+  if not queue or #queue == 0 then
+    Store.put(to_path, nil)
+    return
+  end
+
+  local items = {}
+  for _, item in ipairs(queue) do
+    table.insert(items, { body = item.body, reason = item.reason, from_file_path = file_path_of(item.bufnr) })
+  end
+  Store.put(to_path, items)
+end
+
+---ファイルパスから、この Neovim の中でのバッファ番号を取り戻す
+---
+---`resolve_chat_buffer`（`auto_resume.lua`）と同じ手順: 開いていなければ読み込み、
+---chat buffer として登録されていなければ attach する。宛先の解決に失敗したら復元自体を諦めるが、
+---送信元の解決に失敗しても本文は届けられる（`forget` が送信元を落とすのと同じ扱いで、
+---呼び出し側が nil を匿名として受け取る）
+---@param file_path string
+---@return number? bufnr
+local function resolve_bufnr(file_path)
+  if vim.fn.filereadable(file_path) == 0 then
+    return nil
+  end
+
+  local bufnr = vim.fn.bufnr(file_path)
+  if bufnr == -1 then
+    local ok, added = pcall(vim.fn.bufadd, file_path)
+    if not ok or not added or added == 0 then
+      return nil
+    end
+    bufnr = added
+  end
+  pcall(vim.fn.bufload, bufnr)
+
+  local view = require("vibing.presentation.chat.view")
+  if not view.get_chat_buffer(bufnr) then
+    pcall(view.attach_to_buffer, bufnr, file_path)
+  end
+
+  return vim.api.nvim_buf_is_valid(bufnr) and bufnr or nil
+end
+
 ---@param to_bufnr number
 ---@param predicate fun(item: Vibing.Application.MessageQueue.Item): boolean
 local function remove_where(to_bufnr, predicate)
@@ -51,6 +121,7 @@ local function remove_where(to_bufnr, predicate)
   if #queue == 0 then
     pending[to_bufnr] = nil
   end
+  persist(to_bufnr)
 end
 
 ---配達される本文について、オーケストレーション関係を frontmatter に書く
@@ -88,6 +159,7 @@ function M.enqueue_notification(to_bufnr, done_bufnr, reason)
   for _, item in ipairs(queue) do
     if not item.body and item.bufnr == done_bufnr then
       item.reason = reason or item.reason
+      persist(to_bufnr)
       return
     end
   end
@@ -108,6 +180,7 @@ function M.enqueue_notification(to_bufnr, done_bufnr, reason)
 
   table.insert(queue, { bufnr = done_bufnr, reason = reason })
   pending[to_bufnr] = queue
+  persist(to_bufnr)
 end
 
 ---本文を積む
@@ -136,6 +209,7 @@ function M.enqueue_message(to_bufnr, from_bufnr, body)
 
   table.insert(queue, { bufnr = from_bufnr, body = body })
   pending[to_bufnr] = queue
+  persist(to_bufnr)
   return true
 end
 
@@ -179,13 +253,29 @@ function M.flush(to_bufnr)
   end
 
   if not vim.api.nvim_buf_is_valid(to_bufnr) then
+    -- 通常はここより先に `BufDelete`/`BufWipeout` の `forget` がキューごと落としている。
+    -- それでも到達したなら想定外の消え方なので、他の上限落ちと同じく黙らせない
+    notify.warn(
+      string.format("Chat %d vanished without a BufDelete event; dropping %d queued item(s) for it", to_bufnr, #queue),
+      WARN_TITLE
+    )
     pending[to_bufnr] = nil
+    persist(to_bufnr)
     return false
   end
 
   local chat_buf = require("vibing.presentation.chat.view").get_chat_buffer(to_bufnr)
   if not chat_buf then
+    notify.warn(
+      string.format(
+        "Chat %d is not a tracked chat buffer; dropping %d queued item(s) for it",
+        to_bufnr,
+        #queue
+      ),
+      WARN_TITLE
+    )
     pending[to_bufnr] = nil
+    persist(to_bufnr)
     return false
   end
 
@@ -225,6 +315,7 @@ function M.flush(to_bufnr)
   -- 失敗した配達は二度と再現しない。残しておけば次の完了イベントで作り直しなしに再試行できる
   if ok and result and result.success then
     pending[to_bufnr] = nil
+    persist(to_bufnr)
 
     -- 送信が受理されたことと、ターンが始まったことは別。`ChatBuffer:send_message()` が返すのは
     -- 「リクエストとして扱ったか」で、リミット中の予約（`_try_schedule_instead_of_send`）でも、
@@ -261,7 +352,14 @@ function M.forget(bufnr)
     return
   end
 
+  -- パスは消える前につかむ。`BufWipeout` まで進んだあとでは名前が取れず、そうなると
+  -- ディスク上の実体だけが取り残されて次回起動で作り直る（実害は小さい: チャットファイル
+  -- 自体は消えていないので、単にこのバッファを閉じた事実より1つ古い状態が復元されるだけ）
+  local forgotten_path = file_path_of(bufnr)
   pending[bufnr] = nil
+  if forgotten_path then
+    Store.put(forgotten_path, nil)
+  end
 
   for to_bufnr, queue in pairs(pending) do
     for _, item in ipairs(queue) do
@@ -270,9 +368,54 @@ function M.forget(bufnr)
       end
     end
 
+    -- `item.bufnr` の匿名化も含めて、この時点の queue をまとめてディスクに書き直す
+    -- （`remove_where` 自身が persist する）
     remove_where(to_bufnr, function(item)
       return not item.body and item.bufnr == bufnr
     end)
+  end
+end
+
+---再起動を跨いで残っていた配達待ちを、いま開いているプロジェクトぶん読み込み直す
+---
+---宛先だけを見る。積んだ本文の送信元が復元できなくても本文そのものは届けられる（`forget` が
+---送信元だけ匿名化するのと同じ理由）が、宛先が復元できないキューは配る場所が無いので諦める。
+---
+---復元した宛先はこの時点でまだ何のターンも走っていないので、その場で `flush` を試す。
+---ためておいて次の完了イベントを待つだけだと、再起動直後に誰の完了イベントも来なければ
+---二度と試されない
+---@param cwd string? テスト用。省略時は現在のプロジェクト（`pending_resume.lua` の enumerate 系と同じ）
+function M.restore(cwd)
+  local entries = Store.load(cwd)
+  if next(entries) == nil then
+    return
+  end
+
+  local restored = {}
+  for to_path, items in pairs(entries) do
+    if type(items) == "table" and #items > 0 then
+      local to_bufnr = resolve_bufnr(to_path)
+      if to_bufnr then
+        local queue = {}
+        for _, stored in ipairs(items) do
+          if type(stored) == "table" then
+            table.insert(queue, {
+              bufnr = stored.from_file_path and resolve_bufnr(stored.from_file_path) or nil,
+              body = stored.body,
+              reason = stored.reason,
+            })
+          end
+        end
+        if #queue > 0 then
+          pending[to_bufnr] = queue
+          table.insert(restored, to_bufnr)
+        end
+      end
+    end
+  end
+
+  for _, to_bufnr in ipairs(restored) do
+    M.flush(to_bufnr)
   end
 end
 

--- a/lua/vibing/application/chat/message_queue.lua
+++ b/lua/vibing/application/chat/message_queue.lua
@@ -98,7 +98,15 @@ local function resolve_bufnr(file_path)
 
   local view = require("vibing.presentation.chat.view")
   if not view.get_chat_buffer(bufnr) then
-    pcall(view.attach_to_buffer, bufnr, file_path)
+    -- 戻り値を見ないと、attach が失敗した（壊れた frontmatter で parse が例外を投げた等）
+    -- バッファも「解決できた」ことになる。呼び出し元の `restore()` はそれを配達可能と誤認し、
+    -- 直後の `flush()` が「追跡されていないチャットバッファ」に落ちて警告つきでキューを
+    -- 消す — 本来は「今回は無理だったので次回また試す」であるべき場面で、実際にディスク上の
+    -- エントリまで失う
+    local ok, attached = pcall(view.attach_to_buffer, bufnr, file_path)
+    if not ok or not attached then
+      return nil
+    end
   end
 
   return vim.api.nvim_buf_is_valid(bufnr) and bufnr or nil
@@ -379,7 +387,16 @@ end
 ---再起動を跨いで残っていた配達待ちを、いま開いているプロジェクトぶん読み込み直す
 ---
 ---宛先だけを見る。積んだ本文の送信元が復元できなくても本文そのものは届けられる（`forget` が
----送信元だけ匿名化するのと同じ理由）が、宛先が復元できないキューは配る場所が無いので諦める。
+---送信元だけ匿名化するのと同じ理由）が、宛先が復元できないキューは配る場所が無いので諦める —
+---そのチャットファイルごと消えている（削除・リネーム）なら、次回起動でも変わらないので
+---ディスクからも落とす。attach 失敗などの一時的な理由（`resolve_bufnr` 参照）とは区別する。
+---
+---**通知アイテムは送信元の匿名化ができない。** `bufnr` は本文では「送信元」（無くても配達できる）
+---だが、通知では「止まったチャット」そのものを指す必須フィールド（`enqueue_notification` 参照）。
+---解決できないまま `bufnr = nil` で積むと、`delivery_message.lua` がそれを表示しようとして
+---`vim.api.nvim_buf_is_valid(nil)` 等で失敗し、`flush` は毎回失敗として扱う——同じ宛先に
+---積まれた他のメッセージ・通知まで巻き込んで二度と配れなくなる。解決できない通知はここで
+---捨てる（`forget` が消えた相手の通知を捨てるのと同じ扱い）。
 ---
 ---復元した宛先はこの時点でまだ何のターンも走っていないので、その場で `flush` を試す。
 ---ためておいて次の完了イベントを待つだけだと、再起動直後に誰の完了イベントも来なければ
@@ -399,17 +416,25 @@ function M.restore(cwd)
         local queue = {}
         for _, stored in ipairs(items) do
           if type(stored) == "table" then
-            table.insert(queue, {
-              bufnr = stored.from_file_path and resolve_bufnr(stored.from_file_path) or nil,
-              body = stored.body,
-              reason = stored.reason,
-            })
+            if stored.body then
+              table.insert(queue, {
+                bufnr = stored.from_file_path and resolve_bufnr(stored.from_file_path) or nil,
+                body = stored.body,
+              })
+            else
+              local about_bufnr = stored.from_file_path and resolve_bufnr(stored.from_file_path) or nil
+              if about_bufnr then
+                table.insert(queue, { bufnr = about_bufnr, reason = stored.reason })
+              end
+            end
           end
         end
         if #queue > 0 then
           pending[to_bufnr] = queue
           table.insert(restored, to_bufnr)
         end
+      elseif vim.fn.filereadable(to_path) == 0 then
+        Store.put(to_path, nil, cwd)
       end
     end
   end

--- a/lua/vibing/infrastructure/storage/message_queue_store.lua
+++ b/lua/vibing/infrastructure/storage/message_queue_store.lua
@@ -54,15 +54,6 @@ function M.get_path(cwd)
   return root .. "/.vibing/message-queue.json"
 end
 
---- Resolve the store that owns a given chat file — same anchoring reason as
---- `pending_resume.get_path_for_chat`: a `:cd` between queueing and restore must not land on a
---- different project's store.
---- @param chat_file_path string
---- @return string
-function M.get_path_for_chat(chat_file_path)
-  return M.get_path(vim.fn.fnamemodify(chat_file_path, ":h"))
-end
-
 --- Read the whole store for a project.
 --- A missing or corrupt file yields an empty table: entries that cannot be read are entries that
 --- silently do not restore, which is the safe direction — the in-memory queue is still the

--- a/lua/vibing/infrastructure/storage/message_queue_store.lua
+++ b/lua/vibing/infrastructure/storage/message_queue_store.lua
@@ -1,0 +1,130 @@
+--- Persistence for chat-to-chat message queue entries that survive a Neovim restart
+---
+--- `message_queue.lua` keeps its live queue in memory, keyed by bufnr — a bufnr is only valid for
+--- the Neovim process that created it. A destination chat can sit parked for hours on a
+--- usage-limit reset (`pending_resume.lua` exists for exactly that gap, and its own doc notes a
+--- restart is common across it), and a message queued for delivery to it would otherwise vanish
+--- with nothing on disk to show it was ever there. State lives in
+--- `<project root>/.vibing/message-queue.json` (gitignored like the rest of `.vibing/`), keyed by
+--- the destination chat's file path, and is reloaded on startup by `message_queue.lua`'s
+--- `M.restore()`.
+---
+--- @module vibing.infrastructure.storage.message_queue_store
+
+local Git = require("vibing.core.utils.git")
+local Fs = require("vibing.core.utils.fs")
+
+local M = {}
+
+--- @class Vibing.MessageQueueStore.Item
+--- @field body string|nil Present for a message item; absent for a notification item
+--- @field reason string|nil Notification items only (`ChatBuffer:get_stop_reason()`)
+--- @field from_file_path string|nil Sender's chat file path. Absent when the sender had no
+---   file (unnamed buffer) or, for a message item, when its sender was later forgotten.
+
+--- Memoized `git rev-parse` results, keyed by the directory asked about. Mirrors
+--- `pending_resume.lua`'s cache for the same reason: several round trips per call would otherwise
+--- each spawn a synchronous subprocess on the main thread.
+--- @type table<string, string|false>
+local root_cache = {}
+
+--- @param dir string|nil
+--- @return string|nil
+local function git_root_cached(dir)
+  local key = dir or "<cwd>"
+  local cached = root_cache[key]
+  if cached ~= nil then
+    return cached or nil
+  end
+  local root = Git.get_root(dir)
+  root_cache[key] = root or false
+  return root
+end
+
+--- Drop memoized roots (test helper; also useful after a worktree is added or removed)
+function M.clear_cache()
+  root_cache = {}
+end
+
+--- Resolve the store path for a working directory
+--- @param cwd? string
+--- @return string
+function M.get_path(cwd)
+  local root = git_root_cached(cwd) or cwd or vim.fn.getcwd()
+  return root .. "/.vibing/message-queue.json"
+end
+
+--- Resolve the store that owns a given chat file — same anchoring reason as
+--- `pending_resume.get_path_for_chat`: a `:cd` between queueing and restore must not land on a
+--- different project's store.
+--- @param chat_file_path string
+--- @return string
+function M.get_path_for_chat(chat_file_path)
+  return M.get_path(vim.fn.fnamemodify(chat_file_path, ":h"))
+end
+
+--- Read the whole store for a project.
+--- A missing or corrupt file yields an empty table: entries that cannot be read are entries that
+--- silently do not restore, which is the safe direction — the in-memory queue is still the
+--- primary copy while Neovim is running.
+--- @param cwd? string
+--- @return table<string, Vibing.MessageQueueStore.Item[]>
+function M.load(cwd)
+  local path = M.get_path(cwd)
+  if vim.fn.filereadable(path) == 0 then
+    return {}
+  end
+
+  local ok, lines = pcall(vim.fn.readfile, path)
+  if not ok or not lines or #lines == 0 then
+    return {}
+  end
+
+  local decoded_ok, decoded = pcall(vim.json.decode, table.concat(lines, "\n"))
+  if not decoded_ok or type(decoded) ~= "table" then
+    vim.notify("[vibing] Ignoring unreadable message-queue.json", vim.log.levels.WARN)
+    return {}
+  end
+
+  return decoded
+end
+
+--- Overwrite the whole store
+--- @param entries table<string, Vibing.MessageQueueStore.Item[]>
+--- @param cwd? string
+--- @return boolean success
+function M.save(entries, cwd)
+  local path = M.get_path(cwd)
+  Fs.ensure_dir(vim.fn.fnamemodify(path, ":h"))
+
+  -- vim.json.encode turns an empty Lua table into "[]" (an array), which decodes back as a list
+  -- and would break every keyed lookup on the next load. Store an explicit empty object instead.
+  local json = next(entries) == nil and "{}" or vim.json.encode(entries)
+
+  local ok, err = pcall(vim.fn.writefile, { json }, path)
+  if not ok then
+    vim.notify("[vibing] Failed to write message-queue.json: " .. tostring(err), vim.log.levels.WARN)
+    return false
+  end
+  return true
+end
+
+--- Record (or clear) one destination's queue.
+--- @param to_file_path string
+--- @param items Vibing.MessageQueueStore.Item[]|nil nil or empty removes the entry
+--- @param cwd? string
+function M.put(to_file_path, items, cwd)
+  local scope = cwd or vim.fn.fnamemodify(to_file_path, ":h")
+  local entries = M.load(scope)
+  if items and #items > 0 then
+    entries[to_file_path] = items
+  else
+    if entries[to_file_path] == nil then
+      return
+    end
+    entries[to_file_path] = nil
+  end
+  M.save(entries, scope)
+end
+
+return M

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -111,6 +111,14 @@ function M.setup(opts)
     end)
   end)
 
+  -- 同じ理由で、そのあいだに積まれたままだったチャット間キューも .vibing/message-queue.json
+  -- から作り直す。インメモリの pending は上のリセット待ちと同じく Neovim の再起動を跨げない
+  vim.schedule(function()
+    pcall(function()
+      require("vibing.application.chat.message_queue").restore()
+    end)
+  end)
+
   -- nvim-dapの停止イベントを購読する。nvim-dapがまだロードされていない可能性があるので
   -- VimEnter後に遅らせる（未インストールならsetup側がfalseを返して何もしない）
   if M.config.dap and M.config.dap.enabled then

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -627,6 +627,25 @@ describe("CompletionNotifier", function()
     assert.is_truthy(sends[1].message:find("the migration is done", 1, true))
   end)
 
+  it("keeps and delivers a queued message when the recipient's own turn ends abnormally (#697)", function()
+    -- send_message.lua's rate-limit (and plain error) branches still fall through to
+    -- add_user_section(), so VibingResponseDone fires exactly as it would for an ordinary stop.
+    -- queue_if_busy's contract is "wait and it resolves"; the entry must not be lost just because
+    -- the turn that finally frees the recipient ended abnormally rather than successfully.
+    local a, b = make_chat(), make_chat()
+    responding[a] = true
+
+    assert.is_true(MessageQueue.enqueue_message(a, b, "queued while A was busy"))
+
+    responding[a] = false
+    stop_reasons[a] = "error"
+    Notifier.on_response_done(a)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+    assert.is_truthy(sends[1].message:find("queued while A was busy", 1, true))
+  end)
+
   it("carries the sender's body rather than telling the reader to go and fetch it", function()
     local a, b = make_chat(), make_chat()
     responding[a] = true

--- a/tests/lua/application/chat/message_queue_spec.lua
+++ b/tests/lua/application/chat/message_queue_spec.lua
@@ -270,3 +270,138 @@ describe("MessageQueue", function()
     assert.is_truthy(err)
   end)
 end)
+
+-- 名前を持つ（=保存先を持つ）チャットに限った永続化の面。無名バッファは
+-- `file_path_of` が nil を返すので上の describe は一切ディスクに触らない。
+describe("MessageQueue persistence (#697)", function()
+  local Store = require("vibing.infrastructure.storage.message_queue_store")
+  local Queue
+  local originals = {}
+  local tmp_root
+  local buffers = {}
+  local responding = {}
+  local sends = {}
+
+  ---@param filename string
+  ---@return number bufnr, string path
+  local function make_named_chat(filename)
+    local path = tmp_root .. "/" .. filename
+    vim.fn.writefile({ "## User <!-- unsent -->", "" }, path)
+    local bufnr = vim.fn.bufadd(path)
+    vim.fn.bufload(bufnr)
+    table.insert(buffers, bufnr)
+    return bufnr, path
+  end
+
+  ---@return number bufnr
+  local function make_chat()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    table.insert(buffers, bufnr)
+    return bufnr
+  end
+
+  before_each(function()
+    tmp_root = vim.fn.tempname()
+    vim.fn.mkdir(tmp_root, "p")
+    Store.clear_cache()
+
+    originals.get_chat_buffer = view.get_chat_buffer
+    originals.send = ProgrammaticSender.send
+    originals.link = OrchestrationLink.link
+
+    buffers, responding, sends = {}, {}, {}
+
+    view.get_chat_buffer = function(bufnr)
+      if not vim.api.nvim_buf_is_valid(bufnr) then
+        return nil
+      end
+      return {
+        is_responding = function()
+          return responding[bufnr] == true
+        end,
+        extract_user_message = function()
+          return nil
+        end,
+      }
+    end
+    ProgrammaticSender.send = function(bufnr, message)
+      table.insert(sends, { bufnr = bufnr, message = message })
+      return { success = true, bufnr = bufnr }
+    end
+    OrchestrationLink.link = function()
+      return true, nil
+    end
+
+    package.loaded["vibing.application.chat.message_queue"] = nil
+    Queue = require("vibing.application.chat.message_queue")
+  end)
+
+  after_each(function()
+    view.get_chat_buffer = originals.get_chat_buffer
+    ProgrammaticSender.send = originals.send
+    OrchestrationLink.link = originals.link
+
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    if tmp_root then
+      vim.fn.delete(tmp_root, "rf")
+    end
+    Store.clear_cache()
+  end)
+
+  it("writes a queued message to disk as soon as it is queued", function()
+    local a, a_path = make_named_chat("a.md")
+    responding[a] = true
+
+    Queue.enqueue_message(a, nil, "queued while busy")
+
+    local stored = Store.load(tmp_root)[a_path]
+    assert.is_not_nil(stored)
+    assert.equals("queued while busy", stored[1].body)
+  end)
+
+  it("clears the disk entry once the queue is actually delivered", function()
+    local a, a_path = make_named_chat("a.md")
+    responding[a] = true
+
+    Queue.enqueue_message(a, nil, "queued while busy")
+    responding[a] = false
+    Queue.flush(a)
+
+    assert.is_nil(Store.load(tmp_root)[a_path])
+  end)
+
+  it("restores a queue that outlived a Neovim restart and delivers it once idle", function()
+    local a, a_path = make_named_chat("a.md")
+    responding[a] = true
+
+    assert.is_true(Queue.enqueue_message(a, nil, "queued while A was busy"))
+    assert.is_not_nil(Store.load(tmp_root)[a_path], "must be on disk before the simulated restart")
+
+    -- Simulate a Neovim restart: the module-level `pending` table is gone, but the chat file (and
+    -- with it, message-queue.json) is still on disk. Nothing is "responding" any more either, since
+    -- a restart kills every CLI process along with it.
+    package.loaded["vibing.application.chat.message_queue"] = nil
+    Queue = require("vibing.application.chat.message_queue")
+    responding[a] = false
+
+    Queue.restore(tmp_root)
+
+    assert.equals(1, #sends)
+    assert.equals(a, sends[1].bufnr)
+    assert.is_truthy(sends[1].message:find("queued while A was busy", 1, true))
+    assert.is_nil(Store.load(tmp_root)[a_path], "delivered — must not be replayed on the next restart")
+  end)
+
+  it("does not persist a queue addressed to an unnamed (unsaved) chat", function()
+    local a = make_chat()
+    responding[a] = true
+
+    Queue.enqueue_message(a, nil, "queued before the chat was ever saved")
+
+    assert.same({}, Store.load(tmp_root))
+  end)
+end)

--- a/tests/lua/application/chat/message_queue_spec.lua
+++ b/tests/lua/application/chat/message_queue_spec.lua
@@ -306,6 +306,7 @@ describe("MessageQueue persistence (#697)", function()
     Store.clear_cache()
 
     originals.get_chat_buffer = view.get_chat_buffer
+    originals.attach_to_buffer = view.attach_to_buffer
     originals.send = ProgrammaticSender.send
     originals.link = OrchestrationLink.link
 
@@ -338,6 +339,7 @@ describe("MessageQueue persistence (#697)", function()
 
   after_each(function()
     view.get_chat_buffer = originals.get_chat_buffer
+    view.attach_to_buffer = originals.attach_to_buffer
     ProgrammaticSender.send = originals.send
     OrchestrationLink.link = originals.link
 
@@ -394,6 +396,85 @@ describe("MessageQueue persistence (#697)", function()
     assert.equals(a, sends[1].bufnr)
     assert.is_truthy(sends[1].message:find("queued while A was busy", 1, true))
     assert.is_nil(Store.load(tmp_root)[a_path], "delivered — must not be replayed on the next restart")
+  end)
+
+  it(
+    "drops a restored notification whose stopped-chat file is gone, rather than corrupting the whole queue",
+    function()
+      -- A notification's bufnr identifies "the chat that stopped" and, unlike a message's sender,
+      -- cannot be delivered anonymously. Restoring it as nil used to make every later flush()
+      -- attempt fail (delivery_message tries to display a nil bufnr), taking every other item
+      -- queued for the same recipient down with it.
+      local a = make_named_chat("a.md")
+      local b, b_path = make_named_chat("b.md")
+      responding[a] = true
+
+      Queue.enqueue_notification(a, b, "waiting_approval")
+      Queue.enqueue_message(a, nil, "still deliverable")
+
+      -- b's chat file is gone by the time we "restart" (deleted, or moved elsewhere).
+      vim.fn.delete(b_path)
+
+      package.loaded["vibing.application.chat.message_queue"] = nil
+      Queue = require("vibing.application.chat.message_queue")
+      responding[a] = false
+
+      Queue.restore(tmp_root)
+
+      assert.equals(1, #sends)
+      assert.is_truthy(sends[1].message:find("still deliverable", 1, true))
+    end
+  )
+
+  it(
+    "keeps the disk entry when a restored buffer fails to attach, rather than deleting it",
+    function()
+      -- resolve_bufnr failing to attach (corrupt frontmatter, etc.) must read as "could not
+      -- resolve this time," not "resolved to nothing." Treating it as resolved used to make
+      -- restore() hand flush() an untracked bufnr, which warns and then deletes the disk entry —
+      -- turning a one-time attach failure into a permanent loss.
+      local a, a_path = make_named_chat("a.md")
+      responding[a] = true
+
+      assert.is_true(Queue.enqueue_message(a, nil, "queued while busy"))
+      assert.is_not_nil(Store.load(tmp_root)[a_path])
+
+      package.loaded["vibing.application.chat.message_queue"] = nil
+      Queue = require("vibing.application.chat.message_queue")
+      responding[a] = false
+      view.get_chat_buffer = function()
+        return nil
+      end
+      view.attach_to_buffer = function()
+        return nil
+      end
+
+      Queue.restore(tmp_root)
+
+      assert.equals(0, #sends)
+      assert.is_not_nil(Store.load(tmp_root)[a_path], "must survive to be retried on the next restart")
+    end
+  )
+
+  it("purges a restored entry whose destination chat file no longer exists on disk", function()
+    local a_path = tmp_root .. "/gone.md"
+    vim.fn.writefile({ "## User <!-- unsent -->", "" }, a_path)
+    local a = vim.fn.bufadd(a_path)
+    vim.fn.bufload(a)
+    table.insert(buffers, a)
+    responding[a] = true
+    Queue.enqueue_message(a, nil, "orphaned")
+    responding[a] = false
+
+    vim.fn.delete(a_path)
+
+    package.loaded["vibing.application.chat.message_queue"] = nil
+    Queue = require("vibing.application.chat.message_queue")
+
+    Queue.restore(tmp_root)
+
+    assert.equals(0, #sends)
+    assert.is_nil(Store.load(tmp_root)[a_path], "the chat file is gone for good; stop carrying it forward")
   end)
 
   it("does not persist a queue addressed to an unnamed (unsaved) chat", function()

--- a/tests/lua/infrastructure/storage/message_queue_store_spec.lua
+++ b/tests/lua/infrastructure/storage/message_queue_store_spec.lua
@@ -1,0 +1,63 @@
+describe("message_queue_store", function()
+  local Store = require("vibing.infrastructure.storage.message_queue_store")
+
+  local tmp_root
+
+  before_each(function()
+    tmp_root = vim.fn.tempname()
+    vim.fn.mkdir(tmp_root, "p")
+    Store.clear_cache()
+  end)
+
+  after_each(function()
+    if tmp_root then
+      vim.fn.delete(tmp_root, "rf")
+    end
+    Store.clear_cache()
+  end)
+
+  it("returns an empty table when no store exists", function()
+    assert.same({}, Store.load(tmp_root))
+  end)
+
+  it("round-trips a destination's queue", function()
+    Store.put("/proj/.vibing/chat/b.md", {
+      { body = "hello", from_file_path = "/proj/.vibing/chat/a.md" },
+    }, tmp_root)
+
+    local entries = Store.load(tmp_root)
+    assert.is_not_nil(entries["/proj/.vibing/chat/b.md"])
+    assert.equals(1, #entries["/proj/.vibing/chat/b.md"])
+    assert.equals("hello", entries["/proj/.vibing/chat/b.md"][1].body)
+  end)
+
+  it("keeps entries for other destinations when one is cleared", function()
+    Store.put("/a.md", { { body = "for a" } }, tmp_root)
+    Store.put("/b.md", { { body = "for b" } }, tmp_root)
+
+    Store.put("/a.md", nil, tmp_root)
+
+    local entries = Store.load(tmp_root)
+    assert.is_nil(entries["/a.md"])
+    assert.is_not_nil(entries["/b.md"])
+  end)
+
+  it("stays a keyed object after the last entry is removed (regression)", function()
+    -- An empty Lua table encodes as "[]", which would decode back as a list and break every
+    -- keyed lookup on the next load — the same regression pending_resume.lua guards against.
+    Store.put("/only.md", { { body = "x" } }, tmp_root)
+    Store.put("/only.md", nil, tmp_root)
+
+    assert.same({}, Store.load(tmp_root))
+    Store.put("/again.md", { { body = "y" } }, tmp_root)
+    assert.is_not_nil(Store.load(tmp_root)["/again.md"])
+  end)
+
+  it("ignores a corrupt store instead of erroring", function()
+    local path = Store.get_path(tmp_root)
+    vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+    vim.fn.writefile({ "{ this is not json" }, path)
+
+    assert.same({}, Store.load(tmp_root))
+  end)
+end)


### PR DESCRIPTION
queue_if_busy's contract is "wait and it resolves," but the in-memory
queue could not survive a Neovim restart during a multi-hour usage-limit
park (the same gap pending_resume.lua and limit_state.lua already
account for), and flush() dropped a queue with no warning when the
recipient buffer turned out to be invalid or untracked.

Add message_queue_store.lua (mirrors pending_resume.lua: JSON under
.vibing/, keyed by the destination chat's file path) and write through
to it on every enqueue/flush/forget. message_queue.lua gains restore(),
wired into init.lua next to auto_resume.restore(), which reloads a
project's queued items on startup and immediately retries delivery for
any recipient that is now idle. The two previously-silent drop paths in
flush() now warn like every other drop in this module.

Also add a regression test proving a queued message survives and gets
delivered when the recipient's own turn ends abnormally (rate limit,
plain error), since send_message.lua's error paths still fall through
to add_user_section() and the normal drain path already handles this
correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015skoixHzBLJpLnAZ3XRNbT