### PR TITLE
fix(orchestration): canonicalize chat paths in task projection and close out the #692 postmortem

### DIFF
--- a/handbook/architecture/orchestration.md
+++ b/handbook/architecture/orchestration.md
@@ -70,6 +70,17 @@ colon-space or a space-`#` inside it, or text that would read back as a boolean 
 `PR #688 -- review` comes out as `task: "PR #688 -- review"`, because a `#` after a space opens a
 comment in plain YAML.
 
+**The projection matches on a canonicalized path, and it has to.** Decoding the entry correctly is
+only half of it — the two sides of the match are spelled by different code: an `orchestrated` entry
+is written from `nvim_buf_get_name`, where Vim has already followed any symlink, while the row it
+must land on is keyed by the path `create_chat` assembled. Reach the chat directory through a link
+and one file has two spellings, the string match misses, and the only symptom is a `task` that is
+silently absent, which reads as "never assigned" rather than as a failure. `project_tasks` and both
+of its callers therefore go through one `canonical_path` (`resolve` ∘ `:p`, the same normalization
+`turn_state.lua` uses to key a chat), and a spec pointing `save_dir` at a symlink pins it — a
+developer on macOS hits it through `$TMPDIR` (`/var` → `/private/var`) while Linux CI stays green,
+so the platform that shows the bug is not the one that gates it.
+
 One design was rejected on the way here:
 
 - **A `task` field on the driven chat's own frontmatter** (the first shape this feature shipped
@@ -343,6 +354,35 @@ Four things about it are not incidental:
   whose **sender** was the deleted chat is still deliverable, so it loses only the sender's name
   and arrives anonymously.
 
+**The queue is written to disk on every change, because "wait and it resolves" outlived the
+process** (#697). `queue_if_busy` promises the sender that a message refused for being untimely is
+still going to arrive; the recipient it is waiting on is very often parked on a usage limit, which
+is a wait measured in hours and the exact window `pending_resume.lua` was built for — so a Neovim
+restart across it took the whole in-memory `pending` table with it, and the report the sender was
+told was safe was gone with nothing on disk to show it had existed. The live queue is still the
+in-memory table; `infrastructure/storage/message_queue_store.lua` is a mirror written by `persist()`
+after every mutation and read back by `M.restore()`, deferred with `vim.schedule` out of `setup()`
+in `init.lua` next to `auto_resume.restore()`, for the same reason and off the startup path.
+
+Three consequences of it being a mirror rather than the primary copy:
+
+- **The store is keyed by chat _file path_, not bufnr**, since a bufnr is only meaningful inside the
+  process that issued it. `restore` resolves each path back to a buffer the way `auto_resume` does
+  (load it, attach it if it is not a tracked chat buffer yet), and delivery is attempted immediately
+  via `flush`. An entry whose **destination file no longer exists** is deleted from the store; one
+  that merely fails to resolve this time is left alone, so a transient failure retries on the next
+  start rather than discarding the message.
+- **A destination with no file name is not persisted at all** and does not warn. A chat created by
+  `:VibingChat` and not yet saved has no path to reopen after a restart, and that state is ordinary
+  rather than exceptional — but such a chat is also reachable right now, so the in-memory queue is
+  the only copy that was ever going to matter for it.
+- **A corrupt or unreadable `message-queue.json` yields an empty table**, saying so once per read
+  and never raising. Failing
+  toward "nothing restored" is the safe direction while the in-memory copy is authoritative; failing
+  loudly at startup would break every chat in the session over a file that only matters after a
+  crash. `save` writes an explicit `{}` for an empty store, because `vim.json.encode` renders an
+  empty Lua table as `[]` and that decodes back as a list, breaking every keyed lookup afterwards.
+
 **A message the sender delivered itself silences the watchdog for one stop.** A send is one event
 with two opposite consequences, so `completion_notifier.on_sent(from, to)` performs both rather
 than leaving the pairing to each caller: it records `edges[to][from]` (the send _is_ the
@@ -584,9 +624,12 @@ path that line describes was never gated). Only that direction is exposed: a wor
 is written once at creation and stays byte-stable across turns (#469), while an orchestrator's
 `orchestrated` grows with each dispatch and would move the cached prefix mid-conversation.
 
-**Out of scope, deliberately:** the orchestrator still does not poll inside its own turn, and
-nothing is persisted — the subscription table and the delivery queue are in memory only, since
-Neovim dying takes the worker chats with it. Backends other than claude can be _notified_ (the
+**Out of scope, deliberately:** the orchestrator still does not poll inside its own turn, and the
+subscription table stays in memory only. The delivery queue no longer does (#697, above), and the
+split is the point: a queued message is a promise made to a sender that must outlive the wait, while
+an `edges` entry is a one-shot subscription to a _stop event_ — and the turn whose stop it was
+waiting for died with the process, so restoring it would arm a wake-up that can never fire.
+Backends other than claude can be _notified_ (the
 event is backend-agnostic) but cannot _subscribe_: `nvim_chat_send_message` is an MCP tool, and
 codex/grok reach no MCP server, the same constraint `features.md` records for AskUserQuestion.
 

--- a/lua/vibing/infrastructure/rpc/handlers/chat.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/chat.lua
@@ -182,6 +182,20 @@ local function sorted_bufnrs(buffers)
   return bufnrs
 end
 
+---`by_absolute_path`の鍵。**両側を必ずこれに通す**
+---
+---投影は「親の`orchestrated`が書いたパス」と「開いているチャットの`file_path`」の文字列一致で
+---決まるが、この2つは出どころが違う: 前者は`nvim_buf_get_name`（Vimがシンボリックリンクを
+---解決したあとの綴り）から、後者はチャット作成時に組み立てたパスから来る。macOSの`$TMPDIR`
+---（`/var` → `/private/var`）のように途中にリンクがあると、同じ1つのファイルが2通りに綴られ、
+---一致が黙って外れる — 失敗は「taskが出ない」だけなので、誤りではなく「頼まれていない」に見える。
+---`turn_state.lua`がチャットパスを鍵にするときと同じ正規化を使う
+---@param path string
+---@return string
+local function canonical_path(path)
+  return vim.fn.resolve(vim.fn.fnamemodify(path, ":p"))
+end
+
 ---taskはチャット自身のfrontmatterではなく、それを頼んだ親の`orchestrated`エントリにしか
 ---無い（#696フォローアップ）。今このセッションで開いている全チャットの`orchestrated`を
 ---展開し、一致するbufnrの行（`by_absolute_path`）に投影する — 対象は既に読み込み済みのチャット
@@ -201,8 +215,7 @@ local function project_tasks(buffers, bufnrs, by_absolute_path, git_root)
       for _, item in ipairs(orchestrated) do
         local path, task = OrchestratedEntry.decode(item)
         if path and task then
-          local abs = vim.fn.fnamemodify(Git.from_display_path(path, git_root), ":p")
-          local target = by_absolute_path[abs]
+          local target = by_absolute_path[canonical_path(Git.from_display_path(path, git_root))]
           if target then
             target.task = task
           end
@@ -242,7 +255,7 @@ function M.list_chats(_)
     }
     table.insert(chats, entry)
     if chat_buf.file_path then
-      by_absolute_path[vim.fn.fnamemodify(chat_buf.file_path, ":p")] = entry
+      by_absolute_path[canonical_path(chat_buf.file_path)] = entry
     end
   end
 
@@ -354,7 +367,7 @@ function M.chat_conflicts(_)
       if files then
         local entry = { bufnr = bufnr, file_path = chat_buf.file_path }
         if chat_buf.file_path then
-          by_absolute_path[vim.fn.fnamemodify(chat_buf.file_path, ":p")] = entry
+          by_absolute_path[canonical_path(chat_buf.file_path)] = entry
         end
         for _, file in ipairs(files) do
           contributors_by_file[file] = contributors_by_file[file] or {}

--- a/tests/lua/application/chat/message_queue_spec.lua
+++ b/tests/lua/application/chat/message_queue_spec.lua
@@ -328,7 +328,11 @@ describe("MessageQueue persistence (#697)", function()
   end
 
   before_each(function()
-    tmp_root = vim.fn.tempname()
+    -- `resolve` は他の一時ディレクトリを使う spec と同じ理由: macOS の `$TMPDIR` は
+    -- `/var` → `/private/var` のリンク下にあり、`bufadd` したバッファの名前は解決後の綴りに
+    -- なる。ストアの鍵はその名前（`file_path_of`）なので、解決前の綴りで組み立てた
+    -- `tmp_root .. "/a.md"` とは一致しない
+    tmp_root = vim.fn.resolve(vim.fn.tempname())
     vim.fn.mkdir(tmp_root, "p")
     Store.clear_cache()
 

--- a/tests/lua/infrastructure/rpc/handlers/chat_list_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/chat_list_spec.lua
@@ -89,6 +89,33 @@ describe("rpc handlers: list_chats", function()
     assert.equals("Issue #696 -- task frontmatter", find_chat(result.chats, issue696.bufnr).task)
   end)
 
+  it("projects the task when the chat directory is reached through a symlink", function()
+    -- The two sides of the projection are spelled by different code: the parent's `orchestrated`
+    -- entry comes from `nvim_buf_get_name` (Vim has already followed the link), the row it has to
+    -- land on comes from the path `create_chat` assembled. Point `save_dir` at a symlink and the
+    -- two spellings differ for every chat -- which is what macOS's `$TMPDIR` (`/var` ->
+    -- `/private/var`) does to this spec's own fixtures on a developer machine while CI stays green.
+    local real_dir = vim.fn.resolve(vim.fn.tempname()) .. "_real/"
+    vim.fn.mkdir(real_dir, "p")
+    local link_dir = vim.fn.resolve(vim.fn.tempname()) .. "_link"
+    vim.fn.system({ "ln", "-s", real_dir, link_dir })
+    if vim.v.shell_error ~= 0 then
+      -- A platform without symlinks cannot exhibit the bug either
+      return
+    end
+    require("vibing").setup({ chat = { save_location_type = "custom", save_dir = link_dir .. "/" } })
+
+    local orchestrator = handler.create_chat({})
+    local worker = handler.create_chat({ from_bufnr = orchestrator.bufnr, task = "PR #688 -- merge" })
+
+    local result = handler.list_chats({})
+
+    assert.equals("PR #688 -- merge", find_chat(result.chats, worker.bufnr).task)
+
+    vim.fn.delete(link_dir)
+    vim.fn.delete(real_dir, "rf")
+  end)
+
   it("reports no context_size for a chat that has not completed a turn", function()
     handler.create_chat({})
 


### PR DESCRIPTION
## 概要

#692（5チャット並行オーケストレーションのポストモーテム）の棚卸しと、その過程で見つかった取りこぼしの修正。

**#692 が挙げた改善項目 3.1〜3.9 / 4章は、すべて子issue #693〜#706 として分割済みで、全部クローズ済みだった。** このPRは「残っていたもの」だけを扱う。

## 変更内容

### 1. `nvim_chat_list` / `nvim_chat_conflicts` の task 投影が、シンボリックリンク越しだと黙って外れる（バグ修正）

`#692` の 3.8（割り当てを frontmatter に残す = #696）と 3.2（`nvim_chat_list` = #695）が実装された結果、
「親の `orchestrated` エントリに書かれた task を、開いているチャットの行に投影する」という突き合わせが入った。
この突き合わせはパス文字列の一致で決まるが、両辺の綴りを作っているコードが別:

- `orchestrated` エントリ側 … `nvim_buf_get_name`（Vimがシンボリックリンクを解決したあとの綴り）
- 投影先の行の鍵 … `create_chat` が組み立てたパス（未解決）

チャットの保存先がリンクを経由していると同じファイルが2通りに綴られ、一致が外れる。
**症状は「task が出ない」だけ**なので、失敗ではなく「そもそも割り当てられていない」に見える。

`project_tasks` と2つの呼び出し元を1つの `canonical_path`（`resolve` ∘ `:p`、`turn_state.lua` がチャットを鍵にするときと同じ正規化）に通すよう修正した。
回帰テストは `save_dir` をシンボリックリンクに向けるので、macOS 固有の再現条件に依存せず Linux でも落ちる。

### 2. macOS で `pnpm test` が落ちていた（テスト修正）

`main`（4c5deba）時点で、このマシンでは `test:lua` が exit 1 になっていた。内訳は上記1に起因する3件と、
`message_queue_spec.lua` の4件。後者はストアの鍵（バッファのファイル名 = 解決済み）と、specが手で組み立てた
期待値（`vim.fn.tempname()` = 未解決）の不一致で、macOS の `$TMPDIR`（`/var` → `/private/var`）だけで起きる。
このリポジトリの他の一時ディレクトリ spec が既にやっている `vim.fn.resolve(vim.fn.tempname())` に揃えた。

Linux CI は緑のままだったので、**CI では見えず開発機だけで落ちる**種類の失敗だった。

### 3. handbook が #697 の実装と逆のことを書いていた（ドキュメント修正）

`handbook/architecture/orchestration.md` は `nothing is persisted — the subscription table and the delivery queue are in memory only` と書いていたが、
#697（3.5 キューの耐久性）で配達キューは `.vibing/message-queue.json` にミラーされるようになっている。
何を鍵にしているか / 復元できなかったエントリをどう扱うか（宛先ファイルが消えていれば削除、解決に失敗しただけなら次回に持ち越す）/
なぜ購読テーブル（`edges`）だけは今も永続化しないのか（待っていた停止イベント自体がプロセスと共に死んでいるので、復元しても発火しない目覚ましを仕掛けることになる）を追記した。

## #692 の棚卸し結果

| #692 の項目 | 子issue | 状態 |
| --- | --- | --- |
| 3.1 通知に末尾を載せる | #693 | 実装 → PR #709 でリバートし、`nvim_get_buffer({last_section, tail_lines})` に誘導する形で決着 |
| 3.1 追加案（最終テキストの自動配達） | #702 | not planned（#710 で前提が変わった、通知の意味論を崩す） |
| 3.2 `nvim_chat_list` / 部分読み取り | #695 / #694 | 実装済み |
| 3.3 並行ブランチの衝突警告 | #699 | 実装済み（`nvim_chat_conflicts`） |
| 3.4 並列度管理 | #701 / #700 | #701 実装済み、#700 は #701 に吸収され not planned |
| 3.5 キューの耐久性 | #697 | 実装済み（本PRでドキュメント補完） |
| 3.6 auto-resume の枯渇が見えない | #698 | 実装済み |
| 3.7 承認委譲の粒度 | #703 | 実装済み（`delegated_approval = "scoped"`） |
| 3.8 割り当てを frontmatter に残す | #696 | 実装済み（本PRで投影のバグを修正） |
| 3.9 E2E成果物の混入 | #704 | 実装済み |
| 4章・5章（チャット vs サブエージェント、運用ルール） | #705 | SKILL.md に反映済み |
| （2.1 の真因: 報告契約がブリーフ依存だった） | #706 | 実装済み（system prompt への注入） |

`#690`（MCPサーバー起動期限）と `#691`（依存の脆弱性監視）は #692 の「関連」に挙がっているだけで、
#692 自身のアクション項目ではないため、このPRの対象外。

## 検証

- `pnpm test`（`test:lua` 182ファイル / `test:node` 61件）… 通過（修正前は `test:lua` が exit 1）
- `pnpm run check` / `pnpm run lint` / `pnpm run check:doc` / `pnpm run format:check` … 通過
- `pnpm run lint:md` … 本PRで触ったファイルにエラーなし（リポジトリ全体には621件の既存エラーがあり、いずれも未変更ファイル）
- `test:eval` は実行していない

fixes #692


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat and task matching when files or save directories are accessed through symbolic links.
  - Improved handling of chat paths across different path representations.

- **Documentation**
  - Documented how task paths are normalized for consistent matching.
  - Documented delivery queue persistence, including deleted files, unnamed destinations, and corrupted data.
  - Clarified which application state remains in memory only.

- **Tests**
  - Added coverage for symbolic-link save directories and normalized temporary paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->