### PR TITLE
fix(ci): remove invalid workflows:write permission that broke claude.yml entirely

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,14 +27,6 @@ jobs:
       issues: write
       id-token: write
       actions: read
-      # GitHub refuses to push a *new* branch ref whose tree contains any .github/workflows/*
-      # file without this scope -- even one this run never touched -- because ref creation has
-      # no prior remote state to diff against, so every blob in the new ref reads as "new" to
-      # that check. This repo always has workflow files in its tree, so every `gh pr create` /
-      # `git push -u origin <new-branch>` this job's Claude Code run does needs it. Without it,
-      # the run can still edit files and commit locally, but push and PR creation fail silently
-      # from the workflow's own summary -- which is exactly what happened on #705.
-      workflows: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
GITHUB_TOKEN's permissions block has no "workflows" scope -- it's not one of
the documented GITHUB_TOKEN permission keys (contents, pull-requests, issues,
id-token, actions, etc.). Declaring it made the whole workflow file
unparseable to GitHub, not just that one permission: every push since the
commit that added it produced a 0-job "failure" run (GitHub's synthetic
"invalid workflow file" result), and `gh api .../actions/workflows/<id>`
reported the workflow's name as its own file path -- the fallback GitHub
uses when it can't read the declared `name:`.

This silently broke every trigger on claude.yml (issue_comment, labeled
issues, pull_request_review), which is why re-labeling issue #697 with
claude:in-progress produced no run at all today, not even a skipped one.

The line was added to fix a real problem (a Claude Code run's `git push -u
origin <new-branch>` failing because the new branch's tree includes
.github/workflows/* files, and GITHUB_TOKEN can't touch those without extra
scope) but GITHUB_TOKEN cannot be granted that scope via `permissions:` at
all -- only a PAT with the `workflow` OAuth scope, or a GitHub App
installation with a "workflows" permission, can. That underlying push
problem needs a different fix; this change only restores the workflow to a
parseable state so labels and comments trigger it again.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nrm9FtRaboNotozmvrUdNS