### PR TITLE
fix(chat): split prose that follows a closing code fence

### DIFF
--- a/handbook/features/chat-ui.md
+++ b/handbook/features/chat-ui.md
@@ -57,6 +57,40 @@ three: `handbook/architecture/orchestration.md` → "Delivered sections".
 Implemented in `lua/vibing/core/utils/timestamp.lua`: `create_header(role, timestamp)`,
 `extract_role(line)`, `has_timestamp(line)`, `extract_timestamp(line)`, `is_header(line)`.
 
+## Code Fences Written into the Buffer
+
+A model sometimes ends a code block and keeps writing on the same line:
+
+````text
+```これで完了です
+````
+
+CommonMark does not accept that as a closing fence — a closing fence may be followed by whitespace
+only — and `tree-sitter-vibing/src/scanner.c` implements the same rule, so the block stays open
+until the next `## <Kind>` header and everything in between is highlighted as code. The chat is
+still valid Markdown; it just reads as one long code block.
+
+`core/utils/markdown_fence.lua` splits that line in two as it is written, at the three write paths
+that put model-authored Markdown into the buffer: `streaming_handler.flush_chunks` (the streamed
+reply), `renderer.addUserSection` (a `Request` / `Report` / `Notice` body delivered from another
+chat) and `summary_inserter` (the `## summary` block).
+
+Two decisions inside it:
+
+- **A remainder that looks like an info string is left alone** (` ```json `). Inside a block that
+  is body text to CommonMark too, so splitting it would rewrite a nested Markdown example rather
+  than repair anything. The split happens only when the remainder does not match
+  `^[%w_%.%+#-]+$` — that is, when it contains a space or a non-ASCII character.
+- **Streaming does not wait for the line to be complete.** A chunk boundary can fall anywhere, and
+  splitting early is safe because the rest of the line is appended to the line the split produced;
+  the finished text is identical either way. A prefix of an info-string-looking word is itself
+  info-string-looking, so no split can be triggered early and then turn out wrong.
+
+The open-fence state is recounted from the buffer on every flush, from the last message header
+down, rather than carried across chunks: `flush_chunks` already reads every line, a header
+terminates an unfinished fence anyway, and a recount cannot drift when a stream is interrupted or
+the user edits the buffer mid-turn.
+
 ## AskUserQuestion Support
 
 Multiple-choice questions render as plain markdown in the chat buffer instead of a native prompt,

--- a/lua/vibing/core/utils/markdown_fence.lua
+++ b/lua/vibing/core/utils/markdown_fence.lua
@@ -54,6 +54,21 @@ local function looks_like_info_string(rest)
   return rest:match("^[%w_%.%+#-]+$") ~= nil
 end
 
+---`## summary` 境界か（大文字小文字を区別しない）
+---
+---`Timestamp.is_header` は User / Assistant / Request / Report / Notice しか認めないが、
+---`tree-sitter-vibing/grammar.js` の `message_header` と `scanner.c` の `consume_message_header`
+---は `summary` も同じ境界として扱う（`summary_inserter.lua` が書く `## summary` ブロックが
+---フェンスの中身に引きずられて壊れないように）。ここで別チェックにしているのは、
+---`Timestamp.is_header` 自体を緩めると `parse_header` を読む他の全呼び出し側
+---（`extract_role` など）に未知の kind が流れ込むため
+---@param line string
+---@return boolean
+local function is_summary_header(line)
+  return line:match("^## [Ss][Uu][Mm][Mm][Aa][Rr][Yy]$") ~= nil
+    or line:match("^## [Ss][Uu][Mm][Mm][Aa][Rr][Yy] ") ~= nil
+end
+
 ---1行分だけ状態を進める
 ---@param state Vibing.Utils.MarkdownFence.State?
 ---@param line string
@@ -72,7 +87,7 @@ local function step(state, line)
   end
 
   -- チャット境界は未閉のフェンスを打ち切る（スキャナ側の `consume_message_header` と同じ扱い）
-  if Timestamp.is_header(line) then
+  if Timestamp.is_header(line) or is_summary_header(line) then
     return nil
   end
 

--- a/lua/vibing/core/utils/markdown_fence.lua
+++ b/lua/vibing/core/utils/markdown_fence.lua
@@ -1,0 +1,131 @@
+---コードフェンスを行単位で正規化する
+---
+---閉じフェンスの直後に文章が続く行（`` ```続きの文章 ``）は CommonMark では閉じフェンスでは
+---なく本文で、`tree-sitter-vibing` のスキャナ（`tree-sitter-vibing/src/scanner.c`）も同じ規則を
+---採っている。つまりブロックは閉じないまま次のメッセージヘッダーまで伸び、そこまでの
+---チャット全体がコードとしてハイライトされる。書き込む側でフェンスと後続テキストを別々の行に
+---割って、そもそもその行を作らせない。
+---
+---**言語名に見える1語（`` ```json ``）は割らない。** ブロック内のそれは CommonMark でも本文
+---なので、markdown を markdown で説明する入れ子の例をこちらが書き換えてしまう。割るのは
+---空白や非 ASCII を含む「情報文字列には見えない」残りだけ。
+
+local Timestamp = require("vibing.core.utils.timestamp")
+
+---@class Vibing.Utils.MarkdownFence.State
+---@field marker string "`" | "~"
+---@field length number 開きフェンスのマーカー数
+
+---@class Vibing.Utils.MarkdownFence
+local M = {}
+
+-- CommonMark がフェンスとして認めるインデントの上限
+local MAX_INDENT = 3
+
+---フェンスに見える行を分解する
+---@param line string
+---@return string? marker
+---@return number? length
+---@return string? rest マーカーの後ろに残った文字列
+local function fence_parts(line)
+  local indent = line:match("^ *")
+  if #indent > MAX_INDENT then
+    return nil
+  end
+
+  local body = line:sub(#indent + 1)
+  local marker = body:sub(1, 1)
+  if marker ~= "`" and marker ~= "~" then
+    return nil
+  end
+
+  local run = body:match("^" .. marker .. "+")
+  if #run < 3 then
+    return nil
+  end
+
+  return marker, #run, body:sub(#run + 1)
+end
+
+---情報文字列（言語名）に見えるか
+---@param rest string
+---@return boolean
+local function looks_like_info_string(rest)
+  return rest:match("^[%w_%.%+#-]+$") ~= nil
+end
+
+---1行分だけ状態を進める
+---@param state Vibing.Utils.MarkdownFence.State?
+---@param line string
+---@return Vibing.Utils.MarkdownFence.State? state
+---@return string? head 分割するときのフェンス側の行
+---@return string? tail 分割するときの後続テキスト
+local function step(state, line)
+  local marker, length, rest = fence_parts(line)
+
+  if not state then
+    -- バッククォートのフェンスは情報文字列にバッククォートを持てない（CommonMark）
+    if marker and not (marker == "`" and rest:find("`", 1, true)) then
+      return { marker = marker, length = length }
+    end
+    return nil
+  end
+
+  -- チャット境界は未閉のフェンスを打ち切る（スキャナ側の `consume_message_header` と同じ扱い）
+  if Timestamp.is_header(line) then
+    return nil
+  end
+
+  if marker ~= state.marker or length < state.length then
+    return state
+  end
+
+  local tail = vim.trim(rest)
+  if tail == "" then
+    return nil
+  end
+  if looks_like_info_string(tail) then
+    return state
+  end
+
+  -- 後続テキストの先頭空白は落とす。残したまま次の行にすると、4個以上でインデント
+  -- コードブロックになり、フェンスを割った意味がなくなる
+  return nil, line:sub(1, #line - #rest), tail
+end
+
+---閉じフェンスに続く文章を次の行へ送り出す
+---@param lines string[]
+---@param state Vibing.Utils.MarkdownFence.State? 先頭行の時点で開いているフェンス
+---@return string[] normalized
+---@return Vibing.Utils.MarkdownFence.State? state 末尾行まで進めた状態
+function M.normalize(lines, state)
+  local result = {}
+
+  for _, line in ipairs(lines) do
+    local next_state, head, tail = step(state, line)
+    if head then
+      table.insert(result, head)
+      table.insert(result, tail)
+    else
+      table.insert(result, line)
+    end
+    state = next_state
+  end
+
+  return result, state
+end
+
+---書き換えずに状態だけ求める（既にバッファへ書かれた行の続きを正規化するために使う）
+---@param lines string[]
+---@param state Vibing.Utils.MarkdownFence.State?
+---@param first number? 走査開始インデックス（既定 1）
+---@param last number? 走査終了インデックス（既定 #lines）
+---@return Vibing.Utils.MarkdownFence.State? state
+function M.scan(lines, state, first, last)
+  for index = first or 1, last or #lines do
+    state = (step(state, lines[index]))
+  end
+  return state
+end
+
+return M

--- a/lua/vibing/domain/chat/buffer_window.lua
+++ b/lua/vibing/domain/chat/buffer_window.lua
@@ -12,9 +12,12 @@ local Timestamp = require("vibing.core.utils.timestamp")
 ---in what I've read so far" apart from "the header is the first line I read", and keep reading
 ---further back only in the first case (`infrastructure/rpc/handlers/buffer.lua`'s chunked scan).
 ---@param lines string[]
+---@param upto integer? Scan `lines[1..upto]` only (default `#lines`), so a caller that already
+---  has the whole buffer but only wants the header for a prefix of it (`streaming_handler.lua`'s
+---  `open_fence`, bounding out the in-progress last line) doesn't have to copy a slice first.
 ---@return integer?
-function M.find_last_header(lines)
-  for i = #lines, 1, -1 do
+function M.find_last_header(lines, upto)
+  for i = upto or #lines, 1, -1 do
     if Timestamp.is_header(lines[i]) then
       return i
     end

--- a/lua/vibing/presentation/chat/modules/renderer.lua
+++ b/lua/vibing/presentation/chat/modules/renderer.lua
@@ -1,3 +1,4 @@
+local MarkdownFence = require("vibing.core.utils.markdown_fence")
 local Timestamp = require("vibing.core.utils.timestamp")
 local Context = require("vibing.application.context.manager")
 
@@ -177,7 +178,8 @@ function M.addUserSection(buf, win, pendingChoices, pendingApproval, initial_mes
 
   -- Insert message content if provided (for programmatic send)
   if initial_message and initial_message ~= "" then
-    local message_lines = vim.split(initial_message, "\n", { plain = true })
+    -- 配達された本文もそのままバッファの markdown になるので、閉じフェンスを割っておく
+    local message_lines = MarkdownFence.normalize(vim.split(initial_message, "\n", { plain = true }))
     for _, line in ipairs(message_lines) do
       table.insert(newLines, line)
     end

--- a/lua/vibing/presentation/chat/modules/streaming_handler.lua
+++ b/lua/vibing/presentation/chat/modules/streaming_handler.lua
@@ -1,6 +1,27 @@
+local MarkdownFence = require("vibing.core.utils.markdown_fence")
 local Timestamp = require("vibing.core.utils.timestamp")
 
 local M = {}
+
+---`upto` 行目までで開いたままになっているコードフェンスを求める
+---
+---状態を持ち回らず毎回数え直すのは、フラッシュのたびにバッファ全行をどのみち読んでいて、
+---走査もヘッダー以降＝今のターンの分で足りるため。持ち回った状態はストリームの中断や
+---バッファの手編集でずれるが、数え直しはずれない
+---@param lines string[]
+---@param upto number
+---@return Vibing.Utils.MarkdownFence.State?
+local function open_fence(lines, upto)
+  local section_start = 1
+  for index = upto, 1, -1 do
+    if Timestamp.is_header(lines[index]) then
+      section_start = index
+      break
+    end
+  end
+
+  return MarkdownFence.scan(lines, nil, section_start, upto)
+end
 
 ---アシスタント応答を開始
 ---
@@ -74,6 +95,10 @@ function M.flush_chunks(buf, win, chunk_buffer)
 
   local chunk_lines = vim.split(chunk_buffer, "\n", { plain = true })
   chunk_lines[1] = last_line .. chunk_lines[1]
+
+  -- 末尾行はまだ途中かもしれないが、ここで割っても続きは割った後の行へ追記されるので、
+  -- 出来上がる本文は同じになる
+  chunk_lines = MarkdownFence.normalize(chunk_lines, open_fence(lines, #lines - 1))
 
   vim.api.nvim_buf_set_lines(buf, #lines - 1, #lines, false, chunk_lines)
 

--- a/lua/vibing/presentation/chat/modules/streaming_handler.lua
+++ b/lua/vibing/presentation/chat/modules/streaming_handler.lua
@@ -1,3 +1,4 @@
+local BufferWindow = require("vibing.domain.chat.buffer_window")
 local MarkdownFence = require("vibing.core.utils.markdown_fence")
 local Timestamp = require("vibing.core.utils.timestamp")
 
@@ -12,14 +13,7 @@ local M = {}
 ---@param upto number
 ---@return Vibing.Utils.MarkdownFence.State?
 local function open_fence(lines, upto)
-  local section_start = 1
-  for index = upto, 1, -1 do
-    if Timestamp.is_header(lines[index]) then
-      section_start = index
-      break
-    end
-  end
-
+  local section_start = BufferWindow.find_last_header(lines, upto) or 1
   return MarkdownFence.scan(lines, nil, section_start, upto)
 end
 

--- a/lua/vibing/presentation/chat/modules/summary_inserter.lua
+++ b/lua/vibing/presentation/chat/modules/summary_inserter.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local MarkdownFence = require("vibing.core.utils.markdown_fence")
 local notify = require("vibing.core.utils.notify")
 
 ---Find "# Vibing Chat" line and first "---" separator after it
@@ -75,6 +76,8 @@ local function prepare_summary_lines(summary_content)
   if #lines == 0 or not lines[1]:lower():match("^##%s*summary") then
     return nil
   end
+
+  lines = MarkdownFence.normalize(lines)
 
   table.insert(lines, "")
   return lines

--- a/tests/lua/core/utils/markdown_fence_spec.lua
+++ b/tests/lua/core/utils/markdown_fence_spec.lua
@@ -1,0 +1,108 @@
+-- 閉じフェンスの直後に文章が続く行を割る正規化のテスト。
+-- 割りすぎるとブロック内に書かれた markdown の例（``` を含む本文）を書き換えてしまうので、
+-- 「割る」側と同じだけ「割らない」側を押さえる。
+
+describe("markdown_fence.normalize", function()
+  local MarkdownFence = require("vibing.core.utils.markdown_fence")
+
+  --- @param lines string[]
+  --- @return string[]
+  local function normalize(lines)
+    return (MarkdownFence.normalize(lines))
+  end
+
+  it("splits prose that follows a closing fence", function()
+    local result = normalize({ "```lua", "local x = 1", "```この続きは本文です" })
+
+    assert.same({ "```lua", "local x = 1", "```", "この続きは本文です" }, result)
+  end)
+
+  it("splits an English sentence that follows a closing fence", function()
+    local result = normalize({ "```", "code", "``` and then we run it" })
+
+    assert.same({ "```", "code", "```", "and then we run it" }, result)
+  end)
+
+  it("leaves a language-name-looking word alone", function()
+    -- ブロック内の "```json" は CommonMark でも閉じフェンスではなく本文。ここで割ると
+    -- markdown を markdown で説明している入れ子の例が壊れる
+    local input = { "````markdown", "```json", '{ "a": 1 }', "```", "````" }
+
+    assert.same(input, normalize(input))
+  end)
+
+  it("leaves a proper closing fence alone", function()
+    local input = { "```lua", "local x = 1", "```", "本文" }
+
+    assert.same(input, normalize(input))
+  end)
+
+  it("leaves an opening fence with an info string alone", function()
+    local input = { "本文", "```lua", "local x = 1" }
+
+    assert.same(input, normalize(input))
+  end)
+
+  it("does not treat a shorter marker run as a closing fence", function()
+    local input = { "````", "``` still inside the block", "````" }
+
+    assert.same(input, normalize(input))
+  end)
+
+  it("handles tilde fences and up to three spaces of indent", function()
+    local result = normalize({ "   ~~~text", "body", "   ~~~あとがき" })
+
+    assert.same({ "   ~~~text", "body", "   ~~~", "あとがき" }, result)
+  end)
+
+  it("keeps the split text off the indented-code-block threshold", function()
+    local result = normalize({ "```", "code", "```      説明" })
+
+    assert.same({ "```", "code", "```", "説明" }, result)
+  end)
+
+  it("stops an unfinished fence at a message header", function()
+    -- スキャナと同じ扱い。ヘッダーで打ち切らないと、次のターンの開始フェンスを
+    -- 「閉じフェンス」と読んでしまう
+    local result = normalize({
+      "```lua",
+      "local x = 1",
+      "## Assistant <!-- 2026-09-10 10:00:00 -->",
+      "```これは新しいブロックの開始",
+    })
+
+    assert.same({
+      "```lua",
+      "local x = 1",
+      "## Assistant <!-- 2026-09-10 10:00:00 -->",
+      "```これは新しいブロックの開始",
+    }, result)
+  end)
+
+  it("reports the open fence so the next call can continue", function()
+    local _, state = MarkdownFence.normalize({ "```lua", "local x = 1" })
+    assert.same({ marker = "`", length = 3 }, state)
+
+    local result = normalize({ "```続き" })
+    assert.same({ "```続き" }, result, "状態を渡さなければブロックの外なので割らない")
+
+    local continued = MarkdownFence.normalize({ "```続き" }, state)
+    assert.same({ "```", "続き" }, continued)
+  end)
+end)
+
+describe("markdown_fence.scan", function()
+  local MarkdownFence = require("vibing.core.utils.markdown_fence")
+
+  it("returns the state without rewriting anything", function()
+    assert.same({ marker = "`", length = 3 }, MarkdownFence.scan({ "```lua", "local x = 1" }))
+    assert.is_nil(MarkdownFence.scan({ "```lua", "local x = 1", "```" }))
+  end)
+
+  it("scans only the requested range", function()
+    local lines = { "```lua", "local x = 1", "```", "本文" }
+
+    assert.same({ marker = "`", length = 3 }, MarkdownFence.scan(lines, nil, 1, 2))
+    assert.is_nil(MarkdownFence.scan(lines, nil, 1, 3))
+  end)
+end)

--- a/tests/lua/core/utils/markdown_fence_spec.lua
+++ b/tests/lua/core/utils/markdown_fence_spec.lua
@@ -79,6 +79,25 @@ describe("markdown_fence.normalize", function()
     }, result)
   end)
 
+  it("stops an unfinished fence at a bare `## summary` boundary", function()
+    -- `Timestamp.is_header` doesn't know "summary" as a kind, but
+    -- tree-sitter-vibing/grammar.js's `message_header` and scanner.c's `consume_message_header`
+    -- both treat it as a boundary too, since `summary_inserter.lua` writes exactly this line.
+    local result = normalize({
+      "```lua",
+      "local x = 1",
+      "## summary",
+      "```これは新しいブロックの開始",
+    })
+
+    assert.same({
+      "```lua",
+      "local x = 1",
+      "## summary",
+      "```これは新しいブロックの開始",
+    }, result)
+  end)
+
   it("reports the open fence so the next call can continue", function()
     local _, state = MarkdownFence.normalize({ "```lua", "local x = 1" })
     assert.same({ marker = "`", length = 3 }, state)

--- a/tests/lua/domain/chat/buffer_window_spec.lua
+++ b/tests/lua/domain/chat/buffer_window_spec.lua
@@ -127,5 +127,19 @@ describe("BufferWindow.slice", function()
 
       assert.equals(3, BufferWindow.find_last_header(lines))
     end)
+
+    it("scans only up to the given bound, ignoring a later header", function()
+      -- streaming_handler.lua's open_fence bounds this out to the second-to-last line, so a
+      -- streamed line that happens to look like a header doesn't count until it is complete.
+      local lines = { "## User <!-- 2026-01-01 00:00:00 -->", "a", "## Assistant <!-- 2026-01-01 00:00:01 -->", "b" }
+
+      assert.equals(1, BufferWindow.find_last_header(lines, 2))
+    end)
+
+    it("returns nil when the bound is before any header", function()
+      local lines = { "a", "## Assistant", "b" }
+
+      assert.equals(nil, BufferWindow.find_last_header(lines, 1))
+    end)
   end)
 end)

--- a/tests/lua/presentation/chat/modules/streaming_handler_spec.lua
+++ b/tests/lua/presentation/chat/modules/streaming_handler_spec.lua
@@ -75,4 +75,64 @@ describe("streaming_handler.stamp_response_end", function()
 
     assert.equals("## Assistant <!-- 2026-09-04 10:05:00 -->", line_at(bufnr, 1))
   end)
+
+  -- ストリームは行の途中でも切れるので、フェンスの正規化はチャンクの切れ目に依存しては
+  -- いけない。閉じフェンスに文章が続く行を1つでも残すと、そこから下が全部コードとして
+  -- ハイライトされる（tree-sitter-vibing/src/scanner.c）
+  describe("flush_chunks", function()
+    it("splits prose that follows a closing fence", function()
+      local bufnr = scratch({ "## Assistant", "" })
+
+      StreamingHandler.flush_chunks(bufnr, nil, "```lua\nlocal x = 1\n```これで完了です\n")
+
+      assert.same({
+        "## Assistant",
+        "```lua",
+        "local x = 1",
+        "```",
+        "これで完了です",
+        "",
+      }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+    end)
+
+    it("splits the same way when the chunk boundary falls inside the line", function()
+      local bufnr = scratch({ "## Assistant", "" })
+
+      StreamingHandler.flush_chunks(bufnr, nil, "```lua\nlocal x = 1\n```これ")
+      StreamingHandler.flush_chunks(bufnr, nil, "で完了です\n")
+
+      assert.same({
+        "## Assistant",
+        "```lua",
+        "local x = 1",
+        "```",
+        "これで完了です",
+        "",
+      }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+    end)
+
+    it("keeps a language-name-looking line inside the block", function()
+      local bufnr = scratch({ "## Assistant", "" })
+
+      StreamingHandler.flush_chunks(bufnr, nil, "````markdown\n")
+      StreamingHandler.flush_chunks(bufnr, nil, "```json\n")
+      StreamingHandler.flush_chunks(bufnr, nil, "````\n")
+
+      assert.same({
+        "## Assistant",
+        "````markdown",
+        "```json",
+        "````",
+        "",
+      }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+    end)
+
+    it("does not carry a fence across the message header", function()
+      local bufnr = scratch({ "## User <!-- 2026-09-04 10:00:00 -->", "```lua", "local x = 1", "## Assistant", "" })
+
+      StreamingHandler.flush_chunks(bufnr, nil, "```これは新しいブロックです\n")
+
+      assert.equals("```これは新しいブロックです", line_at(bufnr, 5))
+    end)
+  end)
 end)


### PR DESCRIPTION
# Pull Request

## Summary

閉じフェンスの直後に文章が続く行（`` ```これで完了です ``）をバッファへ書かないようにしました。CommonMark では閉じフェンスの後ろは空白しか許されず、`tree-sitter-vibing/src/scanner.c` も同じ規則なので、この1行があるとコードブロックが次の `## <Kind>` ヘッダーまで閉じず、そこまでのチャットが丸ごとコードとしてハイライトされていました。

## Changes

- `lua/vibing/core/utils/markdown_fence.lua` を追加。開いているブロック内で「開始フェンス以上の長さの ``` / `~~~` の後ろに空白以外が続く行」をフェンス行と後続テキストの2行に割る（`normalize`）。書き換えずに状態だけ返す `scan` も提供
- 適用箇所は、モデルが書いた markdown がバッファに入る3経路: `streaming_handler.flush_chunks`（ストリーミング応答）、`renderer.addUserSection`（他チャットから配達された Request / Report / Notice 本文）、`summary_inserter`（`## summary`）
- 言語名に見える1語（`` ```json ``）は割らない。ブロック内のそれは CommonMark でも本文なので、割ると markdown の入れ子の例を書き換えてしまう。割るのは残りが `^[%w_%.%+#-]+$` に合致しないとき（空白や非 ASCII を含むとき）だけ
- チャット境界（`## User` などのヘッダー）は未閉フェンスを打ち切る。スキャナ側の `consume_message_header` と同じ扱い
- フェンスの開閉状態はチャンクをまたいで持ち回らず、フラッシュのたびにバッファの直近ヘッダー以降を数え直す。`flush_chunks` は元から全行読んでいるので追加コストは無く、ストリーム中断やバッファの手編集でもずれない
- 行の途中でチャンクが切れても結果は変わらない。割った後の行に続きが追記されるだけで、情報文字列に見える語の接頭辞もまた情報文字列に見えるため、早すぎる分割が後から誤りになることがない

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Test addition or update

## Testing

- [x] Ran `pnpm run test:lua`
- [x] Ran `pnpm run format:check`
- [x] Manual testing completed

`tests/lua/core/utils/markdown_fence_spec.lua`（12件）と `tests/lua/presentation/chat/modules/streaming_handler_spec.lua` の `flush_chunks` 4件を追加し、いずれも green です。

既存の失敗（本 PR とは無関係、main でも同じ失敗を確認）:

- `message_queue_spec` 4件 / `chat_list_spec` 2件 / `chat_conflicts_spec` 1件（#696 / #697 系）
- `test:node` の `valid Lua exits 0`（手元に `luac` が無いため。CI では lua5.3 が入る）。変更した Lua ファイルの構文は `loadfile` で個別に確認済み

### Test Environment

- **Neovim version**: NVIM v0.11 系
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: 現行のローカル環境（pnpm 11.12.0）

## Documentation

- [x] Code comments added/updated (if applicable)

`handbook/features/chat-ui.md` に「Code Fences Written into the Buffer」を追加しました。`.claude/rules/features.md` への1行の不変条件の追記は、ローカルの権限設定で編集がブロックされたため未反映です。追記したい文面:

> **No write path may leave a closing code fence with text after it on the same line.** Such a line closes nothing (CommonMark, and `tree-sitter-vibing/src/scanner.c` with it), so the block swallows the rest of the section. Model-authored Markdown goes through `core/utils/markdown_fence.lua` — `streaming_handler.flush_chunks`, `renderer.addUserSection` and `summary_inserter` — which splits the line and leaves an info-string-looking remainder alone.

## Additional Context

代替案として tree-sitter 側のスキャナを緩め、後続テキストのある行も閉じフェンスとして受理する案もありました。内容を書き換えずに済む一方、md の入れ子例の解釈が CommonMark からずれるため、書き込み側で正規化する方針を選んでいます。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat Markdown rendering when code fences are followed by text on the same line.
  - Correctly handles fenced code blocks across streaming updates and message boundaries.
  - Preserves valid language identifiers and nested Markdown examples.

- **Tests**
  - Added coverage for fence normalization, streaming chunks, indentation, and message transitions.

- **Documentation**
  - Documented code-fence handling behavior in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->