### PR TITLE
docs(skill): add chat-vs-subagent criteria and operator rules to vibing-orchestrate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,6 +54,14 @@ jobs:
             effort "high", passing `--fix` so every CONFIRMED finding is applied to the working
             tree (already checked out on the PR's own branch).
 
+            This is a single unattended batch run, not an interactive session: when it ends, the
+            process exits and nothing wakes it again. Any subagent the skill dispatches (the
+            per-dimension review fan-out, the verify pass) MUST be awaited synchronously within
+            this same turn before you act on its result. Do not end a turn saying you'll "wait" or
+            "be notified" for a background agent to finish — there is no later turn here to
+            receive that notification, so the run would exit with nothing posted and no comment
+            explaining why, exactly like a run that hit `permission_denials`.
+
             Do not run `npm run test:e2e` or `npm run test:eval` — they spend real tokens and are
             never run unattended. `npm test`, `npm run check` and `npm run lint` are fine to
             validate a fix before pushing it.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -108,6 +108,13 @@ jobs:
                don't depend on each other's findings — this is a single unattended run with no
                back-and-forth, so parallel investigation up front is cheaper than discovering a
                constraint after half the implementation is written.
+
+               This is a single unattended batch run, not an interactive session: when it ends,
+               the process exits and nothing wakes it again. Any subagent you dispatch MUST be
+               awaited synchronously within this same turn before you act on its result. Do not
+               end a turn saying you'll "wait" or "be notified" for a background agent to finish —
+               there is no later turn here to receive that notification, so the run would exit
+               with no commit pushed and no PR created, and no comment explaining why.
             3. Plan the implementation. When more than one reasonable approach exists, do not ask
                which one to take — nobody is watching this run. Pick the one you judge best by the
                codebase's own existing conventions (mirror the nearest similar pattern already in

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -90,19 +90,48 @@ jobs:
             This will show you the PR title, body, ALL comments, AND the code changes.
 
             ## Task Instructions
-            After gathering the full context above:
-            1. Read and understand ALL comments and discussions
-            2. For PRs, review the code changes in the diff
-            3. Execute the requested task based on the complete context
-            4. When you complete an implementation task, create a pull request using `gh pr create` command
+            After gathering the full context above, work it like a feature-dev flow:
+
+            1. Read and understand ALL comments and discussions; for PRs, also review the code
+               changes in the diff.
+            2. Investigate the codebase before writing anything. Use the Agent tool to fan out
+               independent, read-only investigation (e.g. "how does module X already do Y",
+               "what other callers exist") when there is more than one thing to check and they
+               don't depend on each other's findings — this is a single unattended run with no
+               back-and-forth, so parallel investigation up front is cheaper than discovering a
+               constraint after half the implementation is written.
+            3. Plan the implementation. When more than one reasonable approach exists, do not ask
+               which one to take — nobody is watching this run. Pick the one you judge best by the
+               codebase's own existing conventions (mirror the nearest similar pattern already in
+               the repo) and proceed; state the choice and why in the PR description so a human can
+               override it later if needed. Only stop short of implementing if the request itself
+               is too ambiguous to act on at all (not merely "which of two valid designs"): in that
+               case, report the ambiguity as a PR comment or issue comment instead of guessing at
+               the task itself.
+            4. Implement the change.
+            5. Verify before creating the PR: run the project's own fast checks relevant to what
+               changed (`npm test`, `npm run check`, `npm run lint` as applicable). Do not run
+               `npm run test:e2e` or `npm run test:eval` — they spend real tokens and are never run
+               unattended.
+            6. When you complete an implementation task, create a pull request using `gh pr create` command
                - Create a descriptive PR title in English using semantic commit format
                - Write the PR body in Japanese with clear description of changes
                - Include "fixes #<issue-number>" if there's a related issue
 
-          # Allow file operations and git/gh commands for implementation tasks. --resume is
-          # appended when lookup-session found a prior session_id for this thread.
+          # Allow file operations, git/gh commands and subagents for implementation tasks.
+          # --resume is appended when lookup-session found a prior session_id for this thread.
+          #
+          # Agent lets this flow fan out independent, read-only investigation before implementing
+          # (see the prompt's step 2) instead of discovering a codebase constraint mid-implementation.
+          #
+          # ToolSearch, TodoWrite, ReportFindings and ScheduleWakeup are this repo's own
+          # INTERNAL_TOOLS set (core/constants/tools.lua): harness-internal, side-effect-free
+          # control tools Claude Code invokes habitually regardless of task. Omitting any one of
+          # them doesn't error, it just gets silently denied every time, which is what stalled the
+          # claude-code-review.yml run before #719 fixed the same gap there -- allow the whole set
+          # here too rather than whack-a-mole one at a time.
           claude_args: >-
-            --allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"
+            --allowed-tools "Read,Edit,Write,Glob,Grep,Agent,ToolSearch,TodoWrite,ReportFindings,ScheduleWakeup,Bash(git:*),Bash(gh:*),Bash(npm:*)"
             ${{ steps.lookup-session.outputs.session_id != '' && format('--resume {0}', steps.lookup-session.outputs.session_id) || '' }}
 
           # Show full output for debugging

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,14 @@ jobs:
       issues: write
       id-token: write
       actions: read
+      # GitHub refuses to push a *new* branch ref whose tree contains any .github/workflows/*
+      # file without this scope -- even one this run never touched -- because ref creation has
+      # no prior remote state to diff against, so every blob in the new ref reads as "new" to
+      # that check. This repo always has workflow files in its tree, so every `gh pr create` /
+      # `git push -u origin <new-branch>` this job's Claude Code run does needs it. Without it,
+      # the run can still edit files and commit locally, but push and PR creation fail silently
+      # from the workflow's own summary -- which is exactly what happened on #705.
+      workflows: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -31,6 +31,9 @@ export const chatTools: Tool[] = [
       'Create a new vibing.nvim chat buffer and return its bufnr and chat file path. ' +
       'Use it to spawn worker chats you then drive with nvim_chat_send_message — the ' +
       'multi-agent orchestration workflow (see the vibing-orchestrate skill). ' +
+      'A chat is for work that must survive a turn, own a branch/worktree, or take a human ' +
+      "approval — one-shot delegated work inside your own turn is a subagent's job instead " +
+      '(see "Chat or subagent?" in the vibing-orchestrate skill). ' +
       'Leave position at its "back" default for workers: that creates the buffer without ' +
       "opening a window, so the user's layout is untouched. " +
       'The new chat starts empty and shares nothing with yours, so every message you send it ' +

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -20,16 +20,16 @@ most expensive mistake a postmortem (#692) found was broadcasting `/simplify` to
 chats — each spawns its own subagents, so that's the chat count times the subagent count, and it
 was one of two runs that hit the session limit. Decide this before creating anything.
 
-| | Subagent | Orchestrated chat |
-| --- | --- | --- |
-| Lifetime | Dies with the parent turn | Survives restarts |
-| Output | One final text blob | Its own transcript |
-| Visibility | None | Buffer can be opened and read, mid-task |
-| Approval prompts | Can't clear one (turn just fails) | Can handle questions and approvals |
-| Owns a branch/worktree | No | Yes, via `working_dir` frontmatter |
-| Survives a rate limit | No | Yes (auto_resume / scheduled resend) |
-| Spin-up cost | Low, no protocol | Floor ~61k tokens + report contract + notifications |
-| Coordination can fail | No — the return value is structurally guaranteed | Yes — this run failed 9 of 18 dispatches |
+|                        | Subagent                                         | Orchestrated chat                                   |
+| ---------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| Lifetime               | Dies with the parent turn                        | Survives restarts                                   |
+| Output                 | One final text blob                              | Its own transcript                                  |
+| Visibility             | None                                             | Buffer can be opened and read, mid-task             |
+| Approval prompts       | Can't clear one (turn just fails)                | Can handle questions and approvals                  |
+| Owns a branch/worktree | No                                               | Yes, via `working_dir` frontmatter                  |
+| Survives a rate limit  | No                                               | Yes (auto_resume / scheduled resend)                |
+| Spin-up cost           | Low, no protocol                                 | Floor ~61k tokens + report contract + notifications |
+| Coordination can fail  | No — the return value is structurally guaranteed | Yes — this run failed 9 of 18 dispatches            |
 
 **A subagent is enough only if all five hold** — one exception and it's a chat:
 

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -13,6 +13,62 @@ Every MCP call here takes `rpc_port`, the value in this chat's system prompt. Wi
 server falls back to the instance registry, which only answers when exactly one Neovim is live —
 and orchestration is precisely the case where several are.
 
+## Chat or subagent?
+
+A chat is a unit of **ownership**; a subagent is a unit of **delegated work inside one turn**. The
+most expensive mistake a postmortem (#692) found was broadcasting `/simplify` to five worker
+chats — each spawns its own subagents, so that's the chat count times the subagent count, and it
+was one of two runs that hit the session limit. Decide this before creating anything.
+
+| | Subagent | Orchestrated chat |
+| --- | --- | --- |
+| Lifetime | Dies with the parent turn | Survives restarts |
+| Output | One final text blob | Its own transcript |
+| Visibility | None | Buffer can be opened and read, mid-task |
+| Approval prompts | Can't clear one (turn just fails) | Can handle questions and approvals |
+| Owns a branch/worktree | No | Yes, via `working_dir` frontmatter |
+| Survives a rate limit | No | Yes (auto_resume / scheduled resend) |
+| Spin-up cost | Low, no protocol | Floor ~61k tokens + report contract + notifications |
+| Coordination can fail | No — the return value is structurally guaranteed | Yes — this run failed 9 of 18 dispatches |
+
+**A subagent is enough only if all five hold** — one exception and it's a chat:
+
+1. It finishes in one round trip, with a definable output, no mid-task change of direction
+2. Nobody needs to watch it run
+3. It doesn't own a branch or worktree — it stays inside the parent's own working tree
+4. It's unlikely to hit an approval prompt (read-heavy, or the parent's session permissions cover it)
+5. You would not want to reread its transcript tomorrow
+
+**Use a chat if any one of these holds:** it spans multiple turns (implement → wait on CI → address
+review → fix → merge); it owns a branch/worktree a later turn still needs; it will hit an approval
+prompt only a human should clear; a human wants to open it mid-task and steer it; it might need
+re-briefing after a partial failure; it has to survive a rate limit; or its transcript is itself the
+record you'll want later.
+
+**General rule: parallelism inside work that already has a chat belongs to subagents. Don't add
+chats to get parallelism** — a chat's floor is ownership, not concurrency.
+
+## Operator rules
+
+- **Don't write the report protocol into a brief.** Creating a worker with `from_bufnr` is enough —
+  the plugin injects it from `orchestrated_by` every turn (#706). Keep the brief to the task itself.
+- **Don't broadcast a subagent-spawning command** (`/simplify`, `/code-review`, …) **to more than one
+  worker at a time.** Each broadcast multiplies concurrency by that command's own subagent count.
+- **Parallelize the implementation step; serialize anything that touches `main`** (merges, cleanup).
+- **Write the assignment table (who owns what) to a file**, not only into your own context — it has
+  to survive a restart or compaction.
+- **Don't take a review finding at face value.** Verify before acting on it; a finding can itself be
+  wrong.
+
+## Environment notes
+
+- **macOS's `nc` cannot hold a conversation with this RPC server.** It closes on stdin EOF before the
+  response comes back over `vim.schedule`. Use Python's `socket.create_connection(...)` with
+  `makefile("rwb")` instead if you need to talk to it directly.
+- **Claude Code's built-in sensitive-file guard refuses `Edit`/`Write` on `.claude/rules/**`,**
+  independent of this project's own permission rules. Don't brief a worker to edit rules files —
+  either do it yourself as the orchestrator, or write the brief assuming a human will clear it.
+
 ## 1. Split the work
 
 Break the request into tasks that can run without waiting on each other. If two tasks would edit


### PR DESCRIPTION
fixes #705

## 問題

`claude-plugin/skills/vibing-orchestrate/SKILL.md` は「どう回すか」は詳しいが「そもそも回すべきか」を書いていなかった。#692 でいちばん高くついた事故（`/simplify` の同報 → 約20サブエージェント並列 → セッション上限）は、この切り分けを間違えた結果だった。

## やったこと

`#692` の該当章を、SKILL.md が実際に使う英語のスタイルに合わせて反映した。

- **`## Chat or subagent?`** — 寿命／成果物／可視性／承認／worktree 所有／レート制限復帰／起動コスト／調整の失敗可能性の比較表、subagent で足りる5条件・チャットに分けるべき7条件、一般則（「すでにチャットを持っている作業の内側の並列化は subagent でやる」）
- **`## Operator rules`** — オーケストレーター側の運用ルール5項目。項目1は #706 が入った現状に合わせて「報告手順はブリーフに書かない（プラグインが注入する）」に書き換え済み
- **`## Environment notes`** — macOS の `nc` が RPC サーバーと会話できない件（Python の `socket.create_connection` + `makefile("rwb")` を使う）と、Claude Code 組み込みの機微ファイルガードが `.claude/rules/**` への Edit/Write を拒否する件（ワーカーに rules の編集を頼まない）
- `nvim_chat_create`（`claude-plugin/mcp-server/src/tools/chat.ts`）のツール説明に、判断基準への1〜2行のポインタを追加

## 追加: `claude.yml`(issueトリガーの実装用Action)のツール許可を見直し

このPRのやり取りの中で見つかった別件。`claude-code-review.yml` は #719 で `Agent` と `INTERNAL_TOOLS`（`ToolSearch`/`TodoWrite`/`ReportFindings`/`ScheduleWakeup`）を `--allowed-tools` に追加済みだったが、`claude.yml`（issueへの `@claude` コメントや `claude:in-progress` ラベルで動く実装用ワークフロー）には同じ抜けが残っていた。同じ修正を適用し、あわせてプロンプトに feature-dev 相当のフロー（調査 → 計画 → 実装 → 検証 → PR作成）を明記。無人実行なので複数の実装方針がありうる場面でも質問はせず、既存コードベースの慣習に最も合う方を選んで進め、その判断根拠をPR本文に書くよう指示した。実装不可能なほど要求自体が曖昧な場合のみ、コメントで報告して止まる。

## 検証

- `npm run lint` — 0 errors
- `npm run lint:md`(SKILL.md 分) — 0 errors
- `npm run check`(Lua構文) — 0 errors
- `claude-plugin/mcp-server`: `npm run build`（tsc）— エラーなし、`npm test`（vitest）— 157 passed
- `.github/workflows/claude.yml` — YAML構文チェック・`prettier --check` 通過
- 実装不要のドキュメントのみの変更のため `test:e2e` は対象外

## 補足: なぜ #705 に反応が無かったか

issue #705 上の前回の自動実行（65ターン、約$1.9消費）は実装自体は完了していたが、GitHub App トークンに `workflows` 権限が無く、リポジトリツリーに `.github/workflows/*.yml` が含まれていたため新規ブランチの push そのものが拒否され、PR が作れなかった。しかもその説明はセッションの最終レスポンスに書かれただけで issue にコメントとして投稿されず、投稿されたのはセッションIDマーカーのみだった。ローカルコミットも実行環境ごと破棄されて残っていない。本 PR はこのセッション（push権限あり）で改めて実装したもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUBMpen23nHytEh7yt14gs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified when to use persistent chats versus one-shot subagents for delegated work.
  - Added guidance on lifecycle, visibility, approvals, worktrees, persistence, cost, and coordination.
  - Documented orchestration rules for reporting, task assignment, branch serialization, and review verification.
  - Added notes for macOS RPC usage and sensitive-file handling.
  - Expanded chat guidance to identify work requiring persistence, branch ownership, or human approval.

- **Chores**
  - Improved automated development and review workflows with broader investigation, validation, and completion guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->