### PR TITLE
feat(grok): fence lightweight calls from project instructions and hooks

### DIFF
--- a/handbook/architecture/lightweight-calls.md
+++ b/handbook/architecture/lightweight-calls.md
@@ -79,7 +79,7 @@ and copilot ignores it, leaving all 62 tools — so the flag reads as working wh
 allowlist, but an entry it cannot map to a real tool id makes it discard the whole restriction:
 `--debug-file` on grok 0.2.101 records
 `tools allowlist had unmappable entries; keeping full grok toolset` for `--tools "none"`, and
-`--tools ""` is ignored the same way copilot's empty list is. So `grok_command_builder` names a
+`--tools ""` is ignored the same way copilot's empty list is. So `grok_lightweight.lua` names a
 real tool — `todo_write`, the only built-in reaching no file, shell or network — and the run logs
 `tools allowlist applied` with the toolset down from 26 to 3. `--permission-mode dontAsk` stands
 in for codex's `approval_policy="never"`.
@@ -90,7 +90,8 @@ genuinely leaves the run hookless. Grok discovers `<cwd>/.grok/hooks/` instead, 
 `GrokSettingsGenerator.ensure` writes once per cwd and nothing ever removes — so `grok_cli`
 skipping `ensure` for a lightweight call only skips _rewriting_ it. Any project that has had one
 ordinary grok chat still has the hook on disk, and a utility call is by definition something that
-happens after a chat.
+happens after a chat. **What closes it is `--cwd`** (below): the run happens somewhere that has no
+`.grok/hooks/` to discover.
 
 **Copilot does not have grok's problem**, despite also writing its hook into the project tree. The
 generated plugin under `<cwd>/.vibing/copilot-plugin/` is reachable only through `--plugin-dir`,
@@ -107,8 +108,7 @@ lightweight call registers none, so a title generation would have died silently 
 its own allowlist leaves it. Deleting the hook file instead was rejected: the cwd is shared with
 every concurrent chat, which still needs it.
 
-**Grok is the one backend that cannot keep the whole `lightweight` bargain,** and that is a
-property of its CLI rather than something left undone here. `--tools` filters built-ins only —
+**Grok's remaining gap is the MCP tools, and only those.** `--tools` filters built-ins only —
 MCP tools are added on top regardless (the advertised count stays ~254 higher either way) and
 grok 0.2.101 has no per-run flag to disable MCP servers, so the builder can only deny their
 _execution_ with `--deny "MCPTool(*)"`, in the `MCPTool(server__tool)` form grok's rules require.
@@ -122,11 +122,65 @@ with it, "denied by a permission policy", and the debug log records
 `deny rule matched (enforced before YOLO) tool="mcp:vibing-nvim__nvim_list_instances"`. Both runs
 passed `--always-approve`, so "before YOLO" is where the `deny` > `ask` > `allow` precedence gets
 confirmed too — which is what makes this not redundant with `dontAsk`.
-Project instructions have no escape hatch at all: grok reads `AGENTS.md`/`CLAUDE.md` from the repo
-and the home directory, and the only switches (`[compat.claude]`, `[mcp_servers]`) are persistent
-config, not per-invocation. `--sandbox read-only` was considered and rejected — grok's own docs
-say its network blocking is a no-op on macOS, and resuming a session under a sandbox profile is
-constrained, which `/summarize` always is.
+`--sandbox read-only` was considered and rejected — grok's own docs say its network blocking is a
+no-op on macOS, and resuming a session under a sandbox profile is constrained, which `/summarize`
+always is.
+
+**`GROK_CLAUDE_MCPS_ENABLED=0` looks like the missing switch and is not.** With it, `grok inspect`
+marks all nine of this machine's servers `[disabled]` — and the run is byte-for-byte the same
+shape: the same eight `MCP handshake succeeded` lines in `--debug-file`, the same
+`tool_count=230` on the turn. `grok inspect` is answering about discovery, not about the session,
+and the two disagree. It is therefore deliberately **not** in `grok_lightweight.lua`'s
+`COMPAT_ENV`: setting it would read as having closed this gap while closing nothing, which is
+`-c mcp_servers={}` (#574) again in a different CLI. That `inspect` and the session can disagree
+is also why nothing below is measured with `inspect` alone.
+
+## What #588 turned out to be
+
+The issue recorded project instructions and project hooks as unreachable on grok, on the grounds
+that `[compat.claude]` and `[mcp_servers]` are persistent `config.toml` keys rather than
+per-invocation ones. That was true of the keys and false of the mechanism: **every `[compat.*]`
+cell also has an environment variable, and env resolves ahead of `config.toml`** ("env var >
+config.toml > remote setting > default"). The environment is per-invocation by definition, so
+`grok_cli` hands `GROK_CLAUDE_RULES_ENABLED=0`, `GROK_CLAUDE_AGENTS_ENABLED=0`,
+`GROK_CLAUDE_SKILLS_ENABLED=0`, `GROK_CLAUDE_HOOKS_ENABLED=0` and their `GROK_CURSOR_*` twins to
+`vim.system()` for the lightweight call only. Nothing the user sees in an ordinary chat moves.
+`[compat.codex]` has only a `sessions` cell — grok's own docs call the rest "reserved and
+currently inert" — so no `GROK_CODEX_*` variable is set.
+
+The other half is `--cwd`. Grok discovers project instructions by walking from the git root down
+to the working directory, and project hooks at `<cwd>/.grok/hooks/`; neither has an off switch,
+but **an empty directory outside any repository is a project with nothing in it**. A lightweight
+call therefore runs from `stdpath("cache")/vibing/grok-lightweight`. One fixed directory rather
+than a fresh `mktemp` one, because grok keys its session store by working directory
+(`~/.grok/sessions/<url-encoded cwd>/`) and a new directory per call would leave one session
+directory per title generated.
+
+Both halves were measured against grok 0.2.101 through the session's own `prompt_context.json`,
+which records the `agents_md_files` grok actually injected — the model-visible answer rather than
+a discovery report, and free, because it is written during session setup before the model is
+called:
+
+| run                                    | injected project instructions                          |
+| -------------------------------------- | ------------------------------------------------------ |
+| unfenced, in this repository           | 10 files, 38,549 chars                                 |
+| `GROK_CLAUDE_{RULES,AGENTS}_ENABLED=0` | 1 file, 7,546 chars — the repo's own `Claude.md`       |
+| `--cwd <empty dir outside a repo>`     | 1 file, 1,531 chars — home-level `~/.claude/Claude.md` |
+| both                                   | **0 files**                                            |
+
+Each half leaves exactly what the other removes, which is why both are needed: the repo's
+`Claude.md` is a _native_ grok project-rules filename and so belongs to no compat cell, while
+`~/.claude/Claude.md` is found from the home directory and so survives any `--cwd`. `skills` is
+in the list because grok advertises skills as slash commands — 47 → 27 in the same run.
+
+Resuming across working directories is what makes this usable on the `/summarize` path, and it was
+checked rather than assumed: grok answers
+`Session <id> found locally (originally in <dir>)` and continues.
+
+Two residues are known and left: grok's _global_ rules (`~/.grok/`) have no switch of any kind,
+and hooks contributed by the user's own grok plugins are per-run unreachable (`--plugin-dir`
+exists only on the `grok agent` subcommand). Both are things the user configured for every grok
+run on the machine, not something the project imposed on a utility call.
 
 The model half of that lives in `modules/non_claude_model.lua`, shared by codex, copilot and grok.
 It was three byte-identical private copies before, and #537 was filed against codex alone — so

--- a/lua/vibing/core/types.lua
+++ b/lua/vibing/core/types.lua
@@ -43,7 +43,7 @@
 ---@field on_tool_use_full fun(tool: string, input: table)? 表示用に間引かない生のツール入力（eval用）
 ---@field _session_id string?
 ---@field _session_id_explicit boolean?
----@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ。各アダプタは「ツールを使わせない・プロジェクト設定とユーザー MCP サーバーを読ませない・フックを登録しない・utility_model を使う」、かつ「これらが CLI 側のスキーマ変更で黙って外れないこと」を果たす責務を負う（claude は --tools ""、codex は read-only サンドボックス + --ignore-user-config、copilot は --available-tools にダミー名、grok は --tools todo_write）。grok だけは CLI 側に手段がなく、プロジェクト指示（AGENTS.md/CLAUDE.md）を読ませないことと MCP ツールの提示を止めることができない（提示は止められないため --deny "MCPTool(*)" で実行のみ拒否している。詳細は handbook/architecture/lightweight-calls.md）
+---@field lightweight boolean? タイトル生成・要約等の軽量ユーティリティ呼び出し用フラグ。各アダプタは「ツールを使わせない・プロジェクト設定とユーザー MCP サーバーを読ませない・フックを登録しない・utility_model を使う」、かつ「これらが CLI 側のスキーマ変更で黙って外れないこと」を果たす責務を負う（claude は --tools ""、codex は read-only サンドボックス + --ignore-user-config、copilot は --available-tools にダミー名、grok は --tools todo_write + 空のスクラッチ作業ディレクトリ + GROK_*_ENABLED 環境変数）。grok だけは MCP ツールの「提示」を止める手段が CLI 側になく、--deny "MCPTool(*)" で実行のみ拒否している（プロジェクト指示とフックは #588 で塞いだ。詳細は handbook/architecture/lightweight-calls.md）
 
 ---@class Vibing.AdapterResponse
 ---@field content string?

--- a/lua/vibing/infrastructure/adapter/grok_cli.lua
+++ b/lua/vibing/infrastructure/adapter/grok_cli.lua
@@ -6,6 +6,7 @@ local Base = require("vibing.infrastructure.adapter.base")
 local CliRuntime = require("vibing.infrastructure.adapter.modules.cli_runtime")
 local RpcEnvironment = require("vibing.infrastructure.adapter.modules.rpc_environment")
 local GrokCommandBuilder = require("vibing.infrastructure.adapter.modules.grok_command_builder")
+local GrokLightweight = require("vibing.infrastructure.adapter.modules.grok_lightweight")
 local GrokEventProcessor = require("vibing.infrastructure.adapter.modules.grok_event_processor")
 local StreamHandler = require("vibing.infrastructure.adapter.modules.stream_handler")
 local SessionManagerModule = require("vibing.infrastructure.adapter.modules.session_manager")
@@ -70,14 +71,19 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
     )
   end
 
-  local cwd = opts.cwd or vim.fn.getcwd()
+  -- Shared with the command builder, so the `--cwd` flag and the process the flag describes
+  -- cannot disagree. For a lightweight call both are the scratch directory.
+  local cwd = GrokLightweight.resolve_cwd(opts) or vim.fn.getcwd()
 
   -- Install project PreToolUse hook (reuses bin/hooks/pre-tool-use.sh) unless fully bypassed.
   -- Grok discovers <cwd>/.grok/hooks/*.json when the folder is trusted.
   --
   -- Lightweight calls skip it too, matching claude_cli and codex_cli. The builder takes their
   -- tools away instead, and routing a title-generation tool call into the chat's approval UI
-  -- would prompt the user about a request they never made.
+  -- would prompt the user about a request they never made. Skipping the write is no longer the
+  -- whole of it: a lightweight call also runs from a directory that has no `.grok/hooks/` to
+  -- discover, so the hook a previous ordinary chat left in the project can no longer be picked up
+  -- (#588).
   local permission_mode = opts.permission_mode or "default"
   if permission_mode ~= "bypassPermissions" and not opts.lightweight then
     local ok_hook, hook_err = pcall(GrokSettingsGenerator.ensure, cwd)
@@ -129,6 +135,13 @@ function GrokCLI:stream(prompt, opts, on_chunk, on_done)
   -- Lets PreToolUse hook identify which chat buffer's stream it belongs to (see ActiveStreamRegistry).
   local env = vim.tbl_extend("force", self._base_env, { VIBING_HANDLE_ID = handle_id })
   RpcEnvironment.bind(env)
+
+  -- The half of the lightweight restriction that is not expressible as a flag: grok's
+  -- `[compat.<vendor>]` cells resolve env var first, so this is the per-invocation switch #588 was
+  -- filed for the absence of. Only the child's environment moves; the user's config is untouched.
+  if opts.lightweight then
+    GrokLightweight.apply_env(env)
+  end
 
   ActiveStreamRegistry.register({
     handle_id = handle_id,

--- a/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_command_builder.lua
@@ -4,6 +4,7 @@
 
 local NonClaudeModel = require("vibing.infrastructure.adapter.modules.non_claude_model")
 local CommonBuilder = require("vibing.infrastructure.adapter.modules.command_builder_common")
+local GrokLightweight = require("vibing.infrastructure.adapter.modules.grok_lightweight")
 local worktree_constants = require("vibing.core.constants.worktree")
 
 local M = {}
@@ -14,52 +15,6 @@ local M = {}
 local GROK_PERMISSION_MODE_FALLBACK = {
   auto = "default",
 }
-
---- The tool allowlist a lightweight utility call runs under.
----
---- Grok's `--tools` is an allowlist ("only the listed tools will be available; all others are
---- removed"), but it **fails open** on anything it cannot map to a real tool id. Verified against
---- grok 0.2.101 via `--debug-file`: `--tools "none"` logs
---- `tools allowlist had unmappable entries; keeping full grok toolset` and leaves every tool in
---- place, and `--tools ""` is ignored outright — the advertised tool count is unchanged from a
---- plain run either way. So the copilot trick of naming nothing is exactly wrong here; the list
---- has to name a tool grok actually has.
----
---- `todo_write` is that tool. Of grok's built-ins (`run_terminal_cmd`, `grep`, `read_file`,
---- `search_replace`, `list_dir`, `web_search`, `web_fetch`, `todo_write`, `task`) it is the only
---- one that touches no file, no shell and no network — it writes an in-session todo list and
---- nothing else. With it the run logs `tools allowlist applied allowed=["todo_write"]` and the
---- toolset drops from 26 to 3 (the tool plus grok's two always-on MCP meta-tools).
-local LIGHTWEIGHT_TOOLS = "todo_write"
-
---- Deny rule covering every MCP tool, in the `MCPTool(server__tool)` form grok's permission
---- rules require -- an `mcp__server__tool` pattern never matches.
----
---- Needed because `--tools` filters grok's *built-in* tools only; the tools its MCP servers
---- expose are added on top regardless, and grok offers no per-run way to turn those servers off.
---- The allowlist cannot reach them, so execution is denied instead. This is weaker than claude's
---- empty `--mcp-config`, which stops them being offered at all.
----
---- Not redundant with the `dontAsk` mode below, which is the tempting reading. grok's own docs
---- say `dontAsk` stops short of auto-denying while always-approve is on, and grok imports the
---- user's `settings.json` permission rules -- so an allow rule there could pre-approve an MCP
---- tool. An explicit deny is what survives both: grok evaluates `deny` > `ask` > `allow`,
---- "regardless of order or source".
----
---- Both halves of that were measured against grok 0.2.101 rather than trusted to the docs:
----
---- 1. The rule *form* is recognised. Loading it from a `.grok/config.toml` moves
----    `grok inspect`'s permission count from 1 to 2, while an invented kind
----    (`TotallyBogusKind(*)`) leaves it at 1 -- and is reported as "0 skipped", so an
----    unrecognised rule vanishes without a word. A wildcard that silently did nothing would look
----    exactly like one that worked.
---- 2. The rule is *enforced*, through this flag, against a real MCP call. Same prompt and flags
----    twice, `--deny` the only difference: without it the model reports the tool called
----    successfully; with it, "denied by a permission policy", and the debug log records
----    `deny rule matched (enforced before YOLO) tool="mcp:vibing-nvim__nvim_list_instances"`.
----    Both runs passed `--always-approve`, so "enforced before YOLO" is also the precedence
----    claim above, confirmed rather than assumed.
-local LIGHTWEIGHT_MCP_DENY = "MCPTool(*)"
 
 local cached_grok_path = nil
 local cached_configured_executable = nil
@@ -214,25 +169,6 @@ local function build_rules(opts, config)
   return table.concat(lines, "\n")
 end
 
---- Append the flags a lightweight utility call (title generation, /summarize, daily summary) runs
---- under, in place of the chat's permission mode.
----
---- Takes no `opts` on purpose: "the utility call does not inherit the chat's permission mode,
---- `bypassPermissions` included" is then enforced by the signature rather than by a comment. The
---- user put the *chat* in that mode, and a title generated behind their back is not the call they
---- made.
---- @param cmd string[]
-local function append_lightweight_flags(cmd)
-  table.insert(cmd, "--tools")
-  table.insert(cmd, LIGHTWEIGHT_TOOLS)
-  table.insert(cmd, "--deny")
-  table.insert(cmd, LIGHTWEIGHT_MCP_DENY)
-  -- codex's `approval_policy="never"`, in grok's vocabulary. grok_cli registers no hook for a
-  -- lightweight call, so a mode that prompts would stall on an approval nothing can answer.
-  table.insert(cmd, "--permission-mode")
-  table.insert(cmd, "dontAsk")
-end
-
 --- Forget the resolved binary path. Test seam only: the cache is process-wide, so a spec that
 --- wants to exercise the "CLI missing" path has to clear what an earlier spec resolved.
 function M._reset_path_cache()
@@ -274,16 +210,20 @@ function M.build(prompt, opts, session_id, config)
   end
 
   if opts.lightweight then
-    append_lightweight_flags(cmd)
+    GrokLightweight.append_flags(cmd)
   elseif opts.permission_mode then
     local mode = GROK_PERMISSION_MODE_FALLBACK[opts.permission_mode] or opts.permission_mode
     table.insert(cmd, "--permission-mode")
     table.insert(cmd, mode)
   end
 
-  if opts.cwd and opts.cwd ~= "" then
+  -- For a lightweight call this is the scratch directory, which is how grok is kept from reading
+  -- the project's AGENTS.md/CLAUDE.md and its `.grok/hooks/`: there is no flag for either, but
+  -- `--cwd` decides which project it is looking at.
+  local cwd = GrokLightweight.resolve_cwd(opts)
+  if cwd and cwd ~= "" then
     table.insert(cmd, "--cwd")
-    table.insert(cmd, opts.cwd)
+    table.insert(cmd, cwd)
   end
 
   local rules = build_rules(opts, config)

--- a/lua/vibing/infrastructure/adapter/modules/grok_lightweight.lua
+++ b/lua/vibing/infrastructure/adapter/modules/grok_lightweight.lua
@@ -1,0 +1,209 @@
+--- What a lightweight utility call runs under on the Grok backend.
+---
+--- Split out of `grok_command_builder` because the restriction stopped being a list of flags: it
+--- is flags, a scratch working directory and a set of environment overrides, and the builder owns
+--- only the first of the three. The measurements behind each one are in
+--- `handbook/architecture/lightweight-calls.md`.
+--- @module vibing.infrastructure.adapter.modules.grok_lightweight
+
+local fs = require("vibing.core.utils.fs")
+
+local M = {}
+
+--- The tool allowlist a lightweight utility call runs under.
+---
+--- Grok's `--tools` is an allowlist ("only the listed tools will be available; all others are
+--- removed"), but it **fails open** on anything it cannot map to a real tool id. Verified against
+--- grok 0.2.101 via `--debug-file`: `--tools "none"` logs
+--- `tools allowlist had unmappable entries; keeping full grok toolset` and leaves every tool in
+--- place, and `--tools ""` is ignored outright — the advertised tool count is unchanged from a
+--- plain run either way. So the copilot trick of naming nothing is exactly wrong here; the list
+--- has to name a tool grok actually has.
+---
+--- `todo_write` is that tool. Of grok's built-ins (`run_terminal_cmd`, `grep`, `read_file`,
+--- `search_replace`, `list_dir`, `web_search`, `web_fetch`, `todo_write`, `task`) it is the only
+--- one that touches no file, no shell and no network — it writes an in-session todo list and
+--- nothing else. With it the run logs `tools allowlist applied allowed=["todo_write"]` and the
+--- toolset drops from 26 to 3 (the tool plus grok's two always-on MCP meta-tools).
+local LIGHTWEIGHT_TOOLS = "todo_write"
+
+--- Deny rule covering every MCP tool, in the `MCPTool(server__tool)` form grok's permission
+--- rules require -- an `mcp__server__tool` pattern never matches.
+---
+--- Needed because `--tools` filters grok's *built-in* tools only; the tools its MCP servers
+--- expose are added on top regardless, and grok offers no per-run way to turn those servers off.
+--- The allowlist cannot reach them, so execution is denied instead. This is weaker than claude's
+--- empty `--mcp-config`, which stops them being offered at all.
+---
+--- Not redundant with the `dontAsk` mode below, which is the tempting reading. grok's own docs
+--- say `dontAsk` stops short of auto-denying while always-approve is on, and grok imports the
+--- user's `settings.json` permission rules -- so an allow rule there could pre-approve an MCP
+--- tool. An explicit deny is what survives both: grok evaluates `deny` > `ask` > `allow`,
+--- "regardless of order or source".
+---
+--- Both halves of that were measured against grok 0.2.101 rather than trusted to the docs:
+---
+--- 1. The rule *form* is recognised. Loading it from a `.grok/config.toml` moves
+---    `grok inspect`'s permission count from 1 to 2, while an invented kind
+---    (`TotallyBogusKind(*)`) leaves it at 1 -- and is reported as "0 skipped", so an
+---    unrecognised rule vanishes without a word. A wildcard that silently did nothing would look
+---    exactly like one that worked.
+--- 2. The rule is *enforced*, through this flag, against a real MCP call. Same prompt and flags
+---    twice, `--deny` the only difference: without it the model reports the tool called
+---    successfully; with it, "denied by a permission policy", and the debug log records
+---    `deny rule matched (enforced before YOLO) tool="mcp:vibing-nvim__nvim_list_instances"`.
+---    Both runs passed `--always-approve`, so "enforced before YOLO" is also the precedence
+---    claim above, confirmed rather than assumed.
+local LIGHTWEIGHT_MCP_DENY = "MCPTool(*)"
+
+--- The `[compat.<vendor>]` cells a lightweight call turns off, as environment variables.
+---
+--- These are what #588 was filed for the absence of. The cells were known — and rejected — as
+--- `config.toml` keys, because editing the user's persistent config to fence one utility call
+--- would change their ordinary chats too. What was missed is that **every cell also has an
+--- environment variable**, resolved ahead of `config.toml`, and the environment is
+--- per-invocation. `grok_cli` hands these to `vim.system` for the lightweight call only.
+---
+--- **`mcps` is deliberately absent.** `GROK_CLAUDE_MCPS_ENABLED=0` makes `grok inspect` mark
+--- every server `[disabled]` and changes nothing about the run — same handshakes, same advertised
+--- tool count. Setting it would read as closing the second gap in #588 while closing nothing,
+--- which is the `-c mcp_servers={}` mistake of #574 in a new costume; `LIGHTWEIGHT_MCP_DENY`
+--- above remains the only thing standing between a utility call and the user's MCP servers.
+--- `[compat.codex]` has only a `sessions` cell, the rest being "reserved and currently inert" per
+--- grok's own docs, so no `GROK_CODEX_*` variable is set.
+---
+--- The measurements: `handbook/architecture/lightweight-calls.md` → "What #588 turned out to be".
+local COMPAT_ENV = {
+  GROK_CLAUDE_RULES_ENABLED = "0",
+  GROK_CLAUDE_AGENTS_ENABLED = "0",
+  GROK_CLAUDE_SKILLS_ENABLED = "0",
+  GROK_CLAUDE_HOOKS_ENABLED = "0",
+  GROK_CURSOR_RULES_ENABLED = "0",
+  GROK_CURSOR_AGENTS_ENABLED = "0",
+  GROK_CURSOR_SKILLS_ENABLED = "0",
+  GROK_CURSOR_HOOKS_ENABLED = "0",
+}
+
+--- Two features a utility call has no business reaching, both documented env toggles.
+---
+--- `GROK_MEMORY=0` is the cross-session memory grok can otherwise fold into the conversation —
+--- the same "context the user did not ask for" that the project instructions are. `GROK_SUBAGENTS=0`
+--- is the second fence under `--tools`: the `task` tool is already outside the allowlist, but the
+--- allowlist is the one restriction here known to fail open, and a subagent inherits none of it.
+local FEATURE_ENV = {
+  GROK_MEMORY = "0",
+  GROK_SUBAGENTS = "0",
+}
+
+--- Where a lightweight call is run from.
+---
+--- Grok discovers project instructions by walking from the git root down to the working
+--- directory, and project hooks at `<cwd>/.grok/hooks/`. Neither has a per-invocation off switch
+--- — but `--cwd` decides what "the project" is, and an empty directory outside any repository is
+--- a project with nothing in it. Together with `COMPAT_ENV` this is what takes the injected
+--- instruction count to zero: each of the two removes exactly what the other leaves.
+---
+--- `stdpath("cache")` rather than a fresh `mktemp` directory because grok keys its session store
+--- by working directory (`~/.grok/sessions/<url-encoded cwd>/`): a new directory per call would
+--- leave one session directory per title generated. It is not under `.vibing/` for the obvious
+--- reason — that is inside the repository being fenced out.
+---
+--- Resuming across working directories is safe, which is what makes this usable on the
+--- `/summarize` path: grok answers `Session <id> found locally (originally in <dir>)` and
+--- continues, rather than failing the lookup.
+local SCRATCH_SUBDIR = "/vibing/grok-lightweight"
+
+local scratch_dir_cache = nil
+local scratch_dir_failed = false
+
+--- The scratch directory, created on first use.
+---
+--- Returns nil rather than raising when it cannot be created: the caller then falls back to the
+--- ordinary working directory, which is the pre-#588 behaviour. A title generation that dies
+--- because a cache directory was unwritable would be a worse trade than one that reads a
+--- CLAUDE.md it did not need.
+--- @return string|nil
+function M.scratch_dir()
+  if scratch_dir_cache then
+    return scratch_dir_cache
+  end
+  if scratch_dir_failed then
+    return nil
+  end
+
+  local path = vim.fn.stdpath("cache") .. SCRATCH_SUBDIR
+  local ok, err = pcall(fs.ensure_dir, path)
+  if not ok then
+    scratch_dir_failed = true
+    vim.notify(
+      string.format(
+        "[vibing:grok] Could not create the lightweight scratch directory (%s); "
+          .. "utility calls will read this project's instructions: %s",
+        path,
+        tostring(err)
+      ),
+      vim.log.levels.WARN
+    )
+    return nil
+  end
+
+  scratch_dir_cache = path
+  return scratch_dir_cache
+end
+
+--- The working directory a grok run uses, for both the `--cwd` flag and the spawned process.
+---
+--- One definition rather than two, because the flag and the process cwd disagreeing is a bug with
+--- no symptom: grok resolves discovery from the flag, so the run would look fenced while the
+--- process sat in the project.
+--- @param opts Vibing.AdapterOpts
+--- @return string|nil
+function M.resolve_cwd(opts)
+  if not opts.lightweight then
+    return opts.cwd
+  end
+  return M.scratch_dir() or opts.cwd
+end
+
+--- Append the flags a lightweight utility call (title generation, /summarize, daily summary) runs
+--- under, in place of the chat's permission mode.
+---
+--- Takes no `opts` on purpose: "the utility call does not inherit the chat's permission mode,
+--- `bypassPermissions` included" is then enforced by the signature rather than by a comment. The
+--- user put the *chat* in that mode, and a title generated behind their back is not the call they
+--- made.
+--- @param cmd string[]
+function M.append_flags(cmd)
+  table.insert(cmd, "--tools")
+  table.insert(cmd, LIGHTWEIGHT_TOOLS)
+  table.insert(cmd, "--deny")
+  table.insert(cmd, LIGHTWEIGHT_MCP_DENY)
+  -- codex's `approval_policy="never"`, in grok's vocabulary. grok_cli registers no hook for a
+  -- lightweight call, so a mode that prompts would stall on an approval nothing can answer.
+  table.insert(cmd, "--permission-mode")
+  table.insert(cmd, "dontAsk")
+end
+
+--- Write the lightweight environment overrides into the environment table the caller will spawn
+--- with. In place, so the single `vim.fn.environ()` copy the adapter already holds stays the one
+--- description of the child's environment.
+--- @param env table<string, string>
+--- @return table<string, string> env
+function M.apply_env(env)
+  for key, value in pairs(COMPAT_ENV) do
+    env[key] = value
+  end
+  for key, value in pairs(FEATURE_ENV) do
+    env[key] = value
+  end
+  return env
+end
+
+--- Forget the resolved scratch directory. Test seam only: the cache is process-wide, so a spec
+--- that stubs `stdpath` has to clear what an earlier one resolved.
+function M._reset_scratch_cache()
+  scratch_dir_cache = nil
+  scratch_dir_failed = false
+end
+
+return M

--- a/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_command_builder_spec.lua
@@ -5,11 +5,24 @@ describe("grok_command_builder", function()
   local original_exepath
   local original_executable
   local original_system
+  local original_stdpath
+  local cache_root
 
   before_each(function()
     original_exepath = vim.fn.exepath
     original_executable = vim.fn.executable
     original_system = vim.fn.system
+    original_stdpath = vim.fn.stdpath
+    -- The lightweight scratch directory is resolved once per process and cached, so it is stubbed
+    -- (and its module reloaded) here rather than left pointing at the developer's real cache.
+    cache_root = vim.fn.tempname()
+    vim.fn.stdpath = function(what)
+      if what == "cache" then
+        return cache_root
+      end
+      return original_stdpath(what)
+    end
+    package.loaded["vibing.infrastructure.adapter.modules.grok_lightweight"] = nil
     vim.fn.exepath = function(name)
       if name == "grok" then
         return "/usr/local/bin/grok"
@@ -40,6 +53,8 @@ describe("grok_command_builder", function()
     vim.fn.exepath = original_exepath
     vim.fn.executable = original_executable
     vim.fn.system = original_system
+    vim.fn.stdpath = original_stdpath
+    vim.fn.delete(cache_root, "rf")
   end)
 
   local function find_flag(cmd, flag)
@@ -402,6 +417,24 @@ describe("grok_command_builder", function()
       local config = { agent = { default_model = "grok-4", utility_model = "grok-3-mini" } }
       local cmd = grok_command_builder.build("hi", { lightweight = true }, nil, config)
       assert.equals("grok-3-mini", value_after(cmd, "--model"))
+    end)
+
+    it("runs from the scratch directory rather than the chat's project (#588)", function()
+      -- Grok has no flag for "ignore this project's AGENTS.md/CLAUDE.md" and none for
+      -- "ignore <cwd>/.grok/hooks/". `--cwd` at an empty directory outside any repository is what
+      -- stands in for both: there is nothing there to discover.
+      local cmd = grok_command_builder.build("hi", { lightweight = true, cwd = "/repo" }, nil, {})
+      assert.equals(cache_root .. "/vibing/grok-lightweight", value_after(cmd, "--cwd"))
+    end)
+
+    it("still fences a resumed session, which /summarize always is", function()
+      local cmd = grok_command_builder.build("hi", { lightweight = true, cwd = "/repo" }, "sess-1", {})
+      assert.equals(cache_root .. "/vibing/grok-lightweight", value_after(cmd, "--cwd"))
+    end)
+
+    it("leaves an ordinary call in the chat's working directory", function()
+      local cmd = grok_command_builder.build("hi", { cwd = "/repo" }, nil, {})
+      assert.equals("/repo", value_after(cmd, "--cwd"))
     end)
   end)
 end)

--- a/tests/lua/infrastructure/adapter/modules/grok_lightweight_spec.lua
+++ b/tests/lua/infrastructure/adapter/modules/grok_lightweight_spec.lua
@@ -1,0 +1,129 @@
+local grok_lightweight = require("vibing.infrastructure.adapter.modules.grok_lightweight")
+
+describe("grok_lightweight", function()
+  local original_stdpath
+  local original_notify
+  local cache_root
+
+  before_each(function()
+    cache_root = vim.fn.tempname()
+    original_stdpath = vim.fn.stdpath
+    original_notify = vim.notify
+    vim.fn.stdpath = function(what)
+      if what == "cache" then
+        return cache_root
+      end
+      return original_stdpath(what)
+    end
+    vim.notify = function() end
+    package.loaded["vibing.infrastructure.adapter.modules.grok_lightweight"] = nil
+    grok_lightweight = require("vibing.infrastructure.adapter.modules.grok_lightweight")
+  end)
+
+  after_each(function()
+    vim.fn.stdpath = original_stdpath
+    vim.notify = original_notify
+    vim.fn.delete(cache_root, "rf")
+  end)
+
+  describe("append_flags", function()
+    local function value_after(cmd, flag)
+      for i, arg in ipairs(cmd) do
+        if arg == flag then
+          return cmd[i + 1]
+        end
+      end
+      return nil
+    end
+
+    it("names a real tool, because grok's allowlist fails open on one it cannot map", function()
+      local cmd = {}
+      grok_lightweight.append_flags(cmd)
+      assert.equals("todo_write", value_after(cmd, "--tools"))
+    end)
+
+    it("denies the MCP tools the allowlist cannot reach", function()
+      local cmd = {}
+      grok_lightweight.append_flags(cmd)
+      assert.equals("MCPTool(*)", value_after(cmd, "--deny"))
+    end)
+
+    it("never waits on an approval prompt no hook is registered to answer", function()
+      local cmd = {}
+      grok_lightweight.append_flags(cmd)
+      assert.equals("dontAsk", value_after(cmd, "--permission-mode"))
+    end)
+  end)
+
+  describe("apply_env", function()
+    it("turns off the claude and cursor compat cells that reach a utility call", function()
+      -- These are the per-invocation form of `[compat.<vendor>]`; env resolves ahead of
+      -- config.toml, which is what lets a utility call be fenced without touching the user's
+      -- persistent configuration.
+      local env = grok_lightweight.apply_env({})
+      for _, vendor in ipairs({ "CLAUDE", "CURSOR" }) do
+        for _, cell in ipairs({ "RULES", "AGENTS", "SKILLS", "HOOKS" }) do
+          assert.equals("0", env[string.format("GROK_%s_%s_ENABLED", vendor, cell)])
+        end
+      end
+    end)
+
+    it("does not set the mcps cell, which grok honours in `inspect` and not in the run", function()
+      -- Measured against grok 0.2.101: with GROK_CLAUDE_MCPS_ENABLED=0 every server is reported
+      -- `[disabled]` by `grok inspect`, and the run still handshakes all eight and still
+      -- advertises the same tool count. Setting it would read as closing #588's second gap while
+      -- closing nothing -- the `-c mcp_servers={}` mistake of #574. `--deny "MCPTool(*)"` is what
+      -- actually stands there.
+      local env = grok_lightweight.apply_env({})
+      assert.is_nil(env.GROK_CLAUDE_MCPS_ENABLED)
+      assert.is_nil(env.GROK_CURSOR_MCPS_ENABLED)
+    end)
+
+    it("disables cross-session memory and subagents", function()
+      local env = grok_lightweight.apply_env({})
+      assert.equals("0", env.GROK_MEMORY)
+      assert.equals("0", env.GROK_SUBAGENTS)
+    end)
+
+    it("writes into the environment it was handed rather than replacing it", function()
+      local env = { PATH = "/usr/bin", VIBING_HANDLE_ID = "h1" }
+      grok_lightweight.apply_env(env)
+      assert.equals("/usr/bin", env.PATH)
+      assert.equals("h1", env.VIBING_HANDLE_ID)
+    end)
+  end)
+
+  describe("resolve_cwd", function()
+    it("runs a lightweight call from an empty directory outside the project", function()
+      local cwd = grok_lightweight.resolve_cwd({ lightweight = true, cwd = "/repo" })
+      assert.equals(cache_root .. "/vibing/grok-lightweight", cwd)
+      assert.equals(1, vim.fn.isdirectory(cwd))
+      assert.same({}, vim.fn.readdir(cwd))
+    end)
+
+    it("leaves an ordinary call in the chat's working directory", function()
+      assert.equals("/repo", grok_lightweight.resolve_cwd({ cwd = "/repo" }))
+      assert.is_nil(grok_lightweight.resolve_cwd({}))
+    end)
+
+    it("falls back to the ordinary directory when the scratch one cannot be created", function()
+      -- A title generation that dies because a cache directory was unwritable would be a worse
+      -- trade than one that reads a CLAUDE.md it did not need.
+      vim.fn.stdpath = function(what)
+        if what == "cache" then
+          return "/dev/null/not-a-directory"
+        end
+        return original_stdpath(what)
+      end
+      assert.equals("/repo", grok_lightweight.resolve_cwd({ lightweight = true, cwd = "/repo" }))
+    end)
+
+    it("resolves the scratch directory once per process", function()
+      local first = grok_lightweight.resolve_cwd({ lightweight = true })
+      vim.fn.stdpath = function()
+        error("stdpath must not be consulted again")
+      end
+      assert.equals(first, grok_lightweight.resolve_cwd({ lightweight = true }))
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

grok の lightweight 呼び出し（タイトル生成 / `/summarize` / デイリーサマリー）が、プロジェクト指示を読み込みプロジェクトフックに触れる状態を解消しました。

`core/types.lua` が課す4つの責務のうち、grok で未達だった「プロジェクト設定を読ませない」「フックを登録しない」を塞ぎました。**MCPツールの提示だけは grok 0.2.101 に手段がなく、実行拒否（`--deny "MCPTool(*)"`）のままです。**

## issue #588 の前提が間違っていた点

issue は「`[compat.claude]` は `config.toml` の永続設定であって per-invocation ではない」ため手段なし、と結論していました。実際には **各 compat セルには対応する環境変数があり、解決順序は `env var > config.toml > remote > default`** です。環境変数は定義上 per-invocation なので、`vim.system()` に渡す子プロセスの環境だけを動かせば、ユーザーの通常チャットには一切影響しません。

もう一方は `--cwd` です。grok はプロジェクト指示を git root → cwd の経路で、プロジェクトフックを `<cwd>/.grok/hooks/` で discover します。どちらにもオフスイッチはありませんが、**リポジトリ外の空ディレクトリは「中身が何もないプロジェクト」** です。

## 計測

grok 0.2.101 に対し、セッション自身の `prompt_context.json`（`~/.grok/sessions/<url-encoded cwd>/<id>/`）で計測しました。ここには grok が実際に注入した `agents_md_files` が記録されます。discovery のレポートではなくモデルが見た答えであり、モデル呼び出し前のセッション設定時に書かれるのでトークンを消費せずに読めます。

| 実行条件 | 注入されたプロジェクト指示 |
| --- | --- |
| 無制限（本リポジトリ内） | 10 ファイル / 38,549 文字 |
| `GROK_CLAUDE_{RULES,AGENTS}_ENABLED=0` | 1 ファイル / 7,546 文字（リポジトリ自身の `Claude.md`） |
| `--cwd <リポジトリ外の空ディレクトリ>` | 1 ファイル / 1,531 文字（`~/.claude/Claude.md`） |
| 両方 | **0 ファイル** |

片方だけでは、もう片方が消す分がそのまま残ります。リポジトリの `Claude.md` は grok ネイティブのプロジェクトルール名なのでどの compat セルにも属さず、`~/.claude/Claude.md` はホームから見つかるので `--cwd` では消えません。`skills` セルも切っているので、スラッシュコマンド数は 47 → 27 に減ります。

`/summarize` はセッション resume を伴いますが、**別 cwd からの resume は動くことを確認済み**です（`Session <id> found locally (originally in <dir>)` と表示して継続）。

## 隔離できなかったもの

- **MCPツールの「提示」**: `--tools` は組み込みツールのみをフィルタし、MCPツールはその上に載ります。`GROK_CLAUDE_MCPS_ENABLED=0` は **`grok inspect` では全サーバーが `[disabled]` になるのに、実行では何も変わりません**（`--debug-file` に同じ8件の `MCP handshake succeeded`、ターンは同じ `tool_count=230`）。設定すれば「塞いだように読める」だけで実際は何も塞がらないため、#574 の `-c mcp_servers={}` と同じ失敗になります。よって **意図的に設定していません**。ツール定義ぶんのトークンは消費され続け、`--deny "MCPTool(*)"` による実行拒否が唯一の防壁のままです。
- **grok のグローバルルール** (`~/.grok/`): 一切スイッチがありません。
- **ユーザー自身の grok プラグインが提供するフック**: `--plugin-dir` は `grok agent` サブコマンドにしか存在せず、per-run では届きません。

後ろ2つはユーザーがマシン全体に対して設定したものであり、プロジェクトがユーティリティ呼び出しに押し付けたものではないので、残置しています。

## Changes

- `lua/vibing/infrastructure/adapter/modules/grok_lightweight.lua` を新設。lightweight のフラグ・スクラッチ作業ディレクトリ・環境変数上書きを1か所に集約（`grok_command_builder.lua` から `--tools` / `--deny` / `--permission-mode` の定義を移設）
- `grok_command_builder.lua` / `grok_cli.lua` が `GrokLightweight.resolve_cwd()` を共有。`--cwd` フラグとプロセスの cwd が食い違わないようにするため（食い違うと「隔離されているように見えて実際はプロジェクト内」という無症状のバグになる）
- スクラッチディレクトリは `stdpath("cache")/vibing/grok-lightweight` 固定。grok はセッションを作業ディレクトリでキーイングするため、毎回 `mktemp` するとタイトル生成1回につきセッションディレクトリが1個増える
- 作成に失敗した場合は警告して通常の作業ディレクトリにフォールバック（キャッシュディレクトリが書けないだけでタイトル生成が落ちるのは割に合わない）
- `handbook/architecture/lightweight-calls.md` と `core/types.lua` の記述を実態に合わせて更新

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

- [x] `pnpm run check` / `pnpm run lint` / `pnpm run lint:md` / `pnpm run format:check` / `pnpm run check:doc`
- [x] `pnpm run test:node`（61 pass）
- [x] `pnpm run test:lua` — `tests/lua/infrastructure/adapter/` 配下は 31 ファイル全て pass。新規 `grok_lightweight_spec.lua` 11件、`grok_command_builder_spec.lua` 37件
- [x] grok 0.2.101 実機で `grok inspect` / `--debug-file` / `prompt_context.json` により上表を計測
- [ ] `test:eval` は実行していません（指示により禁止）

> [!NOTE]
> `tests/lua/application/chat/message_queue_spec.lua`(4) と `rpc/handlers/chat_list_spec.lua`(2) / `chat_conflicts_spec.lua`(1) の計7件が失敗しますが、**このブランチの変更前（stash した状態）でも同じ7件が失敗する既存の failure** です。#696/#697 の orchestration 系で、本 PR とは無関係です。

## Documentation

- [x] Code comments added/updated
- [x] handbook 更新（`handbook/architecture/lightweight-calls.md`）

## Related Issues

Fixes #588
