### PR TITLE
feat(mcp): add agent.mcp.user_servers to exclude user-level MCP servers

### DIFF
--- a/handbook/architecture/plugin-and-commands.md
+++ b/handbook/architecture/plugin-and-commands.md
@@ -86,6 +86,29 @@ Reaching a running Neovim was the entire point of them, so no opt-in was added.
 `.claude-plugin/marketplace.json` is kept — a manual `claude plugin install` still works, and
 deleting it can happen later.
 
+## User MCP servers, and what `--strict-mcp-config` takes with them
+
+`agent.mcp.user_servers = false` (#677) is served by `adapter/modules/cli_mcp_config.lua`. The
+user-facing half — what it costs, what else it drops, the escape hatch — is
+`handbook/configuration.md` → "Excluding User MCP Servers". Two things belong here.
+
+**`--strict-mcp-config` drops a `--plugin-dir` plugin's MCP servers.** The flag's help says it
+ignores "all other MCP configurations", and a plugin manifest is one of them. Measured against
+claude 2.1.231, the `init` event goes from 204 tools (171 MCP) to 30 with zero MCP servers — all
+42 of vibing-nvim's own `nvim_*` tools gone, silently, since the turn still runs. So the flag can
+never be passed on its own: `cli_mcp_config.args` returns the pair, strict flag plus an explicit
+`--mcp-config` built from `plugin_contents.mcp_servers` over the same `plugin_dirs.resolve` list
+the `--plugin-dir` flags came from. The `--plugin-dir` flags stay — only the MCP half of a plugin
+is re-registered by hand; its skills and subagents still arrive through the directory.
+
+**The registered name is the bare manifest one, so the prefix changes** from
+`mcp__plugin_vibing-nvim_vibing-nvim__<tool>` to `mcp__vibing-nvim__<tool>`. Nothing downstream
+had to change, and that is by construction rather than luck:
+`tools.VIBING_NVIM_MCP_TOOL_PATTERNS` already lists both spellings, `can_use_tool`'s hook check
+matches on the suffix, and the system prompt names both forms. That prompt line must stay
+byte-identical whichever path a turn takes (#469), which is why the option is not allowed to
+rewrite it to name only the form that is live.
+
 ## Codex: the Same Plugins Without `--plugin-dir`
 
 The codex backend loads the same resolved list — `plugin_dirs.resolve_entries`, same order, same

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -32,6 +32,7 @@ require("vibing").setup({
     default_model = "sonnet",
     utility_model = "sonnet",
     setting_sources = { "user", "project", "local" },
+    mcp = { user_servers = true },
     git_instructions = false,
     subagent = { enabled = false, show_prefix = false },
     auto_resume_on_limit = { enabled = false, max_retries = 1 },
@@ -160,7 +161,19 @@ agent = {
                             -- Passed to the Claude CLI's --setting-sources flag.
                             -- Drop "user" to skip loading your global CLAUDE.md on
                             -- every chat, reducing fixed per-session token cost.
-                            -- Note: does not affect MCP server loading.
+                            -- Note: does not affect MCP server loading — that is
+                            -- agent.mcp.user_servers, right below.
+
+  mcp = {                   -- Which MCP servers an ordinary turn loads. Claude backend only.
+                            -- Not to be confused with the top-level `mcp` block, which
+                            -- configures vibing.nvim's own RPC server.
+    user_servers = true,    -- Keeps today's behaviour: every server in ~/.claude.json is
+                            -- loaded, because --setting-sources also brings in your own
+                            -- commands, skills and subagents. Set false to pass
+                            -- --strict-mcp-config and re-register only the MCP servers the
+                            -- plugins vibing.nvim loads declare — see "Excluding User MCP
+                            -- Servers".
+  },
 
   git_instructions = false, -- Claude backend only. The CLI's own git status block (branch,
                             -- `git status --short`, recent commits) plus its built-in commit/PR
@@ -381,6 +394,53 @@ skipped with a warning. One more cost: a `developer_instructions` you set in cod
 > Code gates a project's own `.mcp.json` behind approval. vibing.nvim reads the directory by
 > default anyway, on convenience grounds — set `project_dir = false` for repositories you do not
 > trust.
+
+### Excluding User MCP Servers
+
+`agent.mcp.user_servers = false` keeps an ordinary turn down to the MCP servers vibing.nvim
+brought itself:
+
+```lua
+agent = { mcp = { user_servers = false } },
+```
+
+The reason it is not the default, and the reason it is one switch rather than a per-server list,
+is `--setting-sources user,project,local`: that flag is what makes your own `.claude/commands/`,
+skills and subagents work inside a chat, and every MCP server in `~/.claude.json` rides along with
+them. The CLI's only counter-switch is `--strict-mcp-config`, which is **all-or-nothing** — it
+drops the servers a `--plugin-dir` plugin declares too. So the option is a pair: the strict flag
+plus an explicit `--mcp-config` re-registering what each loaded plugin declares.
+
+What that costs and saves, measured against claude 2.1.231 in an environment with 23 registered
+servers (9 local stdio, 14 `claude.ai` connectors), one identical one-line prompt per run:
+
+| run                                             | tools | of which MCP | prompt tokens |
+| ----------------------------------------------- | ----: | -----------: | ------------: |
+| default                                         |   204 |          171 |        46,277 |
+| `--strict-mcp-config` alone (drops vibing-nvim) |    30 |            0 |        42,323 |
+| `user_servers = false`                          |    72 |           42 |        43,293 |
+
+**~3k prompt tokens a turn, about 6%.** Small, because Tool Search (on by default from Claude
+4.5) defers the schemas: what survives in the prompt is a bare name per tool, roughly 23 tokens.
+The startup cost does not move either — the servers connect in the background, `duration_ms` was
+~2s in all three runs.
+
+With Tool Search off (`ENABLE_TOOL_SEARCH=0`) the same two runs are 241,510 and 73,344 prompt
+tokens: **168k tokens, 70%.** That is the case this option is really for.
+
+Three consequences worth knowing before switching it on:
+
+- **Project `.mcp.json` and local-scope servers go too**, not just the user-scope ones —
+  `--strict-mcp-config` does not distinguish. An external server you want to keep can be declared
+  in `.vibing/plugins/<name>/.claude-plugin/plugin.json` under `mcpServers`, which is re-registered
+  along with vibing.nvim's own.
+- **The tool prefix changes** from `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` to the plain
+  `mcp__vibing-nvim__<tool>`. Both are already permitted and both are named in the system prompt,
+  so nothing has to be reconfigured — but a hand-written permission rule naming only the plugin
+  form stops matching.
+- **Claude only.** Codex has no per-run switch narrower than `--ignore-user-config`, which also
+  drops `model_provider`; copilot and grok have none at all for ordinary turns. Lightweight calls
+  on every backend already load no MCP servers (`handbook/architecture/lightweight-calls.md`).
 
 ### Codex Provider Notice
 

--- a/handbook/mcp-tools.md
+++ b/handbook/mcp-tools.md
@@ -21,6 +21,10 @@ vibing.nvim invokes the `claude` CLI with `--setting-sources user,project,local`
 `.claude/commands/` project slash commands, `.claude/skills/`, and global settings/subagents are
 all available inside vibing.nvim sessions automatically — no extra configuration needed.
 
+The MCP half of that is the one part with an off switch: `agent.mcp.user_servers = false` keeps a
+turn down to the servers vibing.nvim's own plugins declare. What it saves and what else it drops:
+`handbook/configuration.md` → "Excluding User MCP Servers".
+
 ## Naming the Tool and the Instance
 
 Two facts decide whether a call reaches the editor the user is looking at, and both have one home

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -120,7 +120,8 @@
 ---@field utility_model string タイトル生成・要約等の軽量ユーティリティ呼び出し専用モデル（デフォルト: "sonnet"）
 ---@field default_effort ("low"|"medium"|"high"|"xhigh"|"max")? 推論量の既定値（未指定ならCLIの既定に任せる）
 ---@field utility_effort ("low"|"medium"|"high"|"xhigh"|"max")? タイトル生成・要約等の軽量呼び出しの推論量（デフォルト: "low"）
----@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）
+---@field setting_sources string[]? Claude CLIの`--setting-sources`に渡す設定読み込み元リスト（例: {"project", "local"}、デフォルト: {"user", "project", "local"}）。MCPサーバーの読み込みには影響しない（`agent.mcp`参照）
+---@field mcp Vibing.AgentMcpConfig? 通常のチャットターンにどのMCPサーバーを載せるかの設定
 ---@field git_instructions boolean? trueでClaude CLI組み込みのgitステータスブロック（ブランチ名・
 ---  直近コミット・`git status --short`）とcommit/PRワークフロー指示をsystem promptに載せる
 ---  （デフォルト: false）。どちらの値でも`CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS`を明示的に書く
@@ -158,6 +159,16 @@
 ---@field enabled boolean? trueで有効（デフォルト: false）
 ---@field at number? 圧縮を始めるcontextのトークン数。0以下で無効（デフォルト: 200000）
 ---@field focus string? Claudeで`/compact <focus>`として渡す指示。Codexでは未使用（デフォルト: 無し）
+
+---@class Vibing.AgentMcpConfig
+---通常のチャットターンに載せるMCPサーバーの範囲（claudeバックエンドのみ）
+---`Vibing.McpConfig`（`config.mcp`）とは別物: あちらはvibing.nvim自身のRPCサーバーの設定
+---@field user_servers boolean? falseでCLIに`--strict-mcp-config`を渡し、vibing.nvim自身が
+---  `--plugin-dir`で持ち込んだプラグインのMCPサーバーだけを`--mcp-config`で明示的に載せ直す
+---  （デフォルト: true）。`--strict-mcp-config`はall-or-nothingなので、`~/.claude.json`の
+---  ユーザースコープだけでなくプロジェクトの`.mcp.json`やlocalスコープのサーバーも一緒に落ちる。
+---  残したい外部サーバーは`.vibing/plugins/<name>/.claude-plugin/plugin.json`の`mcpServers`に
+---  書けば載る。codex/copilot/grokには該当する実行時フラグが無いため効かない
 
 ---@class Vibing.PluginsConfig
 ---セッション限りで読み込むClaude Codeプラグインのディレクトリ設定
@@ -307,6 +318,12 @@ M.defaults = {
     default_effort = nil,
     utility_effort = "low",
     setting_sources = { "user", "project", "local" },
+    mcp = {
+      -- 既定はtrue（現状維持）。`--setting-sources user,project,local` が `~/.claude.json` の
+      -- MCPサーバーを全部載せるのは、ユーザーのcommands/skills/subagentをそのまま使えるように
+      -- するための代償であって、意図した設定ではない。切りたい人だけが切る。
+      user_servers = true,
+    },
     -- CLIはプロセス起動ごとにgitステータスブロックを1回計算してsystem promptの先頭に埋める。
     -- vibing.nvimはターンごとにCLIを起動し直すので、tree を触ったターンの次はそのバイト列が
     -- 変わり、system prompt以降＝全履歴がキャッシュミスになる。既定でoffにする理由はそれで、

--- a/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_command_builder.lua
@@ -3,6 +3,7 @@
 --- @module vibing.infrastructure.adapter.modules.cli_command_builder
 
 local tools_constants = require("vibing.core.constants.tools")
+local CliMcpConfig = require("vibing.infrastructure.adapter.modules.cli_mcp_config")
 local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
 local PluginDirs = require("vibing.infrastructure.plugins.plugin_dirs")
 local worktree_constants = require("vibing.core.constants.worktree")
@@ -236,6 +237,11 @@ function M.build(prompt, opts, session_id, config, settings_path)
       table.insert(cmd, "--plugin-dir")
       table.insert(cmd, plugin_dir)
     end
+
+    -- `agent.mcp.user_servers = false` only: empty otherwise, so the ordinary turn is untouched.
+    -- It has to follow the `--plugin-dir` flags rather than replace them — the plugins still carry
+    -- their skills and subagents in, and only their MCP half is re-registered by hand.
+    vim.list_extend(cmd, CliMcpConfig.args(opts.cwd, config))
   end
 
   -- System prompt additions (worktree convention + chat file path + optional language). This

--- a/lua/vibing/infrastructure/adapter/modules/cli_mcp_config.lua
+++ b/lua/vibing/infrastructure/adapter/modules/cli_mcp_config.lua
@@ -1,0 +1,92 @@
+--- The `--strict-mcp-config` / `--mcp-config` fragment that keeps an ordinary claude turn down to
+--- the MCP servers vibing.nvim brought itself (`agent.mcp.user_servers = false`).
+---
+--- `--setting-sources user,project,local` is what makes the user's own `.claude/commands/`,
+--- skills and subagents work inside a chat, and it drags every MCP server in `~/.claude.json`
+--- along with them. `--strict-mcp-config` is the CLI's only switch for that, and it is
+--- all-or-nothing: measured against claude 2.1.231, it drops the servers a `--plugin-dir` plugin
+--- declares too, taking vibing-nvim's own 42 `nvim_*` tools with them. So the fragment is a pair —
+--- the strict flag *plus* an explicit re-registration of what each loaded plugin declares.
+---
+--- Re-registered under its bare manifest name, the server arrives as `mcp__vibing-nvim__<tool>`
+--- rather than the plugin form `mcp__plugin_vibing-nvim_vibing-nvim__<tool>`. Both spellings are
+--- already covered — `tools.VIBING_NVIM_MCP_TOOL_PATTERNS` lists them, the PreToolUse hook matches
+--- on the suffix, and the system prompt names both — so nothing downstream has to know which of
+--- the two paths a turn took.
+---
+--- Measurements, and why this is claude-only, are in
+--- `handbook/architecture/plugin-and-commands.md` → "User MCP servers".
+--- @module vibing.infrastructure.adapter.modules.cli_mcp_config
+
+local PluginDirs = require("vibing.infrastructure.plugins.plugin_dirs")
+local PluginContents = require("vibing.infrastructure.plugins.plugin_contents")
+
+local M = {}
+
+--- One server, in the shape `--mcp-config` takes.
+---
+--- A remote server is emitted as `type = "http"` because that is the only remote transport a
+--- plugin manifest is read for here — `plugin_contents` carries `url` and not `type`, so an `sse`
+--- server would be re-registered as http. No manifest in this repo declares one; the day one does,
+--- `Vibing.PluginMcpServer` is where the transport has to start being carried.
+--- @param server Vibing.PluginMcpServer
+--- @return table
+local function spec(server)
+  if not server.command then
+    return { type = "http", url = server.url }
+  end
+  local out = { command = server.command, args = server.args }
+  if next(server.env) then
+    out.env = server.env
+  end
+  return out
+end
+
+--- Whether ordinary turns should still load the MCP servers the user configured outside
+--- vibing.nvim. Absent config reads as `true`, so a hand-built config table keeps today's
+--- behaviour.
+--- @param config Vibing.Config
+--- @return boolean
+local function user_servers_enabled(config)
+  local mcp = config.agent and config.agent.mcp
+  if type(mcp) ~= "table" then
+    return true
+  end
+  return mcp.user_servers ~= false
+end
+
+--- The argv fragment for one non-lightweight claude invocation.
+---
+--- Empty while `agent.mcp.user_servers` is left at its default, so the flag pair only ever
+--- appears for a user who asked for it.
+---
+--- Server names are deduplicated first-plugin-wins, matching the precedence `--plugin-dir`
+--- itself gives a duplicate: a project plugin cannot displace the bundled `vibing-nvim` server
+--- by declaring one of its own.
+--- @param cwd string|nil the chat's `working_dir`; nil means Neovim's own cwd
+--- @param config Vibing.Config
+--- @return string[]
+function M.args(cwd, config)
+  if user_servers_enabled(config) then
+    return {}
+  end
+
+  local servers = {}
+  local any = false
+  for _, dir in ipairs(PluginDirs.resolve(cwd, config)) do
+    for _, server in ipairs(PluginContents.mcp_servers(dir)) do
+      if servers[server.name] == nil then
+        servers[server.name] = spec(server)
+        any = true
+      end
+    end
+  end
+
+  -- An empty Lua table encodes as `[]`, which the CLI rejects as an mcpServers map. With
+  -- `plugins.self = false` and no project plugin there is genuinely nothing to register, and the
+  -- turn should still run — with no MCP servers at all, which is what was asked for.
+  local encoded = vim.json.encode({ mcpServers = any and servers or vim.empty_dict() })
+  return { "--strict-mcp-config", "--mcp-config", encoded }
+end
+
+return M

--- a/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/cli_command_builder_spec.lua
@@ -615,4 +615,74 @@ describe("cli_command_builder", function()
       assert.same({}, plugin_dirs(cli_command_builder.build("hello", {}, nil, config, nil)))
     end)
   end)
+
+  describe("agent.mcp.user_servers", function()
+    local function mcp_config(cmd)
+      local idx = find_flag(cmd, "--mcp-config")
+      return idx and cmd[idx + 1] or nil
+    end
+
+    it("leaves an ordinary request untouched by default", function()
+      local cmd = cli_command_builder.build("hello", {}, nil, {}, nil)
+      assert.is_nil(find_flag(cmd, "--strict-mcp-config"))
+      assert.is_nil(find_flag(cmd, "--mcp-config"))
+    end)
+
+    -- --strict-mcp-config also drops the MCP servers a --plugin-dir plugin declares (measured on
+    -- claude 2.1.231: 42 nvim_* tools gone), so the flag is never emitted without the
+    -- re-registration that follows it.
+    it("re-registers the bundled server when user servers are excluded", function()
+      local config = { agent = { mcp = { user_servers = false } } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+
+      assert.is_not_nil(find_flag(cmd, "--strict-mcp-config"))
+      local decoded = vim.json.decode(mcp_config(cmd))
+      assert.is_not_nil(decoded.mcpServers["vibing-nvim"])
+      assert.is_not_nil(decoded.mcpServers["vibing-nvim"].command)
+      assert.equals(1, #vim.tbl_keys(decoded.mcpServers))
+    end)
+
+    -- The plugins still carry their skills and subagents in; only their MCP half is rebuilt.
+    it("keeps the --plugin-dir flags alongside it", function()
+      local config = { agent = { mcp = { user_servers = false } } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      assert.is_not_nil(find_flag(cmd, "--plugin-dir"))
+    end)
+
+    it("registers a project plugin's own server too", function()
+      local project_root = vim.fn.tempname()
+      vim.fn.mkdir(project_root .. "/plugins/extra1/.claude-plugin", "p")
+      vim.fn.writefile({
+        vim.json.encode({
+          name = "extra1",
+          mcpServers = { demo = { command = "sh", args = { "${CLAUDE_PLUGIN_ROOT}/run.sh" } } },
+        }),
+      }, project_root .. "/plugins/extra1/.claude-plugin/plugin.json")
+
+      local config = {
+        agent = { mcp = { user_servers = false }, plugins = { extra = { project_root .. "/plugins/extra1" } } },
+      }
+      local decoded = vim.json.decode(mcp_config(cli_command_builder.build("hello", {}, nil, config, nil)))
+
+      assert.is_not_nil(decoded.mcpServers.demo)
+      assert.same({ project_root .. "/plugins/extra1/run.sh" }, decoded.mcpServers.demo.args)
+      vim.fn.delete(project_root, "rf")
+    end)
+
+    -- With nothing left to register the turn must still run, with no MCP servers at all. An empty
+    -- Lua table encodes as `[]`, which the CLI rejects as an mcpServers map.
+    it("emits an empty object when no plugin declares a server", function()
+      local config = { agent = { mcp = { user_servers = false }, plugins = { self = false, project_dir = false } } }
+      local cmd = cli_command_builder.build("hello", {}, nil, config, nil)
+      assert.equals('{"mcpServers":{}}', mcp_config(cmd))
+    end)
+
+    -- Lightweight already blocks every server with its own empty --mcp-config; the option must not
+    -- turn that into a re-registration of the bundled one.
+    it("does not reach a lightweight call", function()
+      local config = { agent = { mcp = { user_servers = false } } }
+      local cmd = cli_command_builder.build("hello", { lightweight = true }, nil, config, nil)
+      assert.equals('{"mcpServers":{}}', mcp_config(cmd))
+    end)
+  end)
 end)


### PR DESCRIPTION
# Pull Request

## Summary

通常のチャットターンからユーザーレベルのMCPサーバーを外すオプション **`agent.mcp.user_servers`**（既定 `true` = 現状維持）を追加する。

`false` にすると CLI に `--strict-mcp-config` を渡し、vibing.nvim 自身が `--plugin-dir` で持ち込んだプラグインが宣言する MCP サーバーだけを `--mcp-config` で明示的に登録し直す。

計測結果は issue にコメント済み（[#677 comment](https://github.com/shabaraba/vibing.nvim/issues/677#issuecomment-5615069778)）。要点だけ:

| 実行                   | `tools` | うちMCP | promptトークン |
| ---------------------- | ------: | ------: | -------------: |
| 既定                   |     204 |     171 |         46,277 |
| `user_servers = false` |      72 |      42 |         43,293 |

Tool Search 有効時（Claude 4.5 以降の既定）で **約2,984トークン/ターン（6.4%）**。スキーマは遅延ロードされるがツール名の一覧は system prompt に残るため、1ツールあたり約23トークンが床コストとして残っていた。Tool Search 無効時（`ENABLE_TOOL_SEARCH=0`）は 241,510 → 73,344 トークンで **168k（70%）** の差。既定を変えないのは前者の数字が小さいからで、このオプションが本当に効くのは後者のケース。

### 実装上いちばん重要だった発見

**`--strict-mcp-config` は `--plugin-dir` プラグインが宣言した MCP サーバーも落とす。** claude 2.1.231 で計測すると `init` の `tools` が 204 → 30 になり `mcp_servers` が空、vibing-nvim 自身の 42 個の `nvim_*` ツールが丸ごと消える。しかもターンは正常に完走するので気づけない。そのため `cli_mcp_config.args` は常に「strictフラグ + 再登録用 `--mcp-config`」のペアを返し、strictフラグ単独を出す経路を作っていない。

再登録するとサーバー名がマニフェストのままになるので、ツールの prefix が `mcp__plugin_vibing-nvim_vibing-nvim__<tool>` から `mcp__vibing-nvim__<tool>` に変わる。`tools.VIBING_NVIM_MCP_TOOL_PATTERNS` が両方を列挙済み、PreToolUse フックは suffix 一致、system prompt も両形を説明済みだったため、下流の変更は不要だった（system prompt の当該行はキャッシュプレフィックス保護 #469 のため触っていない）。

## Changes

- `lua/vibing/infrastructure/adapter/modules/cli_mcp_config.lua`（新規）— `plugin_dirs.resolve` → `plugin_contents.mcp_servers` から `--mcp-config` の JSON を組み立て、`--strict-mcp-config` と対で返す
- `cli_command_builder.lua` — 非 lightweight 分岐の `--plugin-dir` の直後に上記の argv 断片を追加。`--plugin-dir` フラグ自体は残す（プラグインの skills / agents は引き続きディレクトリ経由で載る。差し替えるのは MCP の半分だけ）
- `config.lua` — `Vibing.AgentMcpConfig` 型注釈と `agent.mcp = { user_servers = true }` の既定値
- `handbook/configuration.md` — 「Excluding User MCP Servers」節（計測表・3つの副作用・逃げ道）と Defaults at a Glance / `setting_sources` の注記更新
- `handbook/architecture/plugin-and-commands.md` — 「User MCP servers, and what `--strict-mcp-config` takes with them」節
- `handbook/mcp-tools.md` — 該当節からのポインタ
- テスト6件を `cli_command_builder_spec.lua` に追加

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test addition or update

## Testing

- [x] Tested locally in Neovim
- [x] Ran `pnpm run check`（`luac -p` 全通過）
- [x] Ran `pnpm run lint`（eslint クリーン）
- [x] Ran `pnpm run format:check`（クリーン）
- [x] Manual testing completed

`pnpm test` は Lua 63件（`cli_command_builder_spec.lua`）+ Node 61件が全通過。なお `tests/lua/application/chat/message_queue_spec.lua`（4件）、`tests/lua/infrastructure/rpc/handlers/chat_list_spec.lua`（2件）、`.../chat_conflicts_spec.lua`（1件）は **本PR適用前のbaseコミットでも同じく失敗する既存の失敗**で、本変更とは無関係（stashして確認済み）。`test:eval` は未実行。

### 実CLIでの受け入れ条件検証（claude 2.1.231）

ビルダーが実際に生成した argv をそのまま実行して確認した。

- `init` の `mcp_servers` が `[{"name":"vibing-nvim","status":"connected"}]` のみ ✅
- `mcp__vibing-nvim__nvim_get_info` を実際に呼び、動作中の Neovim（rpc_port 9877）の実バッファ情報が返ることを確認 ✅ — 素の `--mcp-config` 経路でも RPC のバインドは維持される
- PreToolUse フックは `--settings` で登録され MCP 系フラグとは独立。ツール名照合は `can_use_tool.is_vibing_nvim_mcp_tool` の suffix 一致（`_vibing%-nvim__nvim_[%w_]+$`）で、`mcp__vibing-nvim__` 形も従来どおり一致する ✅

### Test Environment

- **Neovim version**: v0.11 系（`tests/minimal_init.lua`）
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: v22
- **claude CLI**: 2.1.231

## Documentation

- [x] Code comments added/updated
- [x] handbook 更新（`configuration.md` / `architecture/plugin-and-commands.md` / `mcp-tools.md`）

`doc/vibing.txt` は未更新 — コマンド・キーバインド・チャットファイル形式の文書であり、`setup()` の設定キーは `handbook/configuration.md` が正本のため。`.claude/rules/mcp-integration.md` に「`--setting-sources user,project,local` なのでユーザーのMCPサーバーが全部使える」という記述があり、そこへ本オプションへの1行ポインタを足すのが望ましいが、**このワークツリーでは `.claude/rules/**` の編集がガードで拒否されるため未対応**。マージ後に別途追記をお願いしたい。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally with my changes（既存の失敗3ファイルを除く。上記参照）

## Related Issues

Fixes #677

## Additional Context

### 既定を `true` のままにした理由

`--setting-sources user,project,local` はユーザーの `.claude/commands/` / skills / subagents をチャット内で使えるようにするためのもので、MCP サーバーが全部載るのはその代償。切ることで壊れるものがある以上、既定は現状維持が妥当と判断した。

### 副作用として明記したこと（handbook 記載）

- `--strict-mcp-config` は all-or-nothing なので、`~/.claude.json` のユーザースコープだけでなく **プロジェクトの `.mcp.json` や local スコープのサーバーも一緒に落ちる**。残したい外部サーバーは `.vibing/plugins/<name>/.claude-plugin/plugin.json` の `mcpServers` に書けば再登録の対象に入る（既存の仕組みをそのまま逃げ道に使える）
- ツール prefix が `mcp__vibing-nvim__` 側に変わるので、`mcp__plugin_...` 形だけを名指しした手書きの権限ルールは一致しなくなる
- claude バックエンド限定。codex には `--ignore-user-config` より狭いスイッチが無く（`model_provider` も落ちてしまう）、copilot / grok には通常ターン向けの該当フラグが無い。lightweight 呼び出しは全バックエンドで既に MCP を載せていない

### issue 提案3（frontmatter でのサーバー個別指定）は見送り

`--strict-mcp-config` が all-or-nothing である以上、個別指定は「残したいサーバーの定義を vibing.nvim 側で持ち直す」ことになり `~/.claude.json` との二重管理になる。上記の `.vibing/plugins/` 経由の逃げ道で当面足りると判断した。必要になれば別 issue で。
