### PR TITLE
ci: add label-driven Codex workflows

### DIFF
--- a/.github/CODEX.md
+++ b/.github/CODEX.md
@@ -1,0 +1,27 @@
+# Codex label-driven automation
+
+The repository has two opt-in Codex workflows:
+
+- Add `codex:in-progress` to an issue to let Codex implement it and open a pull request.
+- Add `codex:in-review` to a same-repository pull request to let Codex review it, push
+  high-confidence fixes to that branch, and post one Japanese review comment.
+
+Only label events initiated by `shabaraba` are accepted. The implementation workflow creates or
+updates `codex:in-progress`, `codex:in-review`, and `codex:failed` after it lands on `main`; it can
+also be run manually once to set them up.
+
+## Required secret
+
+Create the repository Actions secret `OPENAI_API_KEY`. The official `openai/codex-action` uses it
+through its Responses API proxy; a ChatGPT or Codex subscription login is not a replacement for
+this secret.
+
+## Execution boundary
+
+Codex runs with the official `:workspace` permission profile. It can inspect and edit the checkout
+but has no direct network access. Dependencies and GitHub context are prepared before the Codex
+step, while fixed workflow scripts own commits, pushes, pull-request creation, comments, and label
+transitions after Codex exits.
+
+The workflows deliberately skip `npm run test:e2e` and `npm run test:eval` in unattended runs
+because those suites spend model tokens.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,29 +50,37 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Run the `/code-review` skill against PR #${{ github.event.pull_request.number }} at
-            effort "high", passing `--fix` so every CONFIRMED finding is applied to the working
-            tree (already checked out on the PR's own branch).
+            First run the built-in `/simplify` skill against the changes introduced by
+            PR #${{ github.event.pull_request.number }}. Let its three parallel reviewers inspect
+            code reuse, code quality, and efficiency; aggregate their findings and apply the
+            behavior-preserving fixes to the working tree (already checked out on the PR's own
+            branch).
+
+            After `/simplify` and its fixes have fully completed, run the `/code-review` skill
+            against the resulting PR diff at effort "high", passing `--fix` so every CONFIRMED
+            finding is applied too. The code review must consider both the original PR changes and
+            any simplifications just made.
 
             This is a single unattended batch run, not an interactive session: when it ends, the
-            process exits and nothing wakes it again. Any subagent the skill dispatches (the
-            per-dimension review fan-out, the verify pass) MUST be awaited synchronously within
-            this same turn before you act on its result. Do not end a turn saying you'll "wait" or
-            "be notified" for a background agent to finish — there is no later turn here to
-            receive that notification, so the run would exit with nothing posted and no comment
-            explaining why, exactly like a run that hit `permission_denials`.
+            process exits and nothing wakes it again. Any subagent either skill dispatches (the
+            simplify passes, per-dimension review fan-out, and verify pass) MUST be awaited
+            synchronously within this same turn before you act on its result. Do not end a turn
+            saying you'll "wait" or "be notified" for a background agent to finish — there is no
+            later turn here to receive that notification, so the run would exit with nothing
+            posted and no comment explaining why, exactly like a run that hit
+            `permission_denials`.
 
             Do not run `npm run test:e2e` or `npm run test:eval` — they spend real tokens and are
             never run unattended. `npm test`, `npm run check` and `npm run lint` are fine to
             validate a fix before pushing it.
 
-            After the skill finishes:
+            After both skills finish:
             1. If it changed any files, stage and commit them (English summary, one commit) and
                `git push` to this same branch. Do not create a new branch, rebase, or
                force-push.
             2. Post the review as a SINGLE PR comment (`gh pr comment`, called exactly once) in
                Japanese, covering:
-               - which CONFIRMED findings were auto-fixed and pushed (file:line)
+               - which simplifications and CONFIRMED findings were auto-fixed and pushed (file:line)
                - which findings are PLAUSIBLE or were left alone, with file:line, so a human can
                  judge them
                - if nothing was found, say so briefly instead of posting empty sections
@@ -93,9 +101,9 @@ jobs:
           # pushed despite a real ~2.5 minute, $2 run) points to. Allow the whole set rather than
           # whack-a-mole one at a time.
           #
-          # Agent lets /code-review fan out subagents per review dimension and adversarially
-          # verify each finding, which is the whole point of asking for effort "high" -- without
-          # it the skill silently degrades to a single-pass, unverified review.
+          # Agent lets /simplify inspect reuse, quality and efficiency in parallel, then lets
+          # /code-review fan out per review dimension and adversarially verify each finding.
+          # Without it both skills silently degrade to single-pass reviews.
           claude_args: >-
             --allowed-tools
             "Read,Edit,Write,Glob,Grep,Agent,ToolSearch,TodoWrite,ReportFindings,ScheduleWakeup,Bash(git:*),Bash(npm test:*),Bash(npm run check:*),Bash(npm run lint:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -1,0 +1,160 @@
+name: Codex Code Review
+
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    if: >-
+      github.event.label.name == 'codex:in-review' &&
+      github.event.sender.login == 'shabaraba' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout PR head branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare pull request context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,title,body,author,baseRefName,headRefName,comments,reviews \
+            > .codex-pr-context.json
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label "codex:failed" 2>/dev/null || true
+
+      - name: Run Codex review
+        id: codex_review
+        # v1.12; pin the full commit SHA so a tag move cannot change executable code.
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          permission-profile: ":workspace"
+          effort: high
+          output-file: .codex-review-result.json
+          output-schema: |
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "status": { "type": "string", "enum": ["clean", "fixed", "blocked"] },
+                "commit_title": { "type": "string" },
+                "comment": { "type": "string" }
+              },
+              "required": ["status", "commit_title", "comment"]
+            }
+          prompt: |
+            You are the unattended code-review agent for PR
+            #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Read .codex-pr-context.json, CLAUDE.md, and relevant project guidance. Review only the
+            changes in origin/${{ github.event.pull_request.base.ref }}...HEAD. Focus on concrete
+            correctness, regression, security, concurrency, compatibility, and missing-test risks;
+            avoid subjective style findings.
+
+            Apply a fix directly to the working tree only for findings you have confirmed with
+            high confidence. Add or update tests and run relevant fast checks. Never run npm run
+            test:e2e or npm run test:eval because they spend real model tokens. Do not commit,
+            push, post GitHub comments, or modify .codex-pr-context.json; the workflow handles
+            those operations after you exit.
+
+            This is one non-interactive run. If you delegate review dimensions or verification,
+            await every delegated task before returning. Never leave a background task running or
+            promise to wait for a later notification, because there is no later turn.
+
+            All human-facing output must be Japanese. Set status to "fixed" when you changed files,
+            "clean" when no high-confidence fix is required, or "blocked" when review cannot be
+            completed. commit_title must be an English Conventional Commit-style summary for any
+            fixes (and a harmless placeholder when there are none). comment must be the complete,
+            single Markdown PR review comment: list confirmed findings and fixes with file:line,
+            any plausible unresolved concerns, and checks run; if nothing was found, say so briefly.
+
+      - name: Push fixes and post one review comment
+        id: publish
+        if: steps.codex_review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          test -s .codex-review-result.json
+          STATUS="$(jq -r '.status' .codex-review-result.json)"
+          TITLE="$(jq -r '.commit_title' .codex-review-result.json)"
+          COMMENT_FILE="$(mktemp)"
+          jq -r '.comment' .codex-review-result.json > "$COMMENT_FILE"
+          rm -f .codex-pr-context.json .codex-review-result.json
+
+          if [ "$STATUS" = "blocked" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$COMMENT_FILE"
+            echo "status=blocked" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "$TITLE"
+            git push origin HEAD
+            STATUS="fixed"
+          elif [ "$STATUS" = "fixed" ]; then
+            STATUS="clean"
+          fi
+
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$COMMENT_FILE"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Report an automation failure
+        if: >-
+          always() &&
+          (steps.codex_review.outcome != 'success' || steps.publish.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "Codex のレビュー処理に失敗しました。ログ: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Reflect the run outcome on the PR label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh label create "codex:failed" --repo "$GITHUB_REPOSITORY" --force \
+            --color "D73A4A" --description "The latest Codex run failed or needs input"
+          if [ "${{ steps.codex_review.outcome }}" = "success" ] \
+            && [ "${{ steps.publish.outcome }}" = "success" ] \
+            && [ "${{ steps.publish.outputs.status }}" != "blocked" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "codex:in-review"
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "codex:failed" 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "codex:in-review" --add-label "codex:failed"
+          fi

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -56,7 +56,7 @@ jobs:
         uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          permission-profile: ":workspace"
+          permission-profile: ':workspace'
           effort: high
           output-file: .codex-review-result.json
           output-schema: |

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -75,9 +75,19 @@ jobs:
             #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
             Read .codex-pr-context.json, CLAUDE.md, and relevant project guidance. Review only the
-            changes in origin/${{ github.event.pull_request.base.ref }}...HEAD. Focus on concrete
-            correctness, regression, security, concurrency, compatibility, and missing-test risks;
-            avoid subjective style findings.
+            changes in origin/${{ github.event.pull_request.base.ref }}...HEAD.
+
+            First perform a behavior-preserving simplification pass equivalent to Claude Code's
+            built-in /simplify skill. Use three independent review lenses, in parallel when
+            possible: (1) code reuse and duplication, (2) code quality, clarity, and
+            maintainability, and (3) efficiency and unnecessary work. Aggregate the findings,
+            verify them against the codebase, and apply only high-confidence improvements to the
+            working tree. Do not introduce abstractions unless they make the changed code plainly
+            simpler.
+
+            After that pass is fully complete, review the resulting diff for concrete correctness,
+            regression, security, concurrency, compatibility, and missing-test risks. Avoid
+            subjective style findings.
 
             Apply a fix directly to the working tree only for findings you have confirmed with
             high confidence. Add or update tests and run relevant fast checks. Never run npm run
@@ -85,16 +95,18 @@ jobs:
             push, post GitHub comments, or modify .codex-pr-context.json; the workflow handles
             those operations after you exit.
 
-            This is one non-interactive run. If you delegate review dimensions or verification,
-            await every delegated task before returning. Never leave a background task running or
-            promise to wait for a later notification, because there is no later turn.
+            This is one non-interactive run. If you delegate any simplification lens, review
+            dimension, or verification, await every delegated task before returning. Never leave a
+            background task running or promise to wait for a later notification, because there is
+            no later turn.
 
             All human-facing output must be Japanese. Set status to "fixed" when you changed files,
             "clean" when no high-confidence fix is required, or "blocked" when review cannot be
             completed. commit_title must be an English Conventional Commit-style summary for any
             fixes (and a harmless placeholder when there are none). comment must be the complete,
-            single Markdown PR review comment: list confirmed findings and fixes with file:line,
-            any plausible unresolved concerns, and checks run; if nothing was found, say so briefly.
+            single Markdown PR review comment: summarize simplifications first, then list confirmed
+            review findings and fixes with file:line, any plausible unresolved concerns, and checks
+            run; if nothing was found, say so briefly.
 
       - name: Push fixes and post one review comment
         id: publish

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -80,7 +80,7 @@ jobs:
         uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          permission-profile: ":workspace"
+          permission-profile: ':workspace'
           effort: high
           output-file: .codex-result.json
           output-schema: |

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,192 @@
+name: Codex Implementation
+
+on:
+  issues:
+    types: [labeled]
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/codex.yml
+      - .github/workflows/codex-code-review.yml
+  workflow_dispatch:
+
+concurrency:
+  group: codex-implementation-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  setup-labels:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create Codex labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "codex:in-progress" --repo "$GITHUB_REPOSITORY" --force \
+            --color "1D76DB" --description "Codex is implementing this issue"
+          gh label create "codex:in-review" --repo "$GITHUB_REPOSITORY" --force \
+            --color "5319E7" --description "Codex is reviewing this pull request"
+          gh label create "codex:failed" --repo "$GITHUB_REPOSITORY" --force \
+            --color "D73A4A" --description "The latest Codex run failed or needs input"
+
+  implement:
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.label.name == 'codex:in-progress' &&
+      github.event.sender.login == 'shabaraba'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # Codex runs without network access under :workspace, so install dependencies first.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare branch and issue context
+        id: prepare
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          BRANCH="codex/issue-${ISSUE_NUMBER}-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,title,body,author,labels,comments > .codex-issue-context.json
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label "codex:failed" 2>/dev/null || true
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Run Codex
+        id: codex
+        # v1.12; pin the full commit SHA so a tag move cannot change executable code.
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          permission-profile: ":workspace"
+          effort: high
+          output-file: .codex-result.json
+          output-schema: |
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "status": { "type": "string", "enum": ["completed", "blocked"] },
+                "pr_title": { "type": "string" },
+                "pr_body": { "type": "string" },
+                "report": { "type": "string" }
+              },
+              "required": ["status", "pr_title", "pr_body", "report"]
+            }
+          prompt: |
+            You are the unattended implementation agent for issue
+            #${{ github.event.issue.number }} in ${{ github.repository }}.
+
+            All human-facing text in your final structured result must be Japanese. Read
+            .codex-issue-context.json first; it contains the issue title, body, labels, and every
+            comment. Then read CLAUDE.md and the project documentation it points to as repository
+            guidance, while following Codex's own runtime and safety rules.
+
+            Investigate the existing implementation before changing it. Implement the complete
+            issue using the nearest established patterns, add or update tests, and run the relevant
+            fast checks. Never run npm run test:e2e or npm run test:eval because they spend real
+            model tokens. Do not commit, push, create a pull request, use GitHub, or modify
+            .codex-issue-context.json; the workflow handles those operations after you exit.
+
+            This is one non-interactive run. If you delegate investigation, await every delegated
+            task before acting on it. Do not finish by saying that a background task is still
+            running or that you will wait for a notification: there is no later turn. When more
+            than one sound implementation exists, choose the one most consistent with this
+            codebase and explain the choice in pr_body. Use status "blocked" only when the request
+            is genuinely impossible to implement without missing information or authority.
+
+            pr_title must be an English Conventional Commit-style PR title. pr_body must be a
+            Japanese Markdown PR description with Summary and Testing sections. report must be a
+            concise Japanese issue comment explaining the result and checks run.
+
+      - name: Commit, push, and create pull request
+        id: publish
+        if: steps.codex.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          BRANCH: ${{ steps.prepare.outputs.branch }}
+        run: |
+          test -s .codex-result.json
+          STATUS="$(jq -r '.status' .codex-result.json)"
+          TITLE="$(jq -r '.pr_title' .codex-result.json)"
+          BODY_FILE="$(mktemp)"
+          REPORT_FILE="$(mktemp)"
+          jq -r '.pr_body' .codex-result.json > "$BODY_FILE"
+          jq -r '.report' .codex-result.json > "$REPORT_FILE"
+          rm -f .codex-issue-context.json .codex-result.json
+
+          if [ "$STATUS" = "blocked" ]; then
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$REPORT_FILE"
+            echo "status=blocked" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$(git status --porcelain)" ]; then
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$REPORT_FILE"
+            echo "status=no-changes" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf '\n\nFixes #%s\n' "$ISSUE_NUMBER" >> "$BODY_FILE"
+          git add -A
+          git commit -m "$TITLE"
+          git push --set-upstream origin "$BRANCH"
+          PR_URL="$(gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" \
+            --title "$TITLE" --body-file "$BODY_FILE")"
+          printf '\n\n実装PR: %s\n' "$PR_URL" >> "$REPORT_FILE"
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$REPORT_FILE"
+          echo "status=completed" >> "$GITHUB_OUTPUT"
+
+      - name: Report an automation failure
+        if: >-
+          always() &&
+          (steps.codex.outcome != 'success' || steps.publish.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "Codex の実装処理に失敗しました。ログ: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Reflect the run outcome on the issue label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh label create "codex:failed" --repo "$GITHUB_REPOSITORY" --force \
+            --color "D73A4A" --description "The latest Codex run failed or needs input"
+          if [ "${{ steps.codex.outcome }}" = "success" ] \
+            && [ "${{ steps.publish.outcome }}" = "success" ] \
+            && [ "${{ steps.publish.outputs.status }}" != "blocked" ]; then
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "codex:in-progress"
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "codex:failed" 2>/dev/null || true
+          else
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "codex:in-progress" --add-label "codex:failed"
+          fi


### PR DESCRIPTION
## 概要

Claude Code 用の既存フローと並行して使える、公式 `openai/codex-action` ベースのラベル駆動フローを追加します。

- Issue に `codex:in-progress` を付けると Codex が実装・検証し、固定スクリプトが commit / push / PR 作成を担当
- 同一リポジトリの PR に `codex:in-review` を付けると Codex がレビューし、高信頼度の修正だけを同じブランチへ push
- Codex は `:workspace` 権限プロファイルで実行し、GitHub トークンや直接のネットワークアクセスを持たない
- `shabaraba` によるラベル付与だけを受け付ける
- 結果は日本語で1コメントに集約し、失敗または要入力時は `codex:failed` へ遷移
- 非対話実行中に起動した調査タスクは同じ実行内で必ず待つよう明示
- main への導入時または手動実行時に必要な3ラベルを自動作成

## セットアップ

リポジトリの Actions secret として `OPENAI_API_KEY` を登録してください。ChatGPT / Codex のサブスクリプションログインでは代替できません。

## 検証

- 2 workflow の YAML parse
- 全 `run:` ブロックの `bash -n`
- 末尾空白・改行チェック

`npm run test:e2e` と `npm run test:eval` はモデル課金を伴うため、このCI追加の検証では実行していません。

Fixes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in automation for implementing GitHub issues and opening pull requests when work is completed.
  * Added automated pull request reviews that can suggest and apply high-confidence fixes, update tests, and report results.
  * Added workflow status labels and comments for tracking progress, blocked runs, failures, and completed reviews.
  * Added manual workflow triggering and safeguards for repository and pull request execution.
* **Documentation**
  * Documented workflow setup requirements, permissions, label lifecycle, boundaries, and test exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->