### PR TITLE
feat(agent): pass cost-related environment variables to the Claude CLI

### DIFF
--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -438,6 +438,8 @@ with YAML frontmatter: >
     agent: claude
     mode: code                                # code | plan | explore
     model: sonnet
+    env:                                      # optional: see below
+      - BASH_MAX_OUTPUT_LENGTH=10000
     permission_mode: acceptEdits
     permissions_allow:
       - Read
@@ -484,6 +486,16 @@ frontmatter (not the orchestrator's). A denial can always be delegated
 regardless of scope, since denying grants nothing; only `allow_once` /
 `allow_for_session` answers are checked against it. See the
 vibing-orchestrate skill for how to declare it.
+
+`env` lists `KEY=VALUE` environment variables for this chat's CLI process,
+overriding `agent.env` from |vibing.setup()|. It is for the cost knobs Claude
+Code exposes only through the environment — `BASH_MAX_OUTPUT_LENGTH`,
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, `CLAUDE_CODE_SUBAGENT_MODEL` — so one chat
+can be tuned without touching the rest. Claude backend only. `CLAUDECODE` and
+any `VIBING_*` name is ignored with a warning: those bind the CLI to this
+Neovim and to this chat. An entry that is not `KEY=VALUE` is ignored the same
+way. The table of what is worth setting is in `handbook/configuration.md` →
+"Claude CLI Environment Variables".
 
 ==============================================================================
 9. BACKENDS                                                  *vibing-backends*

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -171,6 +171,14 @@ agent = {
                             -- since both values are written through the CLI's env var.
                             -- An already-set CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS wins either way.
 
+  env = {},                 -- Claude backend only. Extra environment variables for the CLI child
+                            -- process, so the cost knobs Claude Code exposes only through the
+                            -- environment apply to vibing.nvim's calls and not to the `claude` in
+                            -- your terminal. Values are stringified. See "Claude CLI Environment
+                            -- Variables" below for what is worth setting; a chat's `env:`
+                            -- frontmatter overrides this per chat, CLAUDECODE and VIBING_* are
+                            -- refused, and lightweight utility calls get none of it.
+
   subagent = {              -- What a subagent (Task/Agent tool) says in the chat
     enabled = false,        -- Opt-in: passes --forward-subagent-text to the CLI so the
                             -- subagent's own text reaches vibing.nvim at all. Without it
@@ -736,6 +744,63 @@ It refuses while an unsent message is waiting — the automatic path parks your 
 asked to send _that message_, whereas this command was typed on its own and should mean exactly
 one turn. The command remains Claude-only; Codex exposes automatic compaction here, not a matching
 manual slash command.
+
+### Claude CLI Environment Variables
+
+Several of Claude Code's cost knobs have no flag and no settings key — the environment is the only
+way in ([env vars](https://code.claude.com/docs/en/env-vars.md),
+[costs](https://code.claude.com/docs/en/costs.md#reduce-token-usage)). `vim.env.X = ...` in your
+`init.lua` reaches the CLI child, because the spawn inherits `vim.fn.environ()`, but it also
+reaches every `claude` you start from a terminal in that Neovim, and it cannot differ per chat.
+`agent.env` is the scoped version:
+
+```lua
+agent = {
+  env = {
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "20",
+    BASH_MAX_OUTPUT_LENGTH = "10000",
+  },
+},
+```
+
+| Variable                          | Effect                                                                                          |
+| --------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Percentage of the context window at which the CLI auto-compacts. See below                      |
+| `BASH_MAX_OUTPUT_LENGTH`          | Cap on a `Bash` result, in characters (default 30,000)                                          |
+| `CLAUDE_CODE_SUBAGENT_MODEL`      | Model a `Task`/`Agent` call runs on, e.g. `haiku` for exploration                               |
+| `CLAUDE_CODE_PROMPT_CACHE_TTL`    | Prompt cache TTL                                                                                |
+| `MAX_THINKING_TOKENS`             | Thinking budget on older models. Ignored by adaptive-thinking ones — use `agent.default_effort` |
+
+**`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is a percentage, so what it means depends on the model.** On a
+1M-context model (`[1m]`) the default fires at roughly 930k tokens (#669), which is far past the
+point where a turn is expensive; `20` brings that to ~200k. On a 200k model the same `20` fires at
+40k, which is almost certainly too eager. Pick the number from the window your `default_model`
+actually has, and re-check it when you change models. vibing.nvim's own
+[`agent.token_usage.auto_compact`](#automatic-compaction) is the backend-independent alternative:
+it is an absolute token count rather than a percentage, and it compacts between turns instead of
+mid-turn.
+
+**`BASH_MAX_OUTPUT_LENGTH` is usually the larger win.** A tool result is re-sent with every later
+request in the conversation, so one 30k-character test run is paid for on every turn after it, not
+once.
+
+Three rules apply to whatever you put here:
+
+- **A chat's `env:` frontmatter wins**, so one chat can lower `BASH_MAX_OUTPUT_LENGTH` without
+  touching the rest. It is a list of `KEY=VALUE` lines — `doc/vibing.txt` → "CHAT FILE FORMAT".
+- **`CLAUDECODE` and `VIBING_*` are refused with a warning.** They carry the RPC port, the handle
+  ID and the nested-invocation escape that the permission hook, the approval UI and the per-request
+  diff baseline all ride on.
+- **Lightweight utility calls get none of it** (title generation, `/summarize`, the daily summary).
+  They run with no tools and no resumed session, so none of these variables has anything to act on.
+
+A variable already present in Neovim's own environment is overwritten by `agent.env` — declaring it
+here is the more specific statement. `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` is worth naming
+because it also has an option of its own: `agent.env` is merged first and `agent.git_instructions`
+only fills a gap, so writing the variable here wins over that option.
+
+Claude backend only. Codex, Copilot and Grok inherit Neovim's environment as before and read none
+of these names.
 
 ### Subagent Output
 

--- a/lua/vibing/application/chat/inherited_frontmatter.lua
+++ b/lua/vibing/application/chat/inherited_frontmatter.lua
@@ -29,6 +29,9 @@ function M.from_source(source, config)
     model = source.model or (config.agent and config.agent.default_model or "sonnet"),
     -- effortは設定がなければ渡さない（CLI側の既定に委ねる）ので、fallbackもnilで正しい
     effort = source.effort or (config.agent and config.agent.default_effort),
+    -- envもmodel/effortと同じ「このチャットのCLIをどう起動するか」なので引き継ぐ。
+    -- config.agent.envは全チャットに効くのでfallbackは不要
+    env = source.env,
     permission_mode = source.permission_mode or (config.permissions and config.permissions.mode or "acceptEdits"),
     permissions_allow = source.permissions_allow or (config.permissions and config.permissions.allow or {}),
     permissions_deny = source.permissions_deny or (config.permissions and config.permissions.deny or {}),

--- a/lua/vibing/application/chat/send_message.lua
+++ b/lua/vibing/application/chat/send_message.lua
@@ -182,6 +182,7 @@ function M.execute(adapter, callbacks, message, config)
     permissions_session_allow = session_allow,
     permissions_session_deny = session_deny,
     permission_mode = frontmatter.permission_mode,
+    env = frontmatter.env,
     language = lang_code,
     cwd = session_cwd,
     -- ツリースナップショット差分の帰属判定に使う。アダプタはこれをそのまま

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -126,6 +126,15 @@
 ---  （デフォルト: false）。どちらの値でも`CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS`を明示的に書く
 ---  （true→"0"、false→"1"）ので settings.json の`includeGitInstructions`より優先される。
 ---  ただしユーザーが既に環境変数を立てている場合はそちらを尊重して触らない
+---@field env table<string, string|number>? Claude backend専用。CLI子プロセスへ渡す追加の環境変数
+---  （デフォルト: `{}`）。Claude Codeにはコスト系のつまみが環境変数でしか触れないものがあり
+---  （`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` / `BASH_MAX_OUTPUT_LENGTH` /
+---  `CLAUDE_CODE_SUBAGENT_MODEL` など。一覧と推奨値は handbook/configuration.md →
+---  "Claude CLI Environment Variables"）、`vim.env`に書くとターミナルの`claude`にも効いて
+---  しまうため、vibing.nvim経由の呼び出しにだけ効かせる口としてここを用意している。
+---  値は文字列化して渡す。チャットのfrontmatter `env:`（`KEY=VALUE`の並び）が個別に上書きする。
+---  `CLAUDECODE`と`VIBING_*`はvibing.nvim自身がフック往復に使うので、書いても無視して警告する。
+---  軽量ユーティリティ呼び出しには渡さない（ツールもresumeも無く効く先が無い）
 ---@field subagent Vibing.SubagentConfig? subagent（Task/Agentツール）の出力表示設定
 ---@field auto_resume_on_limit Vibing.AutoResumeOnLimitConfig 使用量リミット自動継続設定
 ---@field scheduled_requests Vibing.ScheduledRequestsConfig 予約リクエスト設定
@@ -312,6 +321,9 @@ M.defaults = {
     -- 変わり、system prompt以降＝全履歴がキャッシュミスになる。既定でoffにする理由はそれで、
     -- ブランチ名や直近コミットが要るときはモデルに `git status` / `git log` を1回呼ばせれば済む。
     git_instructions = false,
+    -- CLI子プロセスに足す環境変数。空が既定で、空なら子プロセスのenvは従来と1バイトも変わらない。
+    -- 何を入れると効くかは handbook/configuration.md の表を見る。
+    env = {},
     subagent = {
       enabled = false,
       show_prefix = false,

--- a/lua/vibing/core/types.lua
+++ b/lua/vibing/core/types.lua
@@ -38,6 +38,7 @@
 ---@field permissions_deny string[]?
 ---@field permissions_ask string[]?
 ---@field permission_mode string?
+---@field env string[]? チャットのfrontmatter `env:` に書かれた`KEY=VALUE`の並び。`agent.env`より優先される（`infrastructure/adapter/modules/agent_environment.lua`）
 ---@field cwd string? Effective working directory used for project-local configuration
 ---@field on_tool_use fun(tool: string, file_path: string?)?
 ---@field on_tool_use_full fun(tool: string, input: table)? 表示用に間引かない生のツール入力（eval用）

--- a/lua/vibing/infrastructure/adapter/claude_cli.lua
+++ b/lua/vibing/infrastructure/adapter/claude_cli.lua
@@ -5,6 +5,7 @@
 local Base = require("vibing.infrastructure.adapter.base")
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local RpcEnvironment = require("vibing.infrastructure.adapter.modules.rpc_environment")
+local AgentEnvironment = require("vibing.infrastructure.adapter.modules.agent_environment")
 local CLICommandBuilder = require("vibing.infrastructure.adapter.modules.cli_command_builder")
 local CLIEventProcessor = require("vibing.infrastructure.adapter.modules.cli_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
@@ -131,6 +132,11 @@ function ClaudeCLI:stream(prompt, opts, on_chunk, on_done)
   local env = vim.fn.environ()
   -- Remove CLAUDECODE to allow nested invocation
   env.CLAUDECODE = nil
+
+  -- Ahead of everything below, so a declared variable reads exactly like one the user exported:
+  -- vibing.nvim's own variables still overwrite it, and the git-instructions default below still
+  -- sees "already set, leave it alone".
+  AgentEnvironment.apply(env, self.config, opts)
 
   -- Claude Code forwards this environment to plugin MCP servers, so the numeric port stays out
   -- of the cached prompt.

--- a/lua/vibing/infrastructure/adapter/modules/agent_environment.lua
+++ b/lua/vibing/infrastructure/adapter/modules/agent_environment.lua
@@ -1,0 +1,130 @@
+--- User-declared environment variables for the CLI child process.
+---
+--- Claude Code exposes several cost-related knobs only through the environment
+--- (`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, `BASH_MAX_OUTPUT_LENGTH`, `CLAUDE_CODE_SUBAGENT_MODEL`, …).
+--- Exporting them from `init.lua` reaches the child too, but it also reaches every other `claude`
+--- on the machine and cannot vary per chat. `agent.env` and the chat's `env:` frontmatter are the
+--- two scoped ways in; this module is the single place that decides what they may write.
+--- @module vibing.infrastructure.adapter.modules.agent_environment
+
+local Notify = require("vibing.core.utils.notify")
+
+local M = {}
+
+--- Reported once per key rather than per turn: the sources are a `setup()` table and a chat's
+--- frontmatter, so a bad key is static and would otherwise warn on every request.
+local warned = {}
+
+local function warn_once(key, message)
+  if warned[key] then
+    return
+  end
+  warned[key] = true
+  Notify.warn(message)
+end
+
+--- Variables vibing.nvim owns in the child environment.
+---
+--- `CLAUDECODE` is unset so a nested invocation is possible at all, and the `VIBING_*` family
+--- carries the RPC port and the handle ID that tie the child back to this Neovim and this chat
+--- buffer. Letting a config value write either would break the hook round trip — the permission
+--- gate, the diff baseline and the approval UI all ride on it — so they are refused rather than
+--- merged.
+--- @param key string
+--- @return boolean
+function M.is_reserved(key)
+  return key == "CLAUDECODE" or key:match("^VIBING_") ~= nil
+end
+
+--- Normalize one value to the string `vim.system` expects.
+--- @param key string
+--- @param value any
+--- @return string?
+local function normalize(key, value)
+  local kind = type(value)
+  if kind == "string" then
+    return value
+  end
+  if kind == "number" then
+    return tostring(value)
+  end
+  -- A boolean or a table has no single obvious spelling in an environment ("true"? "1"?), and
+  -- guessing one would set a variable the user did not write.
+  warn_once(key, string.format("agent.env.%s: expected a string or a number, got %s. Ignored.", key, kind))
+  return nil
+end
+
+--- Read the frontmatter form, a list of `KEY=VALUE` strings.
+---
+--- A list rather than a nested map because the chat frontmatter parser is flat by design
+--- (`infrastructure/storage/frontmatter.lua`): it understands scalars and block lists, and an
+--- indented `key: value` under `env:` is silently dropped. `KEY=VALUE` is the shape `env(1)` uses
+--- and the shape the existing list fields already round-trip.
+--- @param value any the raw `env` frontmatter value
+--- @return table<string, string>
+function M.parse_entries(value)
+  local out = {}
+  for _, entry in ipairs(require("vibing.infrastructure.storage.frontmatter").as_list(value)) do
+    local text = tostring(entry)
+    local key, raw = text:match("^%s*([%w_]+)%s*=(.*)$")
+    if key then
+      out[key] = vim.trim(raw)
+    else
+      -- Namespaced, so a malformed entry spelled like a variable name does not silence the
+      -- reserved-key warning for that name, or the other way round.
+      warn_once(
+        "entry:" .. text,
+        string.format("Invalid env frontmatter entry '%s': expected KEY=VALUE. Ignored.", text)
+      )
+    end
+  end
+  return out
+end
+
+--- Merge `agent.env` and the chat's `env:` frontmatter into a child environment, in place.
+---
+--- Applied before `RpcEnvironment.bind` and the `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` default so
+--- that a declared variable behaves exactly like one the user exported: vibing.nvim's own
+--- variables still win, and a variable with its own config knob still reads "already set, leave it
+--- alone".
+--- @param env table<string, string> the child environment, mutated
+--- @param config Vibing.Config?
+--- @param opts Vibing.AdapterOpts?
+function M.apply(env, config, opts)
+  opts = opts or {}
+  -- A lightweight utility call runs with no tools and no resumed session, so every variable this
+  -- feature is for (autocompaction, Bash output length, the subagent model) has nothing to act on.
+  if opts.lightweight then
+    return
+  end
+
+  local declared = {}
+  local from_config = config and config.agent and config.agent.env
+  if type(from_config) == "table" then
+    for key, value in pairs(from_config) do
+      declared[key] = value
+    end
+  end
+  -- The chat's own frontmatter is the narrower scope, so it wins over `setup()`.
+  for key, value in pairs(M.parse_entries(opts.env)) do
+    declared[key] = value
+  end
+
+  for key, value in pairs(declared) do
+    if M.is_reserved(key) then
+      warn_once(key, string.format("%s is set by vibing.nvim and cannot be overridden by env. Ignored.", key))
+    else
+      local normalized = normalize(key, value)
+      if normalized then
+        env[key] = normalized
+      end
+    end
+  end
+end
+
+--- Forget which keys have already been warned about. Test seam.
+function M._reset_warnings()
+  warned = {}
+end
+
+return M

--- a/lua/vibing/infrastructure/storage/frontmatter.lua
+++ b/lua/vibing/infrastructure/storage/frontmatter.lua
@@ -178,6 +178,7 @@ local KEY_ORDER = {
   "agent",
   "model",
   "effort",
+  "env",
   "permission_mode",
   "permissions_allow",
   "permissions_deny",

--- a/tests/lua/infrastructure/adapter/claude_cli_spec.lua
+++ b/tests/lua/infrastructure/adapter/claude_cli_spec.lua
@@ -1,19 +1,21 @@
 ---@diagnostic disable: undefined-field
---- Covers the part of the child environment only `claude_cli` decides: whether the CLI computes
---- its own git status block.
+--- Covers the parts of the child environment only `claude_cli` decides: whether the CLI computes
+--- its own git status block, and the variables the user declared through `agent.env` / the chat's
+--- `env:` frontmatter.
 ---
---- It is an environment assertion rather than an argv one because the CLI has no flag for it, and
---- it belongs here rather than in `stream_options_spec` because no other backend reads the
---- variable. What it protects is a cache property, so nothing downstream fails loudly when it
+--- They are environment assertions rather than argv ones because the CLI has no flag for either,
+--- and they belong here rather than in `stream_options_spec` because no other backend reads them.
+--- What the first protects is a cache property, so nothing downstream fails loudly when it
 --- lapses -- the turns simply cost more.
 
 local helper = require("tests.helpers.adapter_stream")
 local claude = require("vibing.infrastructure.adapter.claude_cli")
+local AgentEnvironment = require("vibing.infrastructure.adapter.modules.agent_environment")
 
 local CONFIG = { agent = { default_model = "sonnet" } }
 local VAR = "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS"
 
-describe("claude_cli git instructions", function()
+describe("claude_cli environment", function()
   local system, ambient
 
   before_each(function()
@@ -38,26 +40,91 @@ describe("claude_cli git instructions", function()
     return system.only_call().opts.env
   end
 
-  it("disables the block by default", function()
-    assert.equals("1", env_for().CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+  describe("git instructions", function()
+    it("disables the block by default", function()
+      assert.equals("1", env_for().CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+    end)
+
+    it("disables it on lightweight calls too", function()
+      -- `--setting-sources ""` does not reach this: the block comes from the CLI's own startup, not
+      -- from project settings, so a title generation would otherwise carry a per-turn prefix as well.
+      assert.equals("1", env_for(nil, { lightweight = true }).CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+    end)
+
+    it("forces the block back on when git_instructions is set", function()
+      -- "0", not unset: unset falls through to `includeGitInstructions` in the user's settings.json,
+      -- so a user who has that key set to false would ask for the block and not get it.
+      assert.equals("0", env_for({ git_instructions = true }).CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+    end)
+
+    it("does not overwrite a value the user set", function()
+      -- "0" is the CLI's own way of forcing the block back on, so overwriting it would take away
+      -- the escape hatch rather than merely duplicating the setting.
+      vim.env[VAR] = "0"
+      assert.equals("0", env_for().CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+    end)
+
+    it("yields to a value declared through agent.env", function()
+      -- `agent.env` is applied first and this default only fills a gap, so the more specific
+      -- statement wins -- the same way an exported variable does.
+      assert.equals(
+        "0",
+        env_for({ env = { CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS = "0" } }).CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS
+      )
+    end)
   end)
 
-  it("disables it on lightweight calls too", function()
-    -- `--setting-sources ""` does not reach this: the block comes from the CLI's own startup, not
-    -- from project settings, so a title generation would otherwise carry a per-turn prefix as well.
-    assert.equals("1", env_for(nil, { lightweight = true }).CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
-  end)
+  describe("agent.env", function()
+    before_each(function()
+      -- Module-level and therefore process-wide: another spec file having already warned about a
+      -- key would otherwise silence the assertion below.
+      AgentEnvironment._reset_warnings()
+    end)
 
-  it("forces the block back on when git_instructions is set", function()
-    -- "0", not unset: unset falls through to `includeGitInstructions` in the user's settings.json,
-    -- so a user who has that key set to false would ask for the block and not get it.
-    assert.equals("0", env_for({ git_instructions = true }).CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
-  end)
+    --- `env_for`'s `only_call` allows one spawn per test; this one compares two.
+    local function next_env(agent, opts)
+      local config = { agent = vim.tbl_extend("force", CONFIG.agent, agent or {}) }
+      helper.run_stream(claude:new(config), opts)
+      local env = system.calls[#system.calls].opts.env
+      -- Regenerated per stream by design (it keys the hook back to this turn), so it is the one
+      -- key two spawns are expected to differ on.
+      env.VIBING_HANDLE_ID = nil
+      return env
+    end
 
-  it("does not overwrite a value the user set", function()
-    -- "0" is the CLI's own way of forcing the block back on, so overwriting it would take away
-    -- the escape hatch rather than merely duplicating the setting.
-    vim.env[VAR] = "0"
-    assert.equals("0", env_for().CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS)
+    it("puts declared variables in the spawn environment", function()
+      local env =
+        env_for({ env = { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = 20, BASH_MAX_OUTPUT_LENGTH = "10000" } })
+      assert.equals("20", env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE)
+      assert.equals("10000", env.BASH_MAX_OUTPUT_LENGTH)
+    end)
+
+    it("lets the chat's frontmatter override the config", function()
+      local env = env_for({ env = { CLAUDE_CODE_SUBAGENT_MODEL = "sonnet" } }, {
+        env = { "CLAUDE_CODE_SUBAGENT_MODEL=haiku" },
+      })
+      assert.equals("haiku", env.CLAUDE_CODE_SUBAGENT_MODEL)
+    end)
+
+    it("changes nothing when unset", function()
+      -- The whole environment, not one key: the feature has to be invisible to a user who never
+      -- set it, since every variable it can carry changes what the turn costs.
+      assert.same(next_env(), next_env({ env = {} }))
+    end)
+
+    it("cannot take over the variables that bind the child to this Neovim", function()
+      local env = env_for({
+        env = { VIBING_NVIM_RPC_PORT = "1234", VIBING_HANDLE_ID = "spoofed", CLAUDECODE = "1" },
+      })
+      -- 9999 is what the helper stubs the RPC server to report.
+      assert.equals("9999", env.VIBING_NVIM_RPC_PORT)
+      assert.is_not.equals("spoofed", env.VIBING_HANDLE_ID)
+      assert.is_nil(env.CLAUDECODE)
+    end)
+
+    it("does not reach a lightweight call", function()
+      local env = env_for({ env = { BASH_MAX_OUTPUT_LENGTH = "10000" } }, { lightweight = true })
+      assert.is_nil(env.BASH_MAX_OUTPUT_LENGTH)
+    end)
   end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/agent_environment_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/agent_environment_spec.lua
@@ -1,0 +1,104 @@
+--- The rules `agent.env` / frontmatter `env:` are merged under, away from the spawn.
+---
+--- `claude_cli_spec` asserts the same feature through a real `stream()` call, which is what the
+--- acceptance criteria ask for; this file is where the branches that never reach a spawn live --
+--- a malformed entry, a reserved key, a value with no obvious spelling.
+
+local AgentEnvironment = require("vibing.infrastructure.adapter.modules.agent_environment")
+
+--- @param agent_env table? config.agent.env
+--- @param frontmatter_env any? the raw `env` frontmatter value
+--- @param opts table? extra adapter opts
+local function apply(agent_env, frontmatter_env, opts)
+  local env = { PATH = "/usr/bin" }
+  AgentEnvironment.apply(
+    env,
+    { agent = { env = agent_env } },
+    vim.tbl_extend("force", { env = frontmatter_env }, opts or {})
+  )
+  return env
+end
+
+describe("agent_environment", function()
+  local warnings, original_notify
+
+  before_each(function()
+    AgentEnvironment._reset_warnings()
+    warnings = {}
+    original_notify = vim.notify
+    vim.notify = function(message)
+      table.insert(warnings, message)
+    end
+  end)
+
+  after_each(function()
+    vim.notify = original_notify
+  end)
+
+  it("leaves the environment untouched when nothing is declared", function()
+    assert.same({ PATH = "/usr/bin" }, apply())
+    assert.same({ PATH = "/usr/bin" }, apply({}, {}))
+  end)
+
+  it("merges config values, stringifying numbers", function()
+    local env = apply({ CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = 20, BASH_MAX_OUTPUT_LENGTH = "10000" })
+    assert.equals("20", env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE)
+    assert.equals("10000", env.BASH_MAX_OUTPUT_LENGTH)
+  end)
+
+  it("lets the chat's frontmatter win over the config", function()
+    -- The narrower scope wins, the same way frontmatter `model:` overrides `default_model`.
+    local env = apply({ BASH_MAX_OUTPUT_LENGTH = "10000" }, { "BASH_MAX_OUTPUT_LENGTH=2000" })
+    assert.equals("2000", env.BASH_MAX_OUTPUT_LENGTH)
+  end)
+
+  it("reads a frontmatter entry written as a bare string", function()
+    -- The parser returns a string rather than a list for a hand-written `env: KEY=VALUE`.
+    assert.equals("haiku", apply(nil, "CLAUDE_CODE_SUBAGENT_MODEL=haiku").CLAUDE_CODE_SUBAGENT_MODEL)
+  end)
+
+  it("ignores a frontmatter entry that is not KEY=VALUE", function()
+    local env = apply(nil, { "BASH_MAX_OUTPUT_LENGTH", "MAX_THINKING_TOKENS=4096" })
+    assert.is_nil(env.BASH_MAX_OUTPUT_LENGTH)
+    assert.equals("4096", env.MAX_THINKING_TOKENS)
+    assert.equals(1, #warnings)
+  end)
+
+  it("refuses the variables vibing.nvim owns", function()
+    -- These carry the RPC port, the handle ID and the nested-invocation escape. A config value
+    -- writing one would break the hook round trip that the permission gate and the diff baseline
+    -- both ride on.
+    local env = apply({ CLAUDECODE = "1", VIBING_NVIM_RPC_PORT = "1234", VIBING_HANDLE_ID = "x" })
+    assert.is_nil(env.CLAUDECODE)
+    assert.is_nil(env.VIBING_NVIM_RPC_PORT)
+    assert.is_nil(env.VIBING_HANDLE_ID)
+    assert.equals(3, #warnings)
+  end)
+
+  it("refuses a reserved key from frontmatter too", function()
+    assert.is_nil(apply(nil, { "VIBING_NVIM_CONTEXT=false" }).VIBING_NVIM_CONTEXT)
+    assert.equals(1, #warnings)
+  end)
+
+  it("ignores a value with no obvious spelling", function()
+    local env = apply({ SOME_FLAG = true, OTHER = { 1 } })
+    assert.is_nil(env.SOME_FLAG)
+    assert.is_nil(env.OTHER)
+    assert.equals(2, #warnings)
+  end)
+
+  it("warns once per key rather than once per turn", function()
+    for _ = 1, 3 do
+      apply({ CLAUDECODE = "1" })
+    end
+    assert.equals(1, #warnings)
+  end)
+
+  it("passes nothing to a lightweight call", function()
+    -- No tools and no resumed session, so autocompaction, Bash output length and the subagent
+    -- model have nothing to act on.
+    local env =
+      apply({ BASH_MAX_OUTPUT_LENGTH = "10000" }, { "MAX_THINKING_TOKENS=4096" }, { lightweight = true })
+    assert.same({ PATH = "/usr/bin" }, env)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

Claude Code のコスト系のつまみには環境変数でしか触れないものがある（`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` / `BASH_MAX_OUTPUT_LENGTH` / `CLAUDE_CODE_SUBAGENT_MODEL` など）。`init.lua` で `vim.env.X = ...` すれば今でも子プロセスには届くが、それはそのNeovimから起動する全ての `claude` に効いてしまうし、チャットごとに変えることもできない。

`agent.env`（全体）とチャットfrontmatterの `env:`（個別）を追加して、vibing.nvim経由の呼び出しにだけスコープを絞れるようにした。

## Changes

- `lua/vibing/infrastructure/adapter/modules/agent_environment.lua` を新設。`agent.env` と frontmatter `env:` をマージして子プロセスのenvに書く唯一の場所
  - 値は文字列化（数値も可）。boolean/tableは綴りが一意に決まらないので警告して無視
  - frontmatter が `agent.env` を上書きする（`model` と `default_model` の関係と同じく、狭いスコープが勝つ）
  - `CLAUDECODE` と `VIBING_*` は警告して無視。RPCポート・handle_id・ネスト起動のescapeを載せていて、権限フック／承認UI／差分ベースラインが全部そこに乗っているため
  - 軽量ユーティリティ呼び出し（タイトル生成・`/summarize`・デイリーサマリ）には渡さない。ツールもresumeも無いので効く先が無い
  - 警告はキーごとに1回だけ。設定とfrontmatterはどちらも静的なので、毎ターン鳴らす意味がない
- `claude_cli.lua` の env 組み立てに `AgentEnvironment.apply` を挿入。`RpcEnvironment.bind` と `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS` の既定より**前**に置いてあるので、宣言した変数は「ユーザーがexportした変数」と全く同じ振る舞いになる（vibing.nvim自身の変数は後から必ず上書きし、`git_instructions` の既定は「既に立っているなら触らない」を維持する）
- frontmatter `env:` は `KEY=VALUE` の文字列リスト。frontmatterパーサは設計上フラット（インデントされた `key: value` は黙って捨てられる）なので、ネストしたマップではなく既存のリストフィールドと同じ形にした
- `inherited_frontmatter.lua` で fork / subagent chat に引き継ぐ（`model` / `effort` と同じ「このチャットのCLIをどう起動するか」の一部）
- ドキュメント: `handbook/configuration.md` に変数の表・推奨値・`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` が `[1m]` と 200k モデルで実効値が変わる話を追加。`doc/vibing.txt` の CHAT FILE FORMAT に `env:` を追加

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

- [x] Ran `pnpm test`（`test:lua` + `test:node`）
- [x] Ran `pnpm run check` / `check:doc` / `lint` / `format:check`

新規テスト:

- `tests/lua/infrastructure/adapter/modules/agent_environment_spec.lua` — spawnまで行かない分岐（不正なエントリ、予約キー、綴りの決まらない値、once-per-key警告）
- `tests/lua/infrastructure/adapter/claude_cli_spec.lua` — 受け入れ条件どおり `vim.system` の呼び出し引数を検証。「設定した変数がenvに入る」「未設定ならenvが1バイトも変わらない」「`VIBING_*` / `CLAUDECODE` を乗っ取れない」「lightweightには届かない」

注: `pnpm test` は本ブランチのベース（`4c5deba`）時点で `message_queue_spec` / rpcハンドラ系に7件の失敗があり、本PRの変更をstashした状態でも同じ7件が出る。本PRで増減はしていない。

## Documentation

- [x] doc/vibing.txt updated
- [x] Code comments added/updated

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally with my changes

## Related Issues

Fixes #676

## Additional Context

issue の記載どおり Claude バックエンドのみ。codex / copilot / grok は従来どおり Neovim の環境をそのまま継承し、これらの名前は読まない。他バックエンドへ広げるときは各アダプタで `AgentEnvironment.apply` を1行呼ぶだけで済む形にしてある。
