### PR TITLE
fix(mcp): keep RPC routing out of cached prompts

### DIFF
--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -20,9 +20,16 @@ The tool catalogue, the orchestration tools, annotations and background LSP anal
 - **`VIBING_NVIM_MCP_TOOL_PATTERNS` (`core/constants/tools.lua`) is hand-maintained**, because
   `--allowedTools` accepts nothing but literals. A stale entry does not break chats — the hook's
   suffix match is what decides — which is why a dead one went unnoticed for so long.
-- **`rpc_port` has to be named explicitly on every call, and a subagent does not inherit it.** The
-  system prompt tells the model to pass its own and to forward it in any task prompt it hands a
-  subagent. The one home for both this and the prefix rule is
+- **The instance is bound out-of-band, so `rpc_port` is omitted.** Both CLI adapters export
+  `VIBING_NVIM_RPC_PORT` (`adapter/modules/rpc_environment.lua`); claude hands the launching
+  environment to plugin MCP servers and codex is told to copy that one variable by name, so a
+  subagent shares the already-bound connection. The numeric port must never re-enter a prompt, a
+  task brief or a tool call — it changes on every Neovim restart, which is what invalidated the
+  cached prefix (#730). **The registry fallback for an unbound server is reads-only**
+  (`mcp-server/src/read-only-methods.ts`, an allowlist — a new method is a writer until it is
+  classified), since the server can also be registered at user scope where an unrelated session
+  would otherwise get `nvim_execute` against whichever Neovim is live. The one home for both this
+  and the prefix rule is
   `claude-plugin/skills/nvim-context/SKILL.md` → "Calling the tools"; other skills state it in a
   line and point there, because a skill is loaded on its own.
 - **Never assume `winnr: 0`.** `nvim_get_window_info({ winnr: 0 })` returns the _active_ window,

--- a/.claude/rules/self-development.md
+++ b/.claude/rules/self-development.md
@@ -15,11 +15,11 @@ query the **running** Neovim with its live LSP servers; generic tools analyze se
 and miss runtime state. Same for buffer and window operations (`nvim_get_buffer`,
 `nvim_set_buffer`, `nvim_list_windows`, `nvim_load_buffer`).
 
-**Omitting `rpc_port`.** Pass the value from your system prompt on every MCP call. Worktrees and
-concurrent chats make several live Neovim instances the normal case, and omitting it falls back to
-the instance registry, which only answers when exactly one is live. `process.env.VIBING_NVIM_RPC_PORT`
-is **not** a substitute: MCP clients forward only a fixed whitelist of variables plus the server
-registration's static `env` block, so it never reaches the MCP server process.
+**Naming an `rpc_port` on an MCP call.** Omit it. The MCP server process is bound to the Neovim
+that launched the chat through `VIBING_NVIM_RPC_PORT`, and a subagent shares that already-bound
+connection. The argument survives only as a compatibility override for a server started manually
+outside vibing.nvim. Putting the numeric port back into a prompt, a task brief or a tool call is
+what #730 removed: it changes on every Neovim restart, so it breaks the cached prompt prefix.
 
 Context is managed with `:VibingContext <file>` / `:VibingClearContext`. Inside a vibing.nvim
 session `VIBING_NVIM_CONTEXT=true` and `VIBING_NVIM_RPC_PORT=<port>` are set.

--- a/claude-plugin/agents/nvim-navigator.md
+++ b/claude-plugin/agents/nvim-navigator.md
@@ -11,11 +11,10 @@ vibing-nvim MCP server, not static file reads.
 **Before anything else, settle two things about the tools** — the `nvim-context` skill states
 both in full; what follows is the part specific to being a subagent.
 
-_Which port._ Every vibing-nvim tool takes an `rpc_port` naming the Neovim instance to talk to,
-and you do **not** inherit the value the chat that spawned you was given. Take it from your task
-prompt; whoever delegates to you is expected to pass it along. If it isn't there, call
-`nvim_list_instances` once and use the port it reports — and if that lists more than one instance,
-say which ones you found and ask rather than guessing.
+_Which instance._ The MCP server process is already bound to the Neovim that launched the parent
+chat, and subagents share that connection. Omit the optional legacy `rpc_port` argument. Only a
+manually started, unbound server should need `nvim_list_instances`; if several instances remain
+plausible there, do not guess — tell the parent what you found and ask it to disambiguate.
 
 _Which prefix._ The tools below are written as `mcp__vibing-nvim__<tool>`, but a plugin-scoped
 plugin load exposes them as `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` instead. If the plain

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -479,7 +479,7 @@ The server uses a simple JSON-RPC protocol over TCP:
 
 - Ensure Neovim is running with MCP enabled
 - Check that RPC server port (9876) is not in use
-- Verify `VIBING_RPC_PORT` environment variable matches config
+- Verify `VIBING_NVIM_RPC_PORT` environment variable matches config
 
 ### Request Timeout
 
@@ -487,7 +487,7 @@ The server uses a simple JSON-RPC protocol over TCP:
 - For heavy LSP operations (e.g., call hierarchy in large projects), consider increasing timeout:
   ```json
   "env": {
-    "VIBING_RPC_PORT": "9876",
+    "VIBING_NVIM_RPC_PORT": "9876",
     "VIBING_RPC_TIMEOUT": "60000"
   }
   ```

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -112,7 +112,7 @@ Add to `~/.claude.json`:
       "command": "node",
       "args": ["/path/to/vibing.nvim/claude-plugin/mcp-server/dist/index.js"],
       "env": {
-        "VIBING_RPC_PORT": "9876",
+        "VIBING_NVIM_RPC_PORT": "9876",
         "VIBING_RPC_TIMEOUT": "30000"
       }
     }
@@ -122,7 +122,8 @@ Add to `~/.claude.json`:
 
 **Environment Variables:**
 
-- `VIBING_RPC_PORT`: RPC server port (default: 9876)
+- `VIBING_NVIM_RPC_PORT`: Neovim RPC server port. vibing.nvim supplies this automatically;
+  configure it only when launching the MCP server manually.
 - `VIBING_RPC_TIMEOUT`: Request timeout in milliseconds (default: 30000 = 30 seconds)
 
 ### 3. Enable MCP in vibing.nvim

--- a/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/chat-tools.test.ts
@@ -32,7 +32,7 @@ describe('chat tools (worktree redesign)', () => {
     expect(typeof handlers.nvim_chat_send_message).toBe('function');
   });
 
-  it('registers nvim_ask_user_question with chat_bufnr, rpc_port, and questions all required', () => {
+  it('registers nvim_ask_user_question with chat_bufnr and questions required', () => {
     const tool = allTools.find((t) => t.name === 'nvim_ask_user_question');
     expect(tool).toBeDefined();
     const inputSchema = tool?.inputSchema as {
@@ -40,25 +40,21 @@ describe('chat tools (worktree redesign)', () => {
       properties: Record<string, unknown>;
     };
     expect(inputSchema.required).toContain('chat_bufnr');
-    // Still required despite the registry fallback added for read-only tools: this one cancels
-    // the in-flight turn, and every Claude Code session on the machine can see it.
-    expect(inputSchema.required).toContain('rpc_port');
+    expect(inputSchema.required).not.toContain('rpc_port');
     expect(inputSchema.required).toContain('questions');
     expect(inputSchema.properties.chat_bufnr).toBeDefined();
     expect(inputSchema.properties.rpc_port).toBeDefined();
     expect(inputSchema.properties.questions).toBeDefined();
   });
 
-  it('registers nvim_chat_create with rpc_port required and everything else optional', () => {
+  it('registers nvim_chat_create with every argument optional', () => {
     const tool = allTools.find((t) => t.name === 'nvim_chat_create');
     expect(tool).toBeDefined();
     const inputSchema = tool?.inputSchema as {
       required?: string[];
       properties: Record<string, any>;
     };
-    // It creates a buffer, so it is a write: it must name its instance rather than fall back to
-    // the registry (see requireRpcPort in ../tools/common.ts).
-    expect(inputSchema.required).toEqual(['rpc_port']);
+    expect(inputSchema.required).toEqual([]);
     expect(inputSchema.properties.position.enum).toEqual([...CHAT_POSITIONS]);
     expect(inputSchema.properties.working_dir).toBeDefined();
   });
@@ -100,11 +96,21 @@ describe('chat tools (worktree redesign)', () => {
     expect(result.content[0].text).toContain('"bufnr": 12');
   });
 
-  it('nvim_chat_create rejects a call missing rpc_port instead of guessing an instance', async () => {
+  it('nvim_chat_create lets callNeovim use the process binding when rpc_port is omitted', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ bufnr: 7 });
 
-    await expect(handlers.nvim_chat_create({ position: 'back' })).rejects.toThrow();
-    expect(rpc.callNeovim).not.toHaveBeenCalled();
+    await handlers.nvim_chat_create({ position: 'back' });
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'create_chat',
+      {
+        position: 'back',
+        working_dir: undefined,
+        from_bufnr: undefined,
+        task: undefined,
+        delegated_scope: undefined,
+      },
+      undefined
+    );
   });
 
   it('nvim_chat_create rejects a position the Lua handler would refuse anyway', async () => {
@@ -125,10 +131,10 @@ describe('chat tools (worktree redesign)', () => {
     expect(rpc.callNeovim).not.toHaveBeenCalled();
   });
 
-  it('registers nvim_chat_send_message with rpc_port required', () => {
+  it('registers nvim_chat_send_message with rpc_port optional', () => {
     const tool = allTools.find((t) => t.name === 'nvim_chat_send_message');
     const inputSchema = tool?.inputSchema as { required?: string[] };
-    expect(inputSchema.required).toContain('rpc_port');
+    expect(inputSchema.required).not.toContain('rpc_port');
   });
 
   it('offers from_bufnr on both chat tools but never requires it', () => {
@@ -352,7 +358,7 @@ describe('chat tools (worktree redesign)', () => {
     };
 
     expect(tool).toBeDefined();
-    expect(inputSchema.required).toContain('rpc_port');
+    expect(inputSchema.required).not.toContain('rpc_port');
     expect(inputSchema.required).toContain('action');
     // Unlike the other two chat tools, this one cannot be called anonymously: it removes a
     // permission gate, so the answer has to be attributable to a chat.
@@ -559,16 +565,16 @@ describe('chat tools (worktree redesign)', () => {
     expect(rpc.callNeovim).not.toHaveBeenCalled();
   });
 
-  it('nvim_ask_user_question rejects a call missing rpc_port instead of falling back to the registry', async () => {
+  it('nvim_ask_user_question lets callNeovim use the process binding when rpc_port is omitted', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ status: 'ok' });
 
-    await expect(
-      handlers.nvim_ask_user_question({
-        chat_bufnr: 12,
-        questions: [{ question: 'Which?', options: [{ label: 'A' }] }],
-      })
-    ).rejects.toThrow();
-    expect(rpc.callNeovim).not.toHaveBeenCalled();
+    const questions = [{ question: 'Which?', options: [{ label: 'A' }] }];
+    await handlers.nvim_ask_user_question({ chat_bufnr: 12, questions });
+    expect(rpc.callNeovim).toHaveBeenCalledWith(
+      'ask_user_question',
+      { chat_bufnr: 12, questions },
+      undefined
+    );
   });
 
   it('nvim_ask_user_question surfaces an error result when the RPC call fails to find a stream', async () => {
@@ -591,8 +597,6 @@ describe('chat tools (worktree redesign)', () => {
       required?: string[];
       properties: Record<string, unknown>;
     };
-    // A read, like nvim_list_buffers: rpc_port falls back to the instance registry rather than
-    // being required (see requireRpcPort's doc comment in ../tools/common.ts).
     expect(inputSchema.required).toEqual([]);
     expect(inputSchema.properties.rpc_port).toBeDefined();
   });
@@ -622,7 +626,7 @@ describe('chat tools (worktree redesign)', () => {
     expect(parsed.chats).toEqual(chats);
   });
 
-  it('nvim_chat_list works without rpc_port, falling back to the instance registry', async () => {
+  it('nvim_chat_list lets the central resolver choose the bound instance', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ chats: [] });
 
     const result = await handlers.nvim_chat_list({});
@@ -667,7 +671,7 @@ describe('chat tools (worktree redesign)', () => {
     expect(parsed.conflicts).toEqual(conflicts);
   });
 
-  it('nvim_chat_conflicts works without rpc_port, falling back to the instance registry', async () => {
+  it('nvim_chat_conflicts lets the central resolver choose the bound instance', async () => {
     vi.mocked(rpc.callNeovim).mockResolvedValue({ conflicts: [] });
 
     const result = await handlers.nvim_chat_conflicts({});

--- a/claude-plugin/mcp-server/src/__tests__/dap-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/dap-tools.test.ts
@@ -27,11 +27,14 @@ describe('dap tools', () => {
       expect(typeof handlers[name]).toBe('function');
     });
 
-    it.each(DAP_TOOLS)('%s requires rpc_port — it targets one debug session', (name) => {
-      const tool = allTools.find((t) => t.name === name);
-      const schema = tool?.inputSchema as { required?: string[] };
-      expect(schema.required).toContain('rpc_port');
-    });
+    it.each(DAP_TOOLS)(
+      '%s leaves rpc_port optional because the server is already bound',
+      (name) => {
+        const tool = allTools.find((t) => t.name === name);
+        const schema = tool?.inputSchema as { required?: string[] };
+        expect(schema.required).not.toContain('rpc_port');
+      }
+    );
 
     it('requires file and line to set a breakpoint', () => {
       const tool = allTools.find((t) => t.name === 'nvim_dap_set_breakpoint');
@@ -86,7 +89,6 @@ describe('dap tools', () => {
 
   describe('rejects before touching Neovim', () => {
     const rejected: Array<[string, string, Record<string, unknown>]> = [
-      ['no rpc_port', 'nvim_dap_get_state', {}],
       ['an empty expression', 'nvim_dap_evaluate', { expression: '', rpc_port: 9876 }],
       ['no expression at all', 'nvim_dap_evaluate', { rpc_port: 9876 }],
       ['no line', 'nvim_dap_set_breakpoint', { file: 'a.py', rpc_port: 9876 }],
@@ -98,6 +100,11 @@ describe('dap tools', () => {
         { file: '../../../etc/passwd', line: 1, rpc_port: 9876 },
       ],
     ];
+
+    it('accepts no rpc_port and lets callNeovim use the process binding', async () => {
+      await handlers.nvim_dap_get_state({});
+      expect(rpc.callNeovim).toHaveBeenCalledWith('dap_get_state', {}, undefined);
+    });
 
     it.each(rejected)('rejects %s', async (_label, name, args) => {
       await expect(handlers[name](args)).rejects.toThrow();

--- a/claude-plugin/mcp-server/src/__tests__/qflist-tools.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/qflist-tools.test.ts
@@ -20,7 +20,7 @@ describe('nvim_set_qflist', () => {
   });
 
   describe('registration', () => {
-    it('is registered as a tool with items and rpc_port required', () => {
+    it('is registered as a tool with items required and rpc_port optional', () => {
       const tool = allTools.find((t) => t.name === 'nvim_set_qflist');
       expect(tool).toBeDefined();
       const inputSchema = tool?.inputSchema as {
@@ -28,7 +28,7 @@ describe('nvim_set_qflist', () => {
         properties: Record<string, unknown>;
       };
       expect(inputSchema.required).toContain('items');
-      expect(inputSchema.required).toContain('rpc_port');
+      expect(inputSchema.required).not.toContain('rpc_port');
       expect(inputSchema.properties.title).toBeDefined();
       expect(inputSchema.properties.open).toBeDefined();
     });
@@ -86,7 +86,6 @@ describe('nvim_set_qflist', () => {
     // Each of these would otherwise reach the editor and produce a quickfix list with dead
     // entries, which the user only discovers when :cnext lands nowhere.
     const rejected: Array<[string, Record<string, unknown>]> = [
-      ['no rpc_port, which would leave the target instance ambiguous', { items: [VALID_ITEM] }],
       ['an empty route', { items: [], rpc_port: 9876 }],
       ['a stop with no filename', { items: [{ lnum: 1 }], rpc_port: 9876 }],
       ['a stop with no lnum', { items: [{ filename: 'a.lua' }], rpc_port: 9876 }],
@@ -99,6 +98,15 @@ describe('nvim_set_qflist', () => {
         { items: [{ filename: '../../../etc/passwd', lnum: 1 }], rpc_port: 9876 },
       ],
     ];
+
+    it('accepts no rpc_port and lets callNeovim use the process binding', async () => {
+      await call({ items: [VALID_ITEM] });
+      expect(rpc.callNeovim).toHaveBeenCalledWith(
+        'set_qflist',
+        { items: [VALID_ITEM], title: undefined, open: undefined },
+        undefined
+      );
+    });
 
     it.each(rejected)('rejects %s', async (_label, args) => {
       await expect(call(args)).rejects.toThrow();

--- a/claude-plugin/mcp-server/src/__tests__/read-only-methods.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/read-only-methods.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { READ_ONLY_METHODS } from '../read-only-methods.js';
+
+/**
+ * The handler *sources*, found by walking up to the package root — this spec is compiled into
+ * `dist/` and run from there too, where `../handlers` holds only `.d.ts` files.
+ */
+function handlersDir(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(dir, 'src', 'handlers');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    dir = path.dirname(dir);
+  }
+  throw new Error('could not locate src/handlers from ' + fileURLToPath(import.meta.url));
+}
+
+/**
+ * Every method a handler asks for by name, taken from the source rather than a hand-kept list —
+ * a new one has to be classified here before this file passes again.
+ */
+function calledMethods(): string[] {
+  const found = new Set<string>();
+  const dir = handlersDir();
+  for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.ts'))) {
+    const source = fs.readFileSync(path.join(dir, file), 'utf8');
+    for (const match of source.matchAll(/callNeovim\(\s*'([a-z_]+)'/g)) {
+      found.add(match[1]);
+    }
+  }
+  if (found.size === 0) {
+    throw new Error('no callNeovim() methods found — the scan, not the code, is broken');
+  }
+  return [...found].sort();
+}
+
+/**
+ * The methods that change Neovim state, and so must never be pointed at a registry-guessed
+ * instance. This is exactly the set `requireRpcPort` used to enforce in each tool's schema.
+ */
+const STATE_CHANGING_METHODS = [
+  'annotate',
+  'answer_approval',
+  'ask_user_question',
+  'buf_set_lines',
+  'clear_annotations',
+  'clear_highlight',
+  'create_chat',
+  'dap_evaluate',
+  'dap_get_stack_trace',
+  'dap_get_state',
+  'dap_get_variables',
+  'dap_set_breakpoint',
+  'execute',
+  'focus_window',
+  'highlight_range',
+  'load_buffer',
+  'send_message',
+  'set_cursor_position',
+  'set_qflist',
+  'set_window_height',
+  'set_window_width',
+  'win_open_file',
+  'win_set_buf',
+];
+
+describe('read-only method allowlist', () => {
+  it('classifies every method the handlers call', () => {
+    const classified = new Set([...READ_ONLY_METHODS, ...STATE_CHANGING_METHODS]);
+    const unclassified = calledMethods().filter((m) => !classified.has(m));
+
+    // A new method defaults to "writer" in rpc.ts, so this failure is a reminder to say which it
+    // is here, not a bug in itself.
+    expect(unclassified, 'unclassified RPC methods').toEqual([]);
+  });
+
+  it('never lets a state-changing method through as a read', () => {
+    for (const method of STATE_CHANGING_METHODS) {
+      expect(READ_ONLY_METHODS.has(method), `${method} must not be read-only`).toBe(false);
+    }
+  });
+
+  it('lists no method no handler calls, so a rename cannot leave a dead entry', () => {
+    const called = new Set(calledMethods());
+    for (const method of READ_ONLY_METHODS) {
+      expect(called.has(method), `${method} is not called by any handler`).toBe(true);
+    }
+  });
+});

--- a/claude-plugin/mcp-server/src/__tests__/rpc-port-policy.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/rpc-port-policy.test.ts
@@ -2,46 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { allTools } from '../tools/index.js';
 
 /**
- * Reads may omit rpc_port and fall back to the instance registry; anything that changes state
- * must name its target. The reason is that this server is installed at Claude Code's *user*
- * scope, so every Claude Code session on the machine sees these tools — including sessions with
- * nothing to do with vibing.nvim, which have no port to pass. See requireRpcPort in
- * tools/common.ts.
- *
- * The list below is the *reads*, not the writes, so the rule fails closed: a tool nobody
- * classified is treated as state-changing and must require the port. Listing the writes instead
- * meant every new state-changing tool broke this test on arrival even though it was correct —
- * which is exactly what happened when nvim_highlight_range landed.
- */
-const READ_ONLY_TOOLS = [
-  'nvim_diagnostics',
-  // Stays a read despite `file_path` opening a chat buffer that was closed (#641). The rule
-  // exists so a state change cannot land on an instance the caller did not name, and this one
-  // cannot: the registry fallback answers only when exactly one Neovim is live. What it leaves
-  // behind is a buffer for a chat file the user already has on disk.
-  'nvim_get_buffer',
-  'nvim_get_cursor',
-  'nvim_get_info',
-  'nvim_get_visual_selection',
-  'nvim_get_window_info',
-  'nvim_get_window_view',
-  'nvim_chat_list',
-  'nvim_chat_conflicts',
-  'nvim_list_buffers',
-  'nvim_list_tabpages',
-  'nvim_list_windows',
-  'nvim_lsp_call_hierarchy_incoming',
-  'nvim_lsp_call_hierarchy_outgoing',
-  'nvim_lsp_definition',
-  'nvim_lsp_document_symbols',
-  'nvim_lsp_hover',
-  'nvim_lsp_references',
-  'nvim_lsp_type_definition',
-];
-
-/**
  * Reading the registry is how you find out which ports exist, so this one cannot take a port at
- * all — it is neither a read that may omit it nor a write that must supply it.
+ * all. Every server-backed tool keeps an optional legacy override for manually launched clients.
  */
 const PORTLESS_TOOLS = ['nvim_list_instances'];
 
@@ -52,23 +14,19 @@ const acceptsRpcPort = (tool: { inputSchema: unknown }) =>
   Boolean((tool.inputSchema as { properties?: Record<string, unknown> })?.properties?.rpc_port);
 
 describe('rpc_port policy', () => {
-  it('requires rpc_port on every tool that is not a known read', () => {
-    const writes = allTools.filter(
-      (t) => !READ_ONLY_TOOLS.includes(t.name) && !PORTLESS_TOOLS.includes(t.name)
-    );
-
-    expect(writes.length).toBeGreaterThan(0);
-    for (const tool of writes) {
-      expect(requiredOf(tool), `${tool.name} must require rpc_port`).toContain('rpc_port');
+  it('never requires the runtime-bound port from the model', () => {
+    for (const tool of allTools) {
+      expect(requiredOf(tool), `${tool.name} should not require rpc_port`).not.toContain(
+        'rpc_port'
+      );
     }
   });
 
-  it('leaves rpc_port optional on the reads', () => {
-    for (const name of READ_ONLY_TOOLS) {
-      const tool = allTools.find((t) => t.name === name);
-      expect(tool, `${name} is not registered`).toBeDefined();
-      expect(acceptsRpcPort(tool!), `${name} should accept rpc_port`).toBe(true);
-      expect(requiredOf(tool!), `${name} should not require rpc_port`).not.toContain('rpc_port');
+  it('keeps an optional override on every server-backed tool', () => {
+    for (const tool of allTools) {
+      if (!PORTLESS_TOOLS.includes(tool.name)) {
+        expect(acceptsRpcPort(tool), `${tool.name} should accept rpc_port`).toBe(true);
+      }
     }
   });
 

--- a/claude-plugin/mcp-server/src/__tests__/rpc.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/rpc.test.ts
@@ -107,6 +107,41 @@ describe('callNeovim port resolution', () => {
     }
   });
 
+  // The pre-#730 `requireRpcPort` schema guard, moved to where the port is resolved: a session
+  // that was never launched by vibing.nvim has neither source, and a guessed instance would let
+  // it drive whichever editor the user happens to have open.
+  it('refuses to guess an instance for a call that changes state', async () => {
+    vi.mocked(listLiveInstances).mockResolvedValue([{ pid: 111, port: 9876, cwd: '/repo' }]);
+
+    await expect(callNeovim('execute', { command: 'qa!' })).rejects.toThrow(
+      /changes Neovim state, so it is not pointed at a guessed instance/
+    );
+  });
+
+  it('runs the same state-changing call once the process is bound', async () => {
+    const nvim = await startFakeNeovim('executed');
+    process.env.VIBING_NVIM_RPC_PORT = String(nvim.port);
+
+    try {
+      await expect(callNeovim('execute', { command: 'echo 1' })).resolves.toBe('executed');
+      expect(vi.mocked(listLiveInstances)).not.toHaveBeenCalled();
+    } finally {
+      nvim.close();
+    }
+  });
+
+  it('runs the same state-changing call when a port is passed explicitly', async () => {
+    const nvim = await startFakeNeovim('executed');
+
+    try {
+      await expect(callNeovim('execute', { command: 'echo 1' }, nvim.port)).resolves.toBe(
+        'executed'
+      );
+    } finally {
+      nvim.close();
+    }
+  });
+
   it('rejects rather than guessing a port when nothing is running', async () => {
     vi.mocked(listLiveInstances).mockResolvedValue([]);
 

--- a/claude-plugin/mcp-server/src/__tests__/rpc.test.ts
+++ b/claude-plugin/mcp-server/src/__tests__/rpc.test.ts
@@ -32,12 +32,56 @@ async function startFakeNeovim(result: unknown): Promise<{ port: number; close: 
 }
 
 describe('callNeovim port resolution', () => {
+  const originalRpcPort = process.env.VIBING_NVIM_RPC_PORT;
+
   beforeEach(() => {
     vi.mocked(listLiveInstances).mockReset();
+    delete process.env.VIBING_NVIM_RPC_PORT;
   });
 
   afterEach(() => {
     closeSocket();
+    if (originalRpcPort === undefined) {
+      delete process.env.VIBING_NVIM_RPC_PORT;
+    } else {
+      process.env.VIBING_NVIM_RPC_PORT = originalRpcPort;
+    }
+  });
+
+  it('uses the process-bound port without consulting the registry', async () => {
+    const nvim = await startFakeNeovim('from-process-environment');
+    process.env.VIBING_NVIM_RPC_PORT = String(nvim.port);
+
+    try {
+      await expect(callNeovim('get_current_file', {})).resolves.toBe('from-process-environment');
+      expect(vi.mocked(listLiveInstances)).not.toHaveBeenCalled();
+    } finally {
+      nvim.close();
+    }
+  });
+
+  it('keeps the process binding authoritative over a legacy tool argument', async () => {
+    const bound = await startFakeNeovim('from-bound-port');
+    const requested = await startFakeNeovim('from-requested-port');
+    process.env.VIBING_NVIM_RPC_PORT = String(bound.port);
+
+    try {
+      await expect(callNeovim('get_current_file', {}, requested.port)).resolves.toBe(
+        'from-bound-port'
+      );
+    } finally {
+      bound.close();
+      requested.close();
+    }
+  });
+
+  it('fails closed when the process binding is invalid', async () => {
+    process.env.VIBING_NVIM_RPC_PORT = 'not-a-port';
+
+    await expect(callNeovim('get_current_file', {}, 9876)).rejects.toThrow(
+      /VIBING_NVIM_RPC_PORT must be an integer from 1 to 65535/
+    );
+    expect(vi.mocked(listLiveInstances)).not.toHaveBeenCalled();
   });
 
   it('uses the given port without consulting the registry', async () => {

--- a/claude-plugin/mcp-server/src/handlers/chat.ts
+++ b/claude-plugin/mcp-server/src/handlers/chat.ts
@@ -19,7 +19,7 @@ const chatCreateArgsSchema = z.object({
   from_bufnr: z.number().optional(),
   task: taskSchema,
   delegated_scope: z.array(z.string()).optional(),
-  rpc_port: z.number(),
+  rpc_port: z.number().optional(),
 });
 
 /**
@@ -77,7 +77,7 @@ const chatSendMessageArgsSchema = z.object({
   from_bufnr: z.number().optional(),
   queue_if_busy: z.boolean().optional(),
   task: taskSchema,
-  rpc_port: z.number(),
+  rpc_port: z.number().optional(),
 });
 
 /**
@@ -145,7 +145,7 @@ export async function handleChatSendMessage(args: any): Promise<any> {
 const askUserQuestionArgsSchema = z.object({
   chat_bufnr: z.number(),
   questions: z.array(z.any()),
-  rpc_port: z.number(),
+  rpc_port: z.number().optional(),
 });
 
 /**
@@ -158,12 +158,9 @@ const askUserQuestionArgsSchema = z.object({
  * so this handler's return value is never actually seen by the model. The user's next message in
  * that buffer (a fresh `--resume`d turn) IS the answer to this call.
  *
- * `chat_bufnr` and `rpc_port` correlate the call to the right chat buffer/Neovim instance when
- * multiple are active concurrently. They are tool arguments rather than env lookups because env
- * can't carry them here — see `resolveRpcPort` in `../rpc.ts`. Both stay required: this tool kills
- * the in-flight turn, so it is one of the write-side tools that must name its target rather than
- * fall back to the registry (see `requireRpcPort` in `../tools/common.ts`).
- * `chat_bufnr` (unlike a per-turn handle_id) is stable across turns of the same conversation,
+ * `chat_bufnr` correlates the call to the right chat buffer when several are active concurrently;
+ * `rpc.ts` binds the MCP process to the right Neovim through its environment. The buffer number
+ * (unlike a per-turn handle_id) is stable across turns of the same conversation,
  * so it doesn't defeat Anthropic's prompt cache — see issue #469. It is the buffer number rather
  * than the chat file path because `:VibingSetFileTitle` renames the file mid-conversation, which
  * would change the system prompt and invalidate that cache — see issue #489.
@@ -195,7 +192,7 @@ const chatAnswerApprovalArgsSchema = z.object({
   file_path: z.string().nullish(),
   action: z.enum(APPROVAL_ACTIONS),
   from_bufnr: z.number(),
-  rpc_port: z.number(),
+  rpc_port: z.number().optional(),
 });
 
 /**
@@ -251,8 +248,7 @@ export async function handleChatAnswerApproval(args: any): Promise<any> {
  *
  * Enumerates every chat buffer `view.list_chat_buffers()` knows about on the Lua side — the same
  * source `application/chat/concurrency.lua` reads to answer "how many chats are responding right
- * now" — and reports each one's status in a single round trip. A read, so `rpc_port` stays
- * optional and falls back to the instance registry like `nvim_list_buffers`.
+ * now" — and reports each one's status in a single round trip.
  */
 export async function handleChatList(args: any): Promise<any> {
   const result = await callNeovim('list_chats', {}, args?.rpc_port);
@@ -264,7 +260,6 @@ export async function handleChatList(args: any): Promise<any> {
 /**
  * Handler for nvim_chat_conflicts
  *
- * A read, like nvim_chat_list: rpc_port stays optional and falls back to the instance registry.
  * The Lua side (`chat_conflicts` in `rpc/handlers/chat.lua`) does all the work — enumerating
  * live chats, resolving each one's `working_dir` to a worktree, diffing it against main/master,
  * and grouping the results by file. This handler only forwards the call and the JSON back.

--- a/claude-plugin/mcp-server/src/handlers/dap.ts
+++ b/claude-plugin/mcp-server/src/handlers/dap.ts
@@ -10,8 +10,8 @@ import { z } from 'zod';
  * This layer only rejects arguments that could not work at all, before touching Neovim.
  */
 
-// Every dap tool targets exactly one debug session, so rpc_port is the one shared requirement.
-const baseArgsSchema = z.object({ rpc_port: z.number() });
+// The MCP process is already bound to one Neovim; rpc_port remains a legacy optional override.
+const baseArgsSchema = z.object({ rpc_port: z.number().optional() });
 
 const stackTraceArgsSchema = baseArgsSchema.extend({ thread_id: z.number().int().optional() });
 const variablesArgsSchema = baseArgsSchema.extend({ frame_id: z.number().int().optional() });

--- a/claude-plugin/mcp-server/src/handlers/qflist.ts
+++ b/claude-plugin/mcp-server/src/handlers/qflist.ts
@@ -13,7 +13,7 @@ const setQflistArgsSchema = z.object({
   items: z.array(qflistItemSchema).min(1),
   title: z.string().optional(),
   open: z.boolean().optional(),
-  rpc_port: z.number(),
+  rpc_port: z.number().optional(),
 });
 
 /**

--- a/claude-plugin/mcp-server/src/read-only-methods.ts
+++ b/claude-plugin/mcp-server/src/read-only-methods.ts
@@ -1,0 +1,35 @@
+/**
+ * The RPC methods that only look at Neovim.
+ *
+ * `rpc.ts` guesses an instance from the registry for these and refuses to for anything else.
+ * Reads are safe to guess: the worst case is answering about the wrong buffer. A call that
+ * changes state is not, because this server can also be registered at Claude Code's *user*
+ * scope, where an ordinary session that has nothing to do with vibing.nvim sees these tools with
+ * no `VIBING_NVIM_RPC_PORT` in its environment. Guessing there would hand it `nvim_execute`,
+ * `nvim_set_buffer` and `nvim_chat_send_message` against whichever editor the user has open.
+ *
+ * **The list is an allowlist, so a new method is a writer until it is added here.** A method name
+ * that says nothing about its behaviour has to count as one; the failure of the opposite shape is
+ * silent, since a missing entry only shows up on a machine running exactly one Neovim.
+ */
+export const READ_ONLY_METHODS = new Set([
+  'buf_get_lines',
+  'chat_conflicts',
+  'diagnostics_get',
+  'get_current_file',
+  'get_cursor_position',
+  'get_visual_selection',
+  'get_window_info',
+  'get_window_view',
+  'list_buffers',
+  'list_chats',
+  'list_tabpages',
+  'list_windows',
+  'lsp_call_hierarchy_incoming',
+  'lsp_call_hierarchy_outgoing',
+  'lsp_definition',
+  'lsp_document_symbols',
+  'lsp_hover',
+  'lsp_references',
+  'lsp_type_definition',
+]);

--- a/claude-plugin/mcp-server/src/rpc.ts
+++ b/claude-plugin/mcp-server/src/rpc.ts
@@ -1,5 +1,6 @@
 import * as net from 'net';
 import { listLiveInstances } from './instance-registry.js';
+import { READ_ONLY_METHODS } from './read-only-methods.js';
 
 const NVIM_RPC_TIMEOUT = parseInt(process.env.VIBING_RPC_TIMEOUT || '30000', 10); // Default 30 seconds
 const RPC_PORT_ENV = 'VIBING_NVIM_RPC_PORT';
@@ -117,8 +118,9 @@ function getSocket(port: number): Promise<net.Socket> {
  * A server launched by vibing.nvim is bound out-of-band through `VIBING_NVIM_RPC_PORT`. Keeping
  * that runtime value in the process environment instead of every tool schema and system prompt
  * preserves the model's cached prefix when Neovim restarts on another port. The explicit argument
- * remains a compatibility fallback for manually launched clients, followed by the registry when
- * exactly one instance is live.
+ * remains a compatibility fallback for manually launched clients, followed -- for reads only --
+ * by the registry when exactly one instance is live. A call that changes state is never pointed
+ * at a guessed instance; see `read-only-methods.ts`.
  *
  * @param method - RPC method name, used only to make the error message actionable
  * @param requestedPort - Legacy port supplied by a tool caller
@@ -127,6 +129,9 @@ function getSocket(port: number): Promise<net.Socket> {
  */
 async function resolveRpcPort(method: string, requestedPort?: number): Promise<number> {
   const configured = process.env[RPC_PORT_ENV];
+  // Blank reads as unset rather than as an error: vibing.nvim only ever writes a real port here,
+  // but a manual `~/.claude.json` env block is hand-edited, and `"VIBING_NVIM_RPC_PORT": ""`
+  // should fall through to `rpc_port` instead of failing every call in the session.
   if (configured !== undefined && configured.trim() !== '') {
     const port = Number(configured);
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
@@ -147,6 +152,14 @@ async function resolveRpcPort(method: string, requestedPort?: number): Promise<n
     throw new Error(
       `callNeovim('${method}'): no running vibing.nvim Neovim instance found. Start Neovim with ` +
         'vibing.nvim loaded, or pass rpc_port explicitly.'
+    );
+  }
+
+  if (!READ_ONLY_METHODS.has(method)) {
+    throw new Error(
+      `callNeovim('${method}'): this call changes Neovim state, so it is not pointed at a guessed ` +
+        `instance. Launch the server from vibing.nvim (which sets ${RPC_PORT_ENV}), set that ` +
+        'variable yourself, or pass rpc_port — call nvim_list_instances to pick one.'
     );
   }
 

--- a/claude-plugin/mcp-server/src/rpc.ts
+++ b/claude-plugin/mcp-server/src/rpc.ts
@@ -2,6 +2,7 @@ import * as net from 'net';
 import { listLiveInstances } from './instance-registry.js';
 
 const NVIM_RPC_TIMEOUT = parseInt(process.env.VIBING_RPC_TIMEOUT || '30000', 10); // Default 30 seconds
+const RPC_PORT_ENV = 'VIBING_NVIM_RPC_PORT';
 
 let requestId = 0;
 
@@ -111,19 +112,35 @@ function getSocket(port: number): Promise<net.Socket> {
 }
 
 /**
- * Work out which Neovim to talk to when the caller did not name a port.
+ * Work out which Neovim to talk to.
  *
- * The MCP server cannot learn the port from its environment: MCP clients forward only a fixed
- * whitelist of variables (HOME, PATH, SHELL, ...) plus the static `env` block in the server's
- * registration, so `VIBING_NVIM_RPC_PORT` — which vibing.nvim does set on the `claude` process —
- * never reaches this process. The instance registry is the one source that does work, and it is
- * only unambiguous when a single Neovim is live.
+ * A server launched by vibing.nvim is bound out-of-band through `VIBING_NVIM_RPC_PORT`. Keeping
+ * that runtime value in the process environment instead of every tool schema and system prompt
+ * preserves the model's cached prefix when Neovim restarts on another port. The explicit argument
+ * remains a compatibility fallback for manually launched clients, followed by the registry when
+ * exactly one instance is live.
  *
  * @param method - RPC method name, used only to make the error message actionable
- * @returns The port of the single live instance
+ * @param requestedPort - Legacy port supplied by a tool caller
+ * @returns The bound, requested, or sole live port
  * @throws When no instance is live, or when more than one is and the caller must disambiguate
  */
-async function resolveRpcPort(method: string): Promise<number> {
+async function resolveRpcPort(method: string, requestedPort?: number): Promise<number> {
+  const configured = process.env[RPC_PORT_ENV];
+  if (configured !== undefined && configured.trim() !== '') {
+    const port = Number(configured);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(
+        `callNeovim('${method}'): ${RPC_PORT_ENV} must be an integer from 1 to 65535, got ${JSON.stringify(configured)}.`
+      );
+    }
+    return port;
+  }
+
+  if (requestedPort !== undefined) {
+    return requestedPort;
+  }
+
   const instances = await listLiveInstances();
 
   if (instances.length === 0) {
@@ -149,11 +166,11 @@ async function resolveRpcPort(method: string): Promise<number> {
  *
  * @param method - The RPC method name to call on the Neovim server
  * @param params - Parameters to include with the RPC call
- * @param port - RPC port to connect to. When omitted, `resolveRpcPort` works it out.
+ * @param port - Legacy RPC port override used only when the process is not already bound.
  * @returns The `result` value from the RPC response. The promise is rejected with the RPC `error` if the response contains one, and is also rejected if the socket closes or the request times out.
  */
 export async function callNeovim(method: string, params: any = {}, port?: number): Promise<any> {
-  const resolvedPort = port ?? (await resolveRpcPort(method));
+  const resolvedPort = await resolveRpcPort(method, port);
   const sock = await getSocket(resolvedPort);
   const id = ++requestId;
 

--- a/claude-plugin/mcp-server/src/tools/annotations.ts
+++ b/claude-plugin/mcp-server/src/tools/annotations.ts
@@ -1,4 +1,4 @@
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const annotationTools = [
   {
@@ -27,7 +27,7 @@ export const annotationTools = [
           description: 'Colours the note (default "info")',
         },
       }),
-      required: requireRpcPort(['bufnr', 'line', 'text']),
+      required: ['bufnr', 'line', 'text'],
     },
   },
   {
@@ -41,7 +41,7 @@ export const annotationTools = [
           description: 'Buffer number (0 for current). Omit to clear every buffer.',
         },
       }),
-      required: requireRpcPort(),
+      required: [],
     },
   },
 ];

--- a/claude-plugin/mcp-server/src/tools/buffer.ts
+++ b/claude-plugin/mcp-server/src/tools/buffer.ts
@@ -1,4 +1,4 @@
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const bufferTools = [
   {
@@ -58,7 +58,7 @@ export const bufferTools = [
           description: 'Buffer number (0 for current buffer)',
         },
       }),
-      required: requireRpcPort(['lines']),
+      required: ['lines'],
     },
   },
   {
@@ -94,7 +94,7 @@ export const bufferTools = [
           description: 'Absolute or relative path to file to load',
         },
       }),
-      required: requireRpcPort(['filepath']),
+      required: ['filepath'],
     },
   },
 ];

--- a/claude-plugin/mcp-server/src/tools/chat.ts
+++ b/claude-plugin/mcp-server/src/tools/chat.ts
@@ -1,5 +1,5 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 /**
  * Chat-related MCP tools
@@ -90,7 +90,7 @@ export const chatTools: Tool[] = [
             'delegated_approval is "scoped" (and none at all if it is unset or true/false).',
         },
       }),
-      required: requireRpcPort([]),
+      required: [],
     },
   },
   {
@@ -163,7 +163,7 @@ export const chatTools: Tool[] = [
       // arrives. JSON Schema could say that with oneOf, but the advertised schema is flattened
       // into the model's tool list, and a required-list of two mutually exclusive keys reads as
       // "pass both".
-      required: requireRpcPort(['message']),
+      required: ['message'],
     },
   },
   {
@@ -227,7 +227,7 @@ export const chatTools: Tool[] = [
           },
         },
       }),
-      required: requireRpcPort(['chat_bufnr', 'questions']),
+      required: ['chat_bufnr', 'questions'],
     },
   },
   {
@@ -283,7 +283,7 @@ export const chatTools: Tool[] = [
       // bufnr/file_path stay out of the required list for the same reason as on
       // nvim_chat_send_message: the handler enforces that exactly one arrives, and listing both
       // as required would read as "pass both".
-      required: requireRpcPort(['action', 'from_bufnr']),
+      required: ['action', 'from_bufnr'],
     },
   },
   {

--- a/claude-plugin/mcp-server/src/tools/common.ts
+++ b/claude-plugin/mcp-server/src/tools/common.ts
@@ -1,20 +1,15 @@
 /**
  * Common RPC port property for all MCP tools
  *
- * Read-only tools may omit `rpc_port`; it then resolves through `resolveRpcPort` in `../rpc.ts` —
- * see that function for why env can't supply the port. Tools that change state keep it required
- * via `requireRpcPort` below. Inside vibing.nvim the model is told to pass the port embedded in
- * its system prompt (see `cli_command_builder.lua`) either way, because worktrees and concurrent
- * chats routinely mean more than one instance is live.
+ * vibing.nvim binds the MCP process to its Neovim instance through `VIBING_NVIM_RPC_PORT`, so
+ * ordinary callers omit this property. It stays available as an optional compatibility override
+ * for clients that launch the server manually; `rpc.ts` falls back to the instance registry when
+ * neither source supplies a port.
  */
 export const rpcPortProperty = {
   rpc_port: {
     type: 'number' as const,
-    // Every tool carries a copy of this string, so its length is multiplied by the tool count.
-    // Keep it to the instruction; the reasoning behind it belongs in the comment above.
-    description:
-      'RPC port of the target Neovim instance (the value in your system prompt this turn). ' +
-      'Never guess it; only reads may omit it.',
+    description: 'Optional legacy override for a manually launched server; normally omit it.',
   },
 };
 
@@ -28,23 +23,4 @@ export function withRpcPort(properties: Record<string, any>): Record<string, any
     ...properties,
     ...rpcPortProperty,
   };
-}
-
-/**
- * Mark a tool as one that must be pointed at an instance explicitly.
- *
- * Registry fallback is fine for reads — the worst case is answering about the wrong buffer. It is
- * not fine for tools that change state, because this MCP server is installed at Claude Code's
- * *user* scope: every Claude Code session on the machine sees these tools, including ones that
- * have nothing to do with vibing.nvim and were never given a port. Letting those omit `rpc_port`
- * would quietly hand them `nvim_execute`, `nvim_set_buffer` and `nvim_chat_send_message` against
- * whichever editor the user happens to have open.
- *
- * So: reads may omit it, writes must name their target.
- *
- * @param required Other required property names for the tool
- * @returns required array with 'rpc_port' included
- */
-export function requireRpcPort(required: string[] = []): string[] {
-  return ['rpc_port', ...required];
 }

--- a/claude-plugin/mcp-server/src/tools/cursor.ts
+++ b/claude-plugin/mcp-server/src/tools/cursor.ts
@@ -1,4 +1,4 @@
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const cursorTools = [
   {
@@ -33,7 +33,7 @@ export const cursorTools = [
             'Window to move the cursor in, as returned by nvim_list_windows. Defaults to the currently active window.',
         },
       }),
-      required: requireRpcPort(['line']),
+      required: ['line'],
     },
   },
   {

--- a/claude-plugin/mcp-server/src/tools/dap.ts
+++ b/claude-plugin/mcp-server/src/tools/dap.ts
@@ -1,5 +1,5 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const dapTools: Tool[] = [
   {
@@ -10,7 +10,7 @@ export const dapTools: Tool[] = [
     inputSchema: {
       type: 'object',
       properties: withRpcPort({}),
-      required: requireRpcPort(),
+      required: [],
     },
   },
   {
@@ -24,7 +24,7 @@ export const dapTools: Tool[] = [
           description: 'Defaults to the thread that is stopped.',
         },
       }),
-      required: requireRpcPort(),
+      required: [],
     },
   },
   {
@@ -40,7 +40,7 @@ export const dapTools: Tool[] = [
           description: 'Defaults to the frame the debugger is currently stopped in.',
         },
       }),
-      required: requireRpcPort(),
+      required: [],
     },
   },
   {
@@ -58,7 +58,7 @@ export const dapTools: Tool[] = [
           description: 'Optional expression; the program only stops when it is true.',
         },
       }),
-      required: requireRpcPort(['file', 'line']),
+      required: ['file', 'line'],
     },
   },
   {
@@ -75,7 +75,7 @@ export const dapTools: Tool[] = [
           description: 'Defaults to the frame the debugger is currently stopped in.',
         },
       }),
-      required: requireRpcPort(['expression']),
+      required: ['expression'],
     },
   },
 ];

--- a/claude-plugin/mcp-server/src/tools/execute.ts
+++ b/claude-plugin/mcp-server/src/tools/execute.ts
@@ -1,4 +1,4 @@
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const executeTools = [
   {
@@ -12,7 +12,7 @@ export const executeTools = [
           description: 'Neovim command to execute',
         },
       }),
-      required: requireRpcPort(['command']),
+      required: ['command'],
     },
   },
 ];

--- a/claude-plugin/mcp-server/src/tools/highlight.ts
+++ b/claude-plugin/mcp-server/src/tools/highlight.ts
@@ -1,4 +1,4 @@
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const highlightTools = [
   {
@@ -28,7 +28,7 @@ export const highlightTools = [
             'until the next highlight or nvim_clear_highlight.',
         },
       }),
-      required: requireRpcPort(['bufnr', 'start_line']),
+      required: ['bufnr', 'start_line'],
     },
   },
   {
@@ -42,7 +42,7 @@ export const highlightTools = [
           description: 'Buffer number (0 for current buffer)',
         },
       }),
-      required: requireRpcPort(['bufnr']),
+      required: ['bufnr'],
     },
   },
 ];

--- a/claude-plugin/mcp-server/src/tools/qflist.ts
+++ b/claude-plugin/mcp-server/src/tools/qflist.ts
@@ -1,5 +1,5 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const qflistTools: Tool[] = [
   {
@@ -43,7 +43,7 @@ export const qflistTools: Tool[] = [
           description: 'Open the quickfix window too. Focus stays where it is.',
         },
       }),
-      required: requireRpcPort(['items']),
+      required: ['items'],
     },
   },
 ];

--- a/claude-plugin/mcp-server/src/tools/window.ts
+++ b/claude-plugin/mcp-server/src/tools/window.ts
@@ -1,4 +1,4 @@
-import { withRpcPort, requireRpcPort } from './common.js';
+import { withRpcPort } from './common.js';
 
 export const windowTools = [
   {
@@ -70,7 +70,7 @@ export const windowTools = [
           description: 'Window height (optional)',
         },
       }),
-      required: requireRpcPort(),
+      required: [],
     },
   },
   {
@@ -84,7 +84,7 @@ export const windowTools = [
           description: 'Window number to focus',
         },
       }),
-      required: requireRpcPort(['winnr']),
+      required: ['winnr'],
     },
   },
   {
@@ -102,7 +102,7 @@ export const windowTools = [
           description: 'Buffer number to display',
         },
       }),
-      required: requireRpcPort(['winnr', 'bufnr']),
+      required: ['winnr', 'bufnr'],
     },
   },
   {
@@ -120,7 +120,7 @@ export const windowTools = [
           description: 'Path to file to open',
         },
       }),
-      required: requireRpcPort(['winnr', 'filepath']),
+      required: ['winnr', 'filepath'],
     },
   },
 ];

--- a/claude-plugin/skills/nvim-context/SKILL.md
+++ b/claude-plugin/skills/nvim-context/SKILL.md
@@ -26,7 +26,9 @@ for a tool whose name **ends** in the one you need rather than assuming it is mi
 bound to the Neovim that launched the chat, and subagents share that connection. The optional
 argument exists only for a server started manually outside vibing.nvim. In that standalone case,
 call `nvim_list_instances` first; use the sole result, or match an explicit cwd/project clue you
-already know. If several remain plausible, say which you found and ask rather than guessing.
+already know. If several remain plausible, say which you found and ask rather than guessing. An
+unbound server answers reads against a single live instance but refuses anything that changes
+state until you name the port, so pass the one `nvim_list_instances` reported.
 
 ## Workflow
 

--- a/claude-plugin/skills/nvim-context/SKILL.md
+++ b/claude-plugin/skills/nvim-context/SKILL.md
@@ -22,19 +22,11 @@ itself provides them, handing the CLI this directory with `--plugin-dir` — the
 `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` instead. If the plain prefix is not available, look
 for a tool whose name **ends** in the one you need rather than assuming it is missing.
 
-**Which instance.** Every tool takes an `rpc_port` naming the target Neovim.
-
-- Inside a vibing.nvim chat, the port is in your system prompt for the turn — pass that exact
-  value on every call.
-- A subagent does **not** inherit it. Take it from your task prompt, and if it isn't there, call
-  `nvim_list_instances` and use the port it reports.
-- Anywhere else (an ordinary Claude Code session that loaded this plugin some other way — a
-  `--plugin-dir` of your own, or a leftover install), `nvim_list_instances` is the only way to
-  know. If it lists more than one, say which you found and ask rather than guessing.
-
-Omitting `rpc_port` works only while exactly one Neovim is live: reads fall back to the instance
-registry, and writes refuse outright. Worktrees and concurrent chats make more than one the normal
-case, so treat the fallback as a diagnostic, not a default.
+**Which instance.** Inside a vibing.nvim chat, omit `rpc_port`: the MCP server process is already
+bound to the Neovim that launched the chat, and subagents share that connection. The optional
+argument exists only for a server started manually outside vibing.nvim. In that standalone case,
+call `nvim_list_instances` first; use the sole result, or match an explicit cwd/project clue you
+already know. If several remain plausible, say which you found and ask rather than guessing.
 
 ## Workflow
 

--- a/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
+++ b/claude-plugin/skills/nvim-lsp-navigation/SKILL.md
@@ -10,10 +10,10 @@ Text search (`Grep`/`Glob`) finds string matches; a language server understands 
 overloads, generics, and cross-file symbol resolution. When `vibing-nvim` MCP tools are
 available and the target filetype has an LSP client attached, prefer LSP-backed answers.
 
-**Before calling anything:** pass `rpc_port` on every tool call — the exact value from your system
-prompt inside a vibing.nvim chat, or from your task prompt if you are a subagent. Only when
-neither supplies one, call `nvim_list_instances`; if that reports more than one instance, say
-which you found and ask rather than picking one. And if the `mcp__vibing-nvim__` prefix below is
+**Before calling anything:** inside a vibing.nvim chat, omit `rpc_port`; the MCP server is already
+bound to the Neovim that launched it. Only a manually started, unbound server should need
+`nvim_list_instances`; if that reports more than one instance, say which you found and ask rather
+than picking one. And if the `mcp__vibing-nvim__` prefix below is
 unavailable, look for a tool name **ending** in the one you need — loaded as a plugin they are
 `mcp__plugin_vibing-nvim_vibing-nvim__<tool>`. The `nvim-context` skill explains both in full.
 

--- a/claude-plugin/skills/vibing-chat-recall/SKILL.md
+++ b/claude-plugin/skills/vibing-chat-recall/SKILL.md
@@ -39,9 +39,7 @@ and stop.
 
 ## Reading the buffer
 
-Pass this turn's `rpc_port` (also in the system prompt) on both calls below — this skill only runs
-inside a vibing.nvim chat, so the port is always there and `nvim_list_instances` is never the
-route. If the
+The MCP server is already bound to this chat's Neovim, so omit `rpc_port` on both calls below. If the
 `mcp__vibing-nvim__` prefix is unavailable, look for a tool name **ending** in the one you need —
 loaded as a plugin they are `mcp__plugin_vibing-nvim_vibing-nvim__<tool>`. The
 `nvim-context` skill explains both in full.

--- a/claude-plugin/skills/vibing-orchestrate/SKILL.md
+++ b/claude-plugin/skills/vibing-orchestrate/SKILL.md
@@ -9,9 +9,8 @@ This chat becomes the orchestrator: it splits the work, creates one worker chat 
 each worker a brief, and later reports back. It does **not** babysit the workers — see "Hand
 control back" below, which is the part that most needs following.
 
-Every MCP call here takes `rpc_port`, the value in this chat's system prompt. Without it the
-server falls back to the instance registry, which only answers when exactly one Neovim is live —
-and orchestration is precisely the case where several are.
+The MCP server process is already bound to this chat's Neovim. Omit the optional legacy
+`rpc_port` argument from every call below.
 
 ## Chat or subagent?
 
@@ -78,7 +77,7 @@ chats editing one working tree will overwrite each other, and nothing in vibing.
 
 Separate worktrees stop the overwriting, not the overlap: two branches can still change the same
 file in ways that only collide at merge time. Once workers are running, call
-`nvim_chat_conflicts({ rpc_port })` — it diffs every live chat's `working_dir` worktree against
+`nvim_chat_conflicts({})` — it diffs every live chat's `working_dir` worktree against
 `main` and names the files two or more of them touch. It warns, it does not block; call it before
 you merge anything, and read the overlapping files in both branches yourself.
 
@@ -88,9 +87,8 @@ five chats for a job that was really one is expensive and the user has to clean 
 ## 2. Create one worker chat per task
 
 ```text
-nvim_chat_create({ rpc_port, position: "back", from_bufnr: <this chat's bufnr> })
+nvim_chat_create({ position: "back", from_bufnr: <this chat's bufnr> })
 nvim_chat_create({
-  rpc_port,
   position: "back",
   from_bufnr: <this chat's bufnr>,
   working_dir: ".vibing/worktrees/fix-auth",
@@ -123,7 +121,6 @@ nvim_chat_create({
 
 ```text
 nvim_chat_send_message({
-  rpc_port,
   file_path: "<worker file_path>",
   from_bufnr: <this chat's bufnr>,
   message: "<the whole task>",
@@ -193,7 +190,7 @@ shapes, and the difference is whether the notice carries a `status:`.
   `nvim_get_buffer` to read _what_ it is stuck on.
 - **Without one** ("have stopped without reporting back") the worker simply stopped without
   reporting, which under the convention above is itself suspect. Read those with
-  `nvim_get_buffer({ rpc_port, file_path, last_section: true, tail_lines: 25 })` — not every
+  `nvim_get_buffer({ file_path, last_section: true, tail_lines: 25 })` — not every
   worker, and not a plain `nvim_get_buffer` call: a worker chat can run to hundreds of thousands
   of lines, and reading it in full pulls that whole transcript into this conversation for the
   rest of it. `last_section` + `tail_lines` gets you the end of its last turn, which is normally
@@ -252,9 +249,8 @@ If the user set `agent.orchestration.delegated_approval` to `true` or `"scoped"`
 instead:
 
 ```text
-nvim_get_buffer({ rpc_port, file_path: "<worker file_path>" })    # read what it is stuck on
+nvim_get_buffer({ file_path: "<worker file_path>" })    # read what it is stuck on
 nvim_chat_answer_approval({
-  rpc_port,
   file_path: "<worker file_path>",
   action: "allow_once",
   from_bufnr: <this chat's bufnr>,

--- a/claude-plugin/skills/vibing-worker/SKILL.md
+++ b/claude-plugin/skills/vibing-worker/SKILL.md
@@ -15,8 +15,6 @@ system-prompt line wins: it is generated fresh for this turn, this file can go s
 
 Call `nvim_chat_send_message` with:
 
-- `rpc_port`: this turn's value, exactly as given in your system prompt — required on every
-  vibing-nvim MCP call, not just this one (see the `nvim-context` skill).
 - `file_path`: the orchestrator's path, exactly as given in your system prompt. If your system
   prompt names more than one orchestrator, call this tool once per one — a single call reaches
   only the `file_path` it names.

--- a/handbook/mcp-setup-example.md
+++ b/handbook/mcp-setup-example.md
@@ -71,7 +71,7 @@ Create or update `~/.claude.json`:
       "command": "node",
       "args": ["/absolute/path/to/vibing.nvim/claude-plugin/mcp-server/dist/index.js"],
       "env": {
-        "VIBING_RPC_PORT": "9876"
+        "VIBING_NVIM_RPC_PORT": "9876"
       }
     }
   }
@@ -183,7 +183,7 @@ Claude uses `nvim_get_info` to get filename, filetype, etc.
 
 **Solutions:**
 
-1. Verify `~/.claude.json` has correct `VIBING_RPC_PORT`
+1. Verify `~/.claude.json` has correct `VIBING_NVIM_RPC_PORT`
 2. Verify Neovim config has matching `mcp.rpc_port`
 3. Restart both Neovim and Claude Code
 
@@ -251,7 +251,7 @@ require("vibing").setup({
       "command": "node",
       "args": ["/path/to/vibing.nvim/claude-plugin/mcp-server/dist/index.js"],
       "env": {
-        "VIBING_RPC_PORT": "8888"
+        "VIBING_NVIM_RPC_PORT": "8888"
       }
     }
   }
@@ -278,12 +278,12 @@ Configure separate MCP servers in `~/.claude.json`:
     "vibing-nvim-1": {
       "command": "node",
       "args": ["/path/to/vibing.nvim/claude-plugin/mcp-server/dist/index.js"],
-      "env": { "VIBING_RPC_PORT": "9876" }
+      "env": { "VIBING_NVIM_RPC_PORT": "9876" }
     },
     "vibing-nvim-2": {
       "command": "node",
       "args": ["/path/to/vibing.nvim/claude-plugin/mcp-server/dist/index.js"],
-      "env": { "VIBING_RPC_PORT": "9877" }
+      "env": { "VIBING_NVIM_RPC_PORT": "9877" }
     }
   }
 }

--- a/handbook/mcp-tools.md
+++ b/handbook/mcp-tools.md
@@ -52,9 +52,24 @@ Codex is told to forward that variable by name. The Node server resolves it befo
 legacy `rpc_port` argument. Consequently the numeric value never enters the system/developer
 prompt or tool calls, and subagents share the already-bound MCP connection.
 
+That claude forwards the launching environment is the load-bearing assumption, so it was measured
+rather than assumed: against **claude 2.1.236**, a throwaway `--plugin-dir` whose one MCP server
+was a shell script dumping `env` received `VIBING_NVIM_RPC_PORT` from the parent process
+unchanged, alongside the registration's own static `env` block. The two are additive — the static
+block does not replace the inherited environment. Re-measure this the same way if a claude release
+starts sandboxing plugin server environments; the symptom would be silent, since the Node server
+then falls through to the registry and keeps working whenever exactly one Neovim is live.
+
 When the server is launched manually rather than by vibing.nvim, `rpc_port` remains available as
-an optional compatibility override. With neither source present, the registry fallback still
-works only when exactly one Neovim instance is live.
+an optional compatibility override. With neither source present, **only reads fall back to the
+registry**, and then only when exactly one Neovim instance is live; a call that changes state
+refuses instead of guessing. That is the rule the per-tool `requireRpcPort` schema guard used to
+enforce, moved to where the port is resolved (`read-only-methods.ts`) because the schemas no
+longer name the port: this server can be registered at Claude Code's _user_ scope, where a
+session that has nothing to do with vibing.nvim sees these tools unbound, and guessing there
+would hand it `nvim_execute` / `nvim_set_buffer` / `nvim_chat_send_message` against whichever
+editor is open. The list is an allowlist, so a newly added method counts as a writer until it is
+classified.
 
 ## Available Tools
 

--- a/handbook/mcp-tools.md
+++ b/handbook/mcp-tools.md
@@ -46,9 +46,15 @@ because `--allowedTools` accepts nothing but literals. A stale entry there does 
 the hook's suffix match is what actually decides, which is exactly why nothing noticed the dead
 one for so long.
 
-**The port has to be named explicitly**, and a subagent does not inherit the chat's. The system
-prompt therefore tells the model both to pass its own `rpc_port` and to forward it in any task
-prompt it hands a subagent.
+**The instance is bound outside the prompt.** Both CLI adapters put the current port in
+`VIBING_NVIM_RPC_PORT`; Claude Code exposes the launching environment to plugin MCP servers, and
+Codex is told to forward that variable by name. The Node server resolves it before the optional
+legacy `rpc_port` argument. Consequently the numeric value never enters the system/developer
+prompt or tool calls, and subagents share the already-bound MCP connection.
+
+When the server is launched manually rather than by vibing.nvim, `rpc_port` remains available as
+an optional compatibility override. With neither source present, the registry fallback still
+works only when exactly one Neovim instance is live.
 
 ## Available Tools
 
@@ -108,7 +114,7 @@ at roughly the right place beats refusing to point.
 
 ## Orchestration Tools
 
-`nvim_chat_create({ rpc_port, position?, working_dir?, from_bufnr?, task?, delegated_scope? })`
+`nvim_chat_create({ position?, working_dir?, from_bufnr?, task?, delegated_scope? })`
 creates a chat buffer and returns `{ bufnr, file_path, working_dir, position, saved }` as JSON, so
 one chat can spawn worker chats, brief each with `nvim_chat_send_message`, and poll them with
 `nvim_get_buffer` — which reports a chat buffer's `responding` / `idle` / `waiting_approval` /
@@ -155,7 +161,7 @@ flush time, same as the immediate path; if several queued messages from the same
 written at delivery rather than when the message is queued, and why the queue is capped:
 `handbook/architecture/orchestration.md`.
 
-`nvim_chat_answer_approval({ rpc_port, file_path|bufnr, action, from_bufnr })` answers another
+`nvim_chat_answer_approval({ file_path|bufnr, action, from_bufnr })` answers another
 chat's pending tool-approval prompt with one of `allow_once` / `deny_once` / `allow_for_session` /
 `deny_for_session`. **It is refused unless `agent.orchestration.delegated_approval` is set**, since
 what it buys is one agent clearing another agent's permission gate; `from_bufnr` is required here
@@ -166,17 +172,17 @@ either way. Why it writes the chosen option line into the worker's buffer instea
 decision directly, and why the watchdog's `waiting_approval` wording changes with the setting:
 `handbook/architecture/orchestration.md` → "Answering a worker's tool approval".
 
-`nvim_chat_list({ rpc_port? })` reports every chat buffer open in this Neovim session in one call —
+`nvim_chat_list({})` reports every chat buffer open in this Neovim session in one call —
 `bufnr`, `file_path`, `chat_status`, `context_size` (the last measured context in tokens, from the
 last turn's own `### Tokens` marker; absent until a turn has completed), `updated_at` (frontmatter
 timestamp; absent until something has written to frontmatter), `orchestrated_by`, and `task` (that
 chat's one-line assignment, projected from its orchestrator's own `orchestrated` entry — present
 only when that orchestrator is _also_ open in this session, since the handler never opens a file
 just to look up a task). Use it instead of polling several worker chats one at a time with
-`nvim_get_buffer`. It is a read like `nvim_list_buffers`, so `rpc_port` stays optional; it only
-lists chats attached in this session — a chat file nobody has opened yet does not appear.
+`nvim_get_buffer`. It only lists chats attached in this session — a chat file nobody has opened
+yet does not appear.
 
-`nvim_chat_conflicts({ rpc_port? })` warns (never blocks) about files that 2+ live chats have
+`nvim_chat_conflicts({})` warns (never blocks) about files that 2+ live chats have
 modified on their own branch — the mechanical version of what #692's postmortem found only because
 a human happened to be looking at both diffs at once (one PR renamed a marker a second PR still
 parsed by the old name; that PR's own tests used a fixture, so nothing caught it). It is a read like

--- a/handbook/multi-instance-testing.md
+++ b/handbook/multi-instance-testing.md
@@ -8,6 +8,12 @@ The multi-instance feature allows Claude Code to interact with multiple running 
 Each instance runs its own RPC server on a different port (9876-9925).
 Instances are tracked in a registry for discovery and management.
 
+The ownership unit is a **Neovim process**, not a chat buffer. All chat buffers in one Neovim
+share that process's port. For a normal vibing.nvim chat, each Claude Code/Codex process receives
+its owning port through `VIBING_NVIM_RPC_PORT`, and its MCP server is bound before any tool call.
+The explicit `rpc_port` examples below exercise the compatibility path for a manually launched,
+unbound MCP server.
+
 ## Architecture Diagrams
 
 ### Before: Single Instance Only (Problem)

--- a/lua/vibing/application/chat/delivery_message.lua
+++ b/lua/vibing/application/chat/delivery_message.lua
@@ -83,8 +83,8 @@ local function notification_section(items, cache)
   if delegation_mode == true then
     waiting_approval_lines = {
       "- waiting_approval — it is sitting on a tool-approval prompt. Read what it is stuck on",
-      "  with nvim_get_buffer, then answer it with nvim_chat_answer_approval({ rpc_port,",
-      "  file_path, action, from_bufnr }) if the tool is plainly within the task you briefed it",
+      "  with nvim_get_buffer, then answer it with nvim_chat_answer_approval({ file_path, action,",
+      "  from_bufnr }) if the tool is plainly within the task you briefed it",
       "  with. If it is not, say which chat is blocked and on what, and let the user decide.",
     }
   elseif delegation_mode == "scoped" then
@@ -92,7 +92,7 @@ local function notification_section(items, cache)
     -- 機械的に断るので、失敗しても1回の無駄な呼び出しで済む（無効時のように必ず失敗するのとは違う）
     waiting_approval_lines = {
       "- waiting_approval — it is sitting on a tool-approval prompt. Read what it is stuck on",
-      "  with nvim_get_buffer, then try nvim_chat_answer_approval({ rpc_port, file_path, action,",
+      "  with nvim_get_buffer, then try nvim_chat_answer_approval({ file_path, action,",
       "  from_bufnr }). It only succeeds if the tool matches that chat's declared delegated_scope",
       "  (deny_once/deny_for_session always succeed). If it fails, say which chat is blocked and",
       "  on what, and let the user decide.",
@@ -108,7 +108,7 @@ local function notification_section(items, cache)
     "A chat with a status above will not move again until someone acts on it:",
     "",
     "- asked_question — it is waiting for an answer. Read the question with",
-    "  nvim_get_buffer({ rpc_port, file_path }) and answer it with nvim_chat_send_message",
+    "  nvim_get_buffer({ file_path }) and answer it with nvim_chat_send_message",
     "  (passing from_bufnr), or put it to the user if only they can decide.",
   }
   vim.list_extend(blocked_explanation, waiting_approval_lines)
@@ -124,7 +124,7 @@ local function notification_section(items, cache)
     or {
       "A chat that finishes its task is expected to report the result to you itself, so a stop with",
       "no report is more likely to be something else: it failed, it stopped to ask a question, or it",
-      "is waiting on a tool approval. Read each one with nvim_get_buffer({ rpc_port, file_path }),",
+      "is waiting on a tool approval. Read each one with nvim_get_buffer({ file_path }),",
       "look at the tail of the transcript, and decide what to do — do not treat its task as done.",
     }
 

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -93,7 +93,7 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   -- The builder raises when the claude binary is missing. send_message.lua does not wrap stream()
   -- in pcall, so without this the chat buffer would show a raw Lua stack trace instead of an
   -- actionable message. Matches copilot_cli.lua.
-  local build_ok, cmd = pcall(CLICommandBuilder.build, prompt, opts, session_id, self.config, settings_path, rpc_port)
+  local build_ok, cmd = pcall(CLICommandBuilder.build, prompt, opts, session_id, self.config, settings_path)
   if not build_ok then
     CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id
@@ -135,11 +135,9 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   env.CLAUDECODE = nil
 
   if rpc_port then
-    -- The MCP server subprocess gets its own rpc_port from the model echoing back the
-    -- system-prompt-embedded value as a tool argument (see cli_command_builder.lua), not from
-    -- env — an MCP client only forwards a fixed env whitelist plus the server's static
-    -- registration config, never the CLI process's own env.
-    env.VIBING_NVIM_RPC_PORT = tostring(rpc_port) -- for hook script
+    -- Claude Code forwards the launching process's environment to plugin MCP servers. The
+    -- server binds to this value directly, keeping the numeric port out of the cached prompt.
+    env.VIBING_NVIM_RPC_PORT = tostring(rpc_port)
     env.VIBING_NVIM_CONTEXT = "true" -- indicates running inside vibing.nvim
   end
   -- Lets the PreToolUse hook identify which chat buffer's stream it belongs to, so concurrent

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -4,6 +4,7 @@
 
 local Base = require("vibing.infrastructure.adapter.base")
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
+local RpcEnvironment = require("vibing.infrastructure.adapter.modules.rpc_environment")
 local CLICommandBuilder = require("vibing.infrastructure.adapter.modules.cli_command_builder")
 local CLIEventProcessor = require("vibing.infrastructure.adapter.modules.cli_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -87,9 +88,6 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
     end
   end
 
-  local rpc_server = require("vibing.infrastructure.rpc.server")
-  local rpc_port = rpc_server.get_port()
-
   -- The builder raises when the claude binary is missing. send_message.lua does not wrap stream()
   -- in pcall, so without this the chat buffer would show a raw Lua stack trace instead of an
   -- actionable message. Matches copilot_cli.lua.
@@ -134,12 +132,9 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   -- Remove CLAUDECODE to allow nested invocation
   env.CLAUDECODE = nil
 
-  if rpc_port then
-    -- Claude Code forwards the launching process's environment to plugin MCP servers. The
-    -- server binds to this value directly, keeping the numeric port out of the cached prompt.
-    env.VIBING_NVIM_RPC_PORT = tostring(rpc_port)
-    env.VIBING_NVIM_CONTEXT = "true" -- indicates running inside vibing.nvim
-  end
+  -- Claude Code forwards this environment to plugin MCP servers, so the numeric port stays out
+  -- of the cached prompt.
+  RpcEnvironment.bind(env)
   -- Lets the PreToolUse hook identify which chat buffer's stream it belongs to, so concurrent
   -- chats don't cross-wire each other's AskUserQuestion/approval UI (see ActiveStreamRegistry).
   env.VIBING_HANDLE_ID = handle_id

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -4,6 +4,7 @@
 
 local Base = require("vibing.infrastructure.adapter.base")
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
+local RpcEnvironment = require("vibing.infrastructure.adapter.modules.rpc_environment")
 local CodexCommandBuilder = require("vibing.infrastructure.adapter.modules.codex_command_builder")
 local CodexProviderNotice = require("vibing.infrastructure.adapter.modules.codex_provider_notice")
 local CodexEventProcessor = require("vibing.infrastructure.adapter.modules.codex_event_processor")
@@ -79,9 +80,6 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   -- The builder raises when the codex binary is missing. send_message.lua does not wrap stream()
   -- in pcall, so without this the chat buffer would show a raw Lua stack trace instead of an
   -- actionable message. Matches copilot_cli.lua.
-  local rpc_server = require("vibing.infrastructure.rpc.server")
-  local rpc_port = rpc_server.get_port()
-
   local build_ok, cmd = pcall(CodexCommandBuilder.build, prompt, opts, session_id, self.config, hook_args)
   if not build_ok then
     CliRuntime.report_build_failure(handle_id, cmd, on_done)
@@ -117,12 +115,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
 
   local env = vim.fn.environ()
 
-  if rpc_port then
-    local port_str = tostring(rpc_port)
-    env.VIBING_NVIM_RPC_PORT = port_str
-    env.VIBING_RPC_PORT = port_str
-    env.VIBING_NVIM_CONTEXT = "true"
-  end
+  RpcEnvironment.bind(env)
   -- Lets the PreToolUse hook identify which chat buffer's stream it belongs to, so concurrent
   -- chats don't cross-wire each other's approval UI (see ActiveStreamRegistry).
   env.VIBING_HANDLE_ID = handle_id

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -82,7 +82,7 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
   local rpc_server = require("vibing.infrastructure.rpc.server")
   local rpc_port = rpc_server.get_port()
 
-  local build_ok, cmd = pcall(CodexCommandBuilder.build, prompt, opts, session_id, self.config, hook_args, rpc_port)
+  local build_ok, cmd = pcall(CodexCommandBuilder.build, prompt, opts, session_id, self.config, hook_args)
   if not build_ok then
     CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id

--- a/lua/vibing/infrastructure/adapter/copilot_cli.lua
+++ b/lua/vibing/infrastructure/adapter/copilot_cli.lua
@@ -4,6 +4,7 @@
 
 local Base = require("vibing.infrastructure.adapter.base")
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
+local RpcEnvironment = require("vibing.infrastructure.adapter.modules.rpc_environment")
 local CopilotCommandBuilder = require("vibing.infrastructure.adapter.modules.copilot_command_builder")
 local CopilotEventProcessor = require("vibing.infrastructure.adapter.modules.copilot_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -116,14 +117,7 @@ function CopilotCLI:stream(prompt, opts, on_chunk, on_done)
 
   local env = vim.fn.environ()
 
-  local rpc_server = require("vibing.infrastructure.rpc.server")
-  local rpc_port = rpc_server.get_port()
-  if rpc_port then
-    local port_str = tostring(rpc_port)
-    env.VIBING_NVIM_RPC_PORT = port_str
-    env.VIBING_RPC_PORT = port_str
-    env.VIBING_NVIM_CONTEXT = "true"
-  end
+  RpcEnvironment.bind(env)
   env.VIBING_HANDLE_ID = handle_id
 
   -- Required so nvim_ask_user_question can resolve this stream's chat callbacks

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -4,6 +4,7 @@
 
 local Base = require("vibing.infrastructure.adapter.base")
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
+local RpcEnvironment = require("vibing.infrastructure.adapter.modules.rpc_environment")
 local GrokCommandBuilder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
 local GrokEventProcessor = require("vibing.infrastructure.adapter.modules.grok_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -69,9 +70,6 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
     )
   end
 
-  local rpc_server = require("vibing.infrastructure.rpc.server")
-  local rpc_port = rpc_server.get_port()
-
   local cwd = opts.cwd or vim.fn.getcwd()
 
   -- Install project PreToolUse hook (reuses bin/hooks/pre-tool-use.sh) unless fully bypassed.
@@ -94,7 +92,7 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
   -- The builder raises when the grok binary is missing. send_message.lua does not wrap stream()
   -- in pcall, so without this the chat buffer would show a raw Lua stack trace instead of an
   -- actionable message. Matches claude_cli.lua and copilot_cli.lua.
-  local build_ok, cmd = pcall(GrokCommandBuilder.build, prompt, opts, session_id, self.config, handle_id, rpc_port)
+  local build_ok, cmd = pcall(GrokCommandBuilder.build, prompt, opts, session_id, self.config)
   if not build_ok then
     CliRuntime.report_build_failure(handle_id, cmd, on_done)
     return handle_id
@@ -130,12 +128,7 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
 
   -- Lets PreToolUse hook identify which chat buffer's stream it belongs to (see ActiveStreamRegistry).
   local env = vim.tbl_extend("force", self._base_env, { VIBING_HANDLE_ID = handle_id })
-  if rpc_port then
-    local port_str = tostring(rpc_port)
-    env.VIBING_NVIM_RPC_PORT = port_str
-    env.VIBING_RPC_PORT = port_str
-    env.VIBING_NVIM_CONTEXT = "true"
-  end
+  RpcEnvironment.bind(env)
 
   ActiveStreamRegistry.register({
     handle_id = handle_id,

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -167,13 +167,8 @@ end
 --- @param session_id string|nil Session ID for resumption
 --- @param config Vibing.Config Plugin config
 --- @param settings_path string|nil Path to hook settings file
---- @param rpc_port number|nil This Neovim instance's RPC server port, embedded in the system
----   prompt so the model can echo it back on every vibing-nvim MCP tool call. The MCP server
----   cannot read it from its own environment (MCP clients forward only a fixed env whitelist),
----   and without it the server falls back to the instance registry — which refuses to choose
----   once more than one Neovim is live, the normal case with worktrees and concurrent chats.
 --- @return string[] Command array for vim.system()
-function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
+function M.build(prompt, opts, session_id, config, settings_path)
   local cmd = { binary_path.resolve() }
 
   table.insert(cmd, "-p")
@@ -291,18 +286,6 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
         .. "and the count, and mention that :VibingClearAnnotations removes the notes."
     )
 
-    if rpc_port then
-      table.insert(
-        system_prompt_lines,
-        "Your rpc_port for this turn is "
-          .. tostring(rpc_port)
-          .. ". You MUST pass this exact value as the rpc_port argument on every vibing-nvim MCP tool "
-          .. "call — never omit it or guess, since other unrelated Neovim instances may be running and "
-          .. "reachable on other ports. A subagent does not inherit this system prompt, so when you "
-          .. "delegate work that will touch Neovim, state the rpc_port in the task prompt you hand it."
-      )
-    end
-
     -- Constant for this buffer's whole life, so it does not churn the cached prefix across the
     -- buffer's own turns (#469). Switching between the parent chat and this one still re-diverges
     -- the shared session's cache — unavoidable while both resume one session_id.
@@ -375,7 +358,7 @@ function M.build(prompt, opts, session_id, config, settings_path, rpc_port)
           .. " — when the task is done, before you act on something you expect will need "
           .. "approval, and the moment you find you cannot proceed — by calling "
           .. "nvim_chat_send_message with that file_path, your own chat buffer number as "
-          .. "from_bufnr, this turn's rpc_port, and queue_if_busy: true. State the conclusion, "
+          .. "from_bufnr and queue_if_busy: true. State the conclusion, "
           .. "what changed, what is unresolved, and what input you need next, briefly: it can "
           .. "read this transcript for the rest, and can be asked the same way if the brief is "
           .. "ambiguous or you get stuck. Do not stop with only a prose report in your own chat "

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -38,10 +38,8 @@ end
 --- @param session_id string|nil Thread ID for session resumption
 --- @param config Vibing.Config Plugin config
 --- @param hook_args string[]|nil Optional -c flag pair for PreToolUse hook injection
---- @param rpc_port number|nil This Neovim instance's RPC server port, told to the model alongside
----   the bundled MCP server so it can name the right Neovim on every tool call
 --- @return string[] Command array for vim.system()
-function M.build(prompt, opts, session_id, config, hook_args, rpc_port)
+function M.build(prompt, opts, session_id, config, hook_args)
   local cmd = { binary_path.resolve(), "exec" }
 
   if session_id then
@@ -152,7 +150,7 @@ function M.build(prompt, opts, session_id, config, hook_args, rpc_port)
   -- `--ignore-user-config --strict-config` above would also reject nothing here, since every key
   -- is one codex knows -- the fence is this branch, not the flags.
   if not opts.lightweight then
-    vim.list_extend(cmd, CodexPluginConfig.args(opts.cwd, config, rpc_port))
+    vim.list_extend(cmd, CodexPluginConfig.args(opts.cwd, config))
   end
 
   -- Build prompt with context prefix and language instruction

--- a/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
@@ -26,6 +26,7 @@
 
 local PluginDirs = require("vibing.infrastructure.plugins.plugin_dirs")
 local PluginContents = require("vibing.infrastructure.plugins.plugin_contents")
+local RpcEnvironment = require("vibing.infrastructure.adapter.modules.rpc_environment")
 local Toml = require("vibing.core.utils.toml")
 local Notify = require("vibing.core.utils.notify")
 
@@ -92,7 +93,7 @@ local function append_server(args, server, forward_rpc_port)
       -- `env_vars` names a host-process variable for codex to copy into the MCP subprocess.
       -- The name is fixed, so changing Neovim's actual port changes only the process environment,
       -- not argv, tool definitions, or any model-visible prompt prefix.
-      override(args, prefix .. ".env_vars", Toml.string_array({ "VIBING_NVIM_RPC_PORT" }))
+      override(args, prefix .. ".env_vars", Toml.string_array({ RpcEnvironment.PORT_VAR }))
     end
   else
     override(args, prefix .. ".url", Toml.string(server.url))

--- a/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
@@ -51,12 +51,12 @@ local function warn_once(cwd, problems)
   )
 end
 
---- Memo of the finished argv, keyed by the plugin directories it was built from plus the port.
+--- Memo of the finished argv, keyed by the plugin directories it was built from.
 --- Building it reads every plugin's manifest and the frontmatter of every SKILL.md -- synchronous
 --- file I/O on the main loop -- and `args` runs on every non-lightweight request, so without this
 --- the codex backend paid that on every message. The key is the resolved directory list rather
 --- than the cwd so that a different `agent.plugins` (or a `plugin_dirs` refresh that changed the
---- list) is a different entry; the port is fixed for the Neovim session.
+--- list) is a different entry.
 --- @type table<string, string[]>
 local cache = {}
 
@@ -79,13 +79,20 @@ end
 --- The `-c` overrides for one MCP server.
 --- @param args string[]
 --- @param server Vibing.PluginMcpServer
-local function append_server(args, server)
+--- @param forward_rpc_port boolean whether to forward the caller's bound Neovim port
+local function append_server(args, server, forward_rpc_port)
   local prefix = "mcp_servers." .. server.name
   if server.command then
     override(args, prefix .. ".command", Toml.string(server.command))
     override(args, prefix .. ".args", Toml.string_array(server.args))
     if next(server.env) then
       override(args, prefix .. ".env", Toml.string_table(server.env))
+    end
+    if forward_rpc_port then
+      -- `env_vars` names a host-process variable for codex to copy into the MCP subprocess.
+      -- The name is fixed, so changing Neovim's actual port changes only the process environment,
+      -- not argv, tool definitions, or any model-visible prompt prefix.
+      override(args, prefix .. ".env_vars", Toml.string_array({ "VIBING_NVIM_RPC_PORT" }))
     end
   else
     override(args, prefix .. ".url", Toml.string(server.url))
@@ -99,14 +106,13 @@ end
 --- The developer message that stands in for `--plugin-dir`'s skill loading and for the claude
 --- system prompt's MCP paragraph.
 ---
---- Byte-stable across the turns of one chat: the entries come in `plugin_dirs` order, the skills
---- in sorted-glob order, and the port is fixed for the Neovim session. Codex's prompt cache
---- matches on a prefix, so any per-turn value here would invalidate it every turn (#469).
+--- Byte-stable across the turns of one chat: the entries come in `plugin_dirs` order and the
+--- skills in sorted-glob order. Codex's prompt cache matches on a prefix, so runtime values such
+--- as the Neovim RPC port must travel out-of-band through the MCP process environment (#469).
 --- @param skills {plugin: string, skill: Vibing.PluginSkill}[]
 --- @param self_server string|nil registered name of the bundled server, nil when it is not loaded
---- @param rpc_port number|nil
 --- @return string|nil
-local function developer_instructions(skills, self_server, rpc_port)
+local function developer_instructions(skills, self_server)
   local lines = {}
 
   if #skills > 0 then
@@ -136,16 +142,6 @@ local function developer_instructions(skills, self_server, rpc_port)
         self_server
       )
     )
-    if rpc_port then
-      table.insert(
-        lines,
-        "Your rpc_port for this turn is "
-          .. tostring(rpc_port)
-          .. ". You MUST pass this exact value as the rpc_port argument on every vibing-nvim MCP tool "
-          .. "call -- never omit it or guess, since other unrelated Neovim instances may be running and "
-          .. "reachable on other ports."
-      )
-    end
   end
 
   if #lines == 0 then
@@ -161,11 +157,10 @@ end
 --- `vibing-nvim` server by declaring one of its own.
 --- @param cwd string|nil the chat's `working_dir`; nil means Neovim's own cwd
 --- @param config Vibing.Config
---- @param rpc_port number|nil this Neovim's RPC port, told to the model when the bundled server loads
 --- @return string[] argv fragment, empty when no plugin applies
-function M.args(cwd, config, rpc_port)
+function M.args(cwd, config)
   local entries = PluginDirs.resolve_entries(cwd, config)
-  local key_parts = { tostring(rpc_port) }
+  local key_parts = {}
   for _, entry in ipairs(entries) do
     table.insert(key_parts, entry.path)
   end
@@ -189,10 +184,11 @@ function M.args(cwd, config, rpc_port)
         table.insert(problems, string.format("%s (server %q)", entry.name, server.name))
       elseif not seen[server.name] then
         seen[server.name] = true
-        append_server(args, server)
+        local is_self_server = entry.path == self_dir and not self_server
+        append_server(args, server, is_self_server)
         -- The bundled server's name is read from its manifest rather than hard-coded, so a
         -- rename there cannot leave the model told about a server that is not registered.
-        if entry.path == self_dir and not self_server then
+        if is_self_server then
           self_server = server.name
         end
       end
@@ -204,7 +200,7 @@ function M.args(cwd, config, rpc_port)
 
   warn_once(cwd, problems)
 
-  local instructions = developer_instructions(skills, self_server, rpc_port)
+  local instructions = developer_instructions(skills, self_server)
   if instructions then
     -- One override, one flag: `-c` replaces a `developer_instructions` the user set in their own
     -- config.toml for the duration of the run. Accepted -- codex offers no additive form

--- a/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
@@ -185,11 +185,13 @@ function M.args(cwd, config)
         table.insert(problems, string.format("%s (server %q)", entry.name, server.name))
       elseif not seen[server.name] then
         seen[server.name] = true
-        local is_self_server = entry.path == self_dir and not self_server
-        append_server(args, server, is_self_server)
+        -- Every server the self plugin declares talks to this Neovim, so every one of them gets
+        -- the port forwarded -- not just the first, which is all the developer message names.
+        local is_self_plugin = entry.path == self_dir
+        append_server(args, server, is_self_plugin)
         -- The bundled server's name is read from its manifest rather than hard-coded, so a
         -- rename there cannot leave the model told about a server that is not registered.
-        if is_self_server then
+        if is_self_plugin and not self_server then
           self_server = server.name
         end
       end

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -241,12 +241,8 @@ function M._reset_path_cache()
 end
 
 --- @param config Vibing.Config Plugin config
---- @param handle_id string|nil Unused. Kept so every backend's builder takes the same arguments;
----   grok reaches no vibing-nvim MCP server, so nothing here needs the handle. The value still
----   travels to the hook, via `VIBING_HANDLE_ID` in the environment `grok_cli` spawns with.
---- @param rpc_port number|nil Unused, for the same reason: passed through the environment, not argv.
 --- @return string[] Command array for vim.system()
-function M.build(prompt, opts, session_id, config, handle_id, rpc_port)
+function M.build(prompt, opts, session_id, config)
   opts = opts or {}
   config = config or {}
 

--- a/lua/vibing/infrastructure/adapter/modules/rpc_environment.lua
+++ b/lua/vibing/infrastructure/adapter/modules/rpc_environment.lua
@@ -1,0 +1,19 @@
+--- Bind a CLI child process to the Neovim instance that launched it.
+local M = {}
+
+M.PORT_VAR = "VIBING_NVIM_RPC_PORT"
+
+---@param env table<string, string>
+function M.bind(env)
+  local port = require("vibing.infrastructure.rpc.server").get_port()
+  if not port then
+    return
+  end
+
+  local value = tostring(port)
+  env[M.PORT_VAR] = value
+  env.VIBING_RPC_PORT = value -- Legacy CLI and hook configurations.
+  env.VIBING_NVIM_CONTEXT = "true"
+end
+
+return M

--- a/lua/vibing/infrastructure/adapter/modules/rpc_environment.lua
+++ b/lua/vibing/infrastructure/adapter/modules/rpc_environment.lua
@@ -12,7 +12,6 @@ function M.bind(env)
 
   local value = tostring(port)
   env[M.PORT_VAR] = value
-  env.VIBING_RPC_PORT = value -- Legacy CLI and hook configurations.
   env.VIBING_NVIM_CONTEXT = "true"
 end
 

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -18,7 +18,7 @@ description, the permission flags, or the model.
 Only one thing: **which tools were called, with what arguments.** Scoring never reads the response
 prose — a check that asserted on wording would fail every time the model rephrased itself, which
 teaches you to ignore the suite. `on_tool_use_full` on the adapter delivers the raw tool input, so
-a check can assert on `rpc_port`, a full Bash command, or a file path.
+a check can assert on `chat_bufnr`, a full Bash command, or a file path.
 
 Non-determinism is handled with pass@k rather than by loosening the checks: a task passes if any
 attempt passes, and the report says which attempt it took.

--- a/tests/evals/tasks.lua
+++ b/tests/evals/tasks.lua
@@ -44,20 +44,16 @@ return {
   },
 
   {
-    id = "ask_user_question/passes_rpc_port",
-    description = "MCPツール呼び出しにこのターンのrpc_portを渡す",
+    id = "ask_user_question/omits_rpc_port",
+    description = "MCPプロセスがNeovimに束縛済みなのでrpc_portをツール引数に重複させない",
     prompt = "Ask me whether to use tabs or spaces. Use the vibing.nvim question tool.",
     check = function(record)
       local input = Harness.find_mcp_call(record, "nvim_ask_user_question")
       if not input then
         return false, "no MCP call to inspect"
       end
-      local expected = require("vibing.infrastructure.rpc.server").get_port()
-      if not input.rpc_port then
-        return false, "omitted rpc_port, so the call would target whichever instance answers"
-      end
-      if tonumber(input.rpc_port) ~= expected then
-        return false, string.format("passed rpc_port=%s, expected %s", tostring(input.rpc_port), tostring(expected))
+      if input.rpc_port ~= nil then
+        return false, "passed rpc_port even though the MCP process is already bound"
       end
       return true
     end,

--- a/tests/helpers/adapter_stream.lua
+++ b/tests/helpers/adapter_stream.lua
@@ -5,8 +5,8 @@
 --- goes into `vim.system`'s options, who gets registered, which timer is armed. Stubbing
 --- `vim.system` exposes all of that without a CLI on the machine.
 ---
---- Shared across the three adapters on purpose. Per-adapter mocks would drift, and the point of
---- these tests is that the three behave the same.
+--- Shared across every adapter on purpose. Per-adapter mocks would drift, and the point of these
+--- tests is that they behave the same.
 --- @module tests.helpers.adapter_stream
 
 local M = {}

--- a/tests/lua/application/chat/delivery_message_spec.lua
+++ b/tests/lua/application/chat/delivery_message_spec.lua
@@ -103,6 +103,8 @@ end)
 describe("DeliveryMessage.build (blocked chats)", function()
   local DeliveryMessage
   local buffers
+  local original_approval_delegate
+  local approval_mode
 
   local function make_buf(name)
     local bufnr = vim.api.nvim_create_buf(false, true)
@@ -115,11 +117,19 @@ describe("DeliveryMessage.build (blocked chats)", function()
 
   before_each(function()
     buffers = {}
+    approval_mode = false
+    original_approval_delegate = package.loaded["vibing.application.chat.approval_delegate"]
+    package.loaded["vibing.application.chat.approval_delegate"] = {
+      mode = function()
+        return approval_mode
+      end,
+    }
     package.loaded["vibing.application.chat.delivery_message"] = nil
     DeliveryMessage = require("vibing.application.chat.delivery_message")
   end)
 
   after_each(function()
+    package.loaded["vibing.application.chat.approval_delegate"] = original_approval_delegate
     package.loaded["vibing.application.chat.delivery_message"] = nil
     for _, bufnr in ipairs(buffers) do
       if vim.api.nvim_buf_is_valid(bufnr) then
@@ -146,6 +156,19 @@ describe("DeliveryMessage.build (blocked chats)", function()
 
     assert.is_truthy(text:find("have stopped without reporting back", 1, true))
     assert.is_falsy(text:find("status:", 1, true))
+    assert.is_falsy(text:find("rpc_port", 1, true))
+  end)
+
+  it("never asks the model to echo routing data when delegated approval is enabled", function()
+    local about = make_buf("worker.md")
+
+    for _, mode in ipairs({ true, "scoped" }) do
+      approval_mode = mode
+      local text = DeliveryMessage.build({ { bufnr = about, reason = "waiting_approval" } })
+
+      assert.is_truthy(text:find("nvim_chat_answer_approval({ file_path, action,", 1, true))
+      assert.is_falsy(text:find("rpc_port", 1, true))
+    end
   end)
 
   it("explains both kinds when a blocked chat and a silent one arrive together", function()

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -157,8 +157,8 @@ describe("cli_command_builder", function()
 
     it("never embeds a handle_id, so the same conversation's system prompt is byte-identical across turns", function()
       local opts = { chat_bufnr = 12 }
-      local cmd1 = cli_command_builder.build("hello", opts, nil, {}, nil, 9878)
-      local cmd2 = cli_command_builder.build("hello again", opts, "session-1", {}, nil, 9878)
+      local cmd1 = cli_command_builder.build("hello", opts, nil, {}, nil)
+      local cmd2 = cli_command_builder.build("hello again", opts, "session-1", {}, nil)
       local idx1 = find_flag(cmd1, "--append-system-prompt")
       local idx2 = find_flag(cmd2, "--append-system-prompt")
       assert.equals(cmd1[idx1 + 1], cmd2[idx2 + 1])
@@ -174,31 +174,20 @@ describe("cli_command_builder", function()
       assert.is_true(prompt_text:find("mcp__plugin_<marketplace>_vibing%-nvim__<tool>") ~= nil)
     end)
 
-    it("embeds the rpc_port and instructs the model to echo it back on every vibing-nvim MCP call", function()
-      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil, 9878)
+    it("keeps the runtime rpc_port out of the model-visible system prompt", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
       local idx = find_flag(cmd, "--append-system-prompt")
       assert.is_not_nil(idx)
       local prompt_text = cmd[idx + 1]
-      assert.is_true(prompt_text:find("Your rpc_port for this turn is 9878", 1, true) ~= nil)
+      assert.is_nil(prompt_text:find("rpc_port for this turn", 1, true))
       assert.is_true(prompt_text:find("mcp__vibing-nvim__", 1, true) ~= nil)
       assert.is_true(prompt_text:find("mcp__plugin_<marketplace>_vibing-nvim__", 1, true) ~= nil)
     end)
 
-    -- A subagent gets its own system prompt, so the port never reaches it on its own. Without
-    -- this half the bundled nvim-navigator agent falls back to nvim_list_instances, which only
-    -- resolves while exactly one Neovim is live.
-    it("tells the model to forward the rpc_port when it delegates to a subagent", function()
-      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil, 9878)
-      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
-      assert.is_true(prompt_text:find("subagent does not inherit this system prompt", 1, true) ~= nil)
-      assert.is_true(prompt_text:find("state the rpc_port in the task prompt", 1, true) ~= nil)
-    end)
-
-    it("omits the rpc_port line when rpc_port is not provided", function()
+    it("does not ask the model to forward runtime routing data to a subagent", function()
       local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
-      local idx = find_flag(cmd, "--append-system-prompt")
-      local prompt_text = cmd[idx + 1]
-      assert.is_nil(prompt_text:find("Your rpc_port for this turn is", 1, true))
+      local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
+      assert.is_nil(prompt_text:find("rpc_port", 1, true))
     end)
   end)
 
@@ -260,8 +249,8 @@ describe("cli_command_builder", function()
       write_project_prompt({ "Project rule: always run the linter." })
 
       local opts = { chat_bufnr = 12 }
-      local cmd1 = cli_command_builder.build("hello", opts, nil, {}, nil, 9878)
-      local cmd2 = cli_command_builder.build("hello again", opts, "session-1", {}, nil, 9878)
+      local cmd1 = cli_command_builder.build("hello", opts, nil, {}, nil)
+      local cmd2 = cli_command_builder.build("hello again", opts, "session-1", {}, nil)
 
       assert.equals(cmd1[find_flag(cmd1, "--append-system-prompt") + 1], cmd2[find_flag(cmd2, "--append-system-prompt") + 1])
     end)
@@ -316,10 +305,13 @@ describe("cli_command_builder", function()
       it("falls back to the project root when the worktree has no file", function()
         write_project_prompt({ "Root rule." })
 
+        local root_cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
         local cmd = cli_command_builder.build("hello", { cwd = worktree_root }, nil, {}, nil)
+        local root_prompt = root_cmd[find_flag(root_cmd, "--append-system-prompt") + 1]
         local prompt_text = cmd[find_flag(cmd, "--append-system-prompt") + 1]
 
         assert.is_true(prompt_text:find("Root rule.", 1, true) ~= nil)
+        assert.equals(root_prompt, prompt_text)
       end)
 
       it("falls back to the project root when the worktree file is empty", function()
@@ -413,7 +405,7 @@ describe("cli_command_builder", function()
       assert.equals("opus", cmd[idx + 1])
     end)
 
-    it("omits the worktree/ask_user_question/rpc_port tool instructions from the system prompt", function()
+    it("omits the worktree and ask_user_question tool instructions from the system prompt", function()
       local cmd = cli_command_builder.build(
         "hello",
         { lightweight = true, chat_bufnr = 12 },

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_subagent_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_subagent_spec.lua
@@ -87,8 +87,8 @@ describe("cli_command_builder subagent chat", function()
     it("stays byte-identical across turns of the same buffer", function()
       -- A per-turn value here would invalidate the cached system prefix on every message (#469).
       local opts = { _subagent_id = AGENT_ID, chat_bufnr = 7 }
-      local first = system_prompt(cli_command_builder.build("hi", opts, nil, {}, nil, 9878))
-      local second = system_prompt(cli_command_builder.build("again", opts, "session-1", {}, nil, 9878))
+      local first = system_prompt(cli_command_builder.build("hi", opts, nil, {}, nil))
+      local second = system_prompt(cli_command_builder.build("again", opts, "session-1", {}, nil))
 
       assert.equals(first, second)
     end)

--- a/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_command_builder_spec.lua
@@ -193,21 +193,20 @@ describe("codex_command_builder", function()
       assert.is_true(has_override(cmd, "developer_instructions="))
     end)
 
-    it("passes the rpc_port into the developer message", function()
-      local cmd = codex_command_builder.build("hello", {}, nil, no_project, nil, 4321)
-      local found = false
+    it("keeps the runtime rpc_port out of the developer message", function()
+      local cmd = codex_command_builder.build("hello", {}, nil, no_project, nil)
       for _, item in ipairs(config_overrides(cmd)) do
-        if vim.startswith(item, "developer_instructions=") and item:find("rpc_port for this turn is 4321", 1, true) then
-          found = true
+        if vim.startswith(item, "developer_instructions=") then
+          assert.is_nil(item:find("rpc_port for this turn", 1, true))
         end
       end
-      assert.is_true(found)
+      assert.is_true(has_override(cmd, "mcp_servers.vibing-nvim.env_vars="))
     end)
 
     -- A utility call owes "no tools, no user MCP servers" (core/types.lua); the bundled server
     -- and a skill list are both.
     it("loads none of it on a lightweight call", function()
-      local cmd = codex_command_builder.build("hello", { lightweight = true }, nil, no_project, nil, 4321)
+      local cmd = codex_command_builder.build("hello", { lightweight = true }, nil, no_project, nil)
       assert.is_false(has_override(cmd, "mcp_servers."))
       assert.is_false(has_override(cmd, "developer_instructions="))
     end)

--- a/tests/lua/infrastructure/adapter/modules/codex_plugin_config_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_plugin_config_spec.lua
@@ -5,6 +5,7 @@ describe("codex_plugin_config", function()
   local project_root
   local original_getcwd
   local original_notify
+  local original_self_plugin_dir
   local notifications
   local config = { agent = { plugins = { project_dir = ".vibing/plugins" } } }
 
@@ -61,6 +62,7 @@ describe("codex_plugin_config", function()
     vim.fn.getcwd = function()
       return project_root
     end
+    original_self_plugin_dir = PluginDirs.self_plugin_dir
     notifications = {}
     original_notify = vim.notify
     vim.notify = function(msg, level)
@@ -69,6 +71,7 @@ describe("codex_plugin_config", function()
   end)
 
   after_each(function()
+    PluginDirs.self_plugin_dir = original_self_plugin_dir
     vim.notify = original_notify
     vim.fn.getcwd = original_getcwd
     vim.fn.delete(project_root, "rf")
@@ -90,6 +93,26 @@ describe("codex_plugin_config", function()
         '["VIBING_NVIM_RPC_PORT"]',
         override(args, "mcp_servers.vibing-nvim.env_vars")
       )
+    end)
+
+    -- Only the first of its servers is named in the developer message, but every one of them
+    -- talks to this Neovim, so every one has to be handed the port.
+    it("forwards the port to every server it declares, not only the first", function()
+      local root = write_plugin("bundled-stub", {
+        name = "bundled-stub",
+        mcpServers = {
+          ["vibing-nvim"] = { command = "first" },
+          ["vibing-nvim-lsp"] = { command = "second" },
+        },
+      })
+      PluginDirs.self_plugin_dir = function()
+        return root
+      end
+
+      local args = CodexPluginConfig.args(nil, { agent = { plugins = { self = false, project_dir = ".vibing/plugins" } } })
+
+      assert.equals('["VIBING_NVIM_RPC_PORT"]', override(args, "mcp_servers.vibing-nvim.env_vars"))
+      assert.equals('["VIBING_NVIM_RPC_PORT"]', override(args, "mcp_servers.vibing-nvim-lsp.env_vars"))
     end)
 
     -- Headless `codex exec` cancels an MCP call at its own approval prompt (openai/codex#24135);
@@ -134,6 +157,8 @@ describe("codex_plugin_config", function()
       assert.equals('["--port", "1"]', override(args, "mcp_servers.deploybot.args"))
       assert.equals('"approve"', override(args, "mcp_servers.deploybot.default_tools_approval_mode"))
       assert.is_nil(override(args, "mcp_servers.deploybot.env"))
+      -- A third party's server has no business knowing this Neovim's RPC port.
+      assert.is_nil(override(args, "mcp_servers.deploybot.env_vars"))
     end)
 
     it("register a streamable HTTP server by url", function()

--- a/tests/lua/infrastructure/adapter/modules/codex_plugin_config_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_plugin_config_spec.lua
@@ -78,7 +78,7 @@ describe("codex_plugin_config", function()
 
   describe("the bundled plugin", function()
     it("registers the vibing-nvim MCP server from its manifest, root expanded", function()
-      local args = CodexPluginConfig.args(nil, config, nil)
+      local args = CodexPluginConfig.args(nil, config)
 
       assert.equals('"sh"', override(args, "mcp_servers.vibing-nvim.command"))
       assert.equals(
@@ -86,36 +86,35 @@ describe("codex_plugin_config", function()
         override(args, "mcp_servers.vibing-nvim.args")
       )
       assert.equals('{ VIBING_RPC_TIMEOUT = "30000" }', override(args, "mcp_servers.vibing-nvim.env"))
+      assert.equals(
+        '["VIBING_NVIM_RPC_PORT"]',
+        override(args, "mcp_servers.vibing-nvim.env_vars")
+      )
     end)
 
     -- Headless `codex exec` cancels an MCP call at its own approval prompt (openai/codex#24135);
     -- `approve` is the only value of the four that never reaches that prompt.
     it("pre-approves its tools at codex's own gate, leaving the decision to the hook", function()
-      local args = CodexPluginConfig.args(nil, config, nil)
+      local args = CodexPluginConfig.args(nil, config)
       assert.equals('"approve"', override(args, "mcp_servers.vibing-nvim.default_tools_approval_mode"))
     end)
 
     it("lists its skills, with the SKILL.md to read, in developer_instructions", function()
-      local instructions = override(CodexPluginConfig.args(nil, config, nil), "developer_instructions")
+      local instructions = override(CodexPluginConfig.args(nil, config), "developer_instructions")
 
       assert.is_truthy(instructions:find("- vibing-nvim:vibing-code-tour: ", 1, true))
       assert.is_truthy(instructions:find(own_plugin_dir() .. "/skills/vibing-code-tour/SKILL.md", 1, true))
     end)
 
-    it("tells the model the tool prefix and its rpc_port", function()
-      local instructions = override(CodexPluginConfig.args(nil, config, 4321), "developer_instructions")
+    it("tells the model the tool prefix without exposing its runtime port", function()
+      local instructions = override(CodexPluginConfig.args(nil, config), "developer_instructions")
 
       assert.is_truthy(instructions:find("mcp__vibing-nvim__<tool>", 1, true))
-      assert.is_truthy(instructions:find("rpc_port for this turn is 4321", 1, true))
-    end)
-
-    it("omits the rpc_port line when there is no port", function()
-      local instructions = override(CodexPluginConfig.args(nil, config, nil), "developer_instructions")
       assert.is_nil(instructions:find("rpc_port for this turn", 1, true))
     end)
 
     it("puts the overrides in -c pairs only", function()
-      local args = CodexPluginConfig.args(nil, config, nil)
+      local args = CodexPluginConfig.args(nil, config)
       for i = 1, #args, 2 do
         assert.equals("-c", args[i])
       end
@@ -129,7 +128,7 @@ describe("codex_plugin_config", function()
         mcpServers = { deploybot = { command = "${CLAUDE_PLUGIN_ROOT}/bin/serve", args = { "--port", "1" } } },
       })
 
-      local args = CodexPluginConfig.args(nil, config, nil)
+      local args = CodexPluginConfig.args(nil, config)
 
       assert.equals('"' .. root .. '/bin/serve"', override(args, "mcp_servers.deploybot.command"))
       assert.equals('["--port", "1"]', override(args, "mcp_servers.deploybot.args"))
@@ -140,7 +139,7 @@ describe("codex_plugin_config", function()
     it("register a streamable HTTP server by url", function()
       write_plugin("remote", { name = "remote", mcpServers = { hosted = { url = "https://x.test/mcp" } } })
 
-      local args = CodexPluginConfig.args(nil, config, nil)
+      local args = CodexPluginConfig.args(nil, config)
 
       assert.equals('"https://x.test/mcp"', override(args, "mcp_servers.hosted.url"))
       assert.is_nil(override(args, "mcp_servers.hosted.command"))
@@ -151,7 +150,7 @@ describe("codex_plugin_config", function()
         deploy = "---\nname: deploy\ndescription: Ship it.\n---\n",
       })
 
-      local instructions = override(CodexPluginConfig.args(nil, config, nil), "developer_instructions")
+      local instructions = override(CodexPluginConfig.args(nil, config), "developer_instructions")
 
       -- The value is the TOML rendering, so the newline between the two lines is the escape.
       assert.is_truthy(
@@ -164,7 +163,7 @@ describe("codex_plugin_config", function()
     it("cannot redeclare the bundled server", function()
       write_plugin("impostor", { name = "impostor", mcpServers = { ["vibing-nvim"] = { command = "evil" } } })
 
-      local args = CodexPluginConfig.args(nil, config, nil)
+      local args = CodexPluginConfig.args(nil, config)
 
       assert.equals('"sh"', override(args, "mcp_servers.vibing-nvim.command"))
       local count = 0
@@ -181,8 +180,8 @@ describe("codex_plugin_config", function()
     it("skip a server whose name the -c key path cannot carry, and warn once", function()
       write_plugin("dotted", { name = "dotted", mcpServers = { ["a.b"] = { command = "c" } } })
 
-      local args = CodexPluginConfig.args(nil, config, nil)
-      CodexPluginConfig.args(nil, config, nil)
+      local args = CodexPluginConfig.args(nil, config)
+      CodexPluginConfig.args(nil, config)
 
       for _, item in ipairs(overrides(args)) do
         assert.is_nil(item:find("a.b", 1, true), item)
@@ -193,39 +192,39 @@ describe("codex_plugin_config", function()
   end)
 
   it("is empty when no plugin applies", function()
-    local args = CodexPluginConfig.args(nil, { agent = { plugins = { self = false, project_dir = false } } }, 99)
+    local args = CodexPluginConfig.args(nil, { agent = { plugins = { self = false, project_dir = false } } })
     assert.same({}, args)
   end)
 
   -- `args` runs on every non-lightweight codex request, and building it is synchronous file I/O
-  -- (every manifest, every SKILL.md frontmatter) on the main loop. Reading them once per
-  -- (cwd, port) keeps that off the per-message path; `:VibingReloadCommands` is the refresh.
-  it("reads the plugins once per plugin list and port until clear_cache", function()
+  -- (every manifest, every SKILL.md frontmatter) on the main loop. Reading them once per plugin
+  -- list keeps that off the per-message path; `:VibingReloadCommands` is the refresh.
+  it("reads the plugins once per plugin list until clear_cache", function()
     local root = write_plugin("tooling", { name = "tooling", mcpServers = { a = { command = "c" } } })
 
-    local first = CodexPluginConfig.args(nil, config, 1)
+    local first = CodexPluginConfig.args(nil, config)
     vim.fn.writefile(
       { vim.json.encode({ name = "tooling", mcpServers = { a = { command = "c" }, b = { command = "d" } } }) },
       root .. "/.claude-plugin/plugin.json"
     )
     PluginDirs.clear_cache()
-    local cached = CodexPluginConfig.args(nil, config, 1)
+    local cached = CodexPluginConfig.args(nil, config)
     assert.same(first, cached)
     assert.is_nil(override(cached, "mcp_servers.b.command"))
 
     CodexPluginConfig.clear_cache()
-    local fresh = CodexPluginConfig.args(nil, config, 1)
+    local fresh = CodexPluginConfig.args(nil, config)
     assert.equals('"d"', override(fresh, "mcp_servers.b.command"))
   end)
 
   it("does not serve one plugin list's argv for another", function()
     write_plugin("tooling", { name = "tooling", mcpServers = { a = { command = "c" } } })
 
-    local with_plugins = CodexPluginConfig.args(nil, config, 1)
+    local with_plugins = CodexPluginConfig.args(nil, config)
     -- plugin_dirs memoizes by cwd alone and documents that a different `agent.plugins` needs its
     -- clear_cache(); what is under test here is that *this* memo then follows the new list.
     PluginDirs.clear_cache()
-    local without = CodexPluginConfig.args(nil, { agent = { plugins = { self = false, project_dir = false } } }, 1)
+    local without = CodexPluginConfig.args(nil, { agent = { plugins = { self = false, project_dir = false } } })
 
     assert.is_not_nil(override(with_plugins, "mcp_servers.a.command"))
     assert.same({}, without)
@@ -234,24 +233,36 @@ describe("codex_plugin_config", function()
   it("hands each caller its own copy, so mutating the argv cannot poison the memo", function()
     write_plugin("tooling", { name = "tooling", mcpServers = { a = { command = "c" } } })
 
-    local first = CodexPluginConfig.args(nil, config, 1)
+    local first = CodexPluginConfig.args(nil, config)
     table.insert(first, "--mutated")
-    local second = CodexPluginConfig.args(nil, config, 1)
+    local second = CodexPluginConfig.args(nil, config)
 
     assert.is_false(vim.tbl_contains(second, "--mutated"))
   end)
 
+  it("produces byte-identical output for a worktree that uses the root plugin set", function()
+    write_plugin("tooling", { name = "tooling", mcpServers = { a = { command = "c" } } })
+    local worktree_root = project_root .. "/.vibing/worktrees/feature-x"
+    vim.fn.mkdir(worktree_root, "p")
+
+    local root = CodexPluginConfig.args(nil, config)
+    local worktree = CodexPluginConfig.args(worktree_root, config)
+
+    assert.same(root, worktree)
+  end)
+
   -- Codex's prompt cache matches on a prefix, so the developer message must not change from one
   -- turn of a chat to the next (#469).
-  it("produces byte-identical output on repeated calls", function()
+  it("produces byte-identical output after the reload caches are cleared", function()
     write_plugin("tooling", { name = "tooling", mcpServers = { a = { command = "c", env = { Z = "1", A = "2" } } } }, {
       one = "---\nname: one\ndescription: First.\n---\n",
       two = "---\nname: two\ndescription: Second.\n---\n",
     })
 
-    local first = CodexPluginConfig.args(nil, config, 1)
+    local first = CodexPluginConfig.args(nil, config)
     PluginDirs.clear_cache()
-    local second = CodexPluginConfig.args(nil, config, 1)
+    CodexPluginConfig.clear_cache()
+    local second = CodexPluginConfig.args(nil, config)
 
     assert.same(first, second)
   end)

--- a/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
@@ -128,7 +128,7 @@ describe("grok_command_builder", function()
     it("names no MCP tool, because Grok cannot reach the vibing-nvim MCP server", function()
       -- Grok registers no MCP server and no chat_bufnr, so an instruction to call
       -- nvim_ask_user_question would name a tool it has no way to invoke. Same position as codex.
-      local cmd = grok_command_builder.build("hello", { chat_bufnr = 12 }, nil, {}, "abc123_456", 9878)
+      local cmd = grok_command_builder.build("hello", { chat_bufnr = 12 }, nil, {})
       local rules_text = cmd[find_flag(cmd, "--rules") + 1]
 
       assert.is_nil(rules_text:find("nvim_ask_user_question", 1, true))
@@ -138,8 +138,8 @@ describe("grok_command_builder", function()
 
     it("embeds no handle_id, so the rules stay byte-identical across turns", function()
       -- A per-turn value here would invalidate the cached prompt prefix on every message (#469).
-      local first = grok_command_builder.build("hello", {}, nil, {}, "handle-1", 9878)
-      local second = grok_command_builder.build("again", {}, "session-1", {}, "handle-2", 9878)
+      local first = grok_command_builder.build("hello", {}, nil, {})
+      local second = grok_command_builder.build("again", {}, "session-1", {})
 
       local a = first[find_flag(first, "--rules") + 1]
       local b = second[find_flag(second, "--rules") + 1]


### PR DESCRIPTION
## Summary

- bind the bundled MCP server to its launching Neovim through VIBING_NVIM_RPC_PORT
- make the shared RPC resolver authoritative for both Claude Code and Codex while retaining rpc_port as an optional legacy override
- remove the numeric port from model-visible prompts, skills, subagent briefs, and tool calls
- keep generated prompt/plugin configuration byte-identical after cache reloads and across worktrees that use the same root configuration

## Verification

- npm test --prefix claude-plugin/mcp-server (348 passed)
- targeted Plenary specs for Claude/Codex builders, adapters, stream environments, and cache stability (175 passed)
- npm run build --prefix claude-plugin/mcp-server
- npm run lint -- --no-warn-ignored
- npm run format:check
- git diff --check

## Local-suite notes

- the full Lua suite still has three unrelated orchestration-link/temp-chat save failures in chat_list_spec.lua and chat_conflicts_spec.lua
- npm run test:node has 57 passing tests and one environment failure because luac is not installed locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP tools automatically connect to the Neovim instance that launched the chat.
  - Tool calls no longer require an `rpc_port` argument in normal use.
  - Manually launched servers can specify `VIBING_NVIM_RPC_PORT`.

- **Bug Fixes**
  - Improved connection selection and validation when multiple or unavailable Neovim instances exist.
  - State-changing actions no longer guess an instance when the server is unbound.

- **Documentation**
  - Updated setup instructions, examples, troubleshooting guidance, and tool references for automatic instance binding and optional manual configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->