### PR TITLE
fix(mcp): rebuild the server in the background instead of missing its startup deadline

### DIFF
--- a/claude-plugin/mcp-server/.gitignore
+++ b/claude-plugin/mcp-server/.gitignore
@@ -1,6 +1,15 @@
 node_modules/
 dist/
 *.log
+
+# bin/rebuild.mjs builds into dist.tmp/ and renames it over dist/, so that a rebuild killed partway
+# leaves the previous build intact instead of a half-written one. dist.superseded/ is the old tree
+# between the two renames, and .build-lock is the pid file that keeps two rebuilds apart. All three
+# are normally gone within milliseconds; they are listed because a killed rebuild leaves them.
+dist.tmp/
+dist.superseded/
+.build-lock
+
 .DS_Store
 bin/.node-path
 

--- a/claude-plugin/mcp-server/README.md
+++ b/claude-plugin/mcp-server/README.md
@@ -61,18 +61,29 @@ it. By hand:
 
 **Auto-build mechanism:** `mcp-server/bin/run.mjs` hashes `package.json`, `package-lock.json`,
 `tsconfig.json`, and everything under `src/` into a fingerprint stored at
-`dist/.build-fingerprint`, and rebuilds whenever that fingerprint changes (or `dist/`/
-`node_modules` are missing) rather than only on first launch. To force a rebuild manually, delete
+`dist/.build-fingerprint`, and compares it on every launch. To force a rebuild manually, delete
 `dist/.build-fingerprint` (or the whole `dist/` directory) and relaunch, or just run
 `npm ci && npm run build` directly in this directory.
 
-That rebuild happens inside the 30 seconds Claude Code allows a plugin's MCP server to start, so
-the install runs with `--prefer-offline --no-audit --no-fund`. npm's registry round-trips are not
-a fixed cost — the same `npm ci` on the same warm cache was measured at 31.1s once and ~1.5s hours
-later — and blowing the deadline leaves the tools silently absent from the session, so the flags
-are there to keep the step bounded by local work rather than by registry latency. A **cold** cache
-still takes minutes and no flag helps; run `./build.sh` once after a dependency bump, which does
-the same install under no deadline and stamps the fingerprint so the next launch skips the build.
+What it does about a mismatch depends on whether there is anything runnable to fall back on, and
+that distinction is the whole point. Claude Code allows a plugin's MCP server 30 seconds to start;
+a build that overruns it leaves the tools **silently** absent from the session — no error anywhere
+the user looks, while the plugin's skills load normally.
+
+- `dist/` holds a finished build of **older** source → it is launched as-is, and
+  `bin/rebuild.mjs` runs **detached**, outside the deadline. The session runs one turn on the
+  previous server instead of none on a missing one, and the next launch picks up the new build.
+- `dist/` holds **no finished build** → there is nothing to launch, so the build runs first. This
+  is the only path still inside the deadline, and the only one that can still end with no tools, so
+  it says so first — over vibing.nvim's RPC server, which reaches `vim.notify`. The launcher's
+  `stderr` does not reach the user (it is captured into Claude Code's own MCP log, and only when
+  the connection times out).
+
+The install runs with `--prefer-offline --no-audit --no-fund` throughout: npm's registry
+round-trips are not a fixed cost — the same `npm ci` on the same warm cache was measured at 31.1s
+once and ~1.5s hours later. A **cold** cache still takes minutes and no flag helps; the background
+rebuild is what absorbs that now. Run `./build.sh` after a dependency bump to do it deliberately —
+the same install under no deadline, stamping the fingerprint so the next launch skips the build.
 See `handbook/architecture/plugin-and-commands.md` → "The MCP server's own startup budget".
 
 ### 1. Build the MCP Server

--- a/claude-plugin/mcp-server/bin/notify-nvim.mjs
+++ b/claude-plugin/mcp-server/bin/notify-nvim.mjs
@@ -1,0 +1,82 @@
+/**
+ * Tell the Neovim that launched this session why the MCP server is slow, or missing.
+ *
+ * The launcher runs inside Claude Code's 30s MCP startup deadline, and until now anything it had
+ * to say about overrunning it went nowhere. Measured against claude 2.1.231 with a stand-in
+ * plugin whose server only writes one line to stderr and sleeps: that line reaches neither the
+ * CLI's stdout nor its stderr. It is captured into
+ * `~/Library/Caches/claude-cli-nodejs/<cwd-slug>/mcp-logs-plugin-<plugin>-<server>/*.jsonl`, and
+ * even there it is buffered -- it appears only when the connection times out, 30s later, next to
+ * `Connection timeout triggered after 30002ms (limit: 30000ms)`.
+ *
+ * So `console.error` is not a channel to the user; vibing.nvim's own RPC server is. Both CLI
+ * adapters export `VIBING_NVIM_RPC_PORT` (`adapter/modules/rpc_environment.lua`) and claude hands
+ * the launching environment to plugin MCP servers, so it is already in this process's env. The
+ * server speaks newline-delimited JSON-RPC on 127.0.0.1; `notify` is a one-line handler on it.
+ *
+ * Delivery has to happen in a *separate* process, which is why this file is both a module and a
+ * script. Its callers are about to block their own event loop in `spawnSync('npm', ...)` for as
+ * long as the build takes, and a socket opened just before that would not connect until the build
+ * finished -- which, in the case worth reporting, is after Claude Code has already killed them.
+ * `spawn()` creates the child before it returns, so the detached copy delivers while the parent
+ * is blocked.
+ */
+import * as net from 'node:net';
+import { spawn } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const RPC_PORT_ENV = 'VIBING_NVIM_RPC_PORT';
+
+/** Short: a notification nobody is listening for must not outlive the thing it describes. */
+const DELIVERY_TIMEOUT_MS = 3000;
+
+const selfPath = fileURLToPath(import.meta.url);
+
+/**
+ * Connect, write one request, leave. Runs in the detached child, whose event loop is free.
+ * @param {string} level one of "info", "warn", "error"
+ * @param {string} message
+ */
+function deliver(level, message) {
+  const port = Number.parseInt(process.env[RPC_PORT_ENV] ?? '', 10);
+  if (!Number.isInteger(port) || port <= 0) return;
+
+  const socket = net.connect({ host: '127.0.0.1', port });
+  socket.setTimeout(DELIVERY_TIMEOUT_MS, () => socket.destroy());
+  // Neovim being gone is the normal case for a launcher started outside vibing.nvim, not a
+  // failure: nothing here is worth an exit code.
+  socket.on('error', () => {});
+  socket.on('connect', () => {
+    socket.end(
+      JSON.stringify({
+        id: 1,
+        method: 'notify',
+        params: { level, message, title: 'MCP Server' },
+      }) + '\n'
+    );
+  });
+}
+
+/**
+ * Ask a detached copy of this file to deliver `message`. Returns immediately and never throws.
+ * @param {string} level one of "info", "warn", "error"
+ * @param {string} message
+ */
+export function notifyNvim(level, message) {
+  if (!process.env[RPC_PORT_ENV]) return;
+  try {
+    spawn(process.execPath, [selfPath, level, message], {
+      detached: true,
+      stdio: 'ignore',
+    }).unref();
+  } catch {
+    // A notification is never worth failing the launch for.
+  }
+}
+
+// Script mode. `process.argv[1]` is compared through realpath because the launcher may be reached
+// through a symlinked plugin directory, in which case the two spellings differ.
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(selfPath)) {
+  deliver(process.argv[2], process.argv.slice(3).join(' '));
+}

--- a/claude-plugin/mcp-server/bin/rebuild.mjs
+++ b/claude-plugin/mcp-server/bin/rebuild.mjs
@@ -1,0 +1,252 @@
+/**
+ * The MCP server's self-build, and the rules that let it run *outside* Claude Code's 30s MCP
+ * startup deadline instead of inside it.
+ *
+ * Imported by run.mjs for the one case that has no alternative (nothing runnable in `dist/`), and
+ * run as a detached script for every other case, where the previous build is launched first and
+ * this catches up in the background. Which case is which is decided in run.mjs.
+ *
+ * Two properties make the background form safe, and both live here:
+ *
+ * - **`dist/` is replaced, never edited.** The compile writes to `dist.tmp/`, the fingerprint is
+ *   stamped there, and only then is the finished tree renamed into place. So `dist/` is always
+ *   some complete build -- a killed rebuild leaves the previous one untouched rather than a
+ *   half-written one, which is what lets run.mjs launch a stale `dist/` without inspecting it.
+ *   It also means the fingerprint file's *presence* answers "was this a finished build?" and its
+ *   *contents* answer "of which source?", two questions the old in-place build had to conflate by
+ *   deleting the fingerprint before it started.
+ * - **One build at a time.** The lock is an `O_EXCL` file whose contents are the holder's pid, so
+ *   taking it is a single atomic call; a lock whose pid no longer answers `kill(pid, 0)` is
+ *   reclaimed rather than obeyed forever.
+ */
+import { existsSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { computeFingerprint, fingerprintFilePath } from './build-fingerprint.mjs';
+import { notifyNvim } from './notify-nvim.mjs';
+
+// Claude Code gives a plugin's MCP server 30s to come up, and this build used to spend that budget
+// before the server was even spawned. `npm ci` defaults to an audit request and a funding request
+// against the registry, and revalidates package metadata it already has cached -- so how long it
+// takes depends on the registry rather than on this machine. Measured against the same warm cache
+// on macOS, plain `npm ci` ran 31.1s once and ~1.5s hours later; these flags held it at ~1.3s
+// throughout. They stay now that the usual path is a background rebuild, because the one path that
+// still runs under the deadline -- a tree with nothing runnable in `dist/` -- needs every second.
+// (A genuinely cold cache still fetches tarballs and still takes minutes; only `./build.sh`, which
+// is under no such deadline, can fix that case.)
+const OFFLINE_FIRST_FLAGS = ['--prefer-offline', '--no-audit', '--no-fund'];
+
+/**
+ * How long the background rebuild waits before touching anything.
+ *
+ * `npm ci` begins by deleting `node_modules`, and the server it is rebuilding for was spawned out
+ * of that very tree moments earlier. Node resolves an ES module graph eagerly at startup and this
+ * server imports nothing dynamically, so once it is loaded the directory no longer matters -- but
+ * that load takes a few hundred milliseconds and npm's own startup is the same order, so racing it
+ * would kill the server this rebuild exists to keep alive. Nothing waits on a detached rebuild, so
+ * the margin costs nothing; the environment variable is how the launcher tests skip it.
+ */
+const STARTUP_GRACE_MS = readIntEnv('VIBING_MCP_REBUILD_GRACE_MS', 5000);
+
+const LOCK_POLL_MS = 100;
+
+/** @param {string} name @param {number} fallback */
+function readIntEnv(name, fallback) {
+  const value = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+/** @param {string} mcpDir */ const distDirPath = (mcpDir) => join(mcpDir, 'dist');
+/** @param {string} mcpDir */ const stagingDirPath = (mcpDir) => join(mcpDir, 'dist.tmp');
+/** @param {string} mcpDir */ const lockFilePath = (mcpDir) => join(mcpDir, '.build-lock');
+
+/**
+ * Is there something in `dist/` worth launching?
+ *
+ * All three parts are required and each is missing for a different reason: no `dist/index.js` and
+ * there is nothing to run, no `node_modules/` and it cannot resolve its imports, no fingerprint
+ * file and the build that produced `dist/` never finished -- so its contents are unknown.
+ * @param {string} mcpDir
+ * @returns {boolean}
+ */
+export function hasCompleteBuild(mcpDir) {
+  return (
+    existsSync(join(distDirPath(mcpDir), 'index.js')) &&
+    existsSync(join(mcpDir, 'node_modules')) &&
+    existsSync(fingerprintFilePath(mcpDir))
+  );
+}
+
+/**
+ * The source `dist/` was built from, or null when no finished build recorded one.
+ * @param {string} mcpDir
+ * @returns {string|null}
+ */
+export function builtFingerprint(mcpDir) {
+  try {
+    return readFileSync(fingerprintFilePath(mcpDir), 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {number|null} pid the lock's contents, or null if it was not there to read
+ * @returns {boolean} false for a lock with no identifiable owner: it vanished under us, or holds
+ *   something this never wrote. Either way there is nobody to wait for.
+ */
+function isHolderAlive(pid) {
+  if (!Number.isInteger(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the pid exists and belongs to another user, which still counts as held.
+    return error.code === 'EPERM';
+  }
+}
+
+/** @param {number} ms */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Take the build lock, or report that another process holds it.
+ * @param {string} mcpDir
+ * @param {number} waitMs how long to keep trying before giving up
+ * @returns {boolean}
+ */
+function acquireLock(mcpDir, waitMs) {
+  const lockFile = lockFilePath(mcpDir);
+  const deadline = Date.now() + waitMs;
+  // A lock with no live holder is reclaimed rather than obeyed: a build killed by SIGKILL (the
+  // machine sleeping mid-`npm ci`) would otherwise block every later rebuild for good, and the
+  // symptom would be the stale server running forever with nothing to explain it. Bounded, because
+  // both readings below can be out of date the moment they are taken and a failure with any other
+  // cause -- an unwritable directory -- must wait rather than spin.
+  let immediateRetries = 2;
+
+  for (;;) {
+    try {
+      // `wx` is O_CREAT|O_EXCL: the file and its contents appear in one atomic step, so a lock that
+      // exists always names its holder.
+      writeFileSync(lockFile, String(process.pid), { flag: 'wx' });
+      return true;
+    } catch {
+      // Held, or this directory cannot be written to.
+    }
+
+    if (immediateRetries > 0 && !isHolderAlive(readHolder(lockFile))) {
+      immediateRetries -= 1;
+      // A lock that vanished between the failed create and the read leaves nothing to remove, and
+      // `force` is what makes that the same code path as reclaiming a dead holder's.
+      rmSync(lockFile, { force: true });
+      continue;
+    }
+
+    if (Date.now() >= deadline) return false;
+    sleepSync(LOCK_POLL_MS);
+  }
+}
+
+/**
+ * @param {string} lockFile
+ * @returns {number|null} the pid the lock names, or null if there was nothing to read
+ */
+function readHolder(lockFile) {
+  try {
+    return Number.parseInt(readFileSync(lockFile, 'utf8').trim(), 10);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} mcpDir
+ * @param {string[]} args
+ * @returns {string|null} null on success, else what failed
+ */
+function runNpm(mcpDir, args) {
+  const result = spawnSync('npm', args, { cwd: mcpDir, stdio: 'inherit' });
+  if (result.error) return `could not run \`npm ${args.join(' ')}\`: ${result.error.message}`;
+  if (result.status !== 0) return `\`npm ${args.join(' ')}\` exited ${result.status}`;
+  return null;
+}
+
+/**
+ * Move the finished tree over the old one.
+ *
+ * Two renames rather than a recursive delete and a rename, so the window in which no `dist/`
+ * exists is two syscalls wide. A launcher landing inside it finds nothing to run and builds
+ * synchronously -- slow, but never wrong.
+ * @param {string} mcpDir
+ */
+function swapIntoPlace(mcpDir) {
+  const dist = distDirPath(mcpDir);
+  const superseded = `${dist}.superseded`;
+
+  rmSync(superseded, { recursive: true, force: true });
+  if (existsSync(dist)) renameSync(dist, superseded);
+  renameSync(stagingDirPath(mcpDir), dist);
+  rmSync(superseded, { recursive: true, force: true });
+}
+
+/**
+ * Install, compile into `dist.tmp/`, stamp it, and swap it in.
+ *
+ * @param {string} mcpDir
+ * @param {{ lockWaitMs?: number }} [options]
+ * @returns {{ ok: boolean, skipped?: boolean, error?: string }} `skipped` means another process
+ *   holds the lock. That is an outcome, not a failure: it is building the same tree, and its
+ *   result lands in the same `dist/`.
+ */
+export function rebuild(mcpDir, { lockWaitMs = 0 } = {}) {
+  if (!acquireLock(mcpDir, lockWaitMs)) return { ok: false, skipped: true };
+
+  const staging = stagingDirPath(mcpDir);
+  try {
+    // Whatever a previous, killed attempt left there says nothing about this source.
+    rmSync(staging, { recursive: true, force: true });
+
+    // Read before the install, so that a source edit landing mid-build is recorded as *not* built
+    // rather than silently claimed by this one.
+    const fingerprint = computeFingerprint(mcpDir);
+    const failure =
+      runNpm(mcpDir, ['ci', ...OFFLINE_FIRST_FLAGS, '--silent']) ??
+      runNpm(mcpDir, ['run', 'build', '--silent', '--', '--outDir', staging]);
+    if (failure) return { ok: false, error: failure };
+
+    // Last, and inside the staging tree: this file's existence is the promise that the tree beside
+    // it is complete, so it must never be written before the compile that fills it.
+    writeFileSync(join(staging, '.build-fingerprint'), fingerprint);
+    swapIntoPlace(mcpDir);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error.message };
+  } finally {
+    rmSync(lockFilePath(mcpDir), { force: true });
+  }
+}
+
+// Script mode: the detached background rebuild run.mjs starts when it launches a stale build
+// rather than make the session wait for a fresh one. Compared through realpath because the plugin
+// directory may be reached through a symlink, in which case the two spellings differ.
+const selfPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(selfPath)) {
+  const mcpDir = join(dirname(selfPath), '..');
+  if (STARTUP_GRACE_MS > 0) await sleep(STARTUP_GRACE_MS);
+
+  const result = rebuild(mcpDir);
+  if (result.ok) {
+    notifyNvim('info', 'MCP server rebuilt. The next request uses the new build.');
+  } else if (!result.skipped) {
+    notifyNvim(
+      'error',
+      `MCP server rebuild failed (${result.error}). ` +
+        'The previous build keeps serving this session; run ./build.sh to fix it.'
+    );
+  }
+}

--- a/claude-plugin/mcp-server/bin/run.mjs
+++ b/claude-plugin/mcp-server/bin/run.mjs
@@ -2,76 +2,108 @@
 /**
  * Self-building launcher for the vibing-nvim MCP server.
  *
- * Claude Code plugin installation does not run an install/build step, so
- * this wrapper builds mcp-server/dist on first launch before exec'ing the
- * compiled server. Used as the `command` for the plugin's bundled MCP
- * server in .claude-plugin/plugin.json.
+ * Claude Code plugin installation does not run an install/build step, so this wrapper builds
+ * mcp-server/dist before exec'ing the compiled server. Used as the `command` for the plugin's
+ * bundled MCP server in .claude-plugin/plugin.json.
  *
- * For "directory"-source plugin installs, CLAUDE_PLUGIN_ROOT points at the
- * live checkout rather than a per-version cache, so a source update (e.g. a
- * `git pull` outside of build.sh) can leave a stale dist/ behind. A content
- * fingerprint of package.json/package-lock.json/src/ (not just dist/index.js
- * presence) is used to detect that and rebuild.
+ * For "directory"-source plugin installs, CLAUDE_PLUGIN_ROOT points at the live checkout rather
+ * than a per-version cache, so a source update (e.g. a `git pull` outside of build.sh) can leave a
+ * stale dist/ behind. A content fingerprint of package.json/package-lock.json/src/ (not just
+ * dist/index.js presence) is used to detect that.
  *
- * This runs `npm ci`/`npm run build` against whatever is checked out at
- * CLAUDE_PLUGIN_ROOT — only add this plugin's marketplace from a source you
- * trust (see the "Trust note" in mcp-server/README.md).
+ * **The build does not get to spend the startup deadline.** Claude Code gives a plugin's MCP
+ * server 30s to connect, and overrunning it is invisible: the server never connects, so
+ * `mcp__plugin_vibing-nvim_vibing-nvim__*` is absent from the model's tool list for the whole
+ * session, while the skills and the `nvim-navigator` agent -- same `--plugin-dir`, no process
+ * needed -- load normally. Nothing logs anywhere the user looks (measured; see notify-nvim.mjs),
+ * so the model concludes the tools do not exist. A cold `npm ci` takes minutes, which no flag
+ * fixes, and the old in-place build never recovered from being killed: it deleted the fingerprint
+ * up front, so the next turn started over from the same place and was killed again (#690).
+ *
+ * So staleness is not what decides whether to build first. Completeness is:
+ *
+ * - `dist/` is a finished build of this source -> launch it. Nothing to do.
+ * - `dist/` is a finished build of *older* source -> launch it anyway, and rebuild detached. The
+ *   session runs one turn on the previous server rather than none on a missing one, and the next
+ *   launch picks the new build up. rebuild.mjs only ever swaps whole trees into place, which is
+ *   what makes an unexamined stale `dist/` safe to run.
+ * - `dist/` holds no finished build -> there is nothing to launch, so build now and hope it fits.
+ *   Say so first, over RPC, because this is the case that can still end with no tools.
+ *
+ * This runs `npm ci`/`npm run build` against whatever is checked out at CLAUDE_PLUGIN_ROOT -- only
+ * add this plugin's marketplace from a source you trust (see the "Trust note" in
+ * mcp-server/README.md).
  */
-import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
-import { spawnSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { computeFingerprint, fingerprintFilePath } from './build-fingerprint.mjs';
+import { computeFingerprint } from './build-fingerprint.mjs';
+import { builtFingerprint, hasCompleteBuild, rebuild } from './rebuild.mjs';
+import { notifyNvim } from './notify-nvim.mjs';
 
 const mcpDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const distEntry = join(mcpDir, 'dist', 'index.js');
-const nodeModulesDir = join(mcpDir, 'node_modules');
-const fingerprintFile = fingerprintFilePath(mcpDir);
+const rebuildScript = join(mcpDir, 'bin', 'rebuild.mjs');
 
-// Claude Code gives a plugin's MCP server 30s to come up, and this launcher
-// spends that budget before the server is even spawned. `npm ci` defaults to an
-// audit request and a funding request against the registry, and revalidates
-// package metadata it already has cached — so how long it takes depends on the
-// registry rather than on this machine. Measured against the same warm cache on
-// macOS, plain `npm ci` ran 31.1s once and ~1.5s hours later; these flags held
-// it at ~1.3s throughout. The point is not the average, it is that without them
-// the step can exceed the deadline at a moment nothing here controls, and the
-// whole vibing-nvim tool set then silently disappears from the session.
-// (A genuinely cold cache still fetches tarballs and still takes minutes; only
-// `./build.sh`, which is under no such deadline, can fix that case.)
-const OFFLINE_FIRST_FLAGS = ['--prefer-offline', '--no-audit', '--no-fund'];
+/**
+ * How long the blocking build may wait for a rebuild already in flight.
+ *
+ * Reached only with nothing to launch, where the alternative to waiting is two `npm ci` runs
+ * writing the same `node_modules`. Kept well inside the 30s deadline: the other process finishing
+ * hands us a `dist/` for free, and if it does not, spending the remainder on our own build is
+ * still better than exiting with none.
+ */
+const BUILD_LOCK_WAIT_MS = 10_000;
 
-function isBuildStale(fingerprint) {
-  if (!existsSync(distEntry) || !existsSync(nodeModulesDir) || !existsSync(fingerprintFile)) {
-    return true;
-  }
-  return readFileSync(fingerprintFile, 'utf8').trim() !== fingerprint;
-}
-
-function run(command, args) {
-  const result = spawnSync(command, args, { cwd: mcpDir, stdio: 'inherit' });
-  const label = `${command} ${args.join(' ')}`;
-  if (result.error) {
-    console.error(`[vibing-nvim] Failed to run: ${label}`);
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    console.error(`[vibing-nvim] Command failed (exit ${result.status}): ${label}`);
-    process.exit(result.status ?? 1);
-  }
-}
-
-const fingerprint = computeFingerprint(mcpDir);
-if (isBuildStale(fingerprint)) {
+function buildBeforeLaunch() {
+  notifyNvim(
+    'warn',
+    'Building the MCP server, with no previous build to fall back on. Claude Code allows 30s; ' +
+      'past that the vibing-nvim tools are missing for this session. Run ./build.sh to build it ' +
+      'without a deadline.'
+  );
   console.error('[vibing-nvim] Building MCP server...');
-  // Drop any existing fingerprint up front so a build that fails partway
-  // (tsc can emit partial output despite reporting errors) never leaves a
-  // stale fingerprint behind that would make a later, unrelated source
-  // state look "already built" against a corrupted dist/.
-  rmSync(fingerprintFile, { force: true });
-  run('npm', ['ci', ...OFFLINE_FIRST_FLAGS, '--silent']);
-  run('npm', ['run', 'build', '--silent']);
-  writeFileSync(fingerprintFile, fingerprint);
+
+  const result = rebuild(mcpDir, { lockWaitMs: BUILD_LOCK_WAIT_MS });
+  // A skipped build means another process holds the lock and may have finished in the meantime;
+  // only its failure to produce anything runnable is fatal here.
+  if (!result.ok && !result.skipped) {
+    console.error(`[vibing-nvim] Build failed: ${result.error}`);
+    notifyNvim('error', `MCP server build failed (${result.error}). Run ./build.sh.`);
+    process.exit(1);
+  }
+  if (!hasCompleteBuild(mcpDir)) {
+    console.error('[vibing-nvim] Build produced no runnable server');
+    notifyNvim('error', 'MCP server build produced nothing runnable. Run ./build.sh.');
+    process.exit(1);
+  }
+}
+
+function rebuildInBackground() {
+  notifyNvim(
+    'info',
+    'MCP server source changed since it was built. This session uses the previous build while a ' +
+      'new one is built in the background.'
+  );
+  console.error('[vibing-nvim] Rebuilding MCP server in the background...');
+
+  try {
+    spawn(process.execPath, [rebuildScript], {
+      cwd: mcpDir,
+      detached: true,
+      stdio: 'ignore',
+      env: process.env,
+    }).unref();
+  } catch (error) {
+    // The launch itself is unaffected: the server about to start is a working one, just older.
+    console.error(`[vibing-nvim] Could not start the background rebuild: ${error.message}`);
+  }
+}
+
+if (!hasCompleteBuild(mcpDir)) {
+  buildBeforeLaunch();
+} else if (builtFingerprint(mcpDir) !== computeFingerprint(mcpDir)) {
+  rebuildInBackground();
 }
 
 const child = spawn(process.execPath, [distEntry], { stdio: 'inherit', env: process.env });

--- a/handbook/architecture/plugin-and-commands.md
+++ b/handbook/architecture/plugin-and-commands.md
@@ -263,18 +263,66 @@ Two pieces were therefore moved off that path, taking a measured ~32ms `setup()`
 A scan moved to first use also reads `vim.fn.getcwd()` at first use, which is the more accurate
 cwd for picking up a project's `.claude/commands/` anyway.
 
-### The MCP server's own startup budget is 30 seconds, and the launcher spends it first
+### The MCP server's own startup budget is 30 seconds, and the launcher no longer spends it
 
 That is a different clock from `setup()`: it starts when the CLI spawns
 `claude-plugin/mcp-server/bin/run.sh` for a turn, and it runs out before the server has said
-anything. `run.mjs` sits inside it, and rebuilds whenever the source fingerprint moved — which is
-every first turn after a `git pull` that touched `src/`.
+anything. `run.mjs` sits inside it.
 
 Overrunning it does not look like a failure. The server simply never connects, so
 `mcp__plugin_vibing-nvim_vibing-nvim__*` is absent from the model's tool list for the whole
 session while the skills and the `nvim-navigator` agent — which come from the same
-`--plugin-dir` and need no process — load normally. Nothing logs, and the model is left to
-conclude the tools do not exist.
+`--plugin-dir` and need no process — load normally. The model is left to conclude the tools do
+not exist. It happened for a full day after #679, and cost half a day to diagnose (#690).
+
+**Nothing about it reaches the user, and that was measured rather than assumed.** A stand-in
+plugin whose MCP server writes one line to stderr and then sleeps, loaded with `--plugin-dir` and
+driven by the token-free `control_request`/`initialize` probe above, put that line in exactly one
+place: `~/Library/Caches/claude-cli-nodejs/<cwd-slug>/mcp-logs-plugin-<plugin>-<server>/*.jsonl`.
+Not the CLI's stdout, not its stderr — and buffered even there, appearing only at
+`Connection timeout triggered after 30002ms (limit: 30000ms)`, 30s late. So `console.error` in the
+launcher is not a channel to anyone. vibing.nvim's own RPC server is: `VIBING_NVIM_RPC_PORT` is
+already in the launcher's environment, and `bin/notify-nvim.mjs` writes one `notify` request to it.
+Delivery goes through a **detached child**, because the launcher's own event loop is about to be
+blocked inside `spawnSync('npm', …)` for exactly as long as the thing being reported.
+
+#### Completeness decides whether to build first, not staleness
+
+`run.mjs` used to rebuild whenever the source fingerprint moved — every first turn after a
+`git pull` that touched `src/` — and the rebuild ran inside the deadline. Now:
+
+| `dist/`                            | What happens                                                  |
+| ---------------------------------- | ------------------------------------------------------------- |
+| a finished build of this source    | launched; nothing else                                        |
+| a finished build of _older_ source | launched anyway, and `bin/rebuild.mjs` runs **detached**      |
+| no finished build (or none at all) | built first, after saying so over RPC — the one deadline case |
+
+The cost is one turn served by the previous server, which is a narrower window than it sounds:
+since #618 the MCP server and the Neovim plugin come from the same checkout, so what is stale is
+one commit of `src/`, and the failure mode is a tool behaving as it did one commit ago. Against
+the alternative — every tool absent, silently, for the whole session — it is not close.
+
+Two properties in `rebuild.mjs` are what make launching an unexamined stale `dist/` safe, and
+neither is optional:
+
+- **`dist/` is replaced, never edited.** The compile writes to `dist.tmp/`, the fingerprint is
+  stamped there, and the finished tree is renamed into place. A rebuild killed partway therefore
+  leaves the _previous_ build intact instead of a half-written one. This is also what lets the
+  fingerprint file's **presence** mean "this was a finished build" and its **contents** mean "of
+  which source" — two questions the old in-place build had to conflate, since it deleted the
+  fingerprint before it started.
+- **One build at a time**, through an `O_EXCL` lock file holding the holder's pid. A lock whose pid
+  no longer answers `kill(pid, 0)` is reclaimed once; obeying it forever would strand the stale
+  server with nothing to explain it.
+
+The background rebuild also waits ~5s before starting, because `npm ci` opens by deleting
+`node_modules` and the server it is rebuilding for was spawned out of that tree moments earlier.
+Node resolves an ES module graph eagerly and the server imports nothing dynamically, so the
+directory stops mattering once it is loaded — but that load and npm's own startup are the same
+order of magnitude. Nothing waits on a detached rebuild, so the margin is free.
+`VIBING_MCP_REBUILD_GRACE_MS` exists so the launcher tests do not sit through it.
+
+#### What the install actually costs
 
 The compile is not the cost and never was — `typescript@7` is the native compiler, and
 `npm run build` is 0.19s. The whole budget goes to `npm ci`, and **what it costs is not a
@@ -293,15 +341,19 @@ each other within that slow window (`--prefer-offline` alone 5.0s, `--no-audit -
 1.3s) and again later, when plain `npm ci` had become as fast as the flagged form.
 
 So `OFFLINE_FIRST_FLAGS` does not remove a fixed 31s. What it removes is **the dependency on
-registry latency inside a deadline that cannot absorb it**: with the flags the step is bounded by
-local work, and end-to-end `run.sh` → `initialize` measures 1.8–2.2s from a stale fingerprint.
-`tests/mcp-server-launcher.test.mjs` runs the real launcher against a fake `npm` to keep the flags
-there.
+registry latency inside a deadline that cannot absorb it**. The flags stay even though the usual
+path no longer runs under the deadline, because the one path that still does — a tree with nothing
+runnable in `dist/` — needs every second.
 
-**A cold cache is the case this does not fix**, and it is the one that most likely caused the
-incident that prompted the change (#679 bumped typescript, vitest and @types/node together, so
-the next launch had to fetch everything). 7 minutes is so far past 30s that every turn's build was
-killed partway, leaving a half-installed `node_modules` and no fingerprint — so the next turn
-tried again from the same place. `./build.sh` is the escape hatch: it runs the same install under
-no deadline and stamps the fingerprint (`bin/write-fingerprint.mjs`), so the next launch skips the
-build entirely. Run it after a dependency bump.
+**A cold cache is the case flags do not fix**, and it is the one that caused #690 (#679 bumped
+typescript, vitest and @types/node together, so the next launch had to fetch everything). 7 minutes
+is so far past 30s that every turn's build was killed partway, leaving a half-installed
+`node_modules` and no fingerprint — so the next turn started from the same place and was killed
+again, forever, until someone ran `./build.sh` by hand. That loop is what the background rebuild
+ends: it is under no deadline, so it finishes, and the session it started in keeps its tools
+throughout. `./build.sh` remains the way to do it deliberately — the same install with no deadline,
+stamping the fingerprint through `bin/write-fingerprint.mjs`. Run it after a dependency bump.
+
+`tests/mcp-server-launcher.test.mjs` runs the real launcher against a fake `npm` first on PATH, so
+it asserts on what the launcher did — the argv it passed, which build it launched, how long it
+took to get there, and what it sent to a stand-in RPC server — rather than on the text of the file.

--- a/lua/vibing/infrastructure/rpc/handlers/init.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/init.lua
@@ -14,6 +14,7 @@ local permission = require("vibing.infrastructure.rpc.handlers.permission")
 local rate_limit = require("vibing.infrastructure.rpc.handlers.rate_limit")
 local qflist = require("vibing.infrastructure.rpc.handlers.qflist")
 local dap = require("vibing.infrastructure.rpc.handlers.dap")
+local notify = require("vibing.infrastructure.rpc.handlers.notify")
 
 -- Export all handlers
 M.buf_get_lines = buffer.buf_get_lines
@@ -72,5 +73,7 @@ M.dap_get_stack_trace = dap.dap_get_stack_trace
 M.dap_get_variables = dap.dap_get_variables
 M.dap_set_breakpoint = dap.dap_set_breakpoint
 M.dap_evaluate = dap.dap_evaluate
+
+M.notify = notify.notify
 
 return M

--- a/lua/vibing/infrastructure/rpc/handlers/notify.lua
+++ b/lua/vibing/infrastructure/rpc/handlers/notify.lua
@@ -1,0 +1,43 @@
+--- Show a message from a process that has no other way to reach the user.
+---
+--- The one caller is the MCP server's launcher (`claude-plugin/mcp-server/bin/notify-nvim.mjs`),
+--- which runs before the server exists and so cannot report through a tool result. Its `stderr`
+--- reaches neither the CLI's own streams nor anything the user reads -- measured; the reasoning is
+--- in that file -- so a message about the launcher missing Claude Code's 30s startup deadline had
+--- nowhere to go, and the whole tool set disappearing from a session looked like nothing at all
+--- (#690).
+---
+--- This is deliberately not `execute`: a caller that only needs to say something should not have
+--- to be trusted with running Lua.
+--- @module vibing.infrastructure.rpc.handlers.notify
+
+local Notify = require("vibing.core.utils.notify")
+
+local M = {}
+
+--- @type table<string, fun(message: string, action: string?)>
+local BY_LEVEL = {
+  info = Notify.info,
+  warn = Notify.warn,
+  error = Notify.error,
+}
+
+--- @param params table? { message: string, level: string?, title: string? }
+--- @return table
+function M.notify(params)
+  params = params or {}
+
+  local message = params.message
+  if type(message) ~= "string" or message == "" then
+    error("notify requires a non-empty message")
+  end
+
+  -- An unrecognised level is shown rather than dropped: the point of this handler is that the
+  -- caller has no second channel to report the mistake on.
+  local emit = BY_LEVEL[params.level] or Notify.info
+  emit(message, type(params.title) == "string" and params.title or nil)
+
+  return { success = true }
+end
+
+return M

--- a/tests/lua/infrastructure/rpc/handlers/notify_spec.lua
+++ b/tests/lua/infrastructure/rpc/handlers/notify_spec.lua
@@ -1,0 +1,50 @@
+describe("rpc handler notify", function()
+  local notify = require("vibing.infrastructure.rpc.handlers.notify")
+
+  local original_notify
+  local shown
+
+  before_each(function()
+    shown = {}
+    original_notify = vim.notify
+    vim.notify = function(message, level)
+      table.insert(shown, { message = message, level = level })
+    end
+  end)
+
+  after_each(function()
+    vim.notify = original_notify
+  end)
+
+  it("shows the message at the requested level", function()
+    local result = notify.notify({ message = "rebuilt", level = "error", title = "MCP Server" })
+
+    assert.is_true(result.success)
+    assert.equals(1, #shown)
+    assert.equals("[vibing] MCP Server: rebuilt", shown[1].message)
+    assert.equals(vim.log.levels.ERROR, shown[1].level)
+  end)
+
+  it("shows a message whose level it does not recognise rather than dropping it", function()
+    -- The MCP server launcher is the caller, and it has no second channel to report a bad level
+    -- on: the whole point of this handler is that its stderr reaches nobody (#690).
+    notify.notify({ message = "something happened", level = "catastrophe" })
+
+    assert.equals(1, #shown)
+    assert.equals(vim.log.levels.INFO, shown[1].level)
+  end)
+
+  it("refuses a call with no message", function()
+    assert.has_error(function()
+      notify.notify({ level = "warn" })
+    end)
+    assert.has_error(function()
+      notify.notify({ message = "" })
+    end)
+    assert.equals(0, #shown)
+  end)
+
+  it("is reachable under the name the launcher sends", function()
+    assert.equals(notify.notify, require("vibing.infrastructure.rpc.handlers").notify)
+  end)
+end)

--- a/tests/mcp-server-launcher.test.mjs
+++ b/tests/mcp-server-launcher.test.mjs
@@ -1,43 +1,63 @@
 #!/usr/bin/env node
 /**
  * claude-plugin/mcp-server/bin/run.mjs runs before the MCP server exists, inside the 30s Claude
- * Code allows a plugin's server to start. Everything it spends there comes out of that budget.
+ * Code allows a plugin's server to start. Everything it spends there comes out of that budget, and
+ * overrunning it is silent: the server never connects, so the whole vibing-nvim tool set vanishes
+ * from the session while the skills from the same `--plugin-dir` load normally. Nothing else in the
+ * project notices, because the failure is a missing tool rather than a failing command.
  *
- * A plain `npm ci` does not fit in it. Measured against a warm cache on macOS, the audit and
- * funding round-trips plus metadata revalidation take 31s on their own — so any commit that
- * leaves the build stale (a `git pull` touching src/, say) makes the launcher time out on every
- * turn, and the whole vibing-nvim tool set vanishes from the session with no error anywhere.
- * Nothing else in the project notices: the failure is a missing tool, not a failing command.
+ * A plain `npm ci` does not reliably fit in that budget, and a cold one takes minutes, which no
+ * flag fixes. So the launcher no longer spends the deadline on a build it can avoid: a `dist/` that
+ * is a *finished* build of older source is launched as-is and rebuilt detached, and only a `dist/`
+ * with nothing runnable in it is built first (#690).
  *
  * These tests run the real launcher against a throwaway mcp-server tree with a fake `npm` first on
- * PATH, so they assert on the argv it actually passes rather than on the text of the file.
+ * PATH, so they assert on what it actually did -- the argv it passed, which build it launched, how
+ * long it took to get there -- rather than on the text of the file.
  */
 
 import { strict as assert } from 'assert';
 import { test } from 'node:test';
 import { spawnSync } from 'node:child_process';
+import * as net from 'node:net';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { mkdtemp, mkdir, copyFile, writeFile, chmod, rm } from 'fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const launcherDir = join(repoRoot, 'claude-plugin/mcp-server/bin');
+const LAUNCHER_FILES = ['run.mjs', 'rebuild.mjs', 'build-fingerprint.mjs', 'notify-nvim.mjs'];
 
 /**
- * A stand-in for npm that records its argv and, for `run build`, produces the dist/ output the
- * launcher goes on to require. Exiting 0 without it would make the launcher fail for a reason
- * these tests are not about.
+ * A stand-in for npm that records its argv and reproduces the two effects the launcher depends on:
+ * `ci` creates node_modules, and `run build` writes an entry point to wherever `--outDir` points
+ * (the rebuild compiles into a staging directory, not into dist/). `NPM_DELAY` makes it slow, which
+ * is how a test tells "the launcher waited for the build" apart from "it did not".
  */
 const FAKE_NPM = `#!/bin/sh
 printf '%s\\n' "$*" >> "$NPM_LOG"
+if [ -n "$NPM_DELAY" ]; then sleep "$NPM_DELAY"; fi
+if [ "$1" = "ci" ]; then
+  mkdir -p node_modules
+fi
 if [ "$1" = "run" ]; then
-  mkdir -p dist
-  echo 'process.exit(0)' > dist/index.js
+  out=dist
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "--outDir" ]; then out="$2"; fi
+    shift
+  done
+  mkdir -p "$out"
+  echo 'process.exit(0)' > "$out/index.js"
 fi
 exit 0
 `;
+
+/** A dist/index.js that proves which build was launched, by leaving a file behind. */
+const markerServer = (path) =>
+  `require('fs').writeFileSync(${JSON.stringify(path)}, 'launched');\nprocess.exit(0);\n`;
 
 /** Build a throwaway tree shaped like claude-plugin/mcp-server/, with the real launcher in it. */
 async function makeTree() {
@@ -46,7 +66,7 @@ async function makeTree() {
   await mkdir(join(dir, 'mcp/src'), { recursive: true });
   await mkdir(join(dir, 'fakebin'), { recursive: true });
 
-  for (const file of ['run.mjs', 'build-fingerprint.mjs']) {
+  for (const file of LAUNCHER_FILES) {
     await copyFile(join(launcherDir, file), join(dir, 'mcp/bin', file));
   }
   await writeFile(join(dir, 'mcp/package.json'), '{ "name": "stub", "version": "0.0.0" }\n');
@@ -59,21 +79,59 @@ async function makeTree() {
   return dir;
 }
 
-/** Run the launcher in `dir`, and return its exit code plus one entry per npm invocation. */
-function runLauncher(dir) {
+/** Run the launcher in `dir`, and return its exit code, elapsed ms, and one entry per npm call. */
+function runLauncher(dir, extraEnv = {}) {
   const log = join(dir, 'npm.log');
+  const env = {
+    ...process.env,
+    PATH: `${join(dir, 'fakebin')}:${process.env.PATH}`,
+    NPM_LOG: log,
+    // The suite may itself be running inside a vibing.nvim session, where this variable names the
+    // developer's live Neovim. Left in place, every launcher under test would notify it.
+    VIBING_NVIM_RPC_PORT: '',
+    // The background rebuild waits for the server it replaces to finish loading node_modules.
+    // Nothing is really loading here, and the tests would only wait.
+    VIBING_MCP_REBUILD_GRACE_MS: '0',
+    ...extraEnv,
+  };
+
+  const startedAt = Date.now();
   const result = spawnSync(process.execPath, [join(dir, 'mcp/bin/run.mjs')], {
-    env: { ...process.env, PATH: `${join(dir, 'fakebin')}:${process.env.PATH}`, NPM_LOG: log },
+    env,
     encoding: 'utf8',
     timeout: 60_000,
   });
+  const elapsedMs = Date.now() - startedAt;
   assert.notEqual(result.status, null, `launcher did not exit: ${result.error ?? 'unknown'}`);
-  const calls = existsSync(log)
-    ? readFileSync(log, 'utf8')
-        .split('\n')
-        .filter((line) => line.length > 0)
-    : [];
-  return { code: result.status, stderr: result.stderr, calls };
+  return { code: result.status, stderr: result.stderr, elapsedMs, calls: npmCalls(dir) };
+}
+
+/** @returns {string[]} one entry per fake-npm invocation so far */
+function npmCalls(dir) {
+  const log = join(dir, 'npm.log');
+  if (!existsSync(log)) return [];
+  return readFileSync(log, 'utf8')
+    .split('\n')
+    .filter((line) => line.length > 0);
+}
+
+/** Wait for `predicate`, which the detached rebuild satisfies on its own schedule. */
+async function eventually(predicate, what, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() >= deadline) assert.fail(`timed out waiting for ${what}`);
+    await sleep(50);
+  }
+}
+
+/** Put a tree into the state a successful `./build.sh` leaves: built, current, complete. */
+function prime(dir) {
+  const primed = runLauncher(dir);
+  // A first run that died leaves no dist/ and no fingerprint, so whatever the test does next would
+  // be measuring a broken launcher rather than the thing it is about.
+  assert.equal(primed.code, 0, `priming run failed: ${primed.stderr}`);
+  return primed;
 }
 
 test('the self-build keeps npm off the registry', async () => {
@@ -94,13 +152,17 @@ test('the self-build keeps npm off the registry', async () => {
   }
 });
 
-test('a stale tree is rebuilt and the compiled server is launched', async () => {
+test('a tree with nothing runnable is built before the server is launched', async () => {
   const dir = await makeTree();
   try {
     const { code, calls, stderr } = runLauncher(dir);
     assert.equal(code, 0, `launcher failed: ${stderr}`);
     assert.equal(calls.length, 2, `expected an install and a build, got ${JSON.stringify(calls)}`);
     assert.ok(calls[1].startsWith('run build'));
+    assert.ok(
+      existsSync(join(dir, 'mcp/dist/.build-fingerprint')),
+      'the finished build left no fingerprint, so the next launch would build it again'
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -109,21 +171,153 @@ test('a stale tree is rebuilt and the compiled server is launched', async () => 
 test('a tree already built for this source is launched without touching npm', async () => {
   const dir = await makeTree();
   try {
-    // node_modules/ is one of the three things isBuildStale checks for; the fake npm does not
-    // create it, so without this the second run would rebuild for a reason unrelated to the
-    // fingerprint.
-    await mkdir(join(dir, 'mcp/node_modules'), { recursive: true });
-    // Assert the priming run worked. A first run that died leaves no dist/ and no fingerprint,
-    // so the second run would rebuild — and this test would then report "spent a build it did
-    // not need" for a build it did need, blaming the fingerprint for a broken launcher.
-    const primed = runLauncher(dir);
-    assert.equal(primed.code, 0, `priming run failed: ${primed.stderr}`);
+    prime(dir);
     await rm(join(dir, 'npm.log'));
 
     const { code, calls } = runLauncher(dir);
     assert.equal(code, 0);
     assert.deepEqual(calls, [], 'an unchanged tree spent a build it did not need');
   } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a stale build is launched at once and rebuilt in the background', async () => {
+  const dir = await makeTree();
+  try {
+    prime(dir);
+    await rm(join(dir, 'npm.log'));
+
+    // The state the incident in #690 started from: source moved, so the recorded fingerprint no
+    // longer matches, but the previous build is intact and perfectly runnable.
+    const marker = join(dir, 'launched-stale');
+    await writeFile(join(dir, 'mcp/dist/index.js'), markerServer(marker));
+    await writeFile(join(dir, 'mcp/src/index.ts'), 'export const x = 2;\n');
+
+    // Long enough that a launcher which waited for the build could not possibly come in under the
+    // assertion below, and short enough not to dominate the suite.
+    const { code, elapsedMs } = runLauncher(dir, { NPM_DELAY: '3' });
+
+    assert.equal(code, 0);
+    assert.ok(existsSync(marker), 'the stale build was not launched');
+    assert.ok(
+      elapsedMs < 2000,
+      `the launcher waited ${elapsedMs}ms for the rebuild; the point is that it does not`
+    );
+
+    await eventually(
+      () => npmCalls(dir).some((call) => call.startsWith('run build')),
+      'the detached rebuild to run'
+    );
+
+    const { computeFingerprint } = await import(
+      pathToFileURL(join(dir, 'mcp/bin/build-fingerprint.mjs')).href
+    );
+    await eventually(
+      () =>
+        existsSync(join(dir, 'mcp/dist/.build-fingerprint')) &&
+        readFileSync(join(dir, 'mcp/dist/.build-fingerprint'), 'utf8').trim() ===
+          computeFingerprint(join(dir, 'mcp')),
+      'the rebuilt tree to be swapped into place'
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a dist left behind by an interrupted build is not launched', async () => {
+  const dir = await makeTree();
+  try {
+    prime(dir);
+    await rm(join(dir, 'npm.log'));
+    // What a build killed partway leaves: output in dist/, but no fingerprint vouching for it. Its
+    // contents are unknown, so launching it would be worse than spending the deadline.
+    await rm(join(dir, 'mcp/dist/.build-fingerprint'));
+    const marker = join(dir, 'launched-partial');
+    await writeFile(join(dir, 'mcp/dist/index.js'), markerServer(marker));
+
+    const { code, calls } = runLauncher(dir);
+
+    assert.equal(code, 0);
+    assert.ok(
+      calls.some((call) => call.startsWith('ci ')),
+      `an unvouched-for dist/ was launched as-is; calls were ${JSON.stringify(calls)}`
+    );
+    assert.ok(!existsSync(marker), 'the partial build was launched');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a rebuild already in flight is not started a second time', async () => {
+  const dir = await makeTree();
+  try {
+    prime(dir);
+    await rm(join(dir, 'npm.log'));
+    await writeFile(join(dir, 'mcp/src/index.ts'), 'export const x = 3;\n');
+
+    // This test process is unquestionably alive, so a lock naming it is a lock that is held.
+    await writeFile(join(dir, 'mcp/.build-lock'), String(process.pid));
+    const held = runRebuildScript(dir);
+    assert.equal(held.status, 0, `rebuild exited ${held.status}: ${held.stderr}`);
+    assert.deepEqual(npmCalls(dir), [], 'a second rebuild ran against a tree already being built');
+
+    // A lock left behind by a process that no longer exists must not block rebuilds for good --
+    // the symptom would be the stale server running forever with nothing to explain it.
+    const dead = spawnSync(process.execPath, ['-e', '']).pid;
+    await writeFile(join(dir, 'mcp/.build-lock'), String(dead));
+    const reclaimed = runRebuildScript(dir);
+    assert.equal(reclaimed.status, 0, `rebuild exited ${reclaimed.status}: ${reclaimed.stderr}`);
+    assert.ok(
+      npmCalls(dir).some((call) => call.startsWith('ci ')),
+      'a lock held by a dead process was obeyed'
+    );
+    assert.ok(!existsSync(join(dir, 'mcp/.build-lock')), 'the rebuild kept its lock');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+function runRebuildScript(dir) {
+  return spawnSync(process.execPath, [join(dir, 'mcp/bin/rebuild.mjs')], {
+    env: {
+      ...process.env,
+      PATH: `${join(dir, 'fakebin')}:${process.env.PATH}`,
+      NPM_LOG: join(dir, 'npm.log'),
+      VIBING_NVIM_RPC_PORT: '',
+      VIBING_MCP_REBUILD_GRACE_MS: '0',
+    },
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+}
+
+test('spending the deadline on a build is reported to Neovim', async () => {
+  const dir = await makeTree();
+  const received = [];
+  const server = net.createServer((socket) => {
+    socket.on('data', (chunk) => {
+      for (const line of chunk.toString().split('\n')) {
+        if (line.length > 0) received.push(JSON.parse(line));
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    // Nothing runnable in dist/, so this is the one path that still spends the startup budget --
+    // and the only one that can still end with no tools in the session. It has to say so, and
+    // stderr is not a channel that reaches anyone (see bin/notify-nvim.mjs).
+    const { code } = runLauncher(dir, { VIBING_NVIM_RPC_PORT: String(server.address().port) });
+    assert.equal(code, 0);
+
+    await eventually(() => received.length > 0, 'the launcher to notify Neovim');
+    const [request] = received;
+    assert.equal(request.method, 'notify');
+    assert.equal(request.params.level, 'warn');
+    assert.match(request.params.message, /build\.sh/);
+  } finally {
+    server.close();
     await rm(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
# Pull Request

## Summary

MCPサーバーのランチャーが Claude Code の30秒起動期限を無言で超過し、`mcp__plugin_vibing-nvim_vibing-nvim__*` がセッションから丸ごと消える問題を修正します。

ビルドするかどうかの判断基準を「フィンガープリントが古いか（staleness）」から「起動できるビルドが揃っているか（completeness）」に変更しました。古いソースの**完成した**ビルドがあるならそれをそのまま起動し、リビルドはデタッチして期限の外で走らせます。期限内でビルドせざるを得ないのは `dist/` に起動できるものが何も無い場合だけで、そのケースは開始前にRPC経由でユーザーに通知します。

## Changes

- **`bin/rebuild.mjs`（新規）**: ビルド本体。`dist.tmp/` にコンパイルしてフィンガープリントを刻んでから `dist/` へrenameで差し替えるので、途中で殺されても前のビルドが無傷で残ります。これにより「フィンガープリントファイルが**存在する** = 完了したビルドである」「**中身** = どのソースのものか」という2つの意味が分離され、ランチャーが古い `dist/` を中身を見ずに起動できるようになります。二重ビルドは `O_EXCL` のロックファイル（中身は保持プロセスのpid）で防ぎ、pidが死んでいるロックは1回だけ奪取します。
- **`bin/run.mjs`**: 判定を3分岐に整理（そのまま起動 / 起動してから裏でリビルド / 先にビルド）。旧実装がビルド前にフィンガープリントを削除していた処理は、staging方式に置き換わったため不要になり削除しました。
- **`bin/notify-nvim.mjs`（新規）**: RPCサーバーへ `notify` を1本投げるだけの小さなクライアント。呼び出し元が直後に `spawnSync('npm', …)` で自分のイベントループを止めるため、**デタッチした子プロセス**から配送します（同一プロセスのソケットではビルド完了後＝殺された後にしか繋がらない）。
- **`rpc/handlers/notify.lua`（新規）**: `vim.notify` を呼ぶだけのRPCハンドラ。「何か言いたいだけの呼び出し元」に `execute` を渡さないために分けています。
- ドキュメント: `handbook/architecture/plugin-and-commands.md` と `claude-plugin/mcp-server/README.md` を実測結果込みで更新。

### 案(b)「stderrに理由を書く」を採らなかった理由（実測）

issue本文で「未確認」とされていた点を先に潰しました。`mcpServers` にstderrへ1行書いてsleepするだけのサーバーを持つ偽プラグインを `--plugin-dir` で渡し、トークンを消費しない `control_request`/`initialize` プローブで検証した結果（claude 2.1.231）:

- そのstderrは claude 本体の stdout にも stderr にも**出ない**
- 出るのは `~/Library/Caches/claude-cli-nodejs/<cwd-slug>/mcp-logs-plugin-<plugin>-<server>/*.jsonl` のみ
- しかもバッファされていて、**30秒のタイムアウト到達時**に `Connection timeout triggered after 30002ms (limit: 30000ms)` と並んで初めて書かれる

つまりランチャーの `console.error` はユーザーへの経路ではありません。確実な経路は `VIBING_NVIM_RPC_PORT`（既にランチャーのenvにある）経由のvibing.nvim自身のRPCサーバーです。

### バックグラウンドリビルドが5秒待つ理由

`npm ci` は `node_modules` の削除から始まり、そのツリーから数百ms前に起動したサーバーがまだモジュールグラフを読み込んでいる可能性があります。Node はESMを起動時に一括解決し、このサーバーは動的importを持たないため読み込み完了後は無関係になりますが、その読み込みとnpm自身の起動は同オーダーです。デタッチされたリビルドを待つものは何も無いのでマージンは無料です。テストは `VIBING_MCP_REBUILD_GRACE_MS` で0にしています。

### 受け入れ条件との対応

- **コールドキャッシュからでもMCPツールが消えない、または消えた理由が届く** → 完成したビルドがあれば消えません。無い場合（初回ビルド）は開始前に `vim.notify` で「30秒で間に合わなければ今セッションはツールが無い / `./build.sh` を実行」と伝えます
- **間に合わなかった場合に次のターンで自動回復するか、何をすべきか分かる** → リビルドは期限の外なので完走し、次のターンから新しいビルドが使われます。失敗した場合も `vim.notify` で報告します
- **既存のフィンガープリント機構と `./build.sh` の役割分担を壊さない** → `build-fingerprint.mjs` / `write-fingerprint.mjs` はそのまま。`build.sh` は無変更で、in-placeビルド＋フィンガープリント刻印は「完成したビルド」として正しく認識されます

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Test addition or update

## Testing

- [x] Ran `npm run validate`（`pnpm run check`）
- [x] Ran `npm run lint`
- [x] Ran `npm run format:check`
- [x] Ran `npm run check:doc`
- [x] Manual testing completed（偽プラグインによるstderr経路の実測、`npm run build -- --outDir` の実tscでの確認）

`tests/mcp-server-launcher.test.mjs` に4件追加（計7件）。いずれも実物の `run.mjs` / `rebuild.mjs` を偽 `npm` をPATH先頭に置いて走らせ、ファイルの文面ではなく実際の挙動を検証します。

- 起動できるものが無いツリーはサーバー起動前にビルドされる
- **古いが完成したビルドは即座に起動され、リビルドは裏で走る**（`npm` を3秒遅くしてランチャーの経過時間が2秒未満であることを確認し、その後 `dist/.build-fingerprint` が新しいソースの値に差し替わるのを待つ）
- **途中で死んだビルドが残した `dist/` は起動されない**（フィンガープリントが無い＝中身が保証されない）
- **進行中のリビルドは二重に起動されない**（死んだpidのロックは奪取される）
- **期限を使うビルドはNeovimに報告される**（スタンドインのRPCサーバーを立てて `notify` リクエストを受信）

`tests/lua/infrastructure/rpc/handlers/notify_spec.lua` を新規追加（4件）。

### 既知の失敗（本PRとは無関係）

`pnpm test` の `test:lua` は7件失敗しますが、**このブランチの変更を `git stash` した状態でも同じ7件が同じように失敗します**（MessageQueue persistence #697 系4件、list_chats/chat_conflicts のタスク投影 #696 系3件）。該当ディレクトリ単独で走らせると通るため、スイート全体でのテスト間状態汚染と思われます。本PRの変更は無関係です。

### Test Environment

- **Neovim version**: NVIM v0.11
- **Operating System**: macOS (Darwin 25.6.0)
- **Node.js version**: v22

## Documentation

- [x] Code comments added/updated
- [x] `handbook/architecture/plugin-and-commands.md`（「The MCP server's own startup budget」節を実測込みで書き直し）
- [x] `claude-plugin/mcp-server/README.md`（Auto-build mechanism 節）

`doc/vibing.txt` は変更なし: ユーザー向けのコマンド・キーバインド・設定オプションは増減していません。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes（上記の既知の失敗を除く）

## Related Issues

Fixes #690

## Additional Context

古い `dist` と新しいLua側が組み合わさる窓について（issueで「要検討」とされていた点）: #618 以降MCPサーバーとNeovimプラグインは同じチェックアウトから来るので、ズレるのは `src/` の1コミット分であり、症状は「あるツールが1コミット前の挙動をする」です。「全ツールが無言で消えたまま1日」という現状の失敗と比べれば十分に狭いと判断しました。

補助案として挙げられていた「Lua側（`plugin_dirs`）でのstale警告」は入れていません。フィンガープリント判定のLua側への複製、またはランチャーが残すstateファイルの読み取りが必要になり、通知がRPC経由で届くようになった以上は冗長なためです。必要なら別issueとして。
