### PR TITLE
test(orchestration): cover the held completion edge on the on_sent dispatch path

### DIFF
--- a/handbook/architecture/orchestration.md
+++ b/handbook/architecture/orchestration.md
@@ -379,7 +379,14 @@ nothing, so subscribers are notified exactly as before.
 **The mirror ordering is covered by a second branch, which is #640.** When the leaf finishes
 _after_ the middle chat's dispatch turn rather than before — the commoner case, since dispatching
 takes seconds and the leaf takes minutes — that turn's queue is empty, so the drain above catches
-nothing. The signal that does catch it was already in the table: `edges[c][b]` exists from B's send
+nothing. #646 reported that same ordering separately, before #640's branch shipped; what it asked
+for is exactly this branch, so the only thing it left to do was pin it on the path an orchestrator
+actually takes. The spec that held it went through `subscribe` directly, which is what
+`nvim_chat_create` calls — the dispatch case is `nvim_chat_send_message` → `on_sent`, which also
+lays down the suppression mark, so branch 2 and that mark have to survive the wait together.
+`completion_notifier_spec.lua`'s `(#646)` case walks both hops through `on_sent` and asserts both
+endings: B reports for itself and the watchdog stays quiet, or B stops silently and the held edge
+fires. The signal that does catch it was already in the table: `edges[c][b]` exists from B's send
 until C completes and means "B is waiting on a chat that has not finished". So `on_response_done`
 now reads as three branches, tried in order:
 

--- a/tests/lua/application/chat/completion_notifier_spec.lua
+++ b/tests/lua/application/chat/completion_notifier_spec.lua
@@ -553,6 +553,48 @@ describe("CompletionNotifier", function()
       assert.equals(a, sends[2].bufnr, "the edge survived to B's real completion")
     end)
 
+    it("survives the whole dispatch-and-wait window on the real send path (#646)", function()
+      -- 上のspecは `subscribe` を直接呼ぶので、実際の `nvim_chat_send_message` が同時に置く
+      -- 抑止マーク（`on_sent` の `reported`）が絡まない。#646 が報告した順序 —— 末端 C が
+      -- 中間 B のディスパッチターンより**後**に終わる —— を、両ホップとも実経路の
+      -- `on_sent` で辿り、B 自身の報告まで含めて通しで確かめる
+      local a, b, c = make_chat(), make_chat(), make_chat()
+
+      Notifier.on_sent(a, b) -- A → B のブリーフ
+      Notifier.on_sent(b, c) -- B → C のディスパッチ
+
+      Notifier.on_response_done(b) -- 「C に送った、待つ」だけの中間ターン
+      assert.equals(0, #sends, "A is not woken by B's intermediate turn")
+
+      Notifier.on_response_done(c) -- C 完了 → B へ配達、B 再稼働
+      assert.equals(1, #sends)
+      assert.equals(b, sends[1].bufnr)
+
+      -- B が C の報告を読み、本命の報告を A に書いて止まる
+      responding[b] = false
+      Notifier.on_sent(b, a)
+      Notifier.on_response_done(b)
+
+      for _, sent in ipairs(sends) do
+        assert.not_equals(a, sent.bufnr, "A already had B's own report; no watchdog on top of it")
+      end
+
+      -- 逆に B が自分から報告しなかった場合は、温存されたエッジが watchdog として発火する
+      local d, e, f = make_chat(), make_chat(), make_chat()
+      sends = {}
+
+      Notifier.on_sent(d, e)
+      Notifier.on_sent(e, f)
+      Notifier.on_response_done(e)
+      Notifier.on_response_done(f)
+      responding[e] = false
+      Notifier.on_response_done(e)
+
+      assert.equals(2, #sends)
+      assert.equals(e, sends[1].bufnr)
+      assert.equals(d, sends[2].bufnr, "the edge was still there when E stopped without reporting")
+    end)
+
     -- ワーカーのバッファは誰も見ていないので、保留したままだと誰も対応できない。
     -- 判定は「停止理由が非nilか」なので、理由が増えれば自動的にこちら側に入る
     for _, reason in ipairs({ "asked_question", "waiting_approval", "error" }) do


### PR DESCRIPTION
## 概要

#646 が報告した取りこぼし ―― A → B → C の2段チャット網で、末端 C が中間 B のディスパッチターンより
**後**に終わると、B の中間ターンで one-shot エッジ `edges[b]` が消費され、A に二度と通知が届かない ――
は、**現行 main で既に修正済み**でした。

調べた結果、#646 が提案していた `is_awaiting(bufnr)` そのものが、#640 / PR #652
(`a08185f` 系列の `a4f0884 feat: fire completion notifications only when a chat has truly stopped`)
で `is_waiting_on_others()` として実装され、`process_done` の**分岐2**になっています。
#646 は #640 とほぼ同時期に独立して立てられ、PR がどちらにも紐付かなかったため open のまま残っていました。

そこで本 PR は、**残っていた回帰テストの穴だけ**を埋めます。

## 根本原因（issue の内容の確認）

`completion_notifier.lua` の `on_response_done` は当初、「このターンは中間ターンだ」の判定に
**自分宛キューが空でないこと**（分岐1 / #638）しか使っていませんでした。C がまだ走っている時点では
B のキューは空なので、この判定は通りません。結果:

1. `subscribe(a, b)` → `edges[b][a]`
2. `subscribe(b, c)` → `edges[c][b]`
3. B の中間ターン終了 → キューが空 → A へ配達して `edges[b]` を消費
4. C 完了 → B が再稼働し、本命の報告を書く
5. B の報告ターン終了 → `edges[b]` は消費済み → **A には二度と通知されない**

現行の分岐2 は、もう一方の信号 `edges[c][b]`（B が C に送った時点から C が完了するまで存在し、
まさに「B は未完了のチャットを待っている」を意味する）を見ることでこれを止めています。
issue の提案どおり、分岐1 の**置き換えではなく拡張**です。

## 残っていた穴

既存の分岐2 の spec は `Notifier.subscribe()` を直接呼んでいます。これは `nvim_chat_create` の経路です。
実際のディスパッチは `nvim_chat_send_message` → `handlers/message.lua` → **`on_sent()`** で、
こちらは購読を張ると同時に **報告の抑止マーク（`reported`）** も置きます。
つまり実運用では「分岐2 の保留」と「抑止マーク」が同じ待ち合わせ窓の中で同時に生きており、
その組み合わせは何にも pin されていませんでした。

## 変更内容

- `tests/lua/application/chat/completion_notifier_spec.lua`: `(#646)` ケースを追加。
  両ホップとも `on_sent()` で辿り、2つの終わり方を両方assert する
  - B が自分から A に報告した場合 → 抑止マークが効き、watchdog は**重ねて**起こさない
  - B が黙って止まった場合 → 温存されたエッジが watchdog として A に発火する
- `handbook/architecture/orchestration.md`: #646 が #640 と同じ順序の別報告であること、
  および `on_sent` 経路を pin したのがどの spec かを記載

## 検証

- 分岐2 の条件を一時的に `if not stop_reason and held then`（= #638 だけの状態）へ戻すと、
  追加した `(#646)` ケースは**落ちます**。空振りテストでないことを実測で確認済み
- `pnpm test` / `pnpm run check` / `pnpm run lint` / `pnpm run lint:md`（変更ファイル）/
  `prettier --check`（変更ファイル）: すべて通過
- `pnpm run test:lua` には既存の失敗が7件ありますが、**このブランチの変更前・main のチェックアウト
  どちらでも同じように落ちる**ため無関係です（`message_queue_spec.lua` の永続化4件、
  `list_chats` 2件、`chat_conflicts` 1件 ―― いずれも #696/#697 系の git root 解決まわり。
  PR #741 の test plan にも同じ失敗が記録されています）
- `test:eval` は実行していません

fixes #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved completion handling across chained chat interactions, ensuring notifications remain valid throughout message dispatch and waiting.
  - Prevented premature wake-ups during intermediate turns.
  - Ensured watchdog behavior still triggers when an expected completion report is not sent.

- **Tests**
  - Added coverage for real message-dispatch flows, including suppression and completion scenarios.

- **Documentation**
  - Clarified the documented ordering and completion behavior for chained interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->