### PR TITLE
test(e2e): cover Neovim-owned background jobs, stop the whole process group

### DIFF
--- a/handbook/mcp-tools.md
+++ b/handbook/mcp-tools.md
@@ -124,7 +124,8 @@ such processes. While MCP integration is enabled, the PreToolUse hook also rejec
 
 Neovim keeps a bounded in-memory output tail and writes the complete merged stdout/stderr stream
 plus metadata under `<git-root>/.vibing/jobs/`. `nvim_job_status` reads one job with an output tail,
-`nvim_job_list` lists the jobs owned by this Neovim instance, `nvim_job_stop` requests SIGTERM, and
+`nvim_job_list` lists the jobs owned by this Neovim instance, `nvim_job_stop` sends SIGTERM to the job's
+process group (the job is its own group leader, so a server behind `npm run dev` or `sh -c` stops too), and
 `nvim_job_wait` waits for exit or readiness for at most 25 seconds without killing the job on
 timeout. Readiness is a separate `pending` / `ready` / `timed_out` state driven by a plain-text
 output substring; a live process is never reported ready merely because it was spawned.

--- a/lua/vibing/application/job/manager.lua
+++ b/lua/vibing/application/job/manager.lua
@@ -189,6 +189,25 @@ local function append_output(job, data)
   end
 end
 
+---Deliver a signal to the whole job, then to the leader.
+---
+---The job is spawned as a process group leader (`detach = true`), so the negative pid addresses
+---every process it started. That is the only way a stop reaches a server behind a wrapper such as
+---`npm run dev` or `sh -c`. `uv.kill` refuses a group that is already gone (or a fake pid in a
+---unit test), and the leader-only `handle:kill` then keeps the old behaviour.
+---@param job Vibing.BackgroundJob
+---@param signal number
+local function signal_job(job, signal)
+  local pid = job.pid
+  if type(pid) == "number" and pid > 0 then
+    local ok = pcall(uv.kill, -pid, signal)
+    if ok then
+      return
+    end
+  end
+  job.handle:kill(signal)
+end
+
 ---@param job Vibing.BackgroundJob
 ---@return boolean
 local function should_notify(job)
@@ -366,6 +385,11 @@ function M.start(params)
   local ok, handle_or_err = pcall(vim.system, command, {
     cwd = cwd,
     env = env,
+    -- Own process group. `nvim_job_stop` has to reach the whole tree, not only the leader:
+    -- `sh -c '...; sleep 60'` or `npm run dev` (npm → node) keeps the stdout pipe open in a
+    -- grandchild, so killing the leader alone leaves the server running and the job reported
+    -- `running` until that grandchild exits on its own (observed in E2E).
+    detach = true,
     text = true,
     stdout = function(err, data)
       if err then
@@ -473,9 +497,7 @@ function M.stop(params)
     return snapshot(job)
   end
   job.stop_requested = true
-  local ok, err = pcall(function()
-    job.handle:kill(15)
-  end)
+  local ok, err = pcall(signal_job, job, 15)
   if not ok then
     job.stop_requested = false
     error("Could not stop background job: " .. tostring(err))
@@ -518,9 +540,7 @@ function M.shutdown()
     if job.status == "running" or job.status == "starting" then
       job.suppress_notification = true
       job.stop_requested = true
-      pcall(function()
-        job.handle:kill(15)
-      end)
+      pcall(signal_job, job, 15)
     end
   end
 end

--- a/tests/e2e/background_job_ready_spec.lua
+++ b/tests/e2e/background_job_ready_spec.lua
@@ -1,0 +1,174 @@
+-- E2E Tests: background job readiness, stop, and the passive completion policy
+--
+-- Companion to background_job_spec.lua, split so each file stays inside the harness's per-file
+-- timeout (tests/e2e-timeout-gate.test.mjs). Assertions read the job manager's own state through
+-- RPC, never the model's prose.
+local helper = require("vibing.testing.e2e_helper")
+
+if not helper.should_run() then
+  return
+end
+
+local TIMEOUTS = {
+  CHAT_CREATION = 2000,
+  BUFFER_READY = 5000,
+  ASSISTANT_RESPONSE = 60000,
+  -- start → wait(until=ready) → stop is three MCP round-trips in one turn.
+  MULTI_TOOL_TURN = 80000,
+  -- SIGTERM to `sh -c '...; sleep 60'` and the exit callback.
+  JOB_STOPPED = 20000,
+  -- A passive Notice is appended as soon as the chat is idle.
+  PASSIVE_NOTICE = 20000,
+  -- Long enough for a turn to have visibly started if one were (wrongly) triggered.
+  SETTLE = 5000,
+  POLL = 500,
+}
+
+describe("E2E: background job readiness and passive notices", function()
+  local nvim_instance
+
+  ---@param code string
+  ---@return any
+  local function exec(code)
+    return vim.fn.rpcrequest(nvim_instance.job_id, "nvim_exec_lua", code, {})
+  end
+
+  local function buffer_text()
+    return table.concat(vim.fn.rpcrequest(nvim_instance.job_id, "nvim_buf_get_lines", 0, 0, -1, false), "\n")
+  end
+
+  local function count_assistant_headers(text)
+    local count = 0
+    for _ in text:gmatch("\n## [^\n]*Assistant[^\n]*") do
+      count = count + 1
+    end
+    return count
+  end
+
+  -- `## Assistant` is written the moment the request starts; the timestamp is added when the turn
+  -- ends. So "n completed turns" is n timestamped headers, not n headers — the tool calls under
+  -- test happen in between. Gives up on the same `**Error:**` line the shared helper watches.
+  ---@param count number
+  ---@param timeout number
+  ---@return boolean ok
+  ---@return string? reason
+  local function wait_for_completed_turns(count, timeout)
+    local deadline = vim.loop.now() + timeout
+    local text = ""
+    while vim.loop.now() < deadline do
+      text = buffer_text()
+      local err = text:match("%*%*Error:%*%* [^\n]*")
+      if err then
+        return false, "the turn failed: " .. err
+      end
+      local done = 0
+      for _ in text:gmatch("\n## Assistant <!%-%-") do
+        done = done + 1
+      end
+      if done >= count then
+        return true
+      end
+      vim.wait(TIMEOUTS.POLL)
+    end
+    return false, string.format("timed out waiting for %d completed turn(s)", count)
+  end
+
+  local function open_chat()
+    helper.send_keys(nvim_instance, ":VibingChat<CR>")
+    vim.wait(TIMEOUTS.CHAT_CREATION)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
+    assert.is_true(ok, "Chat buffer should be created")
+  end
+
+  local function send_prompt(prompt)
+    helper.send_keys(nvim_instance, "G")
+    helper.send_keys(nvim_instance, "i")
+    helper.send_keys(nvim_instance, prompt)
+    helper.send_keys(nvim_instance, "<Esc>")
+    helper.send_keys(nvim_instance, "<CR>")
+  end
+
+  before_each(function()
+    nvim_instance = helper.spawn_nvim_instance({
+      headless = true,
+      init_script = "tests/e2e_init.lua",
+    })
+  end)
+
+  after_each(function()
+    helper.cleanup_instance(nvim_instance)
+  end)
+
+  it("reports readiness from the output pattern and stops on request without a Notice", function()
+    open_chat()
+
+    send_prompt(
+      "Use the vibing-nvim nvim_job_start MCP tool to start the command "
+        .. '["sh", "-c", "echo E2E_READY_MARK; sleep 60"] with name e2e-server, ready_pattern '
+        .. "E2E_READY_MARK, notify never, and this chat's buffer number as from_bufnr. "
+        .. "Then call nvim_job_wait on that job_id with until set to ready. "
+        .. "Then call nvim_job_stop on the same job_id. Reply with the word: done."
+    )
+
+    local ok, reason = wait_for_completed_turns(1, TIMEOUTS.MULTI_TOOL_TURN)
+    assert.is_true(ok, reason or "the start/wait/stop turn should complete")
+
+    local jobs = exec("return require('vibing.application.job.manager').list().jobs")
+    assert.equals(1, #jobs, "exactly one job should have been started")
+    local job_id = jobs[1].id
+    assert.equals("e2e-server", jobs[1].name)
+    assert.equals("never", jobs[1].notify)
+
+    -- Readiness came from the output substring, not from the process merely existing.
+    local status
+    local deadline = vim.loop.now() + TIMEOUTS.JOB_STOPPED
+    repeat
+      status = exec(string.format("return require('vibing.application.job.manager').status({ job_id = %q })", job_id))
+      if status.status ~= "stopped" then
+        vim.wait(TIMEOUTS.POLL)
+      end
+    until status.status == "stopped" or vim.loop.now() >= deadline
+
+    assert.equals("ready", status.readiness, "ready_pattern should have marked the job ready: " .. vim.inspect(status))
+    assert.equals("stopped", status.status, "nvim_job_stop should have terminated the job: " .. vim.inspect(status))
+
+    -- notify = never: no Notice, and no second turn.
+    local text = buffer_text()
+    assert.is_nil(text:find("\n## Notice", 1, true), "notify never must not deliver a Notice")
+    assert.equals(1, count_assistant_headers(text), "notify never must not start another turn")
+  end)
+
+  it("appends a passive Notice on exit without starting an LLM turn", function()
+    open_chat()
+
+    send_prompt(
+      "Use the vibing-nvim nvim_job_start MCP tool to start the command "
+        .. '["sh", "-c", "echo E2E_PASSIVE_OUTPUT"] with name e2e-passive, notify passive, and this '
+        .. "chat's buffer number as from_bufnr. Do not wait for it and do not call any other tool. "
+        .. "Reply with the word: started."
+    )
+
+    local ok, reason = wait_for_completed_turns(1, TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, reason or "the turn that starts the job should complete")
+
+    local jobs = exec("return require('vibing.application.job.manager').list().jobs")
+    assert.equals(1, #jobs, "exactly one job should have been started")
+    assert.equals("passive", jobs[1].notify)
+
+    ok = helper.wait_for_buffer_content(nvim_instance, "\n## Notice", TIMEOUTS.PASSIVE_NOTICE)
+    assert.is_true(ok, "a passive Notice should be appended once the job exits")
+
+    -- Give a wrongly started turn time to write its header, then confirm none did.
+    vim.wait(TIMEOUTS.SETTLE)
+    local text = buffer_text()
+    assert.is_truthy(text:find("Background job `e2e-passive`", 1, true), "the Notice should name the job")
+    assert.is_truthy(text:find("E2E_PASSIVE_OUTPUT", 1, true), "the Notice should include the output tail")
+    assert.equals(1, count_assistant_headers(text), "a passive Notice must not start another turn")
+
+    local responding = exec(
+      "local b = require('vibing.presentation.chat.view').get_chat_buffer(vim.api.nvim_get_current_buf()); "
+        .. "return b and b:is_responding() or false"
+    )
+    assert.is_false(responding, "the chat should be idle after a passive Notice")
+  end)
+end)

--- a/tests/e2e/background_job_spec.lua
+++ b/tests/e2e/background_job_spec.lua
@@ -1,0 +1,208 @@
+-- E2E Tests: Neovim-owned background jobs (nvim_job_start and the Bash backgrounding gate)
+--
+-- Two halves of one feature: the model is told (system prompt) and forced (PreToolUse hook) to
+-- start long-running processes through `nvim_job_start`, and the process that results is owned by
+-- Neovim, so its exit reaches the chat as a `## Notice` after the CLI turn that started it is gone.
+--
+-- Assertions read what vibing.nvim itself records — the job manager's table and the hook's
+-- permission decision — never the model's prose, so a rewording cannot make this flaky.
+local helper = require("vibing.testing.e2e_helper")
+
+-- tests/e2e is swept by `test:lua` too, and every spec here drives a real CLI turn.
+-- Only `test:e2e` sets VIBING_E2E=1; everything else skips rather than quietly spending tokens.
+if not helper.should_run() then
+  return
+end
+
+local TIMEOUTS = {
+  CHAT_CREATION = 2000,
+  BUFFER_READY = 5000,
+  -- The turn has to discover the tool through ToolSearch and round-trip the MCP server, like
+  -- nvim_ask_user_question_spec; same budget.
+  ASSISTANT_RESPONSE = 60000,
+  -- After the job exits, the queued Notice starts a fresh turn on an idle chat. This covers the
+  -- process exit, the queue flush and that second turn.
+  NOTICE_WAKE = 50000,
+  POLL = 500,
+  -- One hook round trip: nc, the RPC handler, the response file. The script itself polls for
+  -- up to 120s, so this is the spec's bound, not the protocol's.
+  HOOK_ROUND_TRIP = 15000,
+}
+
+describe("E2E: Neovim-owned background jobs", function()
+  local nvim_instance
+
+  ---@param code string
+  ---@return any
+  local function exec(code)
+    return vim.fn.rpcrequest(nvim_instance.job_id, "nvim_exec_lua", code, {})
+  end
+
+  local function buffer_text()
+    return table.concat(vim.fn.rpcrequest(nvim_instance.job_id, "nvim_buf_get_lines", 0, 0, -1, false), "\n")
+  end
+
+  -- `## Assistant` is written the moment the request starts; the timestamp is added when the turn
+  -- ends. So "n completed turns" is n timestamped headers, not n headers — the tool calls under
+  -- test happen in between. Gives up on the same `**Error:**` line the shared helper watches.
+  ---@param count number
+  ---@param timeout number
+  ---@return boolean ok
+  ---@return string? reason
+  local function wait_for_completed_turns(count, timeout)
+    local deadline = vim.loop.now() + timeout
+    local text = ""
+    while vim.loop.now() < deadline do
+      text = buffer_text()
+      local err = text:match("%*%*Error:%*%* [^\n]*")
+      if err then
+        return false, "the turn failed: " .. err
+      end
+      local done = 0
+      for _ in text:gmatch("\n## Assistant <!%-%-") do
+        done = done + 1
+      end
+      if done >= count then
+        return true
+      end
+      vim.wait(TIMEOUTS.POLL)
+    end
+    return false, string.format("timed out waiting for %d completed turn(s)", count)
+  end
+
+  local function open_chat()
+    helper.send_keys(nvim_instance, ":VibingChat<CR>")
+    vim.wait(TIMEOUTS.CHAT_CREATION)
+    local ok = helper.wait_for_buffer_name(nvim_instance, "%.md$", TIMEOUTS.BUFFER_READY)
+    assert.is_true(ok, "Chat buffer should be created")
+  end
+
+  local function send_prompt(prompt)
+    helper.send_keys(nvim_instance, "G")
+    helper.send_keys(nvim_instance, "i")
+    helper.send_keys(nvim_instance, prompt)
+    helper.send_keys(nvim_instance, "<Esc>")
+    helper.send_keys(nvim_instance, "<CR>")
+  end
+
+  before_each(function()
+    nvim_instance = helper.spawn_nvim_instance({
+      headless = true,
+      init_script = "tests/e2e_init.lua",
+    })
+  end)
+
+  after_each(function()
+    helper.cleanup_instance(nvim_instance)
+  end)
+
+  it("delivers the job's exit as a Notice that wakes the chat with a new turn", function()
+    open_chat()
+
+    send_prompt(
+      "Use the vibing-nvim nvim_job_start MCP tool to start the command "
+        .. '["sh", "-c", "echo E2E_JOB_OUTPUT"] with name e2e-echo, passing this chat\'s buffer '
+        .. "number as from_bufnr. Do not wait for it and do not call any other tool. Reply with the word: started."
+    )
+
+    local ok, reason = wait_for_completed_turns(1, TIMEOUTS.ASSISTANT_RESPONSE)
+    assert.is_true(ok, reason or "the turn that starts the job should complete")
+
+    -- The tool call is what is under test, and the manager's table is where it lands.
+    local jobs = exec("return require('vibing.application.job.manager').list().jobs")
+    assert.equals(1, #jobs, "nvim_job_start should have registered exactly one job")
+    assert.equals("e2e-echo", jobs[1].name, "the job should carry the requested name")
+    assert.equals("always", jobs[1].notify, "notify should default to always")
+
+    -- The process is Neovim's, so its exit reaches the chat after the CLI turn is gone: a
+    -- `## Notice` section, and — because notify is `always` — a second assistant turn on it.
+    ok, reason = wait_for_completed_turns(2, TIMEOUTS.NOTICE_WAKE)
+    assert.is_true(ok, reason or "the completion Notice should start a second turn")
+
+    local text = buffer_text()
+    assert.is_truthy(text:find("\n## Notice", 1, true), "a Notice section should have been delivered")
+    assert.is_truthy(text:find("Background job `e2e-echo`", 1, true), "the Notice should name the job")
+    assert.is_truthy(text:find("exited with code 0", 1, true), "the Notice should carry the exit status")
+    assert.is_truthy(text:find("E2E_JOB_OUTPUT", 1, true), "the Notice should include the output tail")
+
+    local status = exec(string.format("return require('vibing.application.job.manager').status({ job_id = %q })", jobs[1].id))
+    assert.equals("exited", status.status)
+    assert.equals(0, status.exit_code)
+    assert.equals(1, vim.fn.filereadable(status.log_path), "the full log should be written under .vibing/jobs/")
+  end)
+
+  it("denies Bash backgrounding through the PreToolUse hook and points at nvim_job_start", function()
+    -- Driven without the model, deliberately. The system prompt forbids exactly the call this
+    -- spec needs, and whether the model attempts it anyway is a coin toss (observed both ways),
+    -- so an LLM-driven version asserts nothing on a bad day. What has to hold is the chain the
+    -- model would hit when it does try: the hook script → nc → the child's RPC server → the
+    -- policy in can_use_tool → the response file → exit 2 with the redirect on stderr. Running
+    -- the real script against the real child covers all of it; tests/e2e_init.lua's Bash deny is
+    -- irrelevant because that list is enforced by the CLI (`--disallowedTools`), not here.
+    open_chat()
+
+    local port = exec("return require('vibing.infrastructure.rpc.server').get_port()")
+    assert.is_true(type(port) == "number" and port > 0, "the child's RPC server should be listening")
+
+    -- Record the decision where it is made, which also proves the request reached *this* child.
+    exec([[
+      local cut = require('vibing.infrastructure.permissions.can_use_tool')
+      _G.__e2e_decisions = {}
+      local original = cut.can_use_tool
+      cut.can_use_tool = function(tool_name, input, config)
+        local result = original(tool_name, input, config)
+        table.insert(_G.__e2e_decisions, {
+          tool = tool_name,
+          command = type(input) == 'table' and input.command or nil,
+          behavior = result.behavior,
+          message = result.message,
+        })
+        return result
+      end
+    ]])
+
+    ---@param tool_input table
+    ---@return vim.SystemCompleted
+    local function run_hook(tool_input)
+      local payload = vim.json.encode({
+        hook_event_name = "PreToolUse",
+        tool_name = "Bash",
+        tool_input = tool_input,
+      })
+      return vim.system({ vim.fn.getcwd() .. "/bin/hooks/pre-tool-use.sh" }, {
+        stdin = payload,
+        env = { VIBING_NVIM_RPC_PORT = tostring(port) },
+        text = true,
+      }):wait(TIMEOUTS.HOOK_ROUND_TRIP)
+    end
+
+    local ampersand = run_hook({ command = "sleep 2 &" })
+    assert.equals(2, ampersand.code, "a trailing & must be denied (exit 2): " .. vim.inspect(ampersand))
+    assert.is_truthy(
+      (ampersand.stderr or ""):find("nvim_job_start", 1, true),
+      "the refusal must point at nvim_job_start: " .. tostring(ampersand.stderr)
+    )
+
+    local native = run_hook({ command = "npm run dev", run_in_background = true })
+    assert.equals(2, native.code, "Bash's own run_in_background must be denied: " .. vim.inspect(native))
+
+    -- The gate is specific: a foreground command passes, and passes as "defer" (silent exit 0),
+    -- never as an explicit grant that would skip the CLI's own settings.json rules.
+    local foreground = run_hook({ command = "echo hi" })
+    assert.equals(0, foreground.code, "a foreground command must not be denied: " .. vim.inspect(foreground))
+    assert.equals("", foreground.stdout or "", "a permitted Bash call is a defer, not an allow")
+
+    local decisions = exec("return _G.__e2e_decisions")
+    local denied, allowed = 0, 0
+    for _, decision in ipairs(decisions) do
+      if decision.tool == "Bash" and decision.behavior == "deny" then
+        denied = denied + 1
+        assert.is_truthy(decision.message and decision.message:find("nvim_job_start", 1, true))
+      elseif decision.tool == "Bash" and decision.behavior == "allow" then
+        allowed = allowed + 1
+      end
+    end
+    assert.equals(2, denied, "both detached forms should have been denied by this child: " .. vim.inspect(decisions))
+    assert.equals(1, allowed, "the foreground command should have been evaluated by this child: " .. vim.inspect(decisions))
+  end)
+end)

--- a/tests/lua/application/job/manager_spec.lua
+++ b/tests/lua/application/job/manager_spec.lua
@@ -1,8 +1,10 @@
 local Git = require("vibing.core.utils.git")
+local uv = vim.uv or vim.loop
 
 describe("Neovim-owned background jobs", function()
   local Manager
   local original_system
+  local original_uv_kill
   local original_get_root
   local original_queue
   local tmp_root
@@ -37,7 +39,7 @@ describe("Neovim-owned background jobs", function()
 
     spawn, spawns = {}, {}
     vim.system = function(command, opts, on_exit)
-      spawn = { command = command, opts = opts, on_exit = on_exit, kills = {} }
+      spawn = { command = command, opts = opts, on_exit = on_exit, kills = {}, group_kills = {} }
       table.insert(spawns, spawn)
       return {
         pid = 4242,
@@ -45,6 +47,13 @@ describe("Neovim-owned background jobs", function()
           table.insert(spawn.kills, signal)
         end,
       }
+    end
+    -- A stop addresses the process group first (negative pid), so record that path too; the
+    -- leader-only handle:kill above is only the fallback when the group is already gone.
+    original_uv_kill = uv.kill
+    uv.kill = function(pid, signal)
+      table.insert(spawn.group_kills, { pid = pid, signal = signal })
+      return true
     end
 
     package.loaded["vibing.application.job.manager"] = nil
@@ -56,6 +65,7 @@ describe("Neovim-owned background jobs", function()
       Manager._reset()
     end
     vim.system = original_system
+    uv.kill = original_uv_kill
     Git.get_root = original_get_root
     package.loaded["vibing.application.chat.message_queue"] = original_queue
     package.loaded["vibing.application.job.manager"] = nil
@@ -161,7 +171,10 @@ describe("Neovim-owned background jobs", function()
   it("marks a readiness timeout without pretending the still-running process exited", function()
     local started = start({ ready_pattern = "never printed", ready_timeout_ms = 10, notify = "never" })
 
-    assert.is_true(vim.wait(1000, function()
+    -- Normally satisfied in ~10ms. The bound is generous because `test:lua` starts every spec
+    -- file at once, and on a 4-core box this process can be starved past one second before its
+    -- timer callback is scheduled — which read as a failure of the timeout logic (it was not).
+    assert.is_true(vim.wait(5000, function()
       return Manager.status({ job_id = started.id }).readiness == "timed_out"
     end))
     local status = Manager.status({ job_id = started.id })
@@ -232,9 +245,10 @@ describe("Neovim-owned background jobs", function()
 
     local stopping = Manager.stop({ job_id = started.id })
     assert.equals("running", stopping.status)
-    assert.same({ 15 }, spawn.kills)
+    assert.same({ { pid = -4242, signal = 15 } }, spawn.group_kills, "SIGTERM goes to the whole process group")
+    assert.same({}, spawn.kills, "the leader is not signalled twice when the group kill succeeds")
     Manager.stop({ job_id = started.id })
-    assert.same({ 15 }, spawn.kills, "repeated stop must be idempotent")
+    assert.same({ { pid = -4242, signal = 15 } }, spawn.group_kills, "repeated stop must be idempotent")
 
     spawn.on_exit({ code = 0, signal = 15 })
     assert.is_true(vim.wait(1000, function()


### PR DESCRIPTION
# Pull Request

## Summary

Operation check of the `nvim_job_*` MCP tools from #756 against a child Neovim and the real `claude` CLI, captured as E2E specs. The check found one defect: `nvim_job_stop` only signalled the process-group leader, so a server behind `sh -c` or `npm run dev` kept running and the job stayed `running`. Fixed here by spawning each job as its own process group and stopping the group.

## Changes

- `tests/e2e/background_job_spec.lua`: `nvim_job_start` → exit → `## Notice` → a fresh turn on the source chat; the PreToolUse hook denying `&` and `run_in_background` with the `nvim_job_start` redirect and deferring a foreground command (drives `bin/hooks/pre-tool-use.sh` directly, since whether the model attempts a forbidden Bash call is a coin toss)
- `tests/e2e/background_job_ready_spec.lua`: `ready_pattern` → `nvim_job_wait(until=ready)` → `nvim_job_stop` with `notify=never`; `notify=passive` appending a Notice without starting a turn
- `lua/vibing/application/job/manager.lua`: `detach = true` on spawn; `stop` / `shutdown` send SIGTERM to the process group, falling back to the leader when the group is already gone
- `tests/lua/application/job/manager_spec.lua`: stub the group kill; widen the readiness-timeout wait, which was starved past 1s when `test:lua` starts every spec file at once
- `handbook/mcp-tools.md`: note that `nvim_job_stop` targets the process group

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] CI/CD update

## Testing

- [x] Tested locally in Neovim
- [ ] Ran `npm run validate`
- [x] Ran `npm run lint`
- [x] Ran `npm run format:check`
- [ ] Tested with multiple configurations
- [x] Manual testing completed

`npm run test:e2e` (9 files, 17 tests, all green), `npm test`, `npm run check`, `npm run check:doc`. The stop defect was reproduced without an LLM (`sh -c 'echo READY; sleep 60'` stayed `running` 15s after `stop`; after the fix it is `stopped` in ~0.5s with the grandchild gone).

### Test Environment

- **Neovim version**: NVIM v0.12.5
- **Operating System**: Linux (Claude Code on the web container)
- **Node.js version**: v22.22.2

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CONTRIBUTING.md updated (if applicable)
- [ ] doc/vibing.txt updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [x] Code comments added/updated (if applicable)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

Relates to #753 (stacked on #756)

## Screenshots / Videos

N/A

## Additional Context

`detach = true` means a job survives a SIGKILL of Neovim; a normal exit still stops every job through `shutdown`, so the documented "exiting Neovim terminates its jobs" behaviour holds. Observed in the web container: the child CLI inherits this session's `CLAUDE_CODE_SESSION_ID`, so its stream carries the parent session's id; it did not affect the results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tWdas7CAczW51uixKmkfq

---
_Generated by [Claude Code](https://claude.ai/code/session_019tWdas7CAczW51uixKmkfq)_