### PR TITLE
fix(diff): synthesize patches for gitignored files from PreToolUse backups

### DIFF
--- a/handbook/architecture/per-request-diffs.md
+++ b/handbook/architecture/per-request-diffs.md
@@ -218,6 +218,25 @@ start, including the utility calls that produce no diff at all.
 which is the trade that keeps `git add -A` cheap. The distinction is git's, not ours: `.gitignore`
 governs what gets _added_, so a file that is already tracked keeps showing its modifications even
 when it matches an ignore pattern — verified by committing a file with `add -f` and watching the
-next snapshot diff report it. A genuinely untracked build artifact a Write tool reported anyway
-still reaches `### Modified Files` through `extra_paths` — listed, with no patch section, matching
-what `request_diff.generate` already did for files it could not back up.
+next snapshot diff report it. Forcing the add instead (`git add -A --force`) is not an option: it
+would pull `node_modules` and every build artifact into each snapshot.
+
+That blind spot used to make the two paths asymmetric in the worst way (#735): a solo turn working
+under a gitignored directory took the snapshot path and produced **no patch at all**, while the
+same work with a second chat running in parallel fell back to `request_diff` and produced one —
+whether the patch existed was decided by the routing, not the work. The repair uses the fact that
+the fallback's backups are still alive at that point: `GitSnapshot.generate` returns the paths
+that reached the file list only through `extra_paths` (i.e. the tree diff never saw them), and
+`_supplement_ignored_files` hands them to `RequestDiff.sections_for`, which synthesizes hunks from
+the PreToolUse backups and splices them into the snapshot's patch. That set is exactly the set the
+hook backed up — a tool event carried the file's name, so `request_diff.capture` saw it too. The
+ordering is the invariant: the supplement runs inside `_finalize_snapshot_diff`, before
+`_handle_response` reaches `RequestDiff.clear`.
+
+What the supplement cannot save is a gitignored file with no backup — changed by Bash alone it
+produces no tool event and no list entry at all, and codex's `apply_patch` carries no path in
+`tool_input` so nothing was captured (see `architecture.md` → codex vocabulary). A file that is
+listed but could not get a section from either source is warned about (`vim.notify`) rather than
+silently rendered as list-only, the same no-silent-loss rule as the empty-turn warning above.
+Deliberate list-only cases — binary content, a path outside the base directory, an unchanged
+file — stay silent, since `request_diff.generate` treats them the same way.

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -820,15 +820,73 @@ function M._finalize_snapshot_diff(callbacks, handle_id, modified_file_paths)
   local GitSnapshot = require("vibing.core.utils.git_snapshot")
 
   local base_dir = GitSnapshot.get_root(handle_id) or vim.fn.getcwd()
-  local files, abs_files, patch_content, ok = GitSnapshot.generate(handle_id, modified_file_paths)
+  local files, abs_files, patch_content, ok, extra_only =
+    GitSnapshot.generate(handle_id, modified_file_paths)
   GitSnapshot.clear(handle_id)
 
   if not ok then
     return false
   end
 
+  patch_content = M._supplement_ignored_files(handle_id, base_dir, patch_content, extra_only or {})
+
   M._emit_diff_output(callbacks, base_dir, files, abs_files, patch_content, handle_id)
   return true
+end
+
+---ツリー差分に現れなかった変更ファイル（`.gitignore` 対象など）のpatchを退避から補う
+---
+---`git add -A` も `git diff` も gitignore 対象を拾わないので、そこで作業したターンは主経路の
+---patchが空になる（#735）。だがツールイベントで名前が出ているファイルは request_diff が
+---PreToolUseで内容を退避している集合と同じなので、退避が捨てられる前にhunkを合成して
+---patchに継ぎ足す。呼び出し側の `RequestDiff.clear()`（_handle_response）より前＝この
+---finalizeの中で呼ぶこと。
+---
+---退避が無く合成できなかったファイル（Bash由来・codexのapply_patchなど）は、一覧に載るのに
+---patchが無い＝「静かに消える」形になるので、黙らず通知する。
+---@param handle_id string|nil リクエストのハンドルID
+---@param base_dir string patch内パスの基準ディレクトリ（絶対パス）
+---@param patch_content string|nil スナップショット経路のpatch本文
+---@param extra_only string[] ツリー差分に現れなかった変更ファイルの絶対パス
+---@return string|nil patch_content 合成分を継ぎ足したpatch本文
+function M._supplement_ignored_files(handle_id, base_dir, patch_content, extra_only)
+  if #extra_only == 0 then
+    return patch_content
+  end
+
+  local RequestDiff = require("vibing.core.utils.request_diff")
+  local sections, resolved = RequestDiff.sections_for(handle_id, base_dir, extra_only)
+
+  if #sections > 0 then
+    local body = table.concat(sections, "\n") .. "\n"
+    if patch_content then
+      patch_content = patch_content .. body
+    else
+      -- 主経路のpatchと同じ先頭行（patch_viewerのbase解決に使われる）
+      patch_content = string.format("# vibing-request-diff base: %s\n%s", base_dir, body)
+    end
+  end
+
+  local missing = {}
+  local prefix = base_dir .. "/"
+  for _, abs in ipairs(extra_only) do
+    if not resolved[abs] then
+      table.insert(missing, abs:sub(1, #prefix) == prefix and abs:sub(#prefix + 1) or abs)
+    end
+  end
+  if #missing > 0 then
+    vim.notify(
+      string.format(
+        "[vibing] No patch could be generated for: %s. "
+          .. "The file(s) are outside the git tree and no PreToolUse backup exists; "
+          .. "the changes themselves are still on disk.",
+        table.concat(missing, ", ")
+      ),
+      vim.log.levels.WARN
+    )
+  end
+
+  return patch_content
 end
 
 ---リクエスト単位diff（フォールバック経路）のModified Files出力とpatch生成

--- a/lua/vibing/core/utils/git_snapshot.lua
+++ b/lua/vibing/core/utils/git_snapshot.lua
@@ -497,6 +497,9 @@ end
 ---@return boolean ok 差分を取れたか。falseは「変更が無かった」ではなく「**分からなかった**」で、
 ---  2回目のスナップショットやdiff呼び出しが失敗した場合。呼び出し側はこれを見て request_diff の
 ---  バックアップに退避できる（そちらはこの時点ではまだ捨てられていない）
+---@return string[] extra_only ツリー差分に現れず extra_paths 由来でのみ一覧に載った絶対パス。
+---  `.gitignore` 対象のWrite/Edit変更はここに来る（#735）。呼び出し側は request_diff の退避から
+---  patchセクションを合成して補える
 function M.generate(handle_id, extra_paths)
   local files = {}
   local abs_files = {}
@@ -588,8 +591,11 @@ function M.generate(handle_id, extra_paths)
   end
 
   -- git差分に現れないのにツールイベントには出ているファイルは `.gitignore` 対象の可能性が高い。
-  -- 一覧にだけ載せてpatchセクションは作らない（request_diff.generateと同じ扱い）
+  -- ツリー差分はこれらのpatchを作れないので extra_only として返し、呼び出し側が request_diff の
+  -- PreToolUse退避からセクションを合成して補う（#735）。退避も無いもの（Bash由来など）は
+  -- 一覧にだけ載る
   local base_dir = s and s.root or nil
+  local extra_only = {}
   for path in pairs(extra_paths or {}) do
     local abs = vim.fn.fnamemodify(path, ":p"):gsub("/$", "")
     local rel = abs
@@ -603,10 +609,11 @@ function M.generate(handle_id, extra_paths)
       seen[rel] = true
       table.insert(files, rel)
       table.insert(abs_files, abs)
+      table.insert(extra_only, abs)
     end
   end
 
-  return files, abs_files, patch_content, ok
+  return files, abs_files, patch_content, ok, extra_only
 end
 
 ---refとセッション状態を破棄する（レスポンス処理の最後に必ず呼ぶ）

--- a/lua/vibing/core/utils/request_diff.lua
+++ b/lua/vibing/core/utils/request_diff.lua
@@ -275,6 +275,50 @@ function M.generate(handle_id, base_dir, extra_paths)
   return files, abs_files, patch_content
 end
 
+---スナップショット経路のpatchに継ぎ足す差分セクションを、PreToolUseの退避から合成する
+---
+---主経路のツリー差分は `.gitignore` 対象のファイルを拾えない（#735）。だがWrite/Edit系で
+---触ったファイルなら `capture` の退避があるので、「一覧に載るのにpatchが無い」で終わるはず
+---だった変更をpatchセクションとして復元できる。退避を読むので `clear()` より前に呼ぶこと。
+---
+---`resolved` に載らなかったパスは退避そのものが無い（Bash由来・退避失敗など）。その変更内容は
+---どこにも残っていないので、呼び出し側は黙って流さず通知する。
+---@param handle_id string|nil リクエストのハンドルID
+---@param base_dir string patch内パスの基準ディレクトリ（絶対パス）
+---@param abs_paths string[] ツリー差分に現れなかった変更ファイルの絶対パス
+---@return string[] sections 合成できたdiffセクション
+---@return table<string, boolean> resolved 退避があったパス（キーは abs_paths の要素そのまま）。
+---  セクションを作らなかったものも、generate() が意図的に一覧のみにする種類（変更なし・
+---  バイナリ・base_dir外）なら resolved に入る
+function M.sections_for(handle_id, base_dir, abs_paths)
+  local sections = {}
+  local resolved = {}
+  local s = handle_id and sessions[handle_id] or nil
+  if not s then
+    return sections, resolved
+  end
+  for _, path in ipairs(abs_paths) do
+    local abs = vim.fn.fnamemodify(path, ":p")
+    local entry = s.files[abs]
+    if entry then
+      resolved[path] = true
+      local before = nil
+      if entry.existed and entry.backup_path then
+        before = read_file(entry.backup_path)
+      end
+      local after = read_file(abs)
+      local rel, under_base = to_rel(abs, base_dir)
+      if under_base and not is_vibing_state_path(rel) then
+        local section = build_file_section(rel, entry, abs, before, after)
+        if section then
+          table.insert(sections, section)
+        end
+      end
+    end
+  end
+  return sections, resolved
+end
+
 ---リクエストのバックアップを破棄する（レスポンス処理の最後に必ず呼ぶ）
 ---@param handle_id string|nil
 function M.clear(handle_id)

--- a/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_event_processor.lua
@@ -281,7 +281,10 @@ local function handle_assistant_event(msg, context)
         local input = tool_map[block.id].input or {}
         vim.schedule(function()
           if opts.on_tool_use then
-            opts.on_tool_use(name, input.file_path, input.command)
+            -- NotebookEdit carries its path as notebook_path, not file_path (request_diff.lua's
+            -- own TOOL_PATH_KEYS agrees) — without this fallback modified_file_paths never learns
+            -- about a notebook edit and the gitignored-file patch synthesis has nothing to act on.
+            opts.on_tool_use(name, input.file_path or input.notebook_path, input.command)
           end
           if opts.on_tool_use_full then
             opts.on_tool_use_full(name, input)

--- a/tests/lua/application/chat/send_message_spec.lua
+++ b/tests/lua/application/chat/send_message_spec.lua
@@ -305,11 +305,11 @@ describe("send_message", function()
     -- いけない。そのため「出力した」か「取れなかった」かを戻り値で返す契約になっている。
     local original
 
-    local function stub_git_snapshot(generate)
+    local function stub_git_snapshot(generate, root)
       original = package.loaded["vibing.core.utils.git_snapshot"]
       package.loaded["vibing.core.utils.git_snapshot"] = {
         get_root = function()
-          return "/repo"
+          return root or "/repo"
         end,
         generate = generate,
         clear = function() end,
@@ -376,6 +376,128 @@ describe("send_message", function()
 
       assert.is_true(handled)
       assert.is_truthy(table.concat(appended, ""):find("src/a.lua", 1, true))
+    end)
+
+    it("mixes a synthesized section for a gitignored file into the written patch", function()
+      -- gitignore対象のファイルはツリー差分に現れない（#735）。extra_only として返ってきた
+      -- 分を request_diff の退避から合成し、このターンのpatchファイルに載せる
+      local RequestDiff = require("vibing.core.utils.request_diff")
+      local root = vim.fn.fnamemodify(vim.fn.tempname(), ":p"):gsub("/$", "")
+      vim.fn.mkdir(root .. "/ignored", "p")
+      local file = root .. "/ignored/out.txt"
+      local f = assert(io.open(file, "w"))
+      f:write("before\n")
+      f:close()
+      RequestDiff.capture("h4", "Edit", { file_path = file })
+      f = assert(io.open(file, "w"))
+      f:write("after\n")
+      f:close()
+
+      stub_git_snapshot(function()
+        return { "ignored/out.txt" }, { file }, nil, true, { file }
+      end, root)
+      local appended, state = {}, {}
+
+      local handled =
+        SendMessage._finalize_snapshot_diff(callbacks_recording(appended, state), "h4", {})
+      RequestDiff.clear("h4")
+
+      assert.is_true(handled)
+      local out = table.concat(appended, "")
+      local patch_path = out:match("<!%-%- patch: ([^%s]+) %-%->")
+      assert.is_truthy(patch_path, "no patch annotation written: " .. out)
+      local pf = assert(io.open(patch_path, "r"))
+      local content = pf:read("*a")
+      pf:close()
+      assert.is_truthy(content:find("diff --git a/ignored/out.txt b/ignored/out.txt", 1, true))
+      assert.is_truthy(content:find("+after", 1, true))
+      vim.fn.delete(root, "rf")
+    end)
+  end)
+
+  describe("_supplement_ignored_files", function()
+    -- ツリー差分に現れなかった extra_paths 由来のファイル（#735）の扱い。退避があれば
+    -- hunkを合成してpatchに継ぎ足し、退避も無ければ「patchが無い」ことを通知する
+    local RequestDiff = require("vibing.core.utils.request_diff")
+    local tmp_dir
+    local messages
+    local original_notify
+
+    local function write(path, content)
+      vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+      local f = assert(io.open(path, "w"))
+      f:write(content)
+      f:close()
+    end
+
+    before_each(function()
+      tmp_dir = vim.fn.fnamemodify(vim.fn.tempname(), ":p"):gsub("/$", "")
+      vim.fn.mkdir(tmp_dir, "p")
+      messages = {}
+      original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(messages, { msg = msg, level = level })
+      end
+    end)
+
+    after_each(function()
+      vim.notify = original_notify
+      vim.fn.delete(tmp_dir, "rf")
+    end)
+
+    it("builds a patch from the backup when the snapshot produced none", function()
+      local file = tmp_dir .. "/ignored/gen.txt"
+      write(file, "before\n")
+      RequestDiff.capture("h-sup1", "Edit", { file_path = file })
+      write(file, "after\n")
+
+      local patch = SendMessage._supplement_ignored_files("h-sup1", tmp_dir, nil, { file })
+      RequestDiff.clear("h-sup1")
+
+      assert.is_truthy(patch)
+      assert.equals("# vibing-request-diff base: " .. tmp_dir, patch:match("^[^\n]+"))
+      assert.is_truthy(patch:find("+after", 1, true))
+      assert.equals(0, #messages)
+    end)
+
+    it("appends after the snapshot patch when both exist", function()
+      local file = tmp_dir .. "/ignored/gen.txt"
+      write(file, "before\n")
+      RequestDiff.capture("h-sup2", "Edit", { file_path = file })
+      write(file, "after\n")
+
+      local head = "# vibing-request-diff base: "
+        .. tmp_dir
+        .. "\ndiff --git a/tracked.txt b/tracked.txt\n--- a/tracked.txt\n+++ b/tracked.txt\n@@ -1 +1 @@\n-x\n+y\n"
+      local patch = SendMessage._supplement_ignored_files("h-sup2", tmp_dir, head, { file })
+      RequestDiff.clear("h-sup2")
+
+      local tracked_pos = patch:find("a/tracked.txt", 1, true)
+      local ignored_pos = patch:find("a/ignored/gen.txt", 1, true)
+      assert.is_truthy(tracked_pos)
+      assert.is_truthy(ignored_pos)
+      assert.is_true(tracked_pos < ignored_pos)
+    end)
+
+    it("warns for a listed file whose changes exist nowhere", function()
+      -- Bash由来・codexのapply_patch由来の変更は退避が無く合成できない。黙って流すと
+      -- 「一覧に載るのにpatchが無い」が warning すら無しに再発する
+      local file = tmp_dir .. "/ignored/bash.txt"
+      write(file, "x\n")
+
+      local patch = SendMessage._supplement_ignored_files("h-sup3", tmp_dir, nil, { file })
+
+      assert.is_nil(patch)
+      assert.equals(1, #messages)
+      assert.equals(vim.log.levels.WARN, messages[1].level)
+      assert.is_truthy(messages[1].msg:find("ignored/bash.txt", 1, true))
+    end)
+
+    it("passes the patch through untouched when the tree diff covered everything", function()
+      local patch = SendMessage._supplement_ignored_files("h-sup4", tmp_dir, "existing", {})
+
+      assert.equals("existing", patch)
+      assert.equals(0, #messages)
     end)
   end)
 

--- a/tests/lua/core/utils/git_snapshot_spec.lua
+++ b/tests/lua/core/utils/git_snapshot_spec.lua
@@ -54,8 +54,14 @@ describe("git_snapshot", function()
     local handle = next_handle()
     GitSnapshot.ensure_baseline(handle, repo, "Bash")
     mutate()
-    local files, abs_files, patch = GitSnapshot.generate(handle, extra_paths)
-    return { handle = handle, files = files, abs_files = abs_files, patch = patch }
+    local files, abs_files, patch, _, extra_only = GitSnapshot.generate(handle, extra_paths)
+    return {
+      handle = handle,
+      files = files,
+      abs_files = abs_files,
+      patch = patch,
+      extra_only = extra_only,
+    }
   end
 
   local function init_repo(opts)
@@ -272,13 +278,27 @@ describe("git_snapshot", function()
     end)
 
     it("lists a tool-event path that git does not see, without a patch section", function()
-      -- .gitignore対象でもツール引数で分かっている分は一覧には載せる（patchは作らない）
+      -- .gitignore対象でもツール引数で分かっている分は一覧には載せる。ツリー差分からは
+      -- patchを作れないので extra_only として返し、呼び出し側が request_diff の退避から
+      -- セクションを合成する（#735）
       local turn = run_turn(function()
         write(repo .. "/build.log", "noise\n")
       end, { [repo .. "/build.log"] = true })
 
       assert.same({ "build.log" }, turn.files)
       assert.is_nil(turn.patch)
+      assert.same({ repo .. "/build.log" }, turn.extra_only)
+    end)
+
+    it("does not report a git-visible change as extra_only", function()
+      -- extra_only は「ツリー差分に現れなかった」ものだけ。gitが見えている変更まで入れると、
+      -- 呼び出し側の合成でpatchセクションが二重になる
+      local turn = run_turn(function()
+        write(repo .. "/tracked.txt", "after\n")
+      end, { [repo .. "/tracked.txt"] = true })
+
+      assert.same({ "tracked.txt" }, turn.files)
+      assert.same({}, turn.extra_only)
     end)
 
     it("does not let tool-event fallback add .vibing paths back to the file list", function()

--- a/tests/lua/core/utils/request_diff_spec.lua
+++ b/tests/lua/core/utils/request_diff_spec.lua
@@ -266,6 +266,73 @@ describe("request_diff", function()
     end)
   end)
 
+  describe("sections_for", function()
+    -- スナップショット経路（git_snapshot）はgitignore対象の変更をツリー差分に出せない（#735）。
+    -- 退避があるファイルだけ、patchに継ぎ足すセクションを合成する
+
+    it("synthesizes a section from the backup for a captured file", function()
+      local file = tmp_dir .. "/ignored.txt"
+      write_file(file, "before\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      write_file(file, "after\n")
+
+      local sections, resolved = RequestDiff.sections_for(handle_id, tmp_dir, { file })
+
+      assert.equals(1, #sections)
+      assert.is_truthy(sections[1]:find("diff --git a/ignored.txt b/ignored.txt", 1, true))
+      assert.is_truthy(sections[1]:find("-before", 1, true))
+      assert.is_truthy(sections[1]:find("+after", 1, true))
+      assert.is_true(resolved[file])
+    end)
+
+    it("synthesizes a new-file section for a Write that created the file", function()
+      local file = tmp_dir .. "/created.txt"
+      RequestDiff.capture(handle_id, "Write", { file_path = file })
+      write_file(file, "hello\n")
+
+      local sections, resolved = RequestDiff.sections_for(handle_id, tmp_dir, { file })
+
+      assert.equals(1, #sections)
+      assert.is_truthy(sections[1]:find("--- /dev/null", 1, true))
+      assert.is_true(resolved[file])
+    end)
+
+    it("leaves a path with no backup unresolved so the caller can warn", function()
+      -- Bash由来・codexのapply_patch由来の変更はツールイベントに名前が出ても退避が無い。
+      -- 合成できないことを黙って流すと「一覧に載るのにpatchが無い」が再発する
+      local file = tmp_dir .. "/bash-touched.txt"
+      write_file(file, "x\n")
+
+      local sections, resolved = RequestDiff.sections_for(handle_id, tmp_dir, { file })
+
+      assert.same({}, sections)
+      assert.is_nil(resolved[file])
+    end)
+
+    it("resolves an unchanged captured file without a section", function()
+      -- 変更が無かったことは退避から判断できている。警告対象にしてはいけない
+      local file = tmp_dir .. "/same.txt"
+      write_file(file, "unchanged\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+
+      local sections, resolved = RequestDiff.sections_for(handle_id, tmp_dir, { file })
+
+      assert.same({}, sections)
+      assert.is_true(resolved[file])
+    end)
+
+    it("does not consume the backups (clear still owns their lifetime)", function()
+      local file = tmp_dir .. "/keep.txt"
+      write_file(file, "a\n")
+      RequestDiff.capture(handle_id, "Edit", { file_path = file })
+      write_file(file, "b\n")
+
+      RequestDiff.sections_for(handle_id, tmp_dir, { file })
+
+      assert.is_true(RequestDiff.has_capture(handle_id, file))
+    end)
+  end)
+
   describe("clear", function()
     it("removes backups for the handle", function()
       local file = tmp_dir .. "/a.txt"

--- a/tests/lua/infrastructure/adapter/modules/cli_event_processor_on_tool_use_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_event_processor_on_tool_use_spec.lua
@@ -1,0 +1,66 @@
+describe("cli_event_processor on_tool_use path resolution", function()
+  local processor = require("vibing.infrastructure.adapter.modules.cli_event_processor")
+
+  local function feed(context, event)
+    processor.processLine(vim.json.encode(event), context)
+  end
+
+  local function tool_use_event(id, name, input)
+    return {
+      type = "assistant",
+      message = {
+        role = "assistant",
+        content = { { type = "tool_use", id = id, name = name, input = input } },
+      },
+    }
+  end
+
+  ---on_tool_use fires through vim.schedule, so drain it before asserting.
+  local function drain()
+    vim.wait(50, function()
+      return false
+    end)
+  end
+
+  it("passes notebook_path as the file_path for NotebookEdit", function()
+    local calls = {}
+    local context = {
+      output = {},
+      errorOutput = {},
+      opts = {
+        on_tool_use = function(tool, file_path, command)
+          table.insert(calls, { tool = tool, file_path = file_path, command = command })
+        end,
+      },
+    }
+
+    feed(context, tool_use_event("toolu_1", "NotebookEdit", { notebook_path = "/tmp/notebook.ipynb" }))
+    drain()
+
+    assert.equals(1, #calls)
+    assert.equals("NotebookEdit", calls[1].tool)
+    assert.equals("/tmp/notebook.ipynb", calls[1].file_path)
+  end)
+
+  it("still prefers file_path when both are present", function()
+    local calls = {}
+    local context = {
+      output = {},
+      errorOutput = {},
+      opts = {
+        on_tool_use = function(tool, file_path, command)
+          table.insert(calls, { tool = tool, file_path = file_path, command = command })
+        end,
+      },
+    }
+
+    feed(
+      context,
+      tool_use_event("toolu_2", "Write", { file_path = "/tmp/a.lua", notebook_path = "/tmp/should-not-use.ipynb" })
+    )
+    drain()
+
+    assert.equals(1, #calls)
+    assert.equals("/tmp/a.lua", calls[1].file_path)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

`.gitignore` 対象ディレクトリで作業したターンの patch が、主経路（`git_snapshot`）では生成されない問題の修正（#735）。`git add -A` も `git diff` も gitignore 対象を拾わないため、単独で走ったターンは `### Modified Files` にパスだけが並び patch が作られず、別チャットが並走したターンだけがフォールバック（`request_diff`）経由で patch を出せていた — patch の有無を作業内容ではなく経路選択が決めていた。

ツールイベントで名前が出ているファイルは `request_diff` が PreToolUse で内容を退避している集合と同じであることを利用し、ツリー差分に現れなかった分の hunk を退避から合成して patch に継ぎ足す（issue の提案 (a)）。退避も無く合成できないファイル（Bash 由来・codex の apply_patch）は `vim.notify` で警告し、「静かに消える」を排除する（提案 (b)）。

## Changes

- `git_snapshot.lua`: `generate()` が第5戻り値 `extra_only`（ツリー差分に現れず、ツールイベント由来でのみ一覧に載った絶対パス）を返すように
- `request_diff.lua`: `sections_for(handle_id, base_dir, abs_paths)` を追加。PreToolUse の退避から指定パスの diff セクションを合成する。退避は消費しない（ライフタイムは従来どおり `clear()` が持つ）
- `send_message.lua`: `_supplement_ignored_files()` を追加。`_finalize_snapshot_diff` 内・`RequestDiff.clear()` より前に合成分を patch に継ぎ足す。patch が空だった場合も `# vibing-request-diff base:` ヘッダ付きで新規作成する（patch_viewer / `gd` 互換）。退避が無く合成できなかったファイルは警告する。変更なし・バイナリ・base_dir 外は `request_diff.generate` と同じ「意図的な一覧のみ」なので警告しない
- `handbook/architecture/per-request-diffs.md`: 経緯と不変条件（合成は `RequestDiff.clear` より前・`git add -A --force` が採れない理由・警告の境界）を追記
- テスト 12 件追加（`git_snapshot_spec` 2 / `request_diff_spec` 5 / `send_message_spec` 5）

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Tested locally in Neovim
- [ ] Ran `npm run validate`
- [ ] Ran `npm run lint`
- [ ] Ran `npm run format:check`
- [ ] Tested with multiple configurations
- [x] Manual testing completed

`test:lua` で変更 3 spec（git_snapshot 56 / request_diff 22 / send_message 29）全パス、`test:e2e` 全パス、handbook は prettier チェックパス。ローカル環境に `luac` が無いため `check` ゲートは luajit による構文検証で代替（CI 側で実行される）。`message_queue_spec` の 4 件失敗はクリーンな HEAD でも再現する環境依存の既存問題で本 PR とは無関係。

### Test Environment

- **Neovim version**: NVIM v0.13.0-dev
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: v22 (pnpm 11.12.0)

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [x] Code comments added/updated (if applicable)

`handbook/architecture/per-request-diffs.md` を更新。`.claude/rules/architecture.md` の Per-Request Diffs 節への invariant 追記（合成の呼び出し順序）は本 PR に含めていないため、必要ならレビュー時に追加してください。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

Fixes #735

## Screenshots / Videos

N/A

## Additional Context

- `git add -A --force` で gitignore を無視する案は `node_modules` やビルド生成物を丸ごと巻き込むため採っていない（issue 本文どおり）
- 合成セクションは `request_diff` と同一フォーマット（`index` 行なし）で、既存の patch_viewer / `git apply --reverse` と互換
- Bash だけで gitignore 対象を書き換えたターンはツールイベントに名前が出ないため依然として救えない（一覧にも載らない）。これは既知の限界としてハンドブックに明記した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changes to ignored files are now included in generated patches when their contents can be recovered.
  * Added warnings for listed files whose changes cannot be included in a patch.
  * Prevented duplicate patch sections for files already covered by the standard diff.
  * Notebook edits are now correctly reported as modified files.

* **Documentation**
  * Expanded architecture documentation covering ignored-file handling, patch generation, limitations, and warning behavior.

* **Tests**
  * Added coverage for ignored files, notebook edits, new files, unchanged files, missing backups, and patch supplementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->