### PR TITLE
fix(ci): Claude Code Review's silent no-comment failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,12 +69,22 @@ jobs:
                  judge them
                - if nothing was found, say so briefly instead of posting empty sections
 
+          # Temporarily on: two silent-failure incidents in a row (missing GH_TOKEN, then a
+          # denied-tool stall) were only diagnosable from the raw job log, not this action's own
+          # summarized output. Flip back to false once the review is reliably posting comments.
+          show_full_output: true
           # Enough to run /code-review's own tool-use (read/edit the tree, verify with the repo's
           # test/lint scripts) plus commit, push and comment. Label transitions are handled by the
           # workflow step below, not by Claude, so no gh-edit access is needed here.
+          # TodoWrite is the harness's own side-effect-free planning tool (see
+          # core/constants/tools.lua's INTERNAL_TOOLS in this repo's own permission model) --
+          # Claude Code invokes it habitually on any multi-step task. Omitting it doesn't error,
+          # it just gets silently denied every time, which is what the previous run's
+          # permission_denials_count: 5 (with 0 comments posted and 0 commits pushed despite a
+          # real ~2.5 minute, $2 run) points to.
           claude_args: >-
             --allowed-tools
-            "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(npm test:*),Bash(npm run check:*),Bash(npm run lint:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            "Read,Edit,Write,Glob,Grep,TodoWrite,Bash(git:*),Bash(npm test:*),Bash(npm run check:*),Bash(npm run lint:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       # Runs regardless of whether the step above succeeded, so a crashed or timed-out run still
       # gets reflected on the PR instead of leaving "claude:in-review" stuck forever.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,15 +76,21 @@ jobs:
           # Enough to run /code-review's own tool-use (read/edit the tree, verify with the repo's
           # test/lint scripts) plus commit, push and comment. Label transitions are handled by the
           # workflow step below, not by Claude, so no gh-edit access is needed here.
-          # TodoWrite is the harness's own side-effect-free planning tool (see
-          # core/constants/tools.lua's INTERNAL_TOOLS in this repo's own permission model) --
-          # Claude Code invokes it habitually on any multi-step task. Omitting it doesn't error,
-          # it just gets silently denied every time, which is what the previous run's
-          # permission_denials_count: 5 (with 0 comments posted and 0 commits pushed despite a
-          # real ~2.5 minute, $2 run) points to.
+          #
+          # ToolSearch, TodoWrite, ReportFindings and ScheduleWakeup are this repo's own
+          # INTERNAL_TOOLS set (core/constants/tools.lua): harness-internal, side-effect-free
+          # control tools Claude Code invokes habitually regardless of task. Omitting any one of
+          # them doesn't error, it just gets silently denied every time -- which is what the
+          # previous run's permission_denials_count: 5 (with 0 comments posted and 0 commits
+          # pushed despite a real ~2.5 minute, $2 run) points to. Allow the whole set rather than
+          # whack-a-mole one at a time.
+          #
+          # Agent lets /code-review fan out subagents per review dimension and adversarially
+          # verify each finding, which is the whole point of asking for effort "high" -- without
+          # it the skill silently degrades to a single-pass, unverified review.
           claude_args: >-
             --allowed-tools
-            "Read,Edit,Write,Glob,Grep,TodoWrite,Bash(git:*),Bash(npm test:*),Bash(npm run check:*),Bash(npm run lint:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            "Read,Edit,Write,Glob,Grep,Agent,ToolSearch,TodoWrite,ReportFindings,ScheduleWakeup,Bash(git:*),Bash(npm test:*),Bash(npm run check:*),Bash(npm run lint:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       # Runs regardless of whether the step above succeeded, so a crashed or timed-out run still
       # gets reflected on the PR instead of leaving "claude:in-review" stuck forever.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,12 @@ jobs:
         id: claude-review
         # Pin to specific commit SHA for security (v1.0.216)
         uses: anthropics/claude-code-action@d75b94d5ad426cb8546e6628b6f5f19b84e5cce1
+        # Without this, the `gh pr comment`/`gh pr diff`/`gh pr view` calls the prompt tells
+        # Claude to make inside the sandbox have no credentials and fail silently -- the run
+        # still reports success, but step 2 of the prompt (post the review comment) never
+        # happens. claude.yml's equivalent step sets the same env for the same reason.
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Summary

`claude-code-review.yml` (the `claude:in-review` label workflow) kept completing with `conclusion: success` while posting no PR comment and pushing no fix commit. Three separate silent-failure causes, found by inspecting the raw job logs of repeated live runs against PR #712:

1. **Missing `GH_TOKEN`** — the `Run Claude Code Review` step ran `gh pr comment` / `gh pr diff` / `gh pr view` inside the sandbox with no credentials, so every `gh` call failed authentication silently. `claude.yml`'s equivalent step already sets this; mirrored here.
2. **`--allowed-tools` omitted this repo's own `INTERNAL_TOOLS` set** (`ToolSearch`, `TodoWrite`, `ReportFindings`, `ScheduleWakeup` — see `core/constants/tools.lua`): harness-internal, side-effect-free control tools Claude Code invokes habitually regardless of task. Denying them doesn't error, it just silently derails the run — confirmed by a live run that executed for ~2.5 minutes ($2, 4 turns) yet still pushed nothing and commented nothing, with `permission_denials_count: 5`.
3. **`Agent` wasn't allowed**, so `/code-review`'s effort `"high"` (meant to fan out subagents per review dimension and adversarially verify each finding) silently degraded to a single-pass, unverified review instead of erroring.

Also flipped `show_full_output: true` — both of the above were only diagnosable from the raw job log, not this action's own summarized output. Revert once the review is reliably posting comments.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` — YAML parses
- [x] Live-tested against PR #712 across three iterations (GH_TOKEN fix, then TodoWrite, now the full INTERNAL_TOOLS set + Agent) — each run's job log inspected directly to confirm root cause before the next fix
- [ ] Re-run `claude:in-review` on an open PR after this merges and confirm a comment actually posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkHy9xjqPabgsxALbf9dtD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code review workflow authentication for command-line operations.
  * Expanded available review capabilities.
  * Enabled full output visibility in review job logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->