### PR TITLE
feat: support backend model frontmatter completion

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -216,7 +216,7 @@ AI は同じバッファ内に応答します。`<C-c>` で実行中のリクエ
 | `/clear`                  | コンテキストをクリア                                                       |
 | `/save`                   | 現在のチャットを保存                                                       |
 | `/summarize`              | 会話を要約                                                                 |
-| `/model <model>`          | AI モデルを設定(haiku/sonnet/opus/fable)                                   |
+| `/model <model>`          | 現在の backend に渡す AI モデルを設定                                      |
 | `/effort <level>`         | 推論量を設定(low/medium/high/xhigh/max)                                    |
 | `/help`                   | 利用可能なスラッシュコマンドを表示                                         |
 | `/permissions` or `/perm` | 対話的 Permission Builder — ツールの allow/deny ルールを設定               |
@@ -259,7 +259,7 @@ require("vibing").setup({
     save_location_type = "project", -- "project" | "user" | "custom"
   },
   agent = {
-    default_model = "sonnet",      -- "sonnet" | "opus" | "haiku" | "fable"
+    default_model = "sonnet",      -- backend のモデルID。例: "sonnet" / "gpt-5.6-terra"
   },
   permissions = {
     mode = "acceptEdits",          -- "default" | "acceptEdits" | "plan" | "auto" | "dontAsk" | "bypassPermissions"
@@ -291,7 +291,7 @@ created_at: 2024-01-01T12:00:00
 working_dir: .vibing/worktrees/feature-x  # オプション: 作業ディレクトリ(git ルートからの相対パス)
 agent: claude  # claude | codex | copilot(このチャットに限りグローバルの adapter 設定を上書き)
 mode: code  # code | plan | explore
-model: sonnet  # sonnet | opus | haiku | fable
+model: sonnet  # backend のモデルID。例: sonnet / gpt-5.6-terra
 permission_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk | auto
 permissions_allow:
   - Read

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ help tags.
 | `/clear`                  | Clear context                                                                 |
 | `/save`                   | Save current chat                                                             |
 | `/summarize`              | Summarize conversation                                                        |
-| `/model <model>`          | Set AI model (haiku/sonnet/opus/fable)                                        |
+| `/model <model>`          | Set AI model for the current backend                                          |
 | `/effort <level>`         | Set reasoning effort (low/medium/high/xhigh/max)                              |
 | `/help`                   | Show available slash commands                                                 |
 | `/permissions` or `/perm` | Interactive permission builder - configure tool allow/deny rules              |
@@ -277,7 +277,7 @@ require("vibing").setup({
     save_location_type = "project", -- "project" | "user" | "custom"
   },
   agent = {
-    default_model = "sonnet",      -- "sonnet" | "opus" | "haiku" | "fable"
+    default_model = "sonnet",      -- backend model id, e.g. "sonnet" or "gpt-5.6-terra"
     scheduled_requests = {
       enabled = true,              -- during a usage limit, <CR> schedules instead of sending
     },
@@ -311,7 +311,7 @@ created_at: 2024-01-01T12:00:00
 working_dir: .vibing/worktrees/feature-x  # Optional: working directory (relative to git root)
 agent: claude  # claude | codex | copilot (overrides global adapter setting for this chat)
 mode: code  # code | plan | explore
-model: sonnet  # sonnet | opus | haiku | fable
+model: sonnet  # Backend model id, e.g. sonnet or gpt-5.6-terra
 permission_mode: acceptEdits  # default | acceptEdits | bypassPermissions | plan | dontAsk | auto
 permissions_allow:
   - Read

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -28,7 +28,7 @@ require("vibing").setup({
   adapter = "claude",  -- "claude" | "codex" | "copilot"
   agent = {
     default_mode = "code",     -- "code" | "plan" | "explore"
-    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
+    default_model = "sonnet",  -- backend model id, e.g. "sonnet" or "gpt-5.6-terra"
   },
   chat = {
     window = {
@@ -198,7 +198,7 @@ end
 {
   adapter = "claude",
   agent = {
-    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
+    default_model = "sonnet",  -- backend model id, e.g. "sonnet" or "gpt-5.6-terra"
   },
 }
 ```

--- a/doc/tutorials/getting-started.md
+++ b/doc/tutorials/getting-started.md
@@ -72,11 +72,11 @@ require("vibing").setup()
 
 ```lua
 require("vibing").setup({
-  adapter = "claude",  -- "claude" | "codex"
+  adapter = "claude",  -- "claude" | "codex" | "copilot" | "grok"
 
   -- エージェント設定
   agent = {
-    default_model = "sonnet",  -- "sonnet" | "opus" | "haiku" | "fable"
+    default_model = "sonnet",  -- backend のモデルID。例: "sonnet" / "gpt-5.6-terra"
   },
 
   -- チャットウィンドウ設定

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -360,7 +360,8 @@ Type these on their own line in a chat buffer and send with `<CR>`:
 /clear                  Clear the context
 /save                   Save the current chat
 /summarize              Summarise the conversation
-/model <model>          Set the model for the current backend, e.g. sonnet or gpt-5.6-terra
+/model <model>          Set the model for the current backend
+                        (e.g. sonnet or gpt-5.6-terra)
 /effort <level>         Set the reasoning effort (low|medium|high|xhigh|max)
 /help                   List the available slash commands
 /permissions, /perm     Interactive permission builder

--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -360,7 +360,7 @@ Type these on their own line in a chat buffer and send with `<CR>`:
 /clear                  Clear the context
 /save                   Save the current chat
 /summarize              Summarise the conversation
-/model <model>          Set the model (sonnet|opus|haiku|fable)
+/model <model>          Set the model for the current backend, e.g. sonnet or gpt-5.6-terra
 /effort <level>         Set the reasoning effort (low|medium|high|xhigh|max)
 /help                   List the available slash commands
 /permissions, /perm     Interactive permission builder

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -146,11 +146,9 @@ agent = {
                             -- outside the three values warns and falls back to "code";
                             -- an invalid frontmatter `mode` warns and is dropped.
 
-  default_model = "sonnet", -- Default model for new chats
-                            -- "sonnet": Balanced (recommended)
-                            -- "opus": Most capable
-                            -- "haiku": Fastest
-                            -- "fable": Claude Fable
+  default_model = "sonnet", -- Default backend model id for new chats
+                            -- Claude examples: "sonnet", "opus", "haiku", "fable"
+                            -- Codex example: "gpt-5.6-terra"
 
   utility_model = "sonnet", -- Model used for lightweight utility calls
                             -- (AI title generation, chat summaries, daily summaries).

--- a/lua/vibing/application/chat/commands.lua
+++ b/lua/vibing/application/chat/commands.lua
@@ -229,9 +229,10 @@ end
 ---@return string[]?
 function M.get_argument_completions(command_name)
   local Modes = require("vibing.core.constants.modes")
+  local Agents = require("vibing.core.constants.agents")
   local completions = {
     permission = Modes.PERMISSION_MODES,
-    model = Modes.VALID_MODELS,
+    model = Agents.all_model_values(),
     effort = Modes.EFFORT_LEVELS,
   }
   return completions[command_name]

--- a/lua/vibing/application/chat/handlers/model.lua
+++ b/lua/vibing/application/chat/handlers/model.lua
@@ -1,4 +1,5 @@
 local notify = require("vibing.core.utils.notify")
+local Agents = require("vibing.core.constants.agents")
 
 ---@param args string[]
 ---@param chat_buffer Vibing.ChatBuffer
@@ -12,6 +13,11 @@ return function(args, chat_buffer)
   local model = args[1]
   if model == "" then
     notify.warn("/model <model>", "Usage")
+    return false
+  end
+
+  if not vim.tbl_contains(Agents.all_model_values(), model) then
+    notify.error(string.format("Invalid model: %s (valid: %s)", model, table.concat(Agents.all_model_values(), ", ")))
     return false
   end
 

--- a/lua/vibing/application/chat/handlers/model.lua
+++ b/lua/vibing/application/chat/handlers/model.lua
@@ -1,5 +1,4 @@
 local notify = require("vibing.core.utils.notify")
-local Modes = require("vibing.core.constants.modes")
 
 ---@param args string[]
 ---@param chat_buffer Vibing.ChatBuffer
@@ -11,9 +10,8 @@ return function(args, chat_buffer)
   end
 
   local model = args[1]
-
-  if not Modes.is_valid_model(model) then
-    notify.error(string.format("Invalid model: %s (valid: %s)", model, table.concat(Modes.VALID_MODELS, ", ")))
+  if model == "" then
+    notify.warn("/model <model>", "Usage")
     return false
   end
 

--- a/lua/vibing/application/chat/init.lua
+++ b/lua/vibing/application/chat/init.lua
@@ -33,7 +33,7 @@ function M.setup()
   commands.register({
     name = "model",
     handler = require("vibing.application.chat.handlers.model"),
-    description = string.format("Set AI model: /model <%s>", table.concat(Modes.VALID_MODELS, "|")),
+    description = "Set AI model: /model <model>",
   })
 
   commands.register({

--- a/lua/vibing/application/completion/sources/frontmatter.lua
+++ b/lua/vibing/application/completion/sources/frontmatter.lua
@@ -27,6 +27,16 @@ function M._read_frontmatter_agent()
   return nil
 end
 
+---Resolve the agent whose model candidates should be shown for `model:`.
+---Runtime uses `agent` frontmatter first and then config.adapter; completion should mirror that.
+---@return string "claude" | "codex" | "copilot" | "grok"
+function M._resolve_model_completion_agent()
+  local explicit = M._read_frontmatter_agent()
+  local ok_config, config_module = pcall(require, "vibing.config")
+  local config = ok_config and config_module.get and config_module.get() or nil
+  return require("vibing.core.constants.modes").resolve_agent({ agent = explicit }, config)
+end
+
 ---Detect trigger context for frontmatter fields
 ---@param line string Current line content
 ---@param col number Cursor column (0-indexed)
@@ -48,7 +58,7 @@ function M.get_trigger_context(line, col)
       }
       -- For model field, read the agent value from the buffer frontmatter
       if field_name == "model" then
-        ctx.agent = M._read_frontmatter_agent()
+        ctx.agent = M._resolve_model_completion_agent()
       end
       return ctx
     end

--- a/lua/vibing/application/completion/sources/slash.lua
+++ b/lua/vibing/application/completion/sources/slash.lua
@@ -16,11 +16,11 @@ function M.get_trigger_context(line, col)
   local before_cursor = line:sub(1, col)
 
   -- Pattern 1: "/command arg" - completing argument
-  local cmd_with_arg = before_cursor:match("^%s*/([%w_:-]+)%s+([%w_-]*)$")
+  local cmd_with_arg = before_cursor:match("^%s*/([%w_:-]+)%s+([%w_.%-]*)$")
   if cmd_with_arg then
     local command_name = before_cursor:match("^%s*/([%w_:-]+)%s+")
-    local arg_query = before_cursor:match("%s+([%w_-]*)$") or ""
-    local arg_start = before_cursor:find("%s+[%w_-]*$")
+    local arg_query = before_cursor:match("%s+([%w_.%-]*)$") or ""
+    local arg_start = before_cursor:find("%s+[%w_.%-]*$")
 
     return {
       trigger = "argument",

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -112,10 +112,10 @@
 
 ---@class Vibing.AgentConfig
 ---エージェント設定
----Claudeのモード（code/plan/explore）とモデル（sonnet/opus/haiku/fable）を指定
+---チャットのモード（code/plan/explore）と、各CLI backendへ渡すモデルIDを指定
 ---@field default_mode "code"|"plan"|"explore" 新規チャットのfrontmatterに記録される`mode`の既定値（意味は core/constants/modes.lua の M.AGENT_MODES 参照）
----@field default_model "sonnet"|"opus"|"haiku"|"fable" デフォルトモデル（"sonnet": バランス、"opus": 高性能、"haiku": 高速、"fable": Claude Fable）
----@field utility_model "sonnet"|"opus"|"haiku"|"fable" タイトル生成・要約等の軽量ユーティリティ呼び出し専用モデル（デフォルト: "sonnet"）
+---@field default_model string デフォルトモデル。Claude短縮名（sonnet/opus/haiku/fable）または選択中backendのモデルID
+---@field utility_model string タイトル生成・要約等の軽量ユーティリティ呼び出し専用モデル（デフォルト: "sonnet"）
 ---@field default_effort ("low"|"medium"|"high"|"xhigh"|"max")? 推論量の既定値（未指定ならCLIの既定に任せる）
 ---@field utility_effort ("low"|"medium"|"high"|"xhigh"|"max")? タイトル生成・要約等の軽量呼び出しの推論量（デフォルト: "low"）
 ---@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）

--- a/lua/vibing/core/constants/agents.lua
+++ b/lua/vibing/core/constants/agents.lua
@@ -41,11 +41,13 @@ M.AGENTS = {
     export_name = "CodexCLIAdapter",
     description = "Codex CLI (OpenAI)",
     models = {
-      { value = "gpt-5.5", description = "GPT-5.5 (default)" },
-      { value = "gpt-5.4", description = "gpt-5.4" },
-      { value = "gpt-5.4-mini", description = "GPT-5.4-Mini" },
-      { value = "gpt-5.3-codex", description = "gpt-5.3-codex" },
-      { value = "gpt-5.2", description = "gpt-5.2" },
+      { value = "gpt-6-astra", description = "GPT-6 Astra (strongest Codex work)" },
+      { value = "gpt-5.6-sol", description = "GPT-5.6 Sol (deep reasoning)" },
+      { value = "gpt-5.6-terra", description = "GPT-5.6 Terra (everyday Codex work)" },
+      { value = "gpt-5.6-luna", description = "GPT-5.6 Luna (fast, narrow tasks)" },
+      { value = "gpt-5.5", description = "GPT-5.5 (previous generation)" },
+      { value = "gpt-5-codex", description = "GPT-5 Codex (API-key auth / Responses API)" },
+      { value = "gpt-5.3-codex-spark", description = "GPT-5.3 Codex Spark (preview, when available)" },
     },
   },
   copilot = {
@@ -108,6 +110,27 @@ end
 ---@return Vibing.AgentDefinition 未知のidならDEFAULTの定義
 function M.get(id)
   return M.AGENTS[id] or M.AGENTS[M.DEFAULT]
+end
+
+---@param id string?
+---@return Vibing.AgentModelCandidate[]
+function M.models_for(id)
+  return M.get(id).models
+end
+
+---@return string[] all known model candidate values, keeping backend order and removing duplicates
+function M.all_model_values()
+  local values = {}
+  local seen = {}
+  for _, def in ipairs(M.list()) do
+    for _, model in ipairs(def.models) do
+      if not seen[model.value] then
+        seen[model.value] = true
+        table.insert(values, model.value)
+      end
+    end
+  end
+  return values
 end
 
 return M

--- a/lua/vibing/infrastructure/completion/adapters/cmp.lua
+++ b/lua/vibing/infrastructure/completion/adapters/cmp.lua
@@ -35,7 +35,7 @@ function M.create()
   end
 
   function source:get_keyword_pattern()
-    return [[\%(@\%(file\|agent\):\)\?[[:keyword:]:-]*]]
+    return [[\%(@\%(file\|agent\):\)\?[[:keyword:].:-]*]]
   end
 
   ---@param params table

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -13,11 +13,6 @@ local AGENT_ENUM = vim.tbl_map(function(def)
   return { value = def.id, description = def.description }
 end, Agents.list())
 
-local MODELS_BY_AGENT = {}
-for _, def in ipairs(Agents.list()) do
-  MODELS_BY_AGENT[def.id] = def.models
-end
-
 ---Enum values for frontmatter fields
 local ENUMS = {
   agent = AGENT_ENUM,
@@ -84,7 +79,7 @@ end
 ---@param agent string? "claude" | "codex" | "copilot" (defaults to "claude")
 ---@return Vibing.CompletionItem[]
 function M.get_model_values(agent)
-  local models = MODELS_BY_AGENT[agent] or Agents.models_for(Agents.DEFAULT)
+  local models = Agents.models_for(agent)
   local items = {}
   for _, m in ipairs(models) do
     table.insert(items, {

--- a/lua/vibing/infrastructure/completion/providers/frontmatter.lua
+++ b/lua/vibing/infrastructure/completion/providers/frontmatter.lua
@@ -84,7 +84,7 @@ end
 ---@param agent string? "claude" | "codex" | "copilot" (defaults to "claude")
 ---@return Vibing.CompletionItem[]
 function M.get_model_values(agent)
-  local models = MODELS_BY_AGENT[agent] or MODELS_BY_AGENT[Agents.DEFAULT]
+  local models = MODELS_BY_AGENT[agent] or Agents.models_for(Agents.DEFAULT)
   local items = {}
   for _, m in ipairs(models) do
     table.insert(items, {

--- a/tests/chat_commands_spec.lua
+++ b/tests/chat_commands_spec.lua
@@ -157,6 +157,16 @@ describe("vibing.application.chat.commands", function()
       assert.is_false(result)
     end)
 
+    it("should offer model completions for every registered backend", function()
+      local completions = Commands.get_argument_completions("model")
+
+      assert.is_true(vim.tbl_contains(completions, "sonnet"))
+      assert.is_true(vim.tbl_contains(completions, "gpt-5.6-terra"))
+      assert.is_true(vim.tbl_contains(completions, "gpt-5-codex"))
+      assert.is_true(vim.tbl_contains(completions, "claude-sonnet-5"))
+      assert.is_true(vim.tbl_contains(completions, "grok-4.5"))
+    end)
+
     it("should execute registered command handler", function()
       local handler_called = false
       local handler_args = nil

--- a/tests/chat_init_spec.lua
+++ b/tests/chat_init_spec.lua
@@ -126,7 +126,7 @@ describe("vibing.application.chat.init", function()
         clear = "Clear context",
         save = "Save current chat",
         summarize = "Summarize conversation",
-        model = string.format("Set AI model: /model <%s>", table.concat(Modes.VALID_MODELS, "|")),
+        model = "Set AI model: /model <model>",
         effort = string.format("Set reasoning effort: /effort <%s>", table.concat(Modes.EFFORT_LEVELS, "|")),
       }
 

--- a/tests/completion/frontmatter_spec.lua
+++ b/tests/completion/frontmatter_spec.lua
@@ -74,6 +74,17 @@ describe("Frontmatter completion", function()
       assert.are.equal("Enum", items[1].kind)
     end)
 
+    it("should get current codex model values via get_model_values", function()
+      local items = frontmatter_provider.get_model_values("codex")
+      local values = vim.tbl_map(function(item)
+        return item.word
+      end, items)
+
+      assert.is_true(vim.tbl_contains(values, "gpt-6-astra"))
+      assert.is_true(vim.tbl_contains(values, "gpt-5.6-terra"))
+      assert.is_true(vim.tbl_contains(values, "gpt-5-codex"))
+    end)
+
     it("should fall back to claude models for an unknown agent", function()
       local items = frontmatter_provider.get_model_values("nonexistent")
       assert.are.equal(4, #items)
@@ -344,6 +355,56 @@ describe("Frontmatter completion", function()
     it("does not read an agent line from the body", function()
       open({ "---", "session_id: abc", "---", "agent: codex" })
       assert.is_nil(frontmatter_source._read_frontmatter_agent())
+    end)
+  end)
+
+  describe("model completion agent resolution", function()
+    local buf
+    local previous_buf
+    local config
+    local previous_options
+
+    local function open(lines)
+      previous_buf = vim.api.nvim_get_current_buf()
+      buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      vim.api.nvim_set_current_buf(buf)
+    end
+
+    before_each(function()
+      config = require("vibing.config")
+      previous_options = config.options
+    end)
+
+    after_each(function()
+      config.options = previous_options
+      if previous_buf and vim.api.nvim_buf_is_valid(previous_buf) then
+        vim.api.nvim_set_current_buf(previous_buf)
+      end
+      if buf and vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end)
+
+    it("uses config.adapter for model candidates when frontmatter has no agent", function()
+      config.setup({ adapter = "codex" })
+      open({ "---", "model: gpt", "---", "# Vibing Chat" })
+
+      local ctx = frontmatter_source.get_trigger_context("model: gpt", 10)
+      assert.are.equal("codex", ctx.agent)
+
+      local values = vim.tbl_map(function(item)
+        return item.word
+      end, frontmatter_source.get_candidates_sync(ctx))
+      assert.is_true(vim.tbl_contains(values, "gpt-5.6-terra"))
+    end)
+
+    it("falls back to config.adapter when frontmatter agent is invalid", function()
+      config.setup({ adapter = "codex" })
+      open({ "---", "agent: cdoex", "model: gpt", "---", "# Vibing Chat" })
+
+      local ctx = frontmatter_source.get_trigger_context("model: gpt", 10)
+      assert.are.equal("codex", ctx.agent)
     end)
   end)
 end)

--- a/tests/completion/slash_spec.lua
+++ b/tests/completion/slash_spec.lua
@@ -1,0 +1,12 @@
+local slash_source = require("vibing.application.completion.sources.slash")
+
+describe("Slash completion", function()
+  it("detects dotted model ids as one argument query", function()
+    local ctx = slash_source.get_trigger_context("/model gpt-5.", 13)
+
+    assert.is_not_nil(ctx)
+    assert.are.equal("argument", ctx.trigger)
+    assert.are.equal("model", ctx.command_name)
+    assert.are.equal("gpt-5.", ctx.query)
+  end)
+end)

--- a/tests/lua/application/chat/handlers/model_spec.lua
+++ b/tests/lua/application/chat/handlers/model_spec.lua
@@ -1,0 +1,33 @@
+describe("model handler", function()
+  local handler
+  local original_notify
+
+  before_each(function()
+    original_notify = package.loaded["vibing.core.utils.notify"]
+    package.loaded["vibing.application.chat.handlers.model"] = nil
+    package.loaded["vibing.core.utils.notify"] = {
+      error = function() end,
+      warn = function() end,
+      info = function() end,
+    }
+    handler = require("vibing.application.chat.handlers.model")
+  end)
+
+  after_each(function()
+    package.loaded["vibing.application.chat.handlers.model"] = nil
+    package.loaded["vibing.core.utils.notify"] = original_notify
+  end)
+
+  it("accepts codex model ids and writes them to frontmatter", function()
+    local written
+    local chat_buffer = {
+      update_frontmatter = function(_, key, value)
+        written = { key = key, value = value }
+        return true
+      end,
+    }
+
+    assert.is_true(handler({ "gpt-5.6-terra" }, chat_buffer))
+    assert.same({ key = "model", value = "gpt-5.6-terra" }, written)
+  end)
+end)

--- a/tests/lua/application/chat/handlers/model_spec.lua
+++ b/tests/lua/application/chat/handlers/model_spec.lua
@@ -30,4 +30,17 @@ describe("model handler", function()
     assert.is_true(handler({ "gpt-5.6-terra" }, chat_buffer))
     assert.same({ key = "model", value = "gpt-5.6-terra" }, written)
   end)
+
+  it("rejects a model id that belongs to no backend", function()
+    local written
+    local chat_buffer = {
+      update_frontmatter = function(_, key, value)
+        written = { key = key, value = value }
+        return true
+      end,
+    }
+
+    assert.is_false(handler({ "sonett" }, chat_buffer))
+    assert.is_nil(written)
+  end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
@@ -154,6 +154,12 @@ describe("codex_command_builder", function()
       local cmd = codex_command_builder.build("hi", {}, nil, config, nil)
       assert.equals("gpt-5-codex", cmd[find_flag(cmd, "-m") + 1])
     end)
+
+    it("prefer the frontmatter model passed through opts", function()
+      local config = { agent = { default_model = "gpt-5.5" } }
+      local cmd = codex_command_builder.build("hi", { model = "gpt-5.6-terra" }, nil, config, nil)
+      assert.equals("gpt-5.6-terra", cmd[find_flag(cmd, "-m") + 1])
+    end)
   end)
 
   -- Codex has no `--plugin-dir`; the plugins ride along as `-c` overrides instead

--- a/tests/lua/infrastructure/completion/adapters/cmp_spec.lua
+++ b/tests/lua/infrastructure/completion/adapters/cmp_spec.lua
@@ -1,0 +1,9 @@
+local cmp_adapter = require("vibing.infrastructure.completion.adapters.cmp")
+
+describe("cmp completion adapter", function()
+  it("keeps dotted model ids in the keyword pattern", function()
+    local source = cmp_adapter.create()
+
+    assert.is_true(source:get_keyword_pattern():find(".", 1, true) ~= nil)
+  end)
+end)


### PR DESCRIPTION
## Summary
- allow `/model` and frontmatter `model:` to carry backend-specific model IDs instead of Claude-only short names
- update Codex model completion candidates and make frontmatter model completion follow `agent:` then `config.adapter`
- keep cmp/slash completion working for dotted model IDs like `gpt-5.6-terra`

## Tests
- `git diff --check`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/completion/frontmatter_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/completion/slash_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/infrastructure/completion/adapters/cmp_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/chat_commands_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/chat_init_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/application/chat/handlers/model_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/core/constants/agents_spec.lua"`

## Notes
- `npm run check` could not run in this sandbox because `luac` is not installed.
- `npm run test:lua` currently fails in unrelated RPC/orchestration specs (`chat_list_spec.lua`, `chat_conflicts_spec.lua`) with chat-link save failures; the touched completion/Codex tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model settings now support backend-specific model IDs, including IDs with periods and hyphens.
  * The `/model` command validates supported IDs and provides completion options across available backends.
  * Model completion uses the chat’s configured or specified backend to determine suggestions.
  * Updated configuration examples include additional adapters and backend-specific model IDs.

* **Documentation**
  * Updated model-related guidance in the README, API reference, tutorial, configuration handbook, and help documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->