### PR TITLE
feat(diff): render the turn diff inline with mini.diff

### DIFF
--- a/doc/vibing.txt
+++ b/doc/vibing.txt
@@ -340,6 +340,13 @@ Scheduled requests:~
     every buffer. The notes are virtual text only — no file is modified, and
     unloading a buffer clears its own notes anyway.
 
+                                                          *:VibingDiffClear*
+:VibingDiffClear
+    Remove the inline turn diffs `gd` set with mini.diff from every buffer.
+    Nothing is written: the diff is reference text held against the buffer,
+    so clearing it only stops the highlighting. `:edit` on the file does the
+    same thing as a side effect of reloading it.
+
                                                         *:VibingDebugAnalyze*
 :VibingDebugAnalyze
                                                            *:VibingDebugHelp*
@@ -397,6 +404,16 @@ In a chat buffer:~
     gf          Open the file path under the cursor
     gx          Open the URL on the current line in a browser
     q           Close the chat window
+
+`gd` has two viewers, chosen by `diff.viewer` (default `"auto"`). With
+mini.diff installed it opens the real file and shows that turn's changes on
+it, so mini.diff's own mappings apply: `[h` / `]h` to move between hunks and
+`gH` to reset one, which is a per-hunk revert of what the agent did. Clear it
+with |:VibingDiffClear|. Without mini.diff — or with `diff.viewer = "patch"`
+— it opens a float listing the turn's files with a diff preview, where `r`
+reverts the selected file and `R` the whole patch. When no patch exists for
+the turn at all, both fall back to a plain `git diff` against HEAD, which is
+not limited to that turn's changes.
 
 `<CR>` asks before sending in two cases, and sends normally otherwise. While
 the project has a usage limit on record it offers to park the message until

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -1165,11 +1165,39 @@ When the fallback has nothing either, vibing.nvim says so rather than showing an
 
 ```lua
 diff = {
-  tool = "auto",  -- "auto" / "git" — currently the same thing. Kept as a hook for
-                  -- future backends; `gd` falls back to a plain `git diff` when a
-                  -- turn has no patch file (e.g. an old chat reopened).
+  tool = "auto",    -- "auto" / "git" — currently the same thing. Kept as a hook for
+                    -- future backends; `gd` falls back to a plain `git diff` when a
+                    -- turn has no patch file (e.g. an old chat reopened).
+  viewer = "auto",  -- "auto" / "mini" / "patch" — how `gd` renders that patch.
 }
 ```
+
+### How `gd` renders a patch
+
+`viewer = "patch"` is the built-in float: the turn's files on the left, a diff preview on the
+right, `r` to revert the selected file and `R` to revert the whole patch.
+
+`viewer = "mini"` needs [mini.diff](https://github.com/nvim-mini/mini.diff). It opens the real
+file instead and hands mini.diff the pre-turn text as that buffer's reference, so the change is
+shown on the file you actually edit. mini.diff's own mappings then apply — `[h` / `]h` to move
+between hunks, `gH` to reset one. That reset **is** a per-hunk revert of the agent's change, which
+the float cannot do: mini.diff defines reset as "replace this range with the reference text", with
+no involvement from its source. `:VibingDiffClear` takes the reference back off.
+
+The pre-turn text is recovered by reverse-applying the patch to a throwaway copy of the file
+(`core/utils/patch_text.lua`); the working tree and your index are never touched. Three cases
+cannot produce one and fall back to the float: a binary diff, a file edited since the turn (the
+reverse apply no longer matches its context — this is a real answer, not a bug, since the
+displayed base would otherwise be wrong), and the pre-`base:` header patches the removed mote
+integration wrote.
+
+vibing.nvim never calls `require("mini.diff").setup()` for you. If mini.diff's default Git source
+is active, configure it per buffer or globally as you like — vibing pins `source` to
+`gen_source.none()` on the buffers it touches, and only those, so its reference text cannot be
+overwritten by the next `.git/index` change.
+
+`viewer = "auto"` picks `"mini"` when mini.diff is installed and `"patch"` otherwise. Asking for
+`"mini"` without mini.diff warns once and uses the float.
 
 > **The opt-in `mote` backend has been removed**, along with `diff.mote`, `diff.tool = "mote"`,
 > the `mote_dirs` / `mote_cwd` frontmatter keys, `:VibingMoteDir` and `:VibingCleanMote`. The

--- a/lua/vibing/config.lua
+++ b/lua/vibing/config.lua
@@ -4,6 +4,10 @@
 ---@field tool "git"|"auto" 使用するdiffツール（現在は同義。リクエストごとにワーキングツリーの
 ---  gitツリースナップショットを取り、その差分をパッチとして保存する。`gd` はそのパッチを、
 ---  無ければ通常の git diff を表示する）
+---@field viewer "auto"|"patch"|"mini" `gd` の表示方法。"patch" は従来のフロート（ファイル一覧＋
+---  diffプレビュー、`r`/`R` でrevert）。"mini" は mini.diff で実ファイル上にインライン表示する
+---  （`gH` がhunk単位のrevert、`[h`/`]h` で移動）。"auto" は mini.diff があれば "mini"、
+---  無ければ "patch"
 
 ---@class Vibing.GradientConfig
 ---グラデーションアニメーション設定
@@ -517,6 +521,7 @@ M.defaults = {
   },
   diff = {
     tool = "auto",
+    viewer = "auto",
   },
   permissions = {
     mode = "acceptEdits",
@@ -719,6 +724,12 @@ function M.setup(opts)
       M.options.diff.tool,
       { git = true, auto = true },
       "diff.tool",
+      "auto"
+    )
+    M.options.diff.viewer = validate_enum(
+      M.options.diff.viewer,
+      { auto = true, patch = true, mini = true },
+      "diff.viewer",
       "auto"
     )
   end

--- a/lua/vibing/core/utils/patch_text.lua
+++ b/lua/vibing/core/utils/patch_text.lua
@@ -1,0 +1,103 @@
+---@class Vibing.Utils.PatchText
+---リクエストpatchから「そのターンが始まる前のファイル内容」を復元する。
+---
+---`ui/patch_viewer/revert.lua` も `git apply --reverse` を使うが、あちらは実ワーキングツリーを
+---書き換える revert 機能そのもの。こちらは **読むだけ** なので、対象ファイルを一時ツリーへ複製
+---してからそこに逆適用する。ワーキングツリーにもユーザーのindexにも一切触れない。
+---
+---patchの逆適用をgitにやらせるのは、コンテキスト不一致の検出まで含めて正しく判定させるため。
+---ターン後にユーザーがそのファイルを編集していれば逆適用は失敗し、呼び出し側は「ベースを
+---復元できなかった」と分かる。Luaでhunkを自前適用すると、ここが静かにずれる。
+local M = {}
+
+local Fs = require("vibing.core.utils.fs")
+
+---バイナリdiffは行として扱えない。`git diff --binary` が出すこのヘッダで判別する
+local BINARY_PATCH_PATTERN = "\nGIT binary patch\n"
+
+---@param path string
+---@param content string
+---@return boolean
+local function write_file(path, content)
+  local f = io.open(path, "w")
+  if not f then
+    return false
+  end
+  f:write(content)
+  if not content:match("\n$") then
+    f:write("\n")
+  end
+  f:close()
+  return true
+end
+
+---1ファイル分のdiffを逆適用して、ターン前の内容を行配列で返す
+---
+---@param base_dir string patch内パスの基準ディレクトリ（`git apply -p1` を回すcwd）
+---@param rel_path string patchに現れる通りのパス（base_dir相対）
+---@param file_diff string そのファイルのdiffセクション
+---@return string[]|nil lines 失敗時nil。**空テーブルは失敗ではなく**「ターン前は存在しなかった」
+---@return string|nil err
+function M.before_lines(base_dir, rel_path, file_diff)
+  if file_diff:find(BINARY_PATCH_PATTERN, 1, true) then
+    return nil, "binary diff cannot be shown as text"
+  end
+
+  local abs = base_dir .. "/" .. rel_path
+  if vim.fn.filereadable(abs) ~= 1 then
+    return nil, "file not readable: " .. abs
+  end
+
+  -- `tempname()` は存在しないユニークなパスを返す。ツリーのルートにも、隣に置くpatchファイルの
+  -- 名前にも使う（patchをツリー内に置くと `git apply` の対象に混ざりうる）
+  local tmp_root = vim.fn.tempname()
+  local patch_path = tmp_root .. ".patch"
+  local target = tmp_root .. "/" .. rel_path
+
+  local cleanup = function()
+    vim.fn.delete(tmp_root, "rf")
+    vim.fn.delete(patch_path)
+  end
+
+  if not Fs.ensure_dir(vim.fn.fnamemodify(target, ":h")) then
+    cleanup()
+    return nil, "failed to create temp directory"
+  end
+
+  local copied = (vim.uv or vim.loop).fs_copyfile(abs, target)
+  if not copied then
+    cleanup()
+    return nil, "failed to copy " .. abs
+  end
+
+  if not write_file(patch_path, file_diff) then
+    cleanup()
+    return nil, "failed to write temp patch"
+  end
+
+  local result = vim
+    .system(
+      { "git", "apply", "--reverse", "--whitespace=nowarn", patch_path },
+      { cwd = tmp_root, text = true }
+    )
+    :wait()
+
+  if result.code ~= 0 then
+    local err = vim.trim(result.stderr or "")
+    cleanup()
+    return nil, err ~= "" and err or "git apply --reverse failed"
+  end
+
+  -- 逆適用でファイルが消えたなら、そのターンで新規作成されたファイル。参照テキストは空で、
+  -- mini.diff はバッファ全体を1つの "add" hunk として描く（それが事実として正しい）
+  if vim.fn.filereadable(target) ~= 1 then
+    cleanup()
+    return {}, nil
+  end
+
+  local lines = vim.fn.readfile(target)
+  cleanup()
+  return lines, nil
+end
+
+return M

--- a/lua/vibing/core/utils/patch_text.lua
+++ b/lua/vibing/core/utils/patch_text.lua
@@ -59,9 +59,12 @@ function M.before_lines(base_dir, rel_path, file_diff)
     vim.fn.delete(patch_path)
   end
 
-  if not Fs.ensure_dir(vim.fn.fnamemodify(target, ":h")) then
+  -- `Fs.ensure_dir` は失敗時にfalseではなくLuaのerrorを投げる。呼び出し元は誰もpcallしないので、
+  -- ここで受け止めないと `gd` が生のトレースバックで落ちる（本来はpatch_viewerへフォールバック）
+  local dir_ok, dir_err = pcall(Fs.ensure_dir, vim.fn.fnamemodify(target, ":h"))
+  if not dir_ok then
     cleanup()
-    return nil, "failed to create temp directory"
+    return nil, "failed to create temp directory: " .. tostring(dir_err)
   end
 
   local copied = (vim.uv or vim.loop).fs_copyfile(abs, target)

--- a/lua/vibing/init.lua
+++ b/lua/vibing/init.lua
@@ -403,6 +403,18 @@ function M._register_commands()
       notify.info(string.format("Cleared annotations in %d buffer(s)", count))
     end
   end, { desc = "Clear vibing.nvim inline review annotations from all buffers" })
+
+  vim.api.nvim_create_user_command("VibingDiffClear", function()
+    -- `gd` のインライン表示は実ファイルのバッファに mini.diff の参照テキストを差すだけなので、
+    -- 閉じるウィンドウが無い。`:edit` でも戻せるが、それはファイルの再読み込みでもあるので、
+    -- 参照テキストだけを外す入口を用意する。
+    local count = require("vibing.ui.mini_diff").clear_all()
+    if count == 0 then
+      notify.info("No inline diffs to clear")
+    else
+      notify.info(string.format("Cleared inline diff in %d buffer(s)", count))
+    end
+  end, { desc = "Clear vibing.nvim inline turn diffs (gd) from all buffers" })
   -- `/compact` は未登録のスラッシュコマンドとして素通しでCLIに届く経路が元からあるが、
   -- それだと `/help` の一覧にも補完にも出ず、知っている人しか使えない。コマンドにすると
   -- 「未送信本文があるなら断る」「claude以外なら断る」を一箇所で言える

--- a/lua/vibing/presentation/chat/modules/diff_opener.lua
+++ b/lua/vibing/presentation/chat/modules/diff_opener.lua
@@ -1,0 +1,112 @@
+---@class Vibing.Presentation.DiffOpener
+---`gd`（カーソル下のファイルについて、そのターンの差分を開く）の入口。
+---
+---表示手段は3つあり、上から順に試す:
+---  1. mini.diff で実ファイル上にインライン表示（`diff.viewer` が許し、mini.diffがある場合）
+---  2. `patch_viewer` のフロート（ファイル一覧＋diffプレビュー、`r`/`R` でrevert）
+---  3. patchが見つからないときだけ、HEADとの `git diff`（`diff_selector`）
+---
+---1と2はどちらも **そのターンのpatch** を見るが、3はHEADとの差分なのでターン単位ではない。
+---その違いは `diff_selector` 側に書いてある。
+local M = {}
+
+---設定と実際の環境から、使うビューアを決める
+---@return "mini"|"patch"
+function M.resolve_viewer()
+  -- `setup()` 前は `options` が nil。`gd` は setup 後にしか存在しないキーマップなので実際には
+  -- 起きないが、ここが唯一の分岐点なので nil で落とさない
+  local config = require("vibing.config")
+  local viewer = ((config.options or {}).diff or {}).viewer or "auto"
+
+  if viewer == "patch" then
+    return "patch"
+  end
+
+  local MiniDiff = require("vibing.ui.mini_diff")
+  if MiniDiff.is_available() then
+    return "mini"
+  end
+
+  if viewer == "mini" then
+    -- 明示的に選ばれているのに使えないのは設定ミス。黙ってフォールバックすると、ユーザーは
+    -- 「設定したのに何も変わらない」としか分からない
+    require("vibing.core.utils.notify").warn_once(
+      "config.diff.viewer",
+      'diff.viewer = "mini" but mini.diff is not installed. Falling back to the patch viewer. '
+        .. "Install nvim-mini/mini.diff, or set diff.viewer = \"patch\" to silence this."
+    )
+  end
+
+  return "patch"
+end
+
+---patchをmini.diffでインライン表示する
+---@param patch_filename string
+---@param file_path string
+---@return boolean shown falseなら呼び出し側がpatch_viewerにフォールバックする
+function M._show_inline(patch_filename, file_path)
+  local parser = require("vibing.ui.patch_viewer.parser")
+
+  local patch_path = parser.resolve_patch_path(patch_filename)
+  if not patch_path then
+    return false
+  end
+
+  local patch_content = parser.read_patch_file(patch_path)
+  if not patch_content or patch_content == "" then
+    return false
+  end
+
+  -- baseヘッダが無いのは削除されたmote統合が書いた古いpatch。逆適用できる自己完結したdiffでは
+  -- ないので、ここでは扱えない（patch_viewerは表示だけならできるので、そちらに流す）
+  local base_dir = parser.extract_base_dir(patch_content)
+  if not base_dir then
+    return false
+  end
+
+  return require("vibing.ui.mini_diff").show(base_dir, patch_content, file_path)
+end
+
+---patchが見つからないときのフォールバック
+---@param buf number チャットバッファ
+---@param file_path string
+---@param session_id string|nil
+function M._show_git_diff(buf, file_path, session_id)
+  local DiffSelector = require("vibing.core.utils.diff_selector")
+  local view = require("vibing.presentation.chat.view")
+
+  local cwd = nil
+  local chat_buf = view.get_chat_buffer(buf)
+  if chat_buf then
+    cwd = chat_buf:get_cwd()
+  end
+
+  DiffSelector.show_diff(file_path, session_id, cwd)
+end
+
+---@param buf number チャットバッファ
+function M.open(buf)
+  local FilePath = require("vibing.core.utils.file_path")
+
+  local file_path = FilePath.is_cursor_on_file_path(buf)
+  if not file_path then
+    vim.notify("No file path under cursor", vim.log.levels.INFO)
+    return
+  end
+
+  local PatchFinder = require("vibing.presentation.chat.modules.patch_finder")
+  local session_id = PatchFinder.get_session_id(buf)
+  local patch_filename = PatchFinder.find_nearest_patch(buf)
+
+  if session_id and patch_filename then
+    if M.resolve_viewer() == "mini" and M._show_inline(patch_filename, file_path) then
+      return
+    end
+    require("vibing.ui.patch_viewer").show(session_id, patch_filename, file_path)
+    return
+  end
+
+  M._show_git_diff(buf, file_path, session_id)
+end
+
+return M

--- a/lua/vibing/presentation/chat/modules/keymap_handler.lua
+++ b/lua/vibing/presentation/chat/modules/keymap_handler.lua
@@ -177,34 +177,7 @@ function M.setup(buf, callbacks, keymaps)
     end, { buffer = buf, desc = "Add context" })
 
     vim.keymap.set("n", keymaps.open_diff, function()
-      local FilePath = require("vibing.core.utils.file_path")
-      local PatchFinder = require("vibing.presentation.chat.modules.patch_finder")
-      local PatchViewer = require("vibing.ui.patch_viewer")
-      local view = require("vibing.presentation.chat.view")
-
-      local file_path = FilePath.is_cursor_on_file_path(buf)
-      if not file_path then
-        vim.notify("No file path under cursor", vim.log.levels.INFO)
-        return
-      end
-
-      -- patchファイル方式で表示を試みる
-      local session_id = PatchFinder.get_session_id(buf)
-      local patch_filename = PatchFinder.find_nearest_patch(buf)
-
-      if session_id and patch_filename then
-        -- patchファイルから該当ファイルのdiffを表示
-        PatchViewer.show(session_id, patch_filename, file_path)
-      else
-        -- patchがない場合はHEAD（無ければindex）との git diff にフォールバックする
-        local DiffSelector = require("vibing.core.utils.diff_selector")
-        local cwd = nil
-        local chat_buf = view.get_chat_buffer(buf)
-        if chat_buf then
-          cwd = chat_buf:get_cwd()
-        end
-        DiffSelector.show_diff(file_path, session_id, cwd)
-      end
+      require("vibing.presentation.chat.modules.diff_opener").open(buf)
     end, { buffer = buf, desc = "Open diff for file under cursor" })
 
     vim.keymap.set("n", keymaps.open_file, function()

--- a/lua/vibing/ui/mini_diff.lua
+++ b/lua/vibing/ui/mini_diff.lua
@@ -17,6 +17,17 @@ local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
 ---@type table<number, boolean>
 local marked = {}
 
+-- バッファが消えたら追跡もやめる。怠ると、Neovimがバッファ番号を再利用した時に
+-- `:VibingDiffClear` が無関係な別バッファへ `diff.disable` / `minidiff_config` クリアをかける
+-- （`completion_notifier.lua` の `BufDelete`/`BufWipeout` と同じパターン）
+local cleanup_group = vim.api.nvim_create_augroup("VibingMiniDiffCleanup", { clear = true })
+vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+  group = cleanup_group,
+  callback = function(event)
+    marked[event.buf] = nil
+  end,
+})
+
 ---@return table|nil
 local function mini()
   local ok, m = pcall(require, "mini.diff")
@@ -111,7 +122,12 @@ function M.show(base_dir, patch_content, target_file)
 
   local win = code_window()
   vim.api.nvim_set_current_win(win)
-  vim.cmd.edit(vim.fn.fnameescape(base_dir .. "/" .. rel_path))
+  -- 選ばれたウィンドウのバッファが未保存だと素の `:edit` はE37で落ちる。呼び出し元は
+  -- pcallしないので、ここで受け止めてpatch_viewerへのフォールバックに繋げる
+  local edit_ok = pcall(vim.cmd.edit, vim.fn.fnameescape(base_dir .. "/" .. rel_path))
+  if not edit_ok then
+    return false
+  end
   local buf = vim.api.nvim_get_current_buf()
 
   M._attach(diff, buf, before)

--- a/lua/vibing/ui/mini_diff.lua
+++ b/lua/vibing/ui/mini_diff.lua
@@ -1,0 +1,179 @@
+---@class Vibing.UI.MiniDiff
+---ターンのpatchを、実ファイルのバッファ上にインライン表示する `gd` のビューア。
+---
+---フロート内にdiffテキストを描く `patch_viewer` と違い、こちらは **本物のファイルを開いて**
+---mini.diff の参照テキストにターン前の内容を差す。結果として、そのまま編集でき、`gH` が
+---hunk単位のrevertになる（mini.diffのresetは「バッファのその範囲を参照テキストで置き換える」
+---と定義されていて、sourceに依存しない）。
+---
+---mini.diffは任意依存。無ければ `gd` は `patch_viewer` にフォールバックする。
+local M = {}
+
+local parser = require("vibing.ui.patch_viewer.parser")
+local PatchText = require("vibing.core.utils.patch_text")
+local Frontmatter = require("vibing.infrastructure.storage.frontmatter")
+
+---参照テキストを差したバッファ。`:VibingDiffClear` が戻す対象
+---@type table<number, boolean>
+local marked = {}
+
+---@return table|nil
+local function mini()
+  local ok, m = pcall(require, "mini.diff")
+  if not ok or type(m) ~= "table" then
+    return nil
+  end
+  return m
+end
+
+---@return boolean
+function M.is_available()
+  return mini() ~= nil
+end
+
+---patchに現れる **生のパス** を、カーソル下のファイルパスと突き合わせて解決する
+---
+---`parser.extract_files` はNeovimのcwd相対に正規化してしまうが、ここで欲しいのは一時ツリーに
+---ファイルを置く位置＝patch内の表記そのもの。base_dirはcwdと一致しないことがある（worktree、
+---`working_dir` 指定）ので、正規化済みの値では復元できない。
+---@param patch_content string
+---@param target string
+---@return string|nil
+local function resolve_rel_path(patch_content, target)
+  local abs_target = vim.fn.fnamemodify(target, ":p")
+  for line in patch_content:gmatch("[^\r\n]+") do
+    local raw = line:match("^diff %-%-git a/(.+) b/")
+    if raw then
+      local is_same = raw == target
+        or vim.fn.fnamemodify(raw, ":p") == abs_target
+        -- パス境界での後方一致。base_dir相対の表記が絶対パスの末尾に現れる普通のケース
+        or abs_target:sub(-(#raw + 1)) == "/" .. raw
+      if is_same then
+        return raw
+      end
+    end
+  end
+  return nil
+end
+
+---ファイルを開いてよい通常ウィンドウを選ぶ。無ければ縦分割で作る
+---
+---`gd` はチャットウィンドウから押されるので、そこに `:edit` するとチャットが消える。
+---@return number winnr
+local function code_window()
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.api.nvim_win_is_valid(win) then
+      local buf = vim.api.nvim_win_get_buf(win)
+      -- フロートは閉じられる前提の一時ウィンドウなので、そこにファイルを開くと差分ごと消える。
+      -- `buftype ~= ""` はターミナル・quickfix・help・ファイラ（oil等）で、どれも `:edit` で
+      -- 乗っ取ってよいウィンドウではない。この2つを外すと、残るのは普通のファイル用ウィンドウ
+      local is_float = vim.api.nvim_win_get_config(win).relative ~= ""
+      local is_normal = vim.bo[buf].buftype == ""
+      if not is_float and is_normal and not Frontmatter.is_vibing_chat_buffer(buf) then
+        return win
+      end
+    end
+  end
+
+  vim.cmd("vsplit")
+  return vim.api.nvim_get_current_win()
+end
+
+---ターンのpatchを対象ファイルのバッファ上にインライン表示する
+---@param base_dir string patch内パスの基準ディレクトリ
+---@param patch_content string
+---@param target_file string カーソル下のファイルパス
+---@return boolean shown 表示できたか。falseなら呼び出し側がフォールバックする
+function M.show(base_dir, patch_content, target_file)
+  local diff = mini()
+  if not diff then
+    return false
+  end
+
+  local rel_path = resolve_rel_path(patch_content, target_file)
+  if not rel_path then
+    return false
+  end
+
+  local file_diff = parser.extract_file_diff(patch_content, rel_path)
+  if not file_diff then
+    return false
+  end
+
+  local before, err = PatchText.before_lines(base_dir, rel_path, file_diff)
+  if not before then
+    vim.notify(
+      string.format("[vibing] Inline diff unavailable for %s: %s", rel_path, err or "unknown error"),
+      vim.log.levels.WARN
+    )
+    return false
+  end
+
+  local win = code_window()
+  vim.api.nvim_set_current_win(win)
+  vim.cmd.edit(vim.fn.fnameescape(base_dir .. "/" .. rel_path))
+  local buf = vim.api.nvim_get_current_buf()
+
+  M._attach(diff, buf, before)
+  return true
+end
+
+---@param diff table mini.diffモジュール
+---@param buf number
+---@param before string[]
+function M._attach(diff, buf, before)
+  -- 一度disableしてから設定する。sourceのattachは **enable時にしか起きない** ので、既に
+  -- enable済みのバッファに `minidiff_config` を書いても効かない。`set_ref_text` は未enableの
+  -- バッファをenableするため、この順序なら必ず `none` のsourceで張り直される。
+  --
+  -- これを怠ると、既定のgit sourceがattachしたままになり、次に `.git/index` が動いた時点で
+  -- ターンの参照テキストが黙ってgit indexの内容に置き換わる。
+  pcall(diff.disable, buf)
+
+  local buf_config = vim.b[buf].minidiff_config or {}
+  buf_config.source = diff.gen_source.none()
+  vim.b[buf].minidiff_config = buf_config
+
+  diff.set_ref_text(buf, before)
+  marked[buf] = true
+
+  -- overlayは削除行を仮想テキストで見せる。ターンで消えた行はファイル上に残っていないので、
+  -- これが無いと「何が消えたか」が分からない
+  local data = diff.get_buf_data(buf)
+  if data and not data.overlay then
+    pcall(diff.toggle_overlay, buf)
+  end
+end
+
+---1バッファの参照テキストを外す
+---@param buf number
+function M.clear(buf)
+  marked[buf] = nil
+  if not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+  local diff = mini()
+  if diff then
+    pcall(diff.disable, buf)
+  end
+  vim.b[buf].minidiff_config = nil
+end
+
+---`gd` が差したものをすべて外す
+---@return number cleared 外したバッファ数
+function M.clear_all()
+  local buffers = vim.tbl_keys(marked)
+  for _, buf in ipairs(buffers) do
+    M.clear(buf)
+  end
+  return #buffers
+end
+
+---テスト用
+function M._marked()
+  return vim.tbl_keys(marked)
+end
+
+M._resolve_rel_path = resolve_rel_path
+
+return M

--- a/tests/dev_init.lua
+++ b/tests/dev_init.lua
@@ -1,0 +1,46 @@
+-- init.lua for manually exercising *this* checkout in a throwaway Neovim.
+--
+-- `tests/minimal_init.lua` wires up plenary for the spec runner and `tests/e2e_init.lua` is the
+-- child an E2E spec drives over RPC. This one is for a human: it starts a real editor with this
+-- copy of vibing.nvim loaded, so a git worktree can be tried out without repointing the `dev =
+-- true` entry in the developer's own lazy.nvim config (and without restarting the editor the
+-- chat driving the work is running in).
+--
+--     nvim -u tests/dev_init.lua
+--     nvim --listen /tmp/vibing-dev.sock -u tests/dev_init.lua   -- to drive it over RPC
+--
+-- The root is derived from this file's own location, not from `getcwd()`, for the same reason
+-- `e2e_init.lua` does it: the editor may be started from anywhere, and resolving to the wrong
+-- checkout is exactly the failure this file exists to avoid.
+local repo_root = vim.fs.root(debug.getinfo(1, "S").source:sub(2), "package.json") or vim.fn.getcwd()
+vim.opt.runtimepath:append(repo_root)
+
+vim.opt.swapfile = false
+vim.opt.backup = false
+
+-- The "number" view style of mini.diff colors line numbers, which needs them shown at all.
+vim.opt.number = true
+
+-- mini.diff is an optional dependency of the diff viewer. lazy.nvim does not run here, so take
+-- it from where lazy installed it. Absence is not an error: the viewer is supposed to fall back
+-- to the built-in patch viewer in exactly that case, and this init is also how that fallback
+-- gets tested (move the directory aside, or just do not install it).
+local mini_diff_path = vim.fn.expand("~/.local/share/nvim/lazy/mini.diff")
+if vim.fn.isdirectory(mini_diff_path) == 1 then
+  vim.opt.runtimepath:append(mini_diff_path)
+  local mini_diff = require("mini.diff")
+  mini_diff.setup({
+    -- Same configuration the plugin documents for this integration: no source of its own, so
+    -- nothing is shown until vibing.nvim sets reference text on a buffer.
+    source = mini_diff.gen_source.none(),
+    view = { style = "number" },
+  })
+end
+
+require("vibing").setup({
+  -- The MCP server is a separate build artifact (`./build.sh`) that a fresh worktree does not
+  -- have, and enabling it here would also fight the developer's real Neovim for the RPC port.
+  -- Nothing in the diff viewer path needs it.
+  mcp = { enabled = false },
+  permissions = { mode = "acceptEdits" },
+})

--- a/tests/lua/core/utils/patch_text_spec.lua
+++ b/tests/lua/core/utils/patch_text_spec.lua
@@ -1,0 +1,142 @@
+-- patch_text.lua は「ターンのpatchから、そのターンが始まる前のファイル内容を復元する」モジュール。
+-- mini.diff の参照テキストがこれで作られるので、守りたいのは3つ:
+--   1. 復元した内容が本当にターン前のものであること — 本題
+--   2. 実ワーキングツリーを1バイトも書き換えないこと（revertと違って「読むだけ」）
+--   3. 復元できない場合に、黙って嘘の内容を返すのではなくエラーを返すこと
+-- patchは実物のgitで作り、逆適用も実物のgitにやらせる。
+local PatchText = require("vibing.core.utils.patch_text")
+
+describe("patch_text", function()
+  local repo
+
+  local function git(args)
+    return vim.system(vim.list_extend({ "git" }, args), { cwd = repo, text = true }):wait()
+  end
+
+  local function write(rel, lines)
+    local path = repo .. "/" .. rel
+    vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+    vim.fn.writefile(lines, path)
+  end
+
+  local function read(rel)
+    return vim.fn.readfile(repo .. "/" .. rel)
+  end
+
+  ---base commit と現在のワーキングツリーの差分を、vibing形式のpatch本文として得る
+  ---
+  ---`git diff <base>` ではなく一時indexへ `git add -A` してからツリー同士を比較するのは、
+  ---production（`git_snapshot.lua`）がそうしているから。素の `git diff` は未追跡ファイルを
+  ---出さないので、「ターンが新規作成したファイル」のケースが再現できない。
+  local function patch_for(base)
+    local tmp_index = vim.fn.tempname()
+    local env = { GIT_INDEX_FILE = tmp_index }
+
+    vim.system({ "git", "add", "-A", "--", "." }, { cwd = repo, env = env, text = true }):wait()
+    local tree_result = vim.system({ "git", "write-tree" }, { cwd = repo, env = env, text = true }):wait()
+    local tree = vim.trim(tree_result.stdout or "")
+
+    local result = vim.system({ "git", "diff", "--binary", base, tree, "--", "." }, { cwd = repo, text = true }):wait()
+    vim.fn.delete(tmp_index)
+
+    assert.equals(0, result.code)
+    return result.stdout
+  end
+
+  before_each(function()
+    repo = vim.fn.tempname()
+    vim.fn.mkdir(repo, "p")
+    git({ "init", "-q" })
+    git({ "config", "user.email", "t@example.com" })
+    git({ "config", "user.name", "t" })
+  end)
+
+  after_each(function()
+    vim.fn.delete(repo, "rf")
+  end)
+
+  it("returns the pre-turn content of a modified file", function()
+    write("src/a.txt", { "one", "two", "three" })
+    git({ "add", "-A" })
+    git({ "commit", "-qm", "base" })
+    local base = vim.trim(git({ "rev-parse", "HEAD" }).stdout)
+
+    write("src/a.txt", { "one", "TWO CHANGED", "three", "four" })
+    local file_diff = patch_for(base)
+
+    local before, err = PatchText.before_lines(repo, "src/a.txt", file_diff)
+    assert.is_nil(err)
+    assert.same({ "one", "two", "three" }, before)
+  end)
+
+  it("leaves the working tree untouched", function()
+    write("a.txt", { "original" })
+    git({ "add", "-A" })
+    git({ "commit", "-qm", "base" })
+    local base = vim.trim(git({ "rev-parse", "HEAD" }).stdout)
+
+    write("a.txt", { "edited by the agent" })
+    local file_diff = patch_for(base)
+
+    PatchText.before_lines(repo, "a.txt", file_diff)
+
+    -- 復元は一時ツリーで行われるので、実ファイルはターン後の内容のまま
+    assert.same({ "edited by the agent" }, read("a.txt"))
+    -- indexも動かない（`git diff --cached` が空のまま）
+    assert.equals("", vim.trim(git({ "diff", "--cached", "--name-only" }).stdout))
+  end)
+
+  it("returns an empty reference for a file the turn created", function()
+    write("keep.txt", { "x" })
+    git({ "add", "-A" })
+    git({ "commit", "-qm", "base" })
+    local base = vim.trim(git({ "rev-parse", "HEAD" }).stdout)
+
+    write("new.txt", { "brand new" })
+    local file_diff = patch_for(base)
+
+    local before, err = PatchText.before_lines(repo, "new.txt", file_diff)
+    assert.is_nil(err)
+    -- nil（失敗）ではなく空テーブル。mini.diff はこれをバッファ全体1つの "add" hunk として描く
+    assert.same({}, before)
+  end)
+
+  it("refuses a binary diff instead of returning garbled lines", function()
+    write("bin.dat", { "placeholder" })
+    git({ "add", "-A" })
+    git({ "commit", "-qm", "base" })
+    local base = vim.trim(git({ "rev-parse", "HEAD" }).stdout)
+
+    local f = assert(io.open(repo .. "/bin.dat", "wb"))
+    f:write("\0\1\2\3binary\0content")
+    f:close()
+    local file_diff = patch_for(base)
+
+    local before, err = PatchText.before_lines(repo, "bin.dat", file_diff)
+    assert.is_nil(before)
+    assert.is_truthy(err and err:match("binary"))
+  end)
+
+  it("fails rather than guessing when the file changed after the turn", function()
+    write("a.txt", { "one", "two", "three" })
+    git({ "add", "-A" })
+    git({ "commit", "-qm", "base" })
+    local base = vim.trim(git({ "rev-parse", "HEAD" }).stdout)
+
+    write("a.txt", { "one", "TWO CHANGED", "three" })
+    local file_diff = patch_for(base)
+
+    -- ターン後にユーザーが手で書き換えた: patchのコンテキストがもう合わない
+    write("a.txt", { "completely", "different", "content", "now" })
+
+    local before, err = PatchText.before_lines(repo, "a.txt", file_diff)
+    assert.is_nil(before)
+    assert.is_truthy(err)
+  end)
+
+  it("reports a missing file instead of erroring", function()
+    local before, err = PatchText.before_lines(repo, "nope.txt", "diff --git a/nope.txt b/nope.txt\n")
+    assert.is_nil(before)
+    assert.is_truthy(err and err:match("not readable"))
+  end)
+end)

--- a/tests/lua/presentation/chat/modules/diff_opener_spec.lua
+++ b/tests/lua/presentation/chat/modules/diff_opener_spec.lua
@@ -1,0 +1,78 @@
+-- diff_opener.lua は `gd` の入口。ここで固定したいのは、どのビューアが選ばれるかの分岐だけ。
+-- mini.diff は任意依存なので、その有無はスタブで作る。
+local DiffOpener = require("vibing.presentation.chat.modules.diff_opener")
+local Config = require("vibing.config")
+
+describe("diff_opener", function()
+  local saved_viewer
+  local saved_mini
+
+  local function with_mini(present)
+    package.loaded["mini.diff"] = present and { gen_source = {} } or nil
+  end
+
+  before_each(function()
+    if not Config.options then
+      Config.setup({})
+    end
+    Config.options.diff = Config.options.diff or {}
+    saved_viewer = Config.options.diff.viewer
+    saved_mini = package.loaded["mini.diff"]
+  end)
+
+  after_each(function()
+    Config.options.diff.viewer = saved_viewer
+    package.loaded["mini.diff"] = saved_mini
+  end)
+
+  describe("resolve_viewer", function()
+    it('uses mini.diff when "auto" and it is installed', function()
+      Config.options.diff.viewer = "auto"
+      with_mini(true)
+      assert.equals("mini", DiffOpener.resolve_viewer())
+    end)
+
+    it('falls back to the patch viewer when "auto" and it is not installed', function()
+      Config.options.diff.viewer = "auto"
+      with_mini(false)
+      assert.equals("patch", DiffOpener.resolve_viewer())
+    end)
+
+    it('never uses mini.diff when "patch" is set, even if installed', function()
+      Config.options.diff.viewer = "patch"
+      with_mini(true)
+      assert.equals("patch", DiffOpener.resolve_viewer())
+    end)
+
+    it('falls back rather than failing when "mini" is set but not installed', function()
+      Config.options.diff.viewer = "mini"
+      with_mini(false)
+      -- 設定ミスは警告される（`notify.warn_once`）が、`gd` は必ず何かを表示する
+      assert.equals("patch", DiffOpener.resolve_viewer())
+    end)
+
+    it('defaults to "auto" behaviour when the option is absent', function()
+      Config.options.diff.viewer = nil
+      with_mini(true)
+      assert.equals("mini", DiffOpener.resolve_viewer())
+    end)
+  end)
+
+  describe("_show_inline", function()
+    it("declines a patch file that does not exist", function()
+      assert.is_false(DiffOpener._show_inline("/nope/missing.patch", "a.lua"))
+    end)
+
+    it("declines a patch with no base header", function()
+      -- baseヘッダの無いpatchは削除されたmote統合が書いたもので、逆適用できる自己完結した
+      -- diffではない。patch_viewerなら表示だけはできるので、falseを返して譲る
+      local path = vim.fn.tempname() .. ".patch"
+      vim.fn.writefile({ "diff --git a/a.lua b/a.lua", "@@ -1 +1 @@", "-x", "+y" }, path)
+
+      local shown = DiffOpener._show_inline(path, "a.lua")
+      vim.fn.delete(path)
+
+      assert.is_false(shown)
+    end)
+  end)
+end)

--- a/tests/lua/ui/mini_diff_spec.lua
+++ b/tests/lua/ui/mini_diff_spec.lua
@@ -1,0 +1,136 @@
+-- mini_diff.lua は `gd` のインライン表示。mini.diff は **任意依存** なので、テストは本物を
+-- 要求せずスタブで代用する（CI にも開発者の環境にも入っているとは限らない）。
+--
+-- ここで固定したいのは2つ:
+--   1. patch内の生パスの解決 — base_dir が Neovim の cwd と一致しない（worktree、working_dir）
+--      環境でも、一時ツリーにファイルを置く位置を間違えないこと
+--   2. `_attach` の呼び出し順 — disable → minidiff_config → set_ref_text。この順でないと
+--      sourceが張り替わらず、次の `.git/index` 変更で参照テキストが黙って消える
+local MiniDiff = require("vibing.ui.mini_diff")
+
+describe("mini_diff", function()
+  describe("resolve_rel_path", function()
+    local patch = table.concat({
+      "# vibing-request-diff base: /repo",
+      "diff --git a/lua/vibing/init.lua b/lua/vibing/init.lua",
+      "index 111..222 100644",
+      "--- a/lua/vibing/init.lua",
+      "+++ b/lua/vibing/init.lua",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+      "diff --git a/doc/vibing.txt b/doc/vibing.txt",
+      "index 333..444 100644",
+    }, "\n")
+
+    it("matches an absolute path by its path-boundary suffix", function()
+      assert.equals(
+        "lua/vibing/init.lua",
+        MiniDiff._resolve_rel_path(patch, "/repo/lua/vibing/init.lua")
+      )
+    end)
+
+    it("matches the patch-relative path as written", function()
+      assert.equals("doc/vibing.txt", MiniDiff._resolve_rel_path(patch, "doc/vibing.txt"))
+    end)
+
+    it("does not match on a bare substring", function()
+      -- "init.lua" は patch 内のパスの部分文字列だが、パス境界で切れていないので別物
+      assert.is_nil(MiniDiff._resolve_rel_path(patch, "/repo/other/xinit.lua"))
+    end)
+
+    it("returns nil for a file the patch does not contain", function()
+      assert.is_nil(MiniDiff._resolve_rel_path(patch, "/repo/README.md"))
+    end)
+  end)
+
+  describe("_attach", function()
+    local buf
+
+    before_each(function()
+      buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "after" })
+    end)
+
+    after_each(function()
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end)
+
+    ---呼び出し順を記録するmini.diffのスタブ
+    local function stub(calls)
+      return {
+        gen_source = {
+          none = function()
+            return { name = "none", attach = function() end }
+          end,
+        },
+        disable = function()
+          table.insert(calls, "disable")
+        end,
+        set_ref_text = function()
+          table.insert(calls, "set_ref_text")
+        end,
+        get_buf_data = function()
+          return { overlay = false }
+        end,
+        toggle_overlay = function()
+          table.insert(calls, "toggle_overlay")
+        end,
+      }
+    end
+
+    it("disables the buffer before setting reference text", function()
+      local calls = {}
+      MiniDiff._attach(stub(calls), buf, { "before" })
+
+      -- sourceのattachはenable時にしか起きないので、disableが先でなければ
+      -- `minidiff_config` に書いた `source = none` は効かない
+      assert.equals("disable", calls[1])
+      assert.equals("set_ref_text", calls[2])
+    end)
+
+    it("pins the buffer source to none", function()
+      MiniDiff._attach(stub({}), buf, { "before" })
+
+      local config = vim.b[buf].minidiff_config
+      assert.is_table(config)
+      assert.equals("none", config.source.name)
+    end)
+
+    it("turns the overlay on so deleted lines are visible", function()
+      local calls = {}
+      MiniDiff._attach(stub(calls), buf, { "before" })
+
+      assert.is_truthy(vim.tbl_contains(calls, "toggle_overlay"))
+    end)
+
+    it("records the buffer so VibingDiffClear can find it", function()
+      MiniDiff._attach(stub({}), buf, { "before" })
+
+      assert.is_truthy(vim.tbl_contains(MiniDiff._marked(), buf))
+    end)
+  end)
+
+  describe("is_available", function()
+    it("is false when mini.diff is not installed", function()
+      local saved = package.loaded["mini.diff"]
+      package.loaded["mini.diff"] = nil
+      -- スタブすら無い状態。テスト環境の runtimepath に mini.diff は無い
+      local available = MiniDiff.is_available()
+      package.loaded["mini.diff"] = saved
+
+      assert.is_false(available)
+    end)
+
+    it("is true once mini.diff resolves", function()
+      local saved = package.loaded["mini.diff"]
+      package.loaded["mini.diff"] = { gen_source = {} }
+      local available = MiniDiff.is_available()
+      package.loaded["mini.diff"] = saved
+
+      assert.is_true(available)
+    end)
+  end)
+end)


### PR DESCRIPTION
# Pull Request

## Summary

`gd` はターンの patch をフロートに描いていました。mini.diff が入っていれば **実ファイルを開いて、そのバッファの参照テキストにターン前の内容を差す** 方式を追加します。差分が編集中のファイルそのものの上に出るので、mini.diff のマッピングがそのまま使えます — `[h` / `]h` で hunk 間を移動、`gH` で hunk を reset。

この reset が **hunk 単位の revert** になるのが実質的な機能追加です。フロート側はファイル単位の revert しか持っていませんでした。mini.diff は reset を「その範囲をバッファの参照テキストで置き換える」と定義していて source に依存しないため、追加実装なしでこれが成立します。

mini.diff は **任意依存** です。未インストールなら従来のフロートにフォールバックし、既存の挙動は変わりません。

## Changes

- `lua/vibing/core/utils/patch_text.lua` (new) — patch を一時ツリーへ逆適用して「ターン前の内容」を復元する。**ワーキングツリーにも index にも触らない**（`ui/patch_viewer/revert.lua` の逆適用は実ファイルを書き換える revert 機能そのもので、こちらは読むだけ）
- `lua/vibing/ui/mini_diff.lua` (new) — mini.diff 連携。ウィンドウ選択、参照テキストの設定、`clear`
- `lua/vibing/presentation/chat/modules/diff_opener.lua` (new) — `gd` の入口。mini → patch viewer → `git diff` の3段フォールバック。`keymap_handler.lua` にあった29行のロジックをここへ移した
- `lua/vibing/config.lua` — `diff.viewer`（`"auto"` / `"mini"` / `"patch"`、既定 `"auto"`）
- `lua/vibing/init.lua` — `:VibingDiffClear`
- `doc/vibing.txt`, `handbook/configuration.md` — 上記の説明
- `tests/dev_init.lua` (new) — worktree の checkout をそのまま起動して手で触るための init

### 設計上の判断

**復元できない3ケースはフロートに譲る。** バイナリ diff、ターン後に編集されたファイル（逆適用のコンテキストが合わない）、削除された mote 統合が書いた `base:` ヘッダ無しの旧 patch。特に2つ目は、黙って表示すると **嘘のベースを見せる** ことになるので、失敗を失敗として返しています。

**`vim.b.minidiff_config` を書く前にバッファを disable する。** source の attach は `enable()` 時にしか起きないため、既に enable 済みのバッファに config を書いても古い source が残り、次の `.git/index` 変更でターンの参照テキストが git の内容に黙って置き換わります。この順序は `mini_diff_spec.lua` で固定しました。

**`setup()` は呼ばない。** ユーザーの mini.diff 設定には触れず、vibing が触ったバッファに限って `source` を `gen_source.none()` に固定します。

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test addition or update
- [x] Documentation update
- [x] Code refactoring

## Testing

- [x] Tested locally in Neovim
- [ ] Ran `npm run validate`
- [x] Ran `npm run lint`
- [x] Ran `npm run format:check`
- [x] Tested with multiple configurations
- [x] Manual testing completed

`test:lua` は189スペック全て green（新規23ケース: patch_text 6 / mini_diff 10 / diff_opener 7）。mini.diff はスタブで代用しているので、未インストールの CI でも通ります。

`npm run validate`（= `npm run check`）は `luac` が未インストールの環境のため実行できていません。**これは本 PR の変更とは無関係で、変更前の checkout でも同じく失敗する**ことを確認済みです。代わりに `luajit -b` で `lua/` 配下全ファイルの構文チェックを通しました（エラーなし）。`test:node` の `lua-syntax-gate` が落ちるのも同じ原因です。

### 実機での通し確認

一時 git リポジトリと偽チャットバッファを組み、`gd` を実際に発火させた結果:

```
viewer = mini
file opened: true            chat still alive: true
ref_text set: true           source pinned to none: none
overlay on: true
hunks: 2
  change buf[2,+1] ref[2,+1]
  add    buf[4,+1] ref[3,+0]
summary: #2 +1 ~1
after reset line2: beta      <- gH 相当の hunk 単位 revert が復元
cleared buffers: 1           <- :VibingDiffClear
disabled: true
```

フォールバックも確認: `viewer = "patch"` / mini.diff 不在の `"auto"` / 明示 `"mini"` なのに不在（警告つき）の3つとも、従来のフロートに落ちます。チャットしかウィンドウが無い場合は分割を作り、チャットを潰しません。

### Test Environment

- **Neovim version**: NVIM v0.13.0-dev-1403+g70958dae75-Homebrew
- **Operating System**: macOS 26.6.2
- **Node.js version**: v22.23.2

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [x] doc/vibing.txt updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [x] Code comments added/updated (if applicable)

`handbook/configuration.md` に「How `gd` renders a patch」節を追加しました。

**`.claude/rules/configuration.md` は未更新です。** `diff.viewer` の存在と上記の disable 順序の不変条件を追記すべきですが、ツール権限で編集できませんでした。レビュー時に追記をお願いするか、指示をもらえれば対応します。

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues

なし

## Additional Context

mini.diff を採用したのは、候補（diffview.nvim / gitsigns / delta / difftastic / 組み込み diff モード）の中で **git revision を必要としない唯一の選択肢** だったためです。

vibing のターン差分は `.vibing/patches/*.patch` として保存されますが、`git_snapshot.lua` が作る前後の commit オブジェクトの SHA は破棄されています。diffview や gitsigns を使うにはこの SHA を永続化する必要があり、それには ref の保持ポリシー（件数・日数での sweep）が付いてきます。mini.diff の `set_ref_text()` は任意のテキストを受け取るので、patch だけで完結し、ref の寿命問題が発生しません。古いチャットの `gd` でも動きます。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable `gd` diff viewers: automatic, inline via mini.diff, or the traditional patch preview.
  - Inline diffs open the real file with turn-specific changes and mini.diff navigation when available.
  - Added `:VibingDiffClear` to remove inline diffs from all buffers.
  - Added fallback to a standard `git diff` when no turn patch is available.
- **Documentation**
  - Documented viewer settings, fallback behavior, navigation, and revert shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->