### PR TITLE
fix(build): prune stale Tree-sitter parser artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,9 @@ logs/
 # Build
 dist/
 build/
-/parser/vibing.*
+# Whole directory, not `/parser/vibing.*`: nothing here is tracked, and the pattern has to cover
+# build.sh's dot-prefixed temporary file too, or an interrupted build leaves a visible stray.
+/parser/
 *.min.js
 *.min.css
 

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,24 @@ VIBING_PARSER_OUTPUT_DIR="${SCRIPT_DIR}/parser"
 # Use VIBING_NODE_EXECUTABLE env var if set, otherwise default to "node"
 NODE_EXECUTABLE="${VIBING_NODE_EXECUTABLE:-node}"
 
+# Delete every parser artifact except the one Neovim is meant to load.
+#
+# `vim.treesitter.language.add('vibing')` globs `parser/vibing.*` and loads *the first match*, so a
+# leftover from an interrupted build is not inert -- a name sorting before "vibing.so" is loaded
+# instead of the real parser, and the failure is a wrong grammar rather than a missing one. The
+# directory is git-ignored, so nothing surfaces such a file in `git status` either.
+#
+# This runs before the build, not after, because the run that leaves the garbage behind is by
+# definition the one that does not reach its own cleanup: build.sh is killed by SIGKILL when it
+# exceeds lazy.nvim's build-step timeout (the same hazard run_with_timeout below exists for), and
+# the `rm -f "$parser_tmp"` branches never execute.
+prune_stale_parser_artifacts() {
+    [ -d "$VIBING_PARSER_OUTPUT_DIR" ] || return 0
+    find "$VIBING_PARSER_OUTPUT_DIR" -maxdepth 1 -type f \
+        \( -name 'vibing.*' -o -name '.vibing.so.tmp.*' \) \
+        ! -name 'vibing.so' -exec rm -f {} + 2>/dev/null || true
+}
+
 # The generated parser.c is committed, so building the small chat-boundary parser needs no
 # tree-sitter CLI. A missing compiler is non-fatal: Lua falls back to the previous whole-buffer
 # Markdown parser mapping, leaving vibing.nvim usable on minimal systems.
@@ -23,7 +41,10 @@ build_vibing_parser() {
     local parser_source="${VIBING_PARSER_DIR}/src/parser.c"
     local scanner_source="${VIBING_PARSER_DIR}/src/scanner.c"
     local parser_output="${VIBING_PARSER_OUTPUT_DIR}/vibing.so"
-    local parser_tmp="${parser_output}.tmp.$$"
+    # Deliberately not "${parser_output}.tmp.$$": that name matches the `parser/vibing.*` glob
+    # Neovim loads from. The leading dot keeps the temporary file out of it while staying in the
+    # same directory, which is what makes the `mv` below atomic.
+    local parser_tmp="${VIBING_PARSER_OUTPUT_DIR}/.vibing.so.tmp.$$"
     local compiler="${VIBING_CC:-cc}"
 
     if [ ! -f "$parser_source" ] || [ ! -f "$scanner_source" ]; then
@@ -39,6 +60,7 @@ build_vibing_parser() {
         echo "[vibing.nvim] ⚠ Could not create parser output directory; using Markdown fallback"
         return 0
     fi
+    prune_stale_parser_artifacts
     if "$compiler" -O2 -shared -fPIC -I"${VIBING_PARSER_DIR}/src" \
         "$parser_source" "$scanner_source" -o "$parser_tmp"; then
         if mv "$parser_tmp" "$parser_output"; then

--- a/build.sh
+++ b/build.sh
@@ -29,9 +29,25 @@ NODE_EXECUTABLE="${VIBING_NODE_EXECUTABLE:-node}"
 # the `rm -f "$parser_tmp"` branches never execute.
 prune_stale_parser_artifacts() {
     [ -d "$VIBING_PARSER_OUTPUT_DIR" ] || return 0
-    find "$VIBING_PARSER_OUTPUT_DIR" -maxdepth 1 -type f \
+    local f pid
+    while IFS= read -r -d '' f; do
+        case "$f" in
+        *.tmp.*)
+            # A concurrently running build.sh (a manual rerun while an automated one is
+            # still compiling) has a live temp file matching this same glob. Only its own
+            # dead runs -- the ones this function exists for -- get pruned; a PID that
+            # still answers `kill -0` is a build in progress, not garbage.
+            pid="${f##*.tmp.}"
+            if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                continue
+            fi
+            ;;
+        esac
+        rm -f "$f"
+    done < <(find "$VIBING_PARSER_OUTPUT_DIR" -maxdepth 1 -type f \
         \( -name 'vibing.*' -o -name '.vibing.so.tmp.*' \) \
-        ! -name 'vibing.so' -exec rm -f {} + 2>/dev/null || true
+        ! -name 'vibing.so' -print0 2>/dev/null)
+    return 0
 }
 
 # The generated parser.c is committed, so building the small chat-boundary parser needs no

--- a/tests/parser-artifact-prune.test.mjs
+++ b/tests/parser-artifact-prune.test.mjs
@@ -37,8 +37,12 @@ test('the pruner removes every stale vibing parser artifact and keeps the real o
   const dir = mkdtempSync(join(tmpdir(), 'vibing-parser-prune-'));
   try {
     const strays = [
-      'vibing.so.tmp.4242', // an interrupted build's temporary file, pre-fix naming
-      '.vibing.so.tmp.777', // ... and post-fix naming
+      // Interrupted builds' temporary files, pre- and post-fix naming. The pruner treats a
+      // live PID as a build still in progress rather than garbage (see build.sh), so these use
+      // PIDs no real process can hold -- past any kernel's pid_max -- rather than small numbers
+      // that could coincidentally collide with an unrelated live process in a busy CI container.
+      'vibing.so.tmp.999999991',
+      '.vibing.so.tmp.999999992',
       'vibing.dylib', // sorts before vibing.so, so this one would actually be loaded
       'vibing.wasm',
     ];
@@ -53,6 +57,28 @@ test('the pruner removes every stale vibing parser artifact and keeps the real o
     // markdown.so stands in for a parser the user put here themselves: the sweep is scoped to
     // vibing's own artifacts, not to everything on the runtime path.
     assert.deepEqual(readdirSync(dir).sort(), ['markdown.so', 'vibing.so']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the pruner leaves a concurrently running build.sh alone', () => {
+  // A second `./build.sh` invocation runs prune_stale_parser_artifacts before its own compile
+  // step, same as the first. Without a liveness check, that prune would delete the first
+  // invocation's not-yet-renamed temp file out from under it. Node's own PID stands in for the
+  // first invocation's still-running shell -- it is unambiguously alive for the duration of
+  // this test.
+  const dir = mkdtempSync(join(tmpdir(), 'vibing-parser-prune-live-'));
+  try {
+    const liveTmpName = `.vibing.so.tmp.${process.pid}`;
+    writeFileSync(join(dir, liveTmpName), '');
+    writeFileSync(join(dir, 'vibing.so'), '');
+
+    execFileSync('bash', ['-c', `${extractPruneFunction()}\nprune_stale_parser_artifacts`], {
+      env: { ...process.env, VIBING_PARSER_OUTPUT_DIR: dir },
+    });
+
+    assert.deepEqual(readdirSync(dir).sort(), [liveTmpName, 'vibing.so']);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/parser-artifact-prune.test.mjs
+++ b/tests/parser-artifact-prune.test.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * `vim.treesitter.language.add('vibing')` globs `parser/vibing.*` and loads the *first* match, not
+ * `vibing.so` specifically. So a leftover library in that directory is not inert: one whose name
+ * sorts earlier is loaded instead of the parser build.sh just produced, and the symptom is a
+ * grammar that disagrees with `queries/vibing/*.scm` ("Invalid node type ..."), not a missing
+ * parser. `/parser/` is git-ignored, so such a file never appears in `git status` either.
+ *
+ * Two things keep that from happening, and both are asserted here because both are one careless
+ * edit away from reverting: build.sh prunes the directory before it builds, and its own temporary
+ * file is named so it cannot match the glob in the first place.
+ */
+
+import { strict as assert } from 'assert';
+import { test } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const buildScript = readFileSync(join(repoRoot, 'build.sh'), 'utf8');
+
+/** The shell function under test, lifted out of build.sh so no npm install has to run. */
+function extractPruneFunction() {
+  const match = buildScript.match(/^prune_stale_parser_artifacts\(\) \{\n[\s\S]*?^\}$/m);
+  assert.ok(
+    match,
+    'prune_stale_parser_artifacts() not found in build.sh — if it was renamed, rename it here too ' +
+      'rather than letting this test pass by exercising nothing'
+  );
+  return match[0];
+}
+
+test('the pruner removes every stale vibing parser artifact and keeps the real one', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vibing-parser-prune-'));
+  try {
+    const strays = [
+      'vibing.so.tmp.4242', // an interrupted build's temporary file, pre-fix naming
+      '.vibing.so.tmp.777', // ... and post-fix naming
+      'vibing.dylib', // sorts before vibing.so, so this one would actually be loaded
+      'vibing.wasm',
+    ];
+    for (const name of [...strays, 'vibing.so', 'markdown.so']) {
+      writeFileSync(join(dir, name), '');
+    }
+
+    execFileSync('bash', ['-c', `${extractPruneFunction()}\nprune_stale_parser_artifacts`], {
+      env: { ...process.env, VIBING_PARSER_OUTPUT_DIR: dir },
+    });
+
+    // markdown.so stands in for a parser the user put here themselves: the sweep is scoped to
+    // vibing's own artifacts, not to everything on the runtime path.
+    assert.deepEqual(readdirSync(dir).sort(), ['markdown.so', 'vibing.so']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("build.sh's temporary parser file cannot match Neovim's parser/vibing.* glob", () => {
+  const assignment = buildScript.match(/^\s*local (parser_tmp="[^"]+")$/m);
+  assert.ok(assignment, 'parser_tmp assignment not found in build.sh');
+
+  // Expanded by bash rather than inspected as text: the pre-fix spelling was
+  // "${parser_output}.tmp.$$", whose hazardous basename only appears once the variables are
+  // resolved. A string comparison would read that as safe.
+  const basename = execFileSync(
+    'bash',
+    [
+      '-c',
+      [
+        'VIBING_PARSER_OUTPUT_DIR=/tmp/vibing-parser-glob-check',
+        'parser_output="${VIBING_PARSER_OUTPUT_DIR}/vibing.so"',
+        assignment[1],
+        'basename "$parser_tmp"',
+      ].join('\n'),
+    ],
+    { encoding: 'utf8' }
+  ).trim();
+
+  assert.ok(
+    !/^vibing\./.test(basename),
+    `parser_tmp resolves to "${basename}", which matches parser/vibing.* and can be loaded ` +
+      'instead of the built parser if the build is killed before it renames the file'
+  );
+});


### PR DESCRIPTION
# Pull Request

## Summary

#736 で導入したチャット用 Tree-sitter パーサのビルド成果物が、`parser/` に残骸として溜まりうる問題を塞ぐ。

`vim.treesitter.language.add('vibing')` は `parser/vibing.*` を glob して **先頭の1件** をロードする（`vibing.so` を名指ししているわけではない）。そのため中断されたビルドが残したファイルは無害ではなく、`vibing.so` より前にソートされる名前だと実際にそちらがロードされる。症状は「パーサが無い」ではなく「grammar が `queries/vibing/*.scm` と食い違う」（`Invalid node type "..."`）という分かりにくい形で出る。しかも `/parser/` は git-ignore 対象なので、`git status` にも現れない。

検証: `parser/` に `vibing.dylib` / `vibing.so` / `vibing.so.tmp.99999` を置くと3件とも glob にヒットし、選ばれるのは `vibing.dylib`。

## Changes

- `build.sh`: `prune_stale_parser_artifacts()` を追加し、ビルド**直前**に実行。`parser/` 直下の `vibing.*` と `.vibing.so.tmp.*` のうち `vibing.so` 以外を削除する
  - ビルド「後」ではなく「前」なのは、ゴミを残す実行は定義上その実行自身のクリーンアップに到達しないため。build.sh は lazy.nvim の build-step タイムアウトで SIGKILL されうる（既存の `run_with_timeout` のコメントが認めている通り）ので、失敗時の `rm -f "$parser_tmp"` は走らない
  - 掃除の対象は `vibing.*` に限定した。ユーザーが自分で `parser/` に置いた他言語のパーサは消さない
- `build.sh`: 一時ファイル名を `${parser_output}.tmp.$$` → `${VIBING_PARSER_OUTPUT_DIR}/.vibing.so.tmp.$$` に変更。掃除対象をそもそも作らない側の対処。先頭ドットで glob から外れ、同一ディレクトリのままなので後続の `mv` の原子性は維持される
- `.gitignore`: `/parser/vibing.*` → `/parser/`。ドット付き一時ファイルも含めて確実に無視する。`parser/` 配下に追跡ファイルは元々ひとつも無い
- `tests/parser-artifact-prune.test.mjs`（新規）: 上記2つの不変条件を守るゲート

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Tested locally in Neovim
- [ ] Ran `npm run validate`
- [x] Ran `npm run lint`
- [x] Ran `npm run format:check`
- [ ] Tested with multiple configurations
- [x] Manual testing completed

実行したもの:

- `./build.sh` を実運転 → `✓ Chat Tree-sitter parser built`、`parser/` に残るのは `vibing.so` のみ
- クリーンな Neovim（`--clean -u NONE` + rtp 追加）で `language.add('vibing')`、`injections` / `highlights` クエリの取得がすべて成功
- `tests/lua/infrastructure/treesitter_spec.lua`（3件）、`treesitter_parser_spec.lua`（1件）パス
- `test:node` に追加した2件パス
- `lint`（eslint）、`prettier --check` パス

新規テストが素通りしないことも確認済み: 旧命名 `"${parser_output}.tmp.$$"` はシェル展開すると `vibing.so.tmp.<pid>` になり、2つ目のテストが落ちる。最初この判定を文字列比較で書いていて旧命名を安全と誤判定していたため、bash に展開させる方式に直した。

既知の失敗（本 PR とは無関係）:

- `tests/lua-syntax-gate.test.mjs` — 手元に `luac` が無いため。`npm run check` / `validate` も同じ理由で実行できていない
- `tests/lua/infrastructure/rpc/handlers/chat_conflicts_spec.lua` の #696 follow-up ケース — 本 PR は Lua を1行も変更していない

### Test Environment

- **Neovim version**: NVIM v0.13.0-dev-1403+g70958dae75-Homebrew
- **Operating System**: macOS 26.6.2
- **Node.js version**: v22.23.2

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [x] Code comments added/updated (if applicable)

ユーザーに見える挙動は変わらないので `doc/vibing.txt` の更新は不要。不変条件は `.claude/rules/` に文章を足すのではなくテストで固定した。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

relates to #736

## Additional Context

この掃除は「残骸が誤ってロードされる事故」を防ぐもので、**すでに起動している Neovim が古いパーサを掴んでいる問題は解決しない**。理由は2つ:

1. `dlopen` 済みのライブラリはファイルを削除してもアンロードされない
2. ビルドが失敗した場合、古い `vibing.so` は意図的に残す（コンパイラが一時的に無いだけのユーザーの環境を壊さないため）

そのため `:Lazy update` で grammar の node type が変わった直後は、Neovim を再起動するまで `Invalid node type` が出る窓が残る。ここは別途、`infrastructure/treesitter.lua` の `setup()` でクエリの parse を試し、失敗したら既存の Markdown フォールバックに落として再起動を促す、という対処を検討中。現在のガードは `pcall(language.add, "vibing")`＝「パーサがロードできるか」であって「同梱クエリと整合するか」ではないため、古い `.so` でも成功してしまう。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale or temporary parser artifacts from being loaded instead of the latest parser.
  * Preserved the active parser during cleanup while removing obsolete build artifacts.
  * Ensured temporary parser files do not match Neovim’s parser loading pattern.
  * Protected temporary files belonging to builds that are still in progress.

* **Tests**
  * Added coverage for stale artifact cleanup, active-build preservation, and safe temporary file naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->