### PR TITLE
fix(chat): open markdown links from label text

### DIFF
--- a/lua/vibing/presentation/chat/modules/keymap_handler.lua
+++ b/lua/vibing/presentation/chat/modules/keymap_handler.lua
@@ -90,8 +90,18 @@ local function trim_url(url)
   return url
 end
 
+---URL の直前が Markdown のインラインリンクなら、ラベルの開始位置を返す。
+---`%b[]` はネストした角括弧にも対応する。
+---@param line string
+---@param url_start number URL の 1-indexed byte position
+---@return number|nil
+local function markdown_link_start(line, url_start)
+  return line:sub(1, url_start - 1):match("()%b[]%(%s*<?$")
+end
+
 ---行内からカーソル位置（1-indexed）に対応する URL を探す。
----カーソルが URL 上にあればそれを、なければ最も近い URL を（max_dist 以内で）返す。
+---カーソルが Markdown リンク記法内か URL 上にあればそれを、なければ最も近い URL を
+---（max_dist 以内で）返す。
 ---@param line string 行全体
 ---@param col number カーソルの 1-indexed カラム
 ---@return string|nil
@@ -110,6 +120,10 @@ function M.find_url_on_line(line, col)
     url = trim_url(truncate_at_non_ascii_punct(url))
     local url_end = url_start + #url - 1
 
+    local link_start = markdown_link_start(line, url_start)
+    if link_start and col >= link_start and col <= url_end then
+      return url
+    end
     if col >= url_start and col <= url_end then
       return url
     end

--- a/tests/lua/presentation/chat/modules/keymap_handler_spec.lua
+++ b/tests/lua/presentation/chat/modules/keymap_handler_spec.lua
@@ -99,6 +99,45 @@ describe("keymap_handler.find_url_on_line", function()
     end
   end)
 
+  describe("opens an inline Markdown link from anywhere in its notation", function()
+    local line = "prefix [a sufficiently long link label](https://example.com/docs) suffix"
+    local label_close = line:find("%]%(")
+
+    local positions = {
+      line:find("%["),
+      line:find("sufficiently"),
+      line:find("label"),
+      label_close,
+      label_close + 1,
+      line:find("example"),
+      line:find("%) suffix"),
+    }
+
+    it("resolves the target from its label and delimiters", function()
+      for _, col in ipairs(positions) do
+        assert.equals("https://example.com/docs", KeymapHandler.find_url_on_line(line, col))
+      end
+    end)
+
+    it("selects the link whose label is under the cursor", function()
+      local two_links = "[first long label](https://example.com/one) and [second long label](https://example.com/two)"
+      local col = two_links:find("second")
+      assert.equals("https://example.com/two", KeymapHandler.find_url_on_line(two_links, col))
+    end)
+
+    it("supports nested brackets in the label", function()
+      local nested = "[outer [inner] label](https://example.com/nested)"
+      local col = nested:find("inner")
+      assert.equals("https://example.com/nested", KeymapHandler.find_url_on_line(nested, col))
+    end)
+
+    it("supports angle-bracket destinations", function()
+      local titled = '[documentation](<https://example.com/a_(b)> "a long title")'
+      local col = titled:find("documentation")
+      assert.equals("https://example.com/a_(b)", KeymapHandler.find_url_on_line(titled, col))
+    end)
+  end)
+
   describe("stops at Japanese punctuation adjoining the URL", function()
     local cases = {
       {


### PR DESCRIPTION
## Summary

- detect the full span of inline Markdown links when resolving gx targets
- open the destination from the label, brackets, URL, or optional title
- preserve existing bare-URL behavior and support nested labels and angle-bracket destinations

## Test plan

- nvim --headless -i NONE -u tests/minimal_init.lua -c "PlenaryBustedFile tests/lua/presentation/chat/modules/keymap_handler_spec.lua" (35 passed)
- npm run test:lua (one unrelated failure: tests/lua/infrastructure/rpc/handlers/chat_conflicts_spec.lua:165 expected orchestrator task but received nil)