### PR TITLE
fix(codex): recognize bundled MCP tool names

### DIFF
--- a/claude-plugin/skills/nvim-context/SKILL.md
+++ b/claude-plugin/skills/nvim-context/SKILL.md
@@ -1,10 +1,36 @@
 ---
 name: nvim-context
-description: Use when working on a project that has a running Neovim instance via vibing.nvim (the vibing-nvim MCP server is connected). Reads live buffer, window, cursor, and selection state through vibing-nvim MCP tools before editing or answering, instead of relying on stale file reads or guesses about what the user currently has open or selected.
+description: Use only when the user's request depends on live Neovim state, such as the current buffer, cursor, visual selection, unsaved edits, windows, tabs, or an explicit request to use nvim tools. Do not use for ordinary questions or tasks that do not reference the active editor.
 user-invocable: false
 ---
 
 # Neovim Live Context
+
+## Activation gate
+
+Run this gate before calling any vibing-nvim MCP tool. The presence of a running Neovim
+instance or an available MCP server is not, by itself, a reason to activate this skill.
+
+Activate this skill only when the user's request depends on live editor state, including:
+
+- the current or open file, buffer, window, tab, or split
+- the cursor position, a visual selection, or code "here"
+- unsaved edits in Neovim
+- opening, focusing, jumping to, highlighting, or resizing editor windows
+- executing a Neovim command or querying the live Neovim instance
+- an explicit request to use nvim, vibing-nvim, or Neovim tools
+
+Do not activate this skill for:
+
+- ordinary questions, explanations, or meta questions about this skill or plugin
+- general programming questions that do not depend on the active editor
+- repository tasks that can be handled from on-disk files without live editor state
+- requests that merely happen inside a vibing.nvim chat
+
+If the request does not clearly match an activation case, do not call an nvim tool, do not
+perform a live-state preflight, and do not announce one.
+
+## Active workflow
 
 When the `vibing-nvim` MCP server is available, a real Neovim instance is running and its
 in-memory state (open buffers, splits, cursor position, unsaved edits) is the ground truth —
@@ -30,7 +56,7 @@ already know. If several remain plausible, say which you found and ask rather th
 unbound server answers reads against a single live instance but refuses anything that changes
 state until you name the port, so pass the one `nvim_list_instances` reported.
 
-## Workflow
+## Workflow after activation
 
 1. **Ground yourself first.** Call `mcp__vibing-nvim__nvim_get_info` for the active file and
    `mcp__vibing-nvim__nvim_list_windows` / `mcp__vibing-nvim__nvim_list_buffers` to see everything

--- a/handbook/architecture/plugin-and-commands.md
+++ b/handbook/architecture/plugin-and-commands.md
@@ -138,9 +138,11 @@ vibing.nvim's own PreToolUse hook, exactly as it does for every other tool. `${C
 is expanded to the plugin directory in `command`, `args` and `env` alike, the same substitution
 Claude Code performs, and the `"mcpServers": "./.mcp.json"` file form is followed. Servers are
 deduplicated by name with the first plugin winning, which is `--plugin-dir`'s precedence for a
-duplicate plugin name: a project plugin cannot put its own command behind `mcp__vibing-nvim__*`.
-The tools appear under the plain `mcp__vibing-nvim__<tool>` prefix, which
-`can_use_tool.is_vibing_nvim_mcp_tool` already accepts.
+duplicate plugin name: a project plugin cannot put its own command behind `mcp__vibing_nvim__*`.
+Codex normalizes the server label when it builds tool names, so they appear under the plain
+`mcp__vibing_nvim__<tool>` prefix. `codex_tool_vocabulary` restores the canonical
+`mcp__vibing-nvim__<tool>` spelling before the shared permission check; without that step the
+bundled tools fall through to the ordinary approval path on every new chat.
 
 **Skills go through `developer_instructions`, because there is no skill root to add.** The roots
 codex scans are the user's own; `skills.config` only toggles skills codex already found. So the
@@ -170,13 +172,14 @@ vibing-nvim`, a global entry in `config.toml` — the install `--plugin-dir` was
 An entry an older build left behind is reported and left alone: the per-session override
 deep-merges over it inside vibing.nvim, and a plain `codex` session outside Neovim may rely on it.
 
-**Not verified here, and worth knowing.** Whether codex's PreToolUse hook fires for MCP tool
-calls — and therefore whether the user's `ask`/`deny` lists gate a plugin's MCP tools on this
-backend — could not be measured without a model turn. `developer_instructions` and
-`default_tools_approval_mode` are not on `--strict-config`'s path in an ordinary chat, so a
-future codex that renames either degrades silently: the skills vanish from the prompt, or MCP
-calls start being cancelled. The silent-ignore of `--plugin-dir` has the same shape, and is why
-`plugin_dirs` checks manifests itself.
+**Verified against codex 0.153.4.** PreToolUse fires for MCP calls, so the user's `ask`/`deny`
+lists do gate plugin tools on this backend. Its payload normalizes `vibing-nvim` to
+`mcp__vibing_nvim__...`; the vocabulary conversion above is therefore part of the permission
+boundary, not just display cleanup. `developer_instructions` and `default_tools_approval_mode`
+are not on `--strict-config`'s path in an ordinary chat, so a future codex that renames either
+degrades silently: the skills vanish from the prompt, or MCP calls start being cancelled. The
+silent-ignore of `--plugin-dir` has the same shape, and is why `plugin_dirs` checks manifests
+itself.
 
 ## Slash Command Discovery
 

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -365,8 +365,11 @@ codex can take per run: every `mcpServers` entry becomes a `-c mcp_servers.<name
 (pre-approved at codex's own gate, because headless `codex exec` cancels an MCP call it would
 have prompted for; vibing.nvim's permission hook still decides), and every `skills/<name>/SKILL.md`
 is listed for the model in `-c developer_instructions` with its path, in the same shape codex
-uses for its own skills. The MCP tools are named `mcp__vibing-nvim__<tool>` there, and codex's
-own `.agents/skills` discovery is unaffected. `agents/` has no codex equivalent and is not passed.
+uses for its own skills. Codex normalizes a hyphenated server label to underscores when it builds
+tool names, so the bundled server's tools reach the model — and its own PreToolUse hook — as
+`mcp__vibing_nvim__<tool>`; `codex_tool_vocabulary` restores the canonical `mcp__vibing-nvim__<tool>`
+spelling before the shared permission check runs. Codex's own `.agents/skills` discovery is
+unaffected. `agents/` has no codex equivalent and is not passed.
 A server whose name contains `.` or a space cannot be expressed on the codex command line and is
 skipped with a warning. One more cost: a `developer_instructions` you set in codex's own
 `config.toml` is replaced for vibing.nvim chats, since codex offers no additive form.

--- a/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_plugin_config.lua
@@ -140,7 +140,7 @@ local function developer_instructions(skills, self_server)
         "The vibing-nvim MCP tools are registered as mcp__%s__<tool>; they read and edit the running "
           .. "Neovim instance the user is looking at. Do not call nvim_ask_user_question here -- the "
           .. "choice UI is not wired to this chat, so ask in plain text instead.",
-        self_server
+        self_server:gsub("%-", "_")
       )
     )
   end

--- a/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
@@ -6,6 +6,8 @@
 --- given. See #516.
 --- @module vibing.infrastructure.adapter.modules.codex_tool_vocabulary
 
+local tools_constants = require("vibing.core.constants.tools")
+
 local M = {}
 
 --- Captured from real codex 0.153.4 PreToolUse payloads, which vibing.nvim could not see until the
@@ -27,8 +29,14 @@ local NATIVE_TO_CANONICAL = {
 -- permission layer deliberately speaks the canonical (Claude-compatible) spelling, so restore
 -- only this exact server prefix here. Keeping the match anchored avoids granting the special
 -- bundled-server bypass to a lookalike such as `mcp__my_vibing_nvim__...`.
-local CODEX_VIBING_MCP_PREFIX = "mcp__vibing_nvim__"
-local CANONICAL_VIBING_MCP_PREFIX = "mcp__vibing-nvim__"
+--
+-- Derived from `tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS`, the single definition of the
+-- bundled server's tool-name prefix, instead of a second hardcoded literal: `tools_spec.lua`
+-- reads `claude-plugin/.claude-plugin/plugin.json` and fails if that constant drifts from the
+-- manifest, and this ties the codex-only copy to the same guard rather than leaving one more
+-- string that a manifest rename would silently strand.
+local CANONICAL_VIBING_MCP_PREFIX = (tools_constants.VIBING_NVIM_MCP_TOOL_PATTERNS[1]):gsub("%*$", "")
+local CODEX_VIBING_MCP_PREFIX = (CANONICAL_VIBING_MCP_PREFIX:gsub("%-", "_"))
 
 --- @param native_tool_name string
 --- @return string|nil canonical name, or nil when there is no mapping

--- a/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
+++ b/lua/vibing/infrastructure/adapter/modules/codex_tool_vocabulary.lua
@@ -22,9 +22,20 @@ local NATIVE_TO_CANONICAL = {
   shell = "Bash",
 }
 
+-- MCP server labels are normalized before Codex exposes them as tool names. In particular, the
+-- bundled `vibing-nvim` server reaches PreToolUse as `mcp__vibing_nvim__...`. The shared
+-- permission layer deliberately speaks the canonical (Claude-compatible) spelling, so restore
+-- only this exact server prefix here. Keeping the match anchored avoids granting the special
+-- bundled-server bypass to a lookalike such as `mcp__my_vibing_nvim__...`.
+local CODEX_VIBING_MCP_PREFIX = "mcp__vibing_nvim__"
+local CANONICAL_VIBING_MCP_PREFIX = "mcp__vibing-nvim__"
+
 --- @param native_tool_name string
 --- @return string|nil canonical name, or nil when there is no mapping
 function M.to_canonical(native_tool_name)
+  if native_tool_name:sub(1, #CODEX_VIBING_MCP_PREFIX) == CODEX_VIBING_MCP_PREFIX then
+    return CANONICAL_VIBING_MCP_PREFIX .. native_tool_name:sub(#CODEX_VIBING_MCP_PREFIX + 1)
+  end
   return NATIVE_TO_CANONICAL[native_tool_name]
 end
 

--- a/tests/lua/infrastructure/adapter/modules/codex_plugin_config_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/codex_plugin_config_spec.lua
@@ -132,7 +132,7 @@ describe("codex_plugin_config", function()
     it("tells the model the tool prefix without exposing its runtime port", function()
       local instructions = override(CodexPluginConfig.args(nil, config), "developer_instructions")
 
-      assert.is_truthy(instructions:find("mcp__vibing-nvim__<tool>", 1, true))
+      assert.is_truthy(instructions:find("mcp__vibing_nvim__<tool>", 1, true))
       assert.is_nil(instructions:find("rpc_port for this turn", 1, true))
     end)
 
@@ -184,7 +184,7 @@ describe("codex_plugin_config", function()
     end)
 
     -- The same precedence `--plugin-dir` gives a duplicate plugin name: the bundled server is
-    -- passed first, so a project plugin cannot swap the command behind `mcp__vibing-nvim__*`.
+    -- passed first, so a project plugin cannot swap the command behind `mcp__vibing_nvim__*`.
     it("cannot redeclare the bundled server", function()
       write_plugin("impostor", { name = "impostor", mcpServers = { ["vibing-nvim"] = { command = "evil" } } })
 

--- a/tests/lua/infrastructure/plugins/plugin_contents_spec.lua
+++ b/tests/lua/infrastructure/plugins/plugin_contents_spec.lua
@@ -225,5 +225,22 @@ describe("plugin_contents", function()
       assert.equals(own_plugin_dir() .. "/skills/vibing-code-tour/SKILL.md", names["vibing-code-tour"])
       assert.is_truthy(names["nvim-context"])
     end)
+
+    it("keeps nvim-context behind a live-state activation gate", function()
+      local path
+      for _, skill in ipairs(PluginContents.skills(own_plugin_dir())) do
+        if skill.name == "nvim-context" then
+          path = skill.path
+          break
+        end
+      end
+
+      assert.is_truthy(path)
+      local content = table.concat(vim.fn.readfile(path), "\n")
+
+      assert.is_truthy(content:find("## Activation gate", 1, true))
+      assert.is_truthy(content:find("If the request does not clearly match an activation case", 1, true))
+      assert.is_nil(content:find("before editing or answering", 1, true))
+    end)
   end)
 end)

--- a/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/permission_vocabulary_spec.lua
@@ -110,7 +110,32 @@ describe("permission handler tool vocabulary", function()
   it("is the table codex_cli actually hands over", function()
     local vocabulary = require("vibing.infrastructure.adapter.modules.codex_tool_vocabulary")
     assert.equals("Edit", vocabulary.to_canonical("apply_patch"))
+    assert.equals(
+      "mcp__vibing-nvim__nvim_list_windows",
+      vocabulary.to_canonical("mcp__vibing_nvim__nvim_list_windows")
+    )
+    assert.is_nil(vocabulary.to_canonical("mcp__my_vibing_nvim__nvim_list_windows"))
     assert.is_nil(vocabulary.to_canonical("Read"))
+  end)
+
+  it("pre-approves Codex's normalized name for the bundled vibing-nvim MCP server", function()
+    local vocabulary = require("vibing.infrastructure.adapter.modules.codex_tool_vocabulary")
+    permission.set_active_opts(HANDLE_ID, {
+      cwd = comm_dir,
+      permissions_allow = {},
+      permissions_deny = {},
+      permissions_ask = {},
+      permission_mode = "default",
+      mcp_enabled = true,
+      _tool_vocabulary = vocabulary,
+    })
+
+    write_request("req-codex-mcp", "mcp__vibing_nvim__nvim_list_windows", {})
+    local result = permission.check_tool_permission({ request_id = "req-codex-mcp", handle_id = HANDLE_ID })
+    local response = read_response("req-codex-mcp")
+
+    assert.equals("allowed", result.status)
+    assert.equals("allow", response.hookSpecificOutput.permissionDecision)
   end)
 
   it("normalizes a payload whose keys are not Claude's before reading the tool name", function()


### PR DESCRIPTION
## Summary

- normalize the Codex MCP prefix mcp__vibing_nvim__ back to the canonical vibing-nvim spelling before permission evaluation
- advertise the actual Codex-visible MCP prefix in generated developer instructions
- add regression coverage and document the behavior measured against Codex 0.153.4

## Testing

- permission_vocabulary_spec.lua: 11 passed
- codex_plugin_config_spec.lua: 17 passed
- markdownlint: passed
- git diff --check: passed
- live Neovim check: bundled MCP reads run without per-tool approval after reload

## Notes

The full Lua suite still has three unrelated orchestration-link persistence failures in chat_list_spec.lua and chat_conflicts_spec.lua. The Lua syntax script could not run because luac is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of bundled MCP tools when Codex represents the server name with underscores.
  - Permission settings now correctly apply to these tools, allowing approved tools and blocking denied ones.

- **Documentation**
  - Updated plugin architecture and configuration guidance with verified details about MCP permission checks and tool-name normalization.
  - Clarified how normalized tool names are translated before permission decisions are evaluated.
  - Clarified that the Neovim context skill activates only for requests requiring live Neovim state or explicit Neovim-tool use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->