### PR TITLE
fix(codex): restore per-turn patches and diff previews

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -59,6 +59,22 @@ Claude-only (`handbook/features/chat-ui.md`).
 - **Grok discovers project hooks only inside a git repository** (outside one the gate would
   silently allow everything, so `ensure()` warns), and **copilot's hook is injected as a throwaway
   plugin** under `.vibing/copilot-plugin/` via `--plugin-dir`, with a schema that is not claude's.
+- **Codex's hook key is `hooks.PreToolUse` and it travels with
+  `--dangerously-bypass-hook-trust`.** Both halves fail silently on their own: codex drops an
+  unrecognised `hooks.*` key without a warning (the snake_case spelling meant no hook fired at all
+  — no permission gate, and no diff baseline, so no `.vibing/patches/*.patch` and no `gd` float),
+  and a registered-but-untrusted hook makes `codex exec` **hang** rather than skip. So
+  `codex_settings_generator.get_hook_args()` returns the flag and the `-c` pair as one fragment;
+  do not split them. Verify with `hooks/list` on `codex app-server`, never by eye.
+- **The Codex hook script is copied to `<cwd>/.vibing/codex-pre-tool-use.sh` before launch.** A
+  hook command outside that turn's writable roots makes sandboxed `codex exec` hang instead of
+  reporting a spawn error. Keep staging synchronous and atomic; if it fails, omit the hook rather
+  than registering a command that cannot run. Keep the hook in `bypassPermissions`: that mode
+  bypasses the decision, not the git-snapshot baseline carried by the same PreToolUse round trip.
+- **`codex_tool_vocabulary.lua` has no `normalize_input`, deliberately.** A codex edit carries no
+  path in `tool_input` — the paths are inside the apply_patch envelope in `command`, and there may
+  be several. So granular `paths` rules do not match codex edits. Filling `file_path` from the
+  first path would let a deny rule be evaded by patch ordering; the fix belongs in `matchers.lua`.
 
 Why each seam exists and which CLI version each shape was captured from:
 `handbook/architecture/cli-integration.md` → "Backend Seams".
@@ -133,7 +149,10 @@ or a formatter run through Bash still shows up (#625).
   behaviour has to count as a writer.
 - **`.vibing/` is excluded by pathspec on the diff calls, and only conditionally on `git add -A`**
   — `git add` exits 1 when a pathspec explicitly names an ignored path, including a _negative_
-  one, which silently disabled the whole mechanism until #664.
+  one, which silently disabled the whole mechanism until #664. The same exclusion must also be
+  applied when `extra_paths` is merged into either diff implementation, or tool events add the
+  directory back after git excluded it. Test the path relative to the current worktree root — a
+  worktree itself normally lives below an outer `.vibing/worktrees/`.
 - **The git calls block the main loop** (`vim.system():wait()`): 20ms per `git add -A` on a 9k-file
   tree, 63ms on an 80k one.
 - **`request_diff.lua` stays as the fallback**, and a turn where both come up empty **warns**

--- a/handbook/architecture/cli-integration.md
+++ b/handbook/architecture/cli-integration.md
@@ -213,3 +213,79 @@ These are the seams that stop backend identity leaking into shared code. The rul
   every adapter to register no hooks for utility calls). And installing it is allowed to fail:
   the generator runs under `pcall`, and a failure warns and falls back to the static
   `--deny-tool` flags rather than taking the turn down.
+
+- **Codex's hook needs a PascalCase key and an explicit trust bypass.** Codex has no per-run hook
+  file, so `codex_settings_generator.lua` passes the hook as a `-c` override. Two things about
+  that, both captured from codex 0.153.4, and both of which fail **silently**:
+
+  1. **The key is `hooks.PreToolUse`, not `hooks.pre_tool_use`**, and the handler must sit inside a
+     matcher group: `[{hooks=[{type="command",command=…,timeout=…}]}]`. A flat
+     `[{command=…}]` parses as a group with no handlers. Anything codex does not recognise here is
+     dropped without a warning, an error, or an entry in `hooks/list` — it is valid TOML, so
+     nothing complains.
+
+     vibing.nvim shipped the snake_case key with the flat shape, so **no PreToolUse hook fired on
+     codex at all**. That took two things with it, neither of which looks like a hook problem from
+     the outside: the permission gate (every tool ran ungated, `deny` rules included), and the
+     git-snapshot diff baseline — which is taken in the hook, so `### Modified Files` fell back to
+     tool-event paths, `.vibing/patches/*.patch` stopped being written, and `gd` stopped opening
+     the patch float because `patch_finder` had no `<!-- patch: … -->` to find.
+
+     `hooks/list` on the app-server is the cheap oracle for this, and the one to reach for before
+     believing a hook is registered — it resolves the same config the agent would and reports
+     `warnings`/`errors`, without starting a turn or spending a token:
+
+     ```sh
+     { printf '%s\n' \
+         '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"p","title":"p","version":"0.0.0"}}}' \
+         '{"jsonrpc":"2.0","method":"initialized","params":{}}' \
+         '{"jsonrpc":"2.0","id":3,"method":"hooks/list","params":{}}'; sleep 6; } \
+       | codex app-server -c 'hooks.PreToolUse=[{hooks=[{type="command",command="/x",timeout=1}]}]'
+     ```
+
+     `hooks.PreToolUse` → one resolved hook; `hooks.pre_tool_use` → `hooks: []`, no warnings, no
+     errors. Only `$CODEX_HOME/hooks.json` and plugins are read as hook _files_: a project-local
+     `.codex/hooks.json`, `.codex/hooks/hooks.json` and `-c hooks.managed_dir` were all measured to
+     resolve nothing, including with the project marked trusted.
+
+  2. **`--dangerously-bypass-hook-trust` is not optional, it is part of registering the hook.**
+     Codex 0.153 gates hooks on trust: a resolved hook is reported enabled but `untrusted` until
+     the user reviews it in the TUI, which persists a
+     `trusted_hash` into their real `config.toml`. A session layer cannot grant its own trust —
+     `-c hooks.state.<key>.trusted_hash=<currentHash>` leaves `trustStatus` at `untrusted`
+     (measured, with the hash `hooks/list` itself reported), which is the right call, since
+     otherwise the flag would defeat the mechanism.
+
+     With the key corrected and the flag absent, `codex exec` does not merely skip the hook — it
+     **blocks** waiting for a review that has no terminal to happen in (measured: no output, no
+     tool call, killed at 180s). So the generator returns the flag together with the `-c` pair
+     rather than as a separate option: one without the other either does nothing (old key) or
+     hangs the turn (new key). The honest cost is that for that one invocation it also un-gates the
+     user's own `~/.codex/hooks.json` entries that they added and never reviewed; ones they did
+     review are already trusted and unaffected.
+
+  3. **The command has to name a script inside the turn's writable roots.** A hook pointing at the
+     plugin installation outside the target working directory makes sandboxed `codex exec` block
+     without reporting a spawn error. `codex_settings_generator.ensure()` therefore copies the
+     shared `pre-tool-use.sh` to `<cwd>/.vibing/codex-pre-tool-use.sh`, marks the temporary copy
+     executable, and atomically renames it into place before building argv. It refreshes the copy
+     every turn so a plugin update cannot leave old permission logic behind. If any staging step
+     fails, `codex_cli.lua` warns and omits the hook; registering a command that cannot execute is
+     the hanging outcome.
+
+     This registration also stays present in `bypassPermissions`. The permission handler honors
+     that mode and allows every call, while the same PreToolUse round trip takes the git-snapshot
+     baseline. Skipping the hook would bypass observation along with approval and recreate the
+     missing patch/`gd` failure specifically for users of that mode. Claude's adapter likewise
+     keeps its hook settings in bypass mode.
+
+  The payload codex sends is Claude-compatible (`tool_name`/`tool_input`, deny by exit 2 +
+  stderr), so `pre-tool-use.sh` needs no codex argument. Its shell tool already arrives as
+  `Bash`; a file edit arrives as `apply_patch` with **no path in `tool_input` at all** — the paths
+  are inside the `command` string as an apply_patch envelope, which is why
+  `codex_tool_vocabulary.lua` has no `normalize_input` and says so at length. Consequence, stated
+  there and repeated here because it is a permission gap rather than a cosmetic one: granular
+  `paths` rules never match a codex edit, and `request_diff.capture` backs nothing up for one.
+  Filling `file_path` with the first path a multi-file patch names would read as working while
+  letting a deny rule be evaded by patch ordering, so fixing it properly means teaching
+  `matchers.lua` about a set of paths.

--- a/handbook/architecture/per-request-diffs.md
+++ b/handbook/architecture/per-request-diffs.md
@@ -107,6 +107,14 @@ Three details are not interchangeable:
   whole `.vibing/worktrees/` checkout in the patch. Measured against git 2.50.1: `--ignore-errors`
   and every `:(exclude...)` spelling exit 1 alike, and plain `-- .` exits 0.
 
+  The pathspec is not the last word: tool events are merged afterwards through `extra_paths` so a
+  reported change ignored by git can still appear in `### Modified Files`. That completion step
+  must exclude `.vibing/` too, in both `git_snapshot.generate` and the `request_diff.generate`
+  fallback, or it adds the internal path straight back to the left pane. The predicate runs on the
+  path relative to the current base, not on the absolute path: a managed worktree normally lives
+  at `<main>/.vibing/worktrees/<branch>`, and `lua/plugin.lua` inside that worktree is an ordinary
+  user change when the worktree itself is the current base.
+
   The spec that missed this is worth naming, because the gap was in the fixture rather than in the
   assertions: its `.gitignore` held `ignored/` and `*.log` only, so `.vibing/` was never ignored in
   any test, and the one case pinned for this directory was literally the working one — "even when

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -971,10 +971,11 @@ Because the comparison is between two states of the whole tree, it does not matt
 made the change — **a `sed -i`, a `mv`, or a formatter run through Bash shows up the same way an
 `Edit` does**. Untracked files matched by `.gitignore` are excluded (that is what keeps the cost
 down) — a file that is already tracked still shows its changes even if it matches an ignore
-pattern, because `.gitignore` only governs what gets added. An excluded file that a write tool
+pattern, because `.gitignore` only governs what gets added. An ignored file that a write tool
 reported anyway is still listed under `### Modified Files`, just without a patch section.
-vibing.nvim's own `.vibing/` directory is always excluded, whether or not you have git-ignored it —
-the chat files live there and would otherwise report themselves as your changes.
+vibing.nvim's own `.vibing/` directory is the exception: it is excluded from both the snapshot and
+the tool-event completion, whether or not you have git-ignored it — the chat files live there and
+would otherwise report themselves as your changes.
 
 Your index and working tree are never touched: the snapshot is built with `git add -A` against a
 temporary index (`GIT_INDEX_FILE`), so it takes no `.git/index.lock` and cannot collide with git

--- a/lua/vibing/core/utils/git_snapshot.lua
+++ b/lua/vibing/core/utils/git_snapshot.lua
@@ -31,6 +31,16 @@ local SESSION_TTL_SEC = 3600
 ---@type string
 local EXCLUDE_VIBING_DIR = ":(exclude).vibing"
 
+---Whether a worktree-relative path belongs to vibing.nvim's own state directory.
+---Match the first component only: a worktree itself commonly lives under
+---`<main>/.vibing/worktrees/<branch>`, and its ordinary files must remain visible when that
+---worktree is the current root.
+---@param rel string
+---@return boolean
+local function is_vibing_state_path(rel)
+  return rel == ".vibing" or rel:sub(1, 8) == ".vibing/"
+end
+
 ---`git add` の pathspec。`.vibing` が既に無視されているworktreeでは exclude を **付けない**
 ---
 ---`git add` は「無視対象のパスを明示的に指定した」と判断すると exit 1 を返す。これは
@@ -589,7 +599,7 @@ function M.generate(handle_id, extra_paths)
         rel = abs:sub(#prefix + 1)
       end
     end
-    if not seen[rel] then
+    if not is_vibing_state_path(rel) and not seen[rel] then
       seen[rel] = true
       table.insert(files, rel)
       table.insert(abs_files, abs)

--- a/lua/vibing/core/utils/request_diff.lua
+++ b/lua/vibing/core/utils/request_diff.lua
@@ -72,6 +72,15 @@ local function to_rel(abs, base)
   return abs, false
 end
 
+---Whether a base-relative path belongs to vibing.nvim's own state directory.
+---Only the first component counts. A worktree can itself be located below an outer `.vibing/`,
+---but its normal files are user-visible changes relative to that worktree's own base.
+---@param rel string
+---@return boolean
+local function is_vibing_state_path(rel)
+  return rel == ".vibing" or rel:sub(1, 8) == ".vibing/"
+end
+
 ---TTL超過した放置セッション（キャンセルされたリクエスト等）を破棄
 local function sweep_stale()
   local now = os.time()
@@ -229,8 +238,9 @@ function M.generate(handle_id, base_dir, extra_paths)
       local changed = (before or "") ~= (after or "")
       -- base_dir外のファイルはgit apply（cwd=base_dir、-p1）で復元できるpatchにならないため、
       -- 一覧にのみ載せてdiffセクションは作らない（バイナリも同様、build_file_section内で除外）
-      local section = under_base and build_file_section(rel, entry, abs, before, after) or nil
-      if section or changed then
+      local internal = under_base and is_vibing_state_path(rel)
+      local section = not internal and under_base and build_file_section(rel, entry, abs, before, after) or nil
+      if not internal and (section or changed) then
         seen[abs] = true
         table.insert(files, rel)
         table.insert(abs_files, abs)
@@ -244,9 +254,10 @@ function M.generate(handle_id, base_dir, extra_paths)
   -- フックを通らなかった変更ファイル（退避なし）も一覧にだけは載せる
   for path in pairs(extra_paths or {}) do
     local abs = vim.fn.fnamemodify(path, ":p")
-    if not seen[abs] and not (s and s.files[abs]) then
+    local rel, under_base = to_rel(abs, base_dir)
+    local internal = under_base and is_vibing_state_path(rel)
+    if not internal and not seen[abs] and not (s and s.files[abs]) then
       seen[abs] = true
-      local rel = to_rel(abs, base_dir)
       table.insert(files, rel)
       table.insert(abs_files, abs)
     end

--- a/lua/vibing/infrastructure/adapter/codex_cli.lua
+++ b/lua/vibing/infrastructure/adapter/codex_cli.lua
@@ -68,13 +68,37 @@ function CodexCLI:stream(prompt, opts, on_chunk, on_done)
     )
   end
 
-  local permission_mode = opts.permission_mode or "default"
   local hook_args = nil
   -- Lightweight calls skip hook registration, matching claude_cli.lua. The builder fences them
   -- into a read-only sandbox instead, and routing a title-generation tool call into the chat's
   -- approval UI would prompt the user about a request they never made.
-  if permission_mode ~= "bypassPermissions" and not opts.lightweight then
-    hook_args = CodexSettingsGenerator.get_hook_args()
+  if not opts.lightweight then
+    -- The cwd is not optional here: the generator stages the hook script *inside* it, because
+    -- codex refuses to execute one from outside the sandbox's writable roots and hangs the turn
+    -- rather than reporting it. See CodexSettingsGenerator.ensure.
+    --
+    -- Keep the hook in bypassPermissions too. The permission handler honors that mode and allows
+    -- every call, but the same PreToolUse round trip is also where git_snapshot takes the turn's
+    -- baseline. Removing the hook would bypass observation as well as approval, leaving this mode
+    -- with no patch and therefore no `gd` preview. Claude's adapter keeps the hook for the same
+    -- reason.
+    --
+    -- Guarded like copilot's, and for a sharper reason: if staging fails there is no script for
+    -- codex to run, and registering the hook anyway is exactly the case that hangs. So a failure
+    -- warns and drops the hook -- the turn runs ungated, which is bad, but it runs.
+    local ok_hook, args_or_err =
+      pcall(CodexSettingsGenerator.get_hook_args, opts.cwd or vim.fn.getcwd())
+    if ok_hook then
+      hook_args = args_or_err
+    else
+      vim.notify(
+        string.format(
+          "[vibing:codex] Failed to install the PreToolUse hook, so this turn is not gated by vibing.nvim: %s",
+          tostring(args_or_err)
+        ),
+        vim.log.levels.WARN
+      )
+    end
   end
 
   -- The builder raises when the codex binary is missing. send_message.lua does not wrap stream()

--- a/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_command_builder.lua
@@ -37,7 +37,9 @@ end
 --- @param opts Vibing.AdapterOpts Adapter options
 --- @param session_id string|nil Thread ID for session resumption
 --- @param config Vibing.Config Plugin config
---- @param hook_args string[]|nil Optional -c flag pair for PreToolUse hook injection
+--- @param hook_args string[]|nil Optional argv fragment for PreToolUse hook injection. Opaque
+---   here on purpose: `codex_settings_generator` decides what a registered hook needs, and it
+---   needs more than the `-c` pair (see its TRUST_FLAG comment). Appended verbatim.
 --- @return string[] Command array for vim.system()
 function M.build(prompt, opts, session_id, config, hook_args)
   local cmd = { binary_path.resolve(), "exec" }

--- a/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
@@ -8,9 +8,18 @@
 
 local M = {}
 
+--- Captured from real codex 0.153.4 PreToolUse payloads, which vibing.nvim could not see until the
+--- hook was registered under the key codex actually reads (`codex_settings_generator`):
+---
+---   shell:       {"tool_name":"Bash","tool_input":{"command":"echo hi"}}
+---   file edit:   {"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n…"}}
+---
+--- So codex already speaks Claude's name for its shell tool and needs no entry for it. `shell` is
+--- mapped anyway because it is what older codex sent and the mapping costs nothing.
 --- @type table<string, string>
 local NATIVE_TO_CANONICAL = {
   apply_patch = "Edit", -- Codex's file patch tool maps to Claude's Edit
+  shell = "Bash",
 }
 
 --- @param native_tool_name string
@@ -18,5 +27,30 @@ local NATIVE_TO_CANONICAL = {
 function M.to_canonical(native_tool_name)
   return NATIVE_TO_CANONICAL[native_tool_name]
 end
+
+--- **Deliberately absent: `normalize_input`.** Known gap, not an oversight.
+---
+--- Codex does not put the edited path in a sibling key the way grok (`target_file`) and copilot
+--- (`path`) do -- there is no path in `tool_input` at all. It is inside the `command` string, as an
+--- apply_patch envelope that may name several files at once:
+---
+---   *** Begin Patch
+---   *** Update File: a.lua
+---   *** Add File: b.lua
+---   *** End Patch
+---
+--- Two consequences, both pre-existing and neither introduced by registering the hook (before that
+--- fix no codex tool call reached this module at all):
+---
+---   - granular `paths` rules never match a codex edit, because `matchers.lua` reads a single
+---     `input.file_path`;
+---   - `request_diff.capture` backs nothing up, because it reads `tool_input.file_path`. Harmless
+---     today: the git-snapshot path is the primary one and needs no path, only the baseline.
+---
+--- The reason this is not a two-line fix is the multi-file case. Filling `file_path` with the
+--- *first* path parsed would read as working while letting a deny rule be evaded by patch
+--- ordering, which is worse than not matching at all. Doing it properly means teaching the paths
+--- matcher about a set of paths, and that is a change to shared permission code rather than to
+--- this backend's seam.
 
 return M

--- a/lua/vibing/infrastructure/hooks/codex_settings_generator.lua
+++ b/lua/vibing/infrastructure/hooks/codex_settings_generator.lua
@@ -1,21 +1,158 @@
 --- Codex hook settings generator
---- Provides -c arguments to inject PreToolUse hook into `codex exec`
---- Reuses the same pre-tool-use.sh script as the Claude adapter
+---
+--- Codex has no per-run hook file, so the hook goes in as a `-c` override -- but the script it
+--- points at has to be staged inside the working directory first. See `ensure()`.
 --- @module vibing.infrastructure.hooks.codex_settings_generator
 
+local Fs = require("vibing.core.utils.fs")
 local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
 
 local M = {}
 
---- Get -c arguments for injecting the PreToolUse hook into `codex exec`
---- @return string[] Two-element array: {"-c", "hooks.pre_tool_use=[...]"}
-function M.get_hook_args()
-  local hook_script = SettingsGenerator.get_hook_script_path()
-  local escaped = hook_script:gsub("\\", "\\\\"):gsub('"', '\\"')
+--- Codex's hook timeout, in seconds.
+---
+--- pre-tool-use.sh gives up and denies after ~120s, so this stays above that number for the same
+--- reason copilot's does: whichever side gives up first decides, and the script's deny is the only
+--- one that carries a reason.
+local HOOK_TIMEOUT_SEC = 300
+
+--- The `-c` config key. **PascalCase, and that is load-bearing.**
+---
+--- Codex 0.153 reads `hooks.<PascalCaseEvent>` and silently ignores anything else -- no warning, no
+--- error, no entry in `hooks/list`. vibing.nvim shipped `hooks.pre_tool_use` (snake_case) with a
+--- flat handler list, which parsed as TOML and was then dropped on the floor, so **no PreToolUse
+--- hook fired on codex at all**: no permission gate, and no git-snapshot baseline, which took the
+--- per-request diff and every `.vibing/patches/*.patch` with it.
+---
+--- Verified against codex 0.153.4 by asking the app-server for the hooks it actually resolved
+--- (`handbook/architecture/cli-integration.md` has the runnable form). `hooks/list` is the cheap
+--- oracle here: it resolves the same config the agent would, reports `warnings`/`errors`, and
+--- spends no tokens.
+local HOOK_EVENT_KEY = "hooks.PreToolUse"
+
+--- Codex will not run a hook it has not been told to trust.
+---
+--- Every hook is reported enabled but `untrusted` until the user reviews it in the TUI, which
+--- persists a `trusted_hash` into their real `config.toml`. A `-c` layer cannot grant its own trust
+--- -- `hooks.state.<key>.trusted_hash` passed as a session flag leaves it `untrusted` (measured),
+--- which is the right call on codex's part, since otherwise the flag would defeat the mechanism.
+---
+--- That leaves this flag as the only way for a headless `codex exec` to run the hook, and it is
+--- **not optional**: with the hook registered and untrusted, `codex exec` blocks waiting for a
+--- review that has no terminal to happen in (measured: no output, no tool call, killed at 180s).
+--- So the flag is returned together with the hook rather than as a separate option -- passing one
+--- without the other either does nothing (old key) or hangs the turn (new key).
+---
+--- The cost, stated honestly: for this one invocation it also un-gates the user's own
+--- `~/.codex/hooks.json` entries that they have added but never reviewed. Hooks they *have*
+--- reviewed are already trusted and unaffected.
+local TRUST_FLAG = "--dangerously-bypass-hook-trust"
+
+--- Where the staged copy of the hook script lives, for a given cwd.
+---
+--- Resolved, so this reports the same path `ensure()` writes: that one resolves the cwd, and a
+--- symlinked working directory would otherwise make the two disagree. Same reasoning as
+--- `copilot_settings_generator.plugin_dir`.
+--- @param cwd string
+--- @return string
+function M.script_path(cwd)
+  return vim.fn.resolve(cwd) .. "/.vibing/codex-pre-tool-use.sh"
+end
+
+--- Stage the hook script inside the working directory and return its path.
+---
+--- **Codex will not execute a hook script that lives outside the sandbox's writable roots**
+--- (`workdir`, `/tmp`, `$TMPDIR` -- codex prints them in its own startup banner), and it does not
+--- report that as an error: the turn hangs exactly the way an untrusted hook does. vibing.nvim's
+--- script lives in the installed plugin directory, which is outside the user's project by
+--- definition, so pointing `-c` straight at it hangs every codex turn.
+---
+--- Measured against codex 0.153.4 with `--sandbox workspace-write` (what `codex_command_builder`
+--- passes for every mode but `plan`/`bypassPermissions`), same script, same argv, only the path
+--- moved:
+---
+---     <plugin>/bin/hooks/pre-tool-use.sh   -> hook never ran, turn hung (killed at 180s)
+---     /tmp/pre-tool-use.sh                 -> fired, full RPC round trip
+---     <cwd>/.vibing/pre-tool-use.sh        -> fired, full RPC round trip
+---
+--- The last one is what this does. `/tmp` also works but is machine-wide shared state, where
+--- `<cwd>/.vibing/` is already this plugin's own scratch directory, is git-ignored, and is where
+--- copilot's throwaway plugin goes for the same reason. A symlink is not used: it would point back
+--- out of the writable roots, which is the case that fails.
+---
+--- Copied rather than cached: the source path moves when the plugin is updated or reinstalled, and
+--- a stale copy is a hook that silently answers with old logic. The write goes through a temp file
+--- and a rename because every chat open on this cwd rewrites this path just before spawning its own
+--- codex, and a reader catching a truncated script would get a hook that fails in a way none of the
+--- three decisions covers. `rename(2)` is atomic within a directory. One shared path is safe only
+--- because the contents are identical for every chat -- per-request identity (`VIBING_HANDLE_ID`,
+--- the RPC port) travels in codex's environment, not in this file.
+--- @param cwd? string Working directory (defaults to vim.fn.getcwd())
+--- @return string path Absolute path to the staged script
+function M.ensure(cwd)
+  local path = M.script_path(cwd or vim.fn.getcwd())
+  Fs.ensure_dir(vim.fn.fnamemodify(path, ":h"))
+
+  local source = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+  local src, src_err = io.open(source, "rb")
+  if not src then
+    error("Failed to read the hook script: " .. source .. " (" .. tostring(src_err) .. ")")
+  end
+  local contents = src:read("*a")
+  src:close()
+
+  local tmp_path = string.format("%s.%d.tmp", path, vim.loop.getpid())
+  local out, out_err = io.open(tmp_path, "wb")
+  if not out then
+    error("Failed to stage the codex hook script: " .. tmp_path .. " (" .. tostring(out_err) .. ")")
+  end
+  out:write(contents)
+  out:close()
+
+  -- Before the rename, so the script is never visible at its final path without the bit set.
+  -- setfperm keeps this synchronous without spawning a second process. Besides being cheaper,
+  -- that matters during adapter setup: every `vim.system` call there is an observable CLI launch
+  -- in the stream lifecycle and in its tests.
+  if vim.fn.setfperm(tmp_path, "rwxr-xr-x") ~= 1 then
+    os.remove(tmp_path)
+    error("Failed to make the staged codex hook script executable: " .. tmp_path)
+  end
+
+  local ok, rename_err = os.rename(tmp_path, path)
+  if not ok then
+    os.remove(tmp_path)
+    error("Failed to install the codex hook script: " .. path .. " (" .. tostring(rename_err) .. ")")
+  end
+
+  return path
+end
+
+--- Flags for injecting the PreToolUse hook into `codex exec`
+---
+--- Raises if the script cannot be staged, which is why `codex_cli.lua` calls this under `pcall`:
+--- registering the hook without a script codex can run is the one outcome to avoid, since that is
+--- the shape that hangs rather than the one that merely skips the gate.
+--- @param cwd? string Working directory the codex process will run in
+--- @return string[] argv fragment: {"--dangerously-bypass-hook-trust", "-c", "hooks.PreToolUse=[...]"}
+function M.get_hook_args(cwd)
+  local script = M.ensure(cwd)
+  local escaped = script:gsub("\\", "\\\\"):gsub('"', '\\"')
   return {
+    TRUST_FLAG,
     "-c",
-    string.format('hooks.pre_tool_use=[{command="%s",timeout=120}]', escaped),
+    string.format(
+      -- A matcher group (`{hooks=[...]}`) wrapping `type`-tagged handlers. The handler cannot sit
+      -- at the top level: codex parses `[{command=...}]` as a group with no handlers and resolves
+      -- nothing.
+      '%s=[{hooks=[{type="command",command="%s",timeout=%d}]}]',
+      HOOK_EVENT_KEY,
+      escaped,
+      HOOK_TIMEOUT_SEC
+    ),
   }
 end
+
+M._HOOK_EVENT_KEY = HOOK_EVENT_KEY
+M._HOOK_TIMEOUT_SEC = HOOK_TIMEOUT_SEC
 
 return M

--- a/tests/lua/core/utils/git_snapshot_spec.lua
+++ b/tests/lua/core/utils/git_snapshot_spec.lua
@@ -281,6 +281,20 @@ describe("git_snapshot", function()
       assert.is_nil(turn.patch)
     end)
 
+    it("does not let tool-event fallback add .vibing paths back to the file list", function()
+      -- The git diff already excludes `.vibing`, but FileChange events are merged in afterwards.
+      -- Without the same boundary here, a path under another managed worktree reappears in the
+      -- left pane even though it was correctly absent from the patch.
+      local internal = repo .. "/.vibing/worktrees/other/lua/plugin.lua"
+      local turn = run_turn(function()
+        write(internal, "return {}\n")
+      end, { [internal] = true })
+
+      assert.same({}, turn.files)
+      assert.same({}, turn.abs_files)
+      assert.is_nil(turn.patch)
+    end)
+
     it("does not list a tool-event path twice when git saw it too", function()
       local turn = run_turn(function()
         write(repo .. "/tracked.txt", "after\n")

--- a/tests/lua/core/utils/request_diff_spec.lua
+++ b/tests/lua/core/utils/request_diff_spec.lua
@@ -134,6 +134,40 @@ describe("request_diff", function()
       assert.is_falsy(patch:find("bash-touched.txt", 1, true))
     end)
 
+    it("excludes .vibing paths from both captures and event fallback", function()
+      local internal = tmp_dir .. "/.vibing/worktrees/other/lua/plugin.lua"
+      vim.fn.mkdir(vim.fn.fnamemodify(internal, ":h"), "p")
+      write_file(internal, "before\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = internal })
+      write_file(internal, "after\n")
+
+      local files, abs_files, patch = RequestDiff.generate(
+        handle_id,
+        tmp_dir,
+        { [internal] = true }
+      )
+
+      assert.same({}, files)
+      assert.same({}, abs_files)
+      assert.is_nil(patch)
+    end)
+
+    it("keeps normal files when the base directory itself is inside .vibing", function()
+      local worktree = tmp_dir .. "/.vibing/worktrees/feature"
+      vim.fn.mkdir(worktree, "p")
+      local file = worktree .. "/lua/plugin.lua"
+      vim.fn.mkdir(vim.fn.fnamemodify(file, ":h"), "p")
+      write_file(file, "before\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      write_file(file, "after\n")
+
+      local files, abs_files, patch = RequestDiff.generate(handle_id, worktree, nil)
+
+      assert.same({ "lua/plugin.lua" }, files)
+      assert.same({ file }, abs_files)
+      assert.is_truthy(patch:find("diff --git a/lua/plugin.lua", 1, true))
+    end)
+
     it("keeps requests isolated per handle_id", function()
       local other_handle = handle_id .. "-other"
       local file_a = tmp_dir .. "/a.txt"

--- a/tests/lua/infrastructure/adapter/codex_cli_spec.lua
+++ b/tests/lua/infrastructure/adapter/codex_cli_spec.lua
@@ -11,10 +11,19 @@ local notice = require("vibing.infrastructure.adapter.modules.codex_provider_not
 
 local CONFIG = { agent = { default_model = "sonnet" } }
 
---- Whether the argv carries a `-c hooks.pre_tool_use=...` pair.
+--- Whether the argv carries the hook's `-c` pair.
+---
+--- The key is read from the generator rather than written out here on purpose. Hardcoding it once
+--- already cost us: this helper spelled `hooks.pre_tool_use`, and when that turned out to be a key
+--- codex ignores, the helper would have kept answering "hook registered" for a corrected argv --
+--- inverting every assertion below while the suite stayed green. What this spec is for is whether
+--- the adapter emits the hook at all, not how the generator spells it.
+local HOOK_EVENT_KEY =
+  require("vibing.infrastructure.hooks.codex_settings_generator")._HOOK_EVENT_KEY
+
 local function registers_hook(cmd)
   for index, arg in ipairs(cmd) do
-    if arg == "-c" and type(cmd[index + 1]) == "string" and cmd[index + 1]:find("hooks.pre_tool_use", 1, true) then
+    if arg == "-c" and type(cmd[index + 1]) == "string" and cmd[index + 1]:find(HOOK_EVENT_KEY, 1, true) then
       return true
     end
   end
@@ -47,9 +56,11 @@ describe("codex_cli hook registration", function()
     assert.is_false(registers_hook(system.cli_call().cmd))
   end)
 
-  it("skips it in bypassPermissions, as before", function()
+  it("keeps it in bypassPermissions so diff capture is not bypassed too", function()
     helper.run_stream(adapter, { permission_mode = "bypassPermissions" })
-    assert.is_false(registers_hook(system.cli_call().cmd))
+    local cmd = system.cli_call().cmd
+    assert.is_true(registers_hook(cmd))
+    assert.is_true(vim.tbl_contains(cmd, "--dangerously-bypass-approvals-and-sandbox"))
   end)
 
   it("still fences the lightweight call even with the hook gone", function()

--- a/tests/lua/infrastructure/hooks/codex_settings_generator_spec.lua
+++ b/tests/lua/infrastructure/hooks/codex_settings_generator_spec.lua
@@ -1,0 +1,149 @@
+local CodexSettingsGenerator = require("vibing.infrastructure.hooks.codex_settings_generator")
+local SettingsGenerator = require("vibing.infrastructure.hooks.settings_generator")
+
+--- @param args string[]
+--- @return string|nil the `-c` value, i.e. the argument following the `-c` flag
+local function config_value(args)
+  for i, arg in ipairs(args) do
+    if arg == "-c" then
+      return args[i + 1]
+    end
+  end
+  return nil
+end
+
+describe("codex_settings_generator", function()
+  local tmp_dir
+
+  before_each(function()
+    tmp_dir = vim.fn.tempname()
+    vim.fn.mkdir(tmp_dir, "p")
+  end)
+
+  after_each(function()
+    vim.fn.delete(tmp_dir, "rf")
+  end)
+
+  describe("ensure", function()
+    it("stages the script inside the cwd, where codex is willing to execute it", function()
+      -- Codex will not run a hook from outside the sandbox's writable roots, and it hangs the turn
+      -- instead of reporting it -- so a script left in the installed plugin directory (outside the
+      -- user's project by definition) makes every codex turn hang. Measured against 0.153.4: same
+      -- script and argv, only the path moved, and only the in-cwd and /tmp copies ever fired.
+      local path = CodexSettingsGenerator.ensure(tmp_dir)
+      assert.equals(vim.fn.resolve(tmp_dir) .. "/.vibing/codex-pre-tool-use.sh", path)
+      assert.equals(1, vim.fn.filereadable(path))
+    end)
+
+    it("stages it executable, or codex has nothing it can spawn", function()
+      local path = CodexSettingsGenerator.ensure(tmp_dir)
+      assert.equals(1, vim.fn.executable(path))
+    end)
+
+    it("copies the shared pre-tool-use.sh byte for byte", function()
+      -- A copy, not a rewrite: the deny/allow/defer contract lives in that one script, and a
+      -- second copy of it that drifts is a fail-closed protocol that stops failing closed.
+      local staged = CodexSettingsGenerator.ensure(tmp_dir)
+      local source = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+      assert.equals(
+        table.concat(vim.fn.readfile(source, "b"), "\n"),
+        table.concat(vim.fn.readfile(staged, "b"), "\n")
+      )
+    end)
+
+    it("refreshes a stale copy rather than trusting what is already there", function()
+      -- The source moves when the plugin is updated or reinstalled, and a stale staged copy is a
+      -- hook that silently answers with old logic.
+      local path = CodexSettingsGenerator.ensure(tmp_dir)
+      vim.fn.writefile({ "#!/bin/sh", "exit 0" }, path)
+      CodexSettingsGenerator.ensure(tmp_dir)
+
+      local source = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+      assert.equals(
+        table.concat(vim.fn.readfile(source, "b"), "\n"),
+        table.concat(vim.fn.readfile(path, "b"), "\n")
+      )
+    end)
+
+    it("leaves no temp file behind", function()
+      CodexSettingsGenerator.ensure(tmp_dir)
+      local leftovers = vim.fn.glob(tmp_dir .. "/.vibing/*.tmp", false, true)
+      assert.equals(0, #leftovers, "staging must rename its temp file, not leave it")
+    end)
+  end)
+
+  describe("get_hook_args", function()
+    it("registers the hook under the PascalCase event key codex actually reads", function()
+      -- codex 0.153 ignores `hooks.pre_tool_use` in silence: no warning, no error, and nothing in
+      -- `hooks/list`. vibing.nvim shipped that spelling, so no PreToolUse hook fired on codex at
+      -- all -- taking the permission gate and the git-snapshot diff baseline with it. A regression
+      -- here is invisible at runtime, which is why it is asserted on the literal key.
+      local value = config_value(CodexSettingsGenerator.get_hook_args(tmp_dir))
+      assert.is_not_nil(value)
+      assert.is_truthy(value:match("^hooks%.PreToolUse="))
+      assert.is_nil(value:match("pre_tool_use="))
+    end)
+
+    it("wraps the handler in a matcher group rather than listing it at the top level", function()
+      -- `[{command=...}]` parses as a matcher group with no handlers, so codex resolves zero hooks
+      -- from it. The handler has to sit inside a nested `hooks=[...]` and carry its `type` tag.
+      local value = config_value(CodexSettingsGenerator.get_hook_args(tmp_dir))
+      assert.is_truthy(value:match('%[{hooks=%[{type="command"'))
+    end)
+
+    it("points at the staged copy, never at the installed script", function()
+      local value = config_value(CodexSettingsGenerator.get_hook_args(tmp_dir))
+      local staged = CodexSettingsGenerator.script_path(tmp_dir)
+      assert.is_truthy(value:find(staged, 1, true), "hook command must be the staged copy")
+
+      local source = vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p")
+      assert.is_nil(value:find(source, 1, true), "pointing at the installed script hangs codex")
+    end)
+
+    it("passes the trust bypass, without which codex exec hangs on the hook", function()
+      -- A registered hook is enabled but `untrusted` until reviewed in the TUI, and a
+      -- `-c hooks.state.…trusted_hash` session layer does not grant trust. Headless `codex exec`
+      -- then blocks on a review it cannot show. Dropping this flag while keeping the corrected key
+      -- would turn every codex turn into a hang, so the two travel together.
+      assert.is_truthy(
+        vim.tbl_contains(
+          CodexSettingsGenerator.get_hook_args(tmp_dir),
+          "--dangerously-bypass-hook-trust"
+        )
+      )
+    end)
+
+    it("gives codex a hook timeout that outlasts the script's own wait", function()
+      -- Same invariant as copilot's generator, restated here rather than shared: whichever side
+      -- gives up first decides the outcome, and only the script's deny carries a reason. Raising
+      -- MAX_WAIT in pre-tool-use.sh for Claude's sake must not silently cross this number.
+      local script = io.open(vim.fn.fnamemodify(SettingsGenerator.get_hook_script_path(), ":p"), "r")
+      local source = script:read("*a")
+      script:close()
+
+      local max_wait_ticks = tonumber(source:match("\nMAX_WAIT=(%d+)"))
+      assert.is_not_nil(max_wait_ticks, "could not read MAX_WAIT out of pre-tool-use.sh")
+
+      local script_wait_sec = max_wait_ticks / 10 -- the poll loop sleeps 0.1s per tick
+      assert.is_true(
+        CodexSettingsGenerator._HOOK_TIMEOUT_SEC > script_wait_sec,
+        "codex's hook timeout must outlast the script's own wait"
+      )
+    end)
+
+    it("raises rather than returning args with no script behind them", function()
+      -- Registering the hook without a script codex can run is the case that *hangs* the turn,
+      -- which is strictly worse than skipping the gate. So this fails loudly and `codex_cli` drops
+      -- the hook; it must never come back with a `-c` pair pointing at nothing.
+      local original = SettingsGenerator.get_hook_script_path
+      SettingsGenerator.get_hook_script_path = function()
+        return tmp_dir .. "/definitely-not-here.sh"
+      end
+      local ok, err = pcall(CodexSettingsGenerator.get_hook_args, tmp_dir)
+      SettingsGenerator.get_hook_script_path = original
+
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("hook script", 1, true))
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

- register Codex PreToolUse with the PascalCase event key and matcher-group schema Codex 0.153 resolves
- stage the shared hook script inside the turn working directory, pair it with hook-trust bypass, and retain it in bypassPermissions so snapshot capture still runs
- keep .vibing paths out of both snapshot and request-diff event fallback, restoring clean Modified Files lists and gd patch previews
- document the backend and diff invariants and add regression coverage

## Verification

- 130 focused Lua tests pass on the latest main base
- Codex 0.153.4 hooks/list resolves one enabled hook with no warnings or errors
- help documentation check passes
- Prettier check passes

The full suite was also attempted. Remaining failures reproduce outside these changes and are caused by the restricted test environment or existing message-queue/chat-task projection cases; the Node Lua syntax gate also lacks luac on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Codex integration with more reliable pre-tool permission hooks, including support in bypass-permissions mode.
  * Added compatibility for Codex shell tool events.
  * Increased hook processing timeout for longer-running operations.

* **Bug Fixes**
  * Prevented internal `.vibing/` state files from appearing in snapshots, diffs, and tool-event results.
  * Preserved legitimate files when working inside managed worktrees.

* **Documentation**
  * Expanded configuration and architecture guidance for Codex hooks and diff behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->